### PR TITLE
[GJ-13] Skip checkstyle for arrow installation

### DIFF
--- a/docs/ArrowInstallation.md
+++ b/docs/ArrowInstallation.md
@@ -40,9 +40,9 @@ make install
 # build java
 cd ../../java
 # change property 'arrow.cpp.build.dir' to the relative path of cpp build dir in gandiva/pom.xml
-mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=../cpp/release-build/release/ -DskipTests 
+mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=../cpp/release-build/release/ -DskipTests -Dcheckstyle.skip
 # if you are behine proxy, please also add proxy for socks
-mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=../cpp/release-build/release/ -DskipTests -DsocksProxyHost=${proxyHost} -DsocksProxyPort=1080 
+mvn clean install -P arrow-jni -am -Darrow.cpp.build.dir=../cpp/release-build/release/ -DskipTests -Dcheckstyle.skip -DsocksProxyHost=${proxyHost} -DsocksProxyPort=1080 
 ```
 
 run test


### PR DESCRIPTION
For arrow version arrow-7.0.0-oap, a checkstyle issue lead to the installation failure.

1. better to skip checkstyle in ArrowInstallation.md
2. and need to fix checkstyle issue in arrow-7.0.0-oap branch
https://github.com/oap-project/gluten/issues/13.
