### PR TITLE
[Gluten-129] Adding github actions framework

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem or challenge? Please describe what you are trying to do.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] 
+(This section helps developers understand the context and *why* for this feature, in addition to  the *what*)
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,12 @@
+## What changes were proposed in this pull request?
+
+(Please fill in changes proposed in this fix)
+
+
+## How was this patch tested?
+
+(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
+
+
+(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
+

--- a/.github/workflows/dev_cron.yml
+++ b/.github/workflows/dev_cron.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Dev PR
+
+on:
+
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  process:
+    name: Process
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Comment Issues link
+        if: |
+          github.event_name == 'pull_request_target' &&
+            (github.event.action == 'opened' ||
+             github.event.action == 'edited')
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_cron/issues_link.js`);
+            script({github, context});
+
+      - name: Check title
+        if: |
+          github.event_name == 'pull_request_target' &&
+            (github.event.action == 'opened' ||
+             github.event.action == 'edited')
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_cron/title_check.js`);
+            script({github, context});
+

--- a/.github/workflows/dev_cron/issues_link.js
+++ b/.github/workflows/dev_cron/issues_link.js
@@ -48,7 +48,7 @@ async function haveComment(github, context, pullRequestNumber, body) {
 }
 
 async function commentISSUESURL(github, context, pullRequestNumber, issuesID) {
-  const issuesURL = `https://github.com/oap-project/native-sql-engine/issues/${issuesID}`;
+  const issuesURL = `https://github.com/oap-project/gluten/issues/${issuesID}`;
   if (await haveComment(github, context, pullRequestNumber, issuesURL)) {
     return;
   }

--- a/.github/workflows/dev_cron/issues_link.js
+++ b/.github/workflows/dev_cron/issues_link.js
@@ -19,7 +19,7 @@ function detectISSUESID(title) {
   if (!title) {
     return null;
   }
-  const matched = /^\[GJ-\d+\]/.exec(title);
+  const matched = /^\[Gluten-\d+\]/.exec(title);
   if (!matched) {
     return null;
   }

--- a/.github/workflows/dev_cron/issues_link.js
+++ b/.github/workflows/dev_cron/issues_link.js
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICEGJ-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function detectISSUESID(title) {
+  if (!title) {
+    return null;
+  }
+  const matched = /^\[GJ-\d+\]/.exec(title);
+  if (!matched) {
+    return null;
+  }
+  const issues_number = matched[0].replace(/[^0-9]/ig,"");
+  return issues_number;
+}
+
+async function haveComment(github, context, pullRequestNumber, body) {
+  const options = {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequestNumber,
+    page: 1
+  };
+  while (true) {
+    const response = await github.issues.listComments(options);
+    if (response.data.some(comment => comment.body === body)) {
+      return true;
+    }
+    if (!/;\s*rel="next"/.test(response.headers.link || "")) {
+      break;
+    }
+    options.page++;
+  }
+  return false;
+}
+
+async function commentISSUESURL(github, context, pullRequestNumber, issuesID) {
+  const issuesURL = `https://github.com/oap-project/native-sql-engine/issues/${issuesID}`;
+  if (await haveComment(github, context, pullRequestNumber, issuesURL)) {
+    return;
+  }
+  await github.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequestNumber,
+    body: issuesURL
+  });
+}
+
+module.exports = async ({github, context}) => {
+  const pullRequestNumber = context.payload.number;
+  const title = context.payload.pull_request.title;
+  const issuesID = detectISSUESID(title);
+  if (issuesID) {
+    await commentISSUESURL(github, context, pullRequestNumber, issuesID);
+  }
+};

--- a/.github/workflows/dev_cron/title_check.js
+++ b/.github/workflows/dev_cron/title_check.js
@@ -21,7 +21,7 @@ function haveISSUESID(title) {
   if (!title) {
     return false;
   }
-  return /^\[GJ-\d+\]/.test(title);
+  return /^\[Gluten-\d+\]/.test(title);
 }
 
 async function commentOpenISSUESIssue(github, context, pullRequestNumber) {

--- a/.github/workflows/dev_cron/title_check.js
+++ b/.github/workflows/dev_cron/title_check.js
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICEGJ-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const fs = require("fs");
+
+function haveISSUESID(title) {
+  if (!title) {
+    return false;
+  }
+  return /^\[GJ-\d+\]/.test(title);
+}
+
+async function commentOpenISSUESIssue(github, context, pullRequestNumber) {
+  const {data: comments} = await github.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequestNumber,
+    per_page: 1
+  });
+  if (comments.length > 0) {
+    return;
+  }
+  const commentPath = ".github/workflows/dev_cron/title_check.md";
+  const comment = fs.readFileSync(commentPath).toString();
+  await github.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequestNumber,
+    body: comment
+  });
+}
+
+module.exports = async ({github, context}) => {
+  const pullRequestNumber = context.payload.number;
+  const title = context.payload.pull_request.title;
+  if (!haveISSUESID(title)) {
+    await commentOpenISSUESIssue(github, context, pullRequestNumber);
+  }
+};

--- a/.github/workflows/dev_cron/title_check.md
+++ b/.github/workflows/dev_cron/title_check.md
@@ -1,0 +1,33 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICEGJ-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+Thanks for opening a pull request!
+
+Could you open an issue for this pull request on Github Issues?
+
+https://github.com/oap-project/native-sql-engine/issues
+
+Then could you also rename ***commit message*** and ***pull request title*** in the following format?
+
+    [GJ-${ISSUES_ID}] ${detailed message}
+
+See also:
+
+  * [Other pull requests](https://github.com/oap-project/native-sql-engine/pulls/)
+

--- a/.github/workflows/dev_cron/title_check.md
+++ b/.github/workflows/dev_cron/title_check.md
@@ -21,7 +21,7 @@ Thanks for opening a pull request!
 
 Could you open an issue for this pull request on Github Issues?
 
-https://github.com/oap-project/native-sql-engine/issues
+https://github.com/oap-project/gluten/issues
 
 Then could you also rename ***commit message*** and ***pull request title*** in the following format?
 
@@ -29,5 +29,5 @@ Then could you also rename ***commit message*** and ***pull request title*** in 
 
 See also:
 
-  * [Other pull requests](https://github.com/oap-project/native-sql-engine/pulls/)
+  * [Other pull requests](https://github.com/oap-project/gluten/pulls/)
 

--- a/.github/workflows/dev_cron/title_check.md
+++ b/.github/workflows/dev_cron/title_check.md
@@ -25,7 +25,7 @@ https://github.com/oap-project/gluten/issues
 
 Then could you also rename ***commit message*** and ***pull request title*** in the following format?
 
-    [GJ-${ISSUES_ID}] ${detailed message}
+    [Gluten-${ISSUES_ID}] ${detailed message}
 
 See also:
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Native SQL Engine Unit Tests Suite
+name: Gluten Unit Tests Suite
 
 on:
   pull_request
@@ -51,7 +51,7 @@ jobs:
           sudo make install
       - name: Run unit tests
         run: |
-          cd gluten/cpp/
+          cd cpp/
           mkdir -p build
           cd build
           cmake .. -DBUILD_ARROW=0 -DTESTS=1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -56,8 +56,6 @@ jobs:
           cd build
           cmake .. -DBUILD_ARROW=0 -DTESTS=1
           make
-          cd src
-          ctest -R
 
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Native SQL Engine Unit Tests Suite
+
+on:
+  pull_request
+
+jobs:
+  cpp-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: sudo swapoff -a
+      - run: free
+      - run: sudo apt-get update
+      - run: sudo apt-get install cmake ccache
+      - run: sudo apt-get install libboost-all-dev
+      - name: Install Googletest
+        run: |
+          sudo apt-get install libgtest-dev
+          cd /usr/src/gtest
+          sudo cmake CMakeLists.txt -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local
+          sudo make
+          sudo apt-get install google-mock
+      - name: Install OAP optimized Arrow (C++ libs)
+        run: |
+          cd /tmp
+          git clone https://github.com/oap-project/arrow.git
+          cd arrow && git checkout arrow-7.0.0-oap && cd cpp
+          mkdir build && cd build
+          cmake .. -DARROW_JNI=ON -DARROW_GANDIVA_JAVA=ON -DARROW_GANDIVA=ON -DARROW_PARQUET=ON -DARROW_ORC=ON -DARROW_CSV=ON -DARROW_HDFS=ON -DARROW_FILESYSTEM=ON -DARROW_WITH_SNAPPY=ON -DARROW_JSON=ON -DARROW_DATASET=ON -DARROW_WITH_LZ4=ON -DGTEST_ROOT=/usr/src/gtest && make -j2
+          sudo make install
+      - name: Run unit tests
+        run: |
+          cd gluten/cpp/
+          mkdir -p build
+          cd build
+          cmake .. -DBUILD_ARROW=0 -DTESTS=1
+          make
+          cd src
+          ctest -R
+
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.5.1
+      with:
+        clang-format-version: '10'
+        check-path: 'native-sql-engine/cpp/src'
+        fallback-style: 'Google' # optional

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -77,7 +77,7 @@ jobs:
           sudo cmake CMakeLists.txt -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local
           sudo make
           sudo apt-get install google-mock
-      - name: Install OAP optimized Arrow (C++ libs)
+      - name: Install Velox
         run: |
           cd /tmp
           git clone https://github.com/rui-mo/velox

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,7 +21,7 @@ on:
   pull_request
 
 jobs:
-  cpp-unit-test:
+  arrow-backend-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -56,6 +56,42 @@ jobs:
           cd build
           cmake .. -DBUILD_ARROW=0 -DTESTS=1
           make
+
+  velox-backend-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: sudo swapoff -a
+      - run: free
+      - run: sudo apt-get update
+      - run: sudo apt-get install cmake ccache
+      - run: sudo apt-get install libboost-all-dev
+      - name: Install Googletest
+        run: |
+          sudo apt-get install libgtest-dev
+          cd /usr/src/gtest
+          sudo cmake CMakeLists.txt -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local
+          sudo make
+          sudo apt-get install google-mock
+      - name: Install OAP optimized Arrow (C++ libs)
+        run: |
+          cd /tmp
+          git clone https://github.com/rui-mo/velox
+          cd velox && git checkout velox_for_gazelle_jni
+          bash scripts/setup-ubuntu.sh
+          make
+      - name: Run unit tests
+        run: |
+          cd cpp/
+          mkdir -p build
+          cd build
+          cmake .. -DBUILD_ARROW=0 -DTESTS=1
+          make
+
 
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -68,5 +68,5 @@ jobs:
       uses: jidicula/clang-format-action@v3.5.1
       with:
         clang-format-version: '10'
-        check-path: 'native-sql-engine/cpp/src'
+        check-path: 'gluten/cpp/src'
         fallback-style: 'Google' # optional


### PR DESCRIPTION
This patch adds GHA for below tests:
* each PR should be prefixed with Gluten-: e.g Gluten-12
* format check on C++ code
* trigger unit tests for each PR

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>