### PR TITLE
[OPPRO-10] Hash Join support

### DIFF
--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -76,6 +76,22 @@ std::shared_ptr<gluten::RecordBatchResultIterator> ArrowExecBackend::GetResultIt
   // Make plan
   GLUTEN_ASSIGN_OR_THROW(exec_plan_, arrow::compute::ExecPlan::Make());
   GLUTEN_ASSIGN_OR_THROW(auto node, decl_->AddToPlan(exec_plan_.get()));
+
+  auto include_aug_fields =
+      arrow::FieldRef("__fragment_index").FindOne(*node->output_schema());
+  if (include_aug_fields.ok()) {
+    std::vector<arrow::compute::Expression> fields;
+    auto num_fields = node->output_schema()->num_fields() - 3;
+    fields.reserve(num_fields);
+    for (int i = 0; i < num_fields; ++i) {
+      fields.push_back(arrow::compute::field_ref(i));
+    }
+    GLUTEN_ASSIGN_OR_THROW(node,
+                           arrow::compute::MakeExecNode(
+                               "project", exec_plan_.get(), {node},
+                               arrow::compute::ProjectNodeOptions(std::move(fields))));
+  }
+
   auto output_schema = node->output_schema();
 
   // Add sink node. It's added after constructing plan from decls because sink node

--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -26,6 +26,13 @@
 namespace gazellecpp {
 namespace compute {
 
+const FieldVector kAugmentedFields{
+    field("__fragment_index", arrow::int32()),
+    field("__batch_index", arrow::int32()),
+    field("__last_in_fragment", arrow::boolean()),
+    field("__filename", arrow::utf8()),
+};
+
 ArrowExecBackend::~ArrowExecBackend() {
   if (exec_plan_ != nullptr) {
     exec_plan_->finished().Wait();
@@ -81,7 +88,7 @@ std::shared_ptr<gluten::RecordBatchResultIterator> ArrowExecBackend::GetResultIt
       arrow::FieldRef("__fragment_index").FindOne(*node->output_schema());
   if (include_aug_fields.ok()) {
     std::vector<arrow::compute::Expression> fields;
-    auto num_fields = node->output_schema()->num_fields() - 3;
+    auto num_fields = node->output_schema()->num_fields() - kAugmentedFields.size();
     fields.reserve(num_fields);
     for (int i = 0; i < num_fields; ++i) {
       fields.push_back(arrow::compute::field_ref(i));

--- a/cpp/src/jni/exec_backend.h
+++ b/cpp/src/jni/exec_backend.h
@@ -178,6 +178,8 @@ class ExecBackendBase : public std::enable_shared_from_this<ExecBackendBase> {
         return arrow::float64();
       case substrait::Type::KindCase::kString:
         return arrow::utf8();
+      case substrait::Type::KindCase::kDate:
+        return arrow::date32();
       default:
         return arrow::Status::Invalid("Type not supported: " +
                                       std::to_string(stype.kind_case()));

--- a/cpp/src/jni/exec_backend.h
+++ b/cpp/src/jni/exec_backend.h
@@ -197,6 +197,14 @@ class ExecBackendBase : public std::enable_shared_from_this<ExecBackendBase> {
     if (srel.has_filter() && srel.filter().has_input()) {
       return GetIterInputSchemaFromRel(srel.filter().input());
     }
+    if (srel.has_join()) {
+      if (srel.join().has_left() && srel.join().has_right()) {
+        RETURN_NOT_OK(GetIterInputSchemaFromRel(srel.join().left()));
+        RETURN_NOT_OK(GetIterInputSchemaFromRel(srel.join().right()));
+        return arrow::Status::OK();
+      }
+      return arrow::Status::Invalid("Incomplete Join Rel.");
+    }
     if (!srel.has_read()) {
       return arrow::Status::Invalid("Read Rel expected.");
     }

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -106,6 +106,7 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
   void setInputPlanNode(const ::substrait::AggregateRel& sagg);
   void setInputPlanNode(const ::substrait::ProjectRel& sproject);
   void setInputPlanNode(const ::substrait::FilterRel& sfilter);
+  void setInputPlanNode(const ::substrait::JoinRel& sJoin);
   void setInputPlanNode(const ::substrait::ReadRel& sread);
   void setInputPlanNode(const ::substrait::Rel& srel);
   void setInputPlanNode(const ::substrait::RelRoot& sroot);

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -97,7 +97,7 @@ The modified TPC-H Q6 query is:
 select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate_new >= 8766 and l_shipdate_new < 9131 and l_discount between .06 - 0.01 and .06 + 0.01 and l_quantity < 24
 ```
 
-The modified TPC-H Q6 query is:
+The modified TPC-H Q1 query is:
 ```shell script
 select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice * (1 - l_discount)) as sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge, avg(l_quantity) as avg_qty, avg(l_extendedprice) as avg_price, avg(l_discount) as avg_disc, count(*) as count_order from lineitem where l_shipdate_new <= 10471 group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus
 ```

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.rel;
+
+import io.glutenproject.substrait.expression.ExpressionNode;
+import io.substrait.proto.Expression;
+import io.substrait.proto.JoinRel;
+import io.substrait.proto.Rel;
+import io.substrait.proto.RelCommon;
+
+import java.io.Serializable;
+
+public class JoinRelNode implements RelNode, Serializable {
+    private final RelNode left;
+    private final RelNode right;
+    private final JoinRel.JoinType joinType;
+    private final ExpressionNode expression;
+    private final ExpressionNode postJoinFilter;
+
+    JoinRelNode(RelNode left, RelNode right, JoinRel.JoinType joinType, ExpressionNode expression, ExpressionNode postJoinFilter) {
+        this.left = left;
+        this.right = right;
+        this.joinType = joinType;
+        this.expression = expression;
+        this.postJoinFilter = postJoinFilter;
+    }
+
+    @Override
+    public Rel toProtobuf() {
+        RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
+        relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
+        JoinRel.Builder joinBuilder = JoinRel.newBuilder();
+
+        joinBuilder.setLeft(left.toProtobuf());
+        joinBuilder.setRight(right.toProtobuf());
+        joinBuilder.setType(joinType);
+
+        if (this.expression != null) {
+            joinBuilder.setExpression(expression.toProtobuf());
+        }
+        if (this.postJoinFilter != null) {
+            joinBuilder.setPostJoinFilter(postJoinFilter.toProtobuf());
+        }
+
+        return Rel.newBuilder().setJoin(joinBuilder.build()).build();
+    }
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
@@ -18,6 +18,7 @@
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;
+import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
 import io.substrait.proto.Expression;
 import io.substrait.proto.JoinRel;
 import io.substrait.proto.Rel;
@@ -26,37 +27,52 @@ import io.substrait.proto.RelCommon;
 import java.io.Serializable;
 
 public class JoinRelNode implements RelNode, Serializable {
-    private final RelNode left;
-    private final RelNode right;
-    private final JoinRel.JoinType joinType;
-    private final ExpressionNode expression;
-    private final ExpressionNode postJoinFilter;
+  private final RelNode left;
+  private final RelNode right;
+  private final JoinRel.JoinType joinType;
+  private final ExpressionNode expression;
+  private final ExpressionNode postJoinFilter;
+  private final AdvancedExtensionNode extensionNode;
 
-    JoinRelNode(RelNode left, RelNode right, JoinRel.JoinType joinType, ExpressionNode expression, ExpressionNode postJoinFilter) {
-        this.left = left;
-        this.right = right;
-        this.joinType = joinType;
-        this.expression = expression;
-        this.postJoinFilter = postJoinFilter;
+  JoinRelNode(
+      RelNode left,
+      RelNode right,
+      JoinRel.JoinType joinType,
+      ExpressionNode expression,
+      ExpressionNode postJoinFilter,
+      AdvancedExtensionNode extensionNode) {
+    this.left = left;
+    this.right = right;
+    this.joinType = joinType;
+    this.expression = expression;
+    this.postJoinFilter = postJoinFilter;
+    this.extensionNode = extensionNode;
+  }
+
+  @Override
+  public Rel toProtobuf() {
+    RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
+    relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
+    JoinRel.Builder joinBuilder = JoinRel.newBuilder();
+
+    joinBuilder.setType(joinType);
+
+    if (left != null) {
+      joinBuilder.setLeft(left.toProtobuf());
+    }
+    if (right != null) {
+      joinBuilder.setRight(right.toProtobuf());
+    }
+    if (expression != null) {
+      joinBuilder.setExpression(expression.toProtobuf());
+    }
+    if (postJoinFilter != null) {
+      joinBuilder.setPostJoinFilter(postJoinFilter.toProtobuf());
+    }
+    if (extensionNode != null) {
+      joinBuilder.setAdvancedExtension(extensionNode.toProtobuf());
     }
 
-    @Override
-    public Rel toProtobuf() {
-        RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
-        relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
-        JoinRel.Builder joinBuilder = JoinRel.newBuilder();
-
-        joinBuilder.setLeft(left.toProtobuf());
-        joinBuilder.setRight(right.toProtobuf());
-        joinBuilder.setType(joinType);
-
-        if (this.expression != null) {
-            joinBuilder.setExpression(expression.toProtobuf());
-        }
-        if (this.postJoinFilter != null) {
-            joinBuilder.setPostJoinFilter(postJoinFilter.toProtobuf());
-        }
-
-        return Rel.newBuilder().setJoin(joinBuilder.build()).build();
-    }
+    return Rel.newBuilder().setJoin(joinBuilder.build()).build();
+  }
 }

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -11,23 +11,17 @@ import java.util.ArrayList;
 public class ReadRelNode implements RelNode, Serializable {
     private final ArrayList<TypeNode> types = new ArrayList<>();
     private final ArrayList<String> names = new ArrayList<>();
-    private final ExpressionNode filterNode;
     private final SubstraitContext context;
+    private final ExpressionNode filterNode;
+    private final Long iteratorIndex;
 
     ReadRelNode(ArrayList<TypeNode> types, ArrayList<String> names,
-                ExpressionNode filterNode, SubstraitContext context) {
+                SubstraitContext context, ExpressionNode filterNode, Long iteratorIndex) {
         this.types.addAll(types);
         this.names.addAll(names);
+        this.context = context;
         this.filterNode = filterNode;
-        this.context = context;
-    }
-
-    ReadRelNode(ArrayList<TypeNode> types, ArrayList<String> names,
-                SubstraitContext context) {
-        this.types.addAll(types);
-        this.names.addAll(names);
-        this.filterNode = null;
-        this.context = context;
+        this.iteratorIndex = iteratorIndex;
     }
 
     @Override
@@ -50,7 +44,9 @@ public class ReadRelNode implements RelNode, Serializable {
         if (filterNode != null) {
             readBuilder.setFilter(filterNode.toProtobuf());
         }
-        if (context.getLocalFilesNode() != null) {
+        if (this.iteratorIndex != null) {
+            readBuilder.setLocalFiles(context.getInputIteratorNode(iteratorIndex).toProtobuf());
+        } else if (context.getLocalFilesNode() != null) {
             readBuilder.setLocalFiles(context.getLocalFilesNode().toProtobuf());
         } else if (context.getExtensionTableNode() != null) {
             readBuilder.setExtensionTable(context.getExtensionTableNode().toProtobuf());

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -17,70 +17,66 @@
 
 package io.glutenproject.substrait.rel;
 
-import io.glutenproject.expression.ConverterUtils;
 import io.glutenproject.expression.ConverterUtils$;
 import io.glutenproject.substrait.SubstraitContext;
 import io.glutenproject.substrait.expression.AggregateFunctionNode;
 import io.glutenproject.substrait.expression.ExpressionNode;
 import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
 import io.glutenproject.substrait.type.TypeNode;
+import io.substrait.proto.JoinRel;
+
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 
 import java.util.ArrayList;
 
-/**
- * Contains helper functions for constructing substrait relations.
- */
+/** Contains helper functions for constructing substrait relations. */
 public class RelBuilder {
   private RelBuilder() {}
 
-  public static RelNode makeFilterRel(RelNode input,
-                                      ExpressionNode condition) {
+  public static RelNode makeFilterRel(RelNode input, ExpressionNode condition) {
     return new FilterRelNode(input, condition);
   }
 
-  public static RelNode makeFilterRel(RelNode input,
-                                      ExpressionNode condition,
-                                      AdvancedExtensionNode extensionNode) {
+  public static RelNode makeFilterRel(
+      RelNode input, ExpressionNode condition, AdvancedExtensionNode extensionNode) {
     return new FilterRelNode(input, condition, extensionNode);
   }
 
-  public static RelNode makeProjectRel(RelNode input,
-                                       ArrayList<ExpressionNode> expressionNodes) {
+  public static RelNode makeProjectRel(RelNode input, ArrayList<ExpressionNode> expressionNodes) {
     return new ProjectRelNode(input, expressionNodes);
   }
 
-  public static RelNode makeProjectRel(RelNode input,
-                                       ArrayList<ExpressionNode> expressionNodes,
-                                       AdvancedExtensionNode extensionNode) {
+  public static RelNode makeProjectRel(
+      RelNode input,
+      ArrayList<ExpressionNode> expressionNodes,
+      AdvancedExtensionNode extensionNode) {
     return new ProjectRelNode(input, expressionNodes, extensionNode);
   }
 
-  public static RelNode makeAggregateRel(RelNode input,
-                                         ArrayList<ExpressionNode> groupings,
-                                         ArrayList<AggregateFunctionNode> aggregateFunctionNodes) {
+  public static RelNode makeAggregateRel(
+      RelNode input,
+      ArrayList<ExpressionNode> groupings,
+      ArrayList<AggregateFunctionNode> aggregateFunctionNodes) {
     return new AggregateRelNode(input, groupings, aggregateFunctionNodes);
   }
 
-  public static RelNode makeAggregateRel(RelNode input,
-                                         ArrayList<ExpressionNode> groupings,
-                                         ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
-                                         AdvancedExtensionNode extensionNode) {
+  public static RelNode makeAggregateRel(
+      RelNode input,
+      ArrayList<ExpressionNode> groupings,
+      ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
+      AdvancedExtensionNode extensionNode) {
     return new AggregateRelNode(input, groupings, aggregateFunctionNodes, extensionNode);
   }
 
-  public static RelNode makeReadRel(ArrayList<TypeNode> types, ArrayList<String> names,
-                                    ExpressionNode filter, SubstraitContext context) {
-    return new ReadRelNode(types, names, filter, context);
+  public static RelNode makeReadRel(
+      ArrayList<TypeNode> types,
+      ArrayList<String> names,
+      ExpressionNode filter,
+      SubstraitContext context) {
+    return new ReadRelNode(types, names, context, filter, null);
   }
 
-  public static RelNode makeReadRel(ArrayList<TypeNode> types, ArrayList<String> names,
-                                    SubstraitContext context) {
-    return new ReadRelNode(types, names, context);
-  }
-
-  public static RelNode makeReadRel(ArrayList<Attribute> attributes,
-                                    SubstraitContext context) {
+  public static RelNode makeReadRel(ArrayList<Attribute> attributes, SubstraitContext context) {
     ArrayList<TypeNode> typeList = new ArrayList<>();
     ArrayList<String> nameList = new ArrayList<>();
     ConverterUtils$ converter = ConverterUtils$.MODULE$;
@@ -90,8 +86,20 @@ public class RelBuilder {
     }
 
     // The iterator index will be added in the path of LocalFiles.
-    context.setLocalFilesNode(LocalFilesBuilder.makeLocalFiles(
-            converter.ITERATOR_PREFIX().concat(context.getIteratorIndex().toString())));
-    return new ReadRelNode(typeList, nameList, context);
+    Long iteratorIndex = context.nextIteratorIndex();
+    context.setIteratorNode(
+        iteratorIndex,
+        LocalFilesBuilder.makeLocalFiles(
+            converter.ITERATOR_PREFIX().concat(iteratorIndex.toString())));
+    return new ReadRelNode(typeList, nameList, context, null, iteratorIndex);
+  }
+
+  public static RelNode makeJoinRel(
+      RelNode left,
+      RelNode right,
+      JoinRel.JoinType joinType,
+      ExpressionNode expression,
+      ExpressionNode postJoinFilter) {
+    return new JoinRelNode(left, right, joinType, expression, postJoinFilter);
   }
 }

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -100,6 +100,16 @@ public class RelBuilder {
       JoinRel.JoinType joinType,
       ExpressionNode expression,
       ExpressionNode postJoinFilter) {
-    return new JoinRelNode(left, right, joinType, expression, postJoinFilter);
+    return makeJoinRel(left, right, joinType, expression, postJoinFilter, null);
+  }
+
+  public static RelNode makeJoinRel(
+      RelNode left,
+      RelNode right,
+      JoinRel.JoinType joinType,
+      ExpressionNode expression,
+      ExpressionNode postJoinFilter,
+      AdvancedExtensionNode extensionNode) {
+    return new JoinRelNode(left, right, joinType, expression, postJoinFilter, extensionNode);
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -104,7 +104,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   val forceShuffledHashJoin: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.forceshuffledhashjoin", "false").toBoolean &&
-        enableCpu
+      enableCpu
 
   // enable or disable columnar sortmergejoin
   // this should be set with preferSortMergeJoin=false

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -70,7 +70,7 @@ trait IIteratorApi extends IBackendsApi {
    *
    * @return
    */
-  def genFinalStageIterator(iter: Iterator[ColumnarBatch],
+  def genFinalStageIterator(inputIterators: Seq[Iterator[ColumnarBatch]],
                             numaBindingInfo: GlutenNumaBindingInfo, listJars: Seq[String],
                             signature: String, sparkConf: SparkConf,
                             outputAttributes: Seq[Attribute], rootNode: PlanNode,

--- a/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -17,21 +17,27 @@
 
 package io.glutenproject.execution
 
+import java.util
+
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.util.control.Breaks.{break, breakable}
 
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
-import io.glutenproject.expression._
-import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
-import io.glutenproject.substrait.rel.{LocalFilesBuilder, RelBuilder, RelNode}
-import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.GlutenConfig
+import io.glutenproject.expression._
+import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.expression.{
+  AggregateFunctionNode,
+  ExpressionBuilder,
+  ExpressionNode
+}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
+import io.glutenproject.substrait.rel.{LocalFilesBuilder, RelBuilder, RelNode}
 import io.glutenproject.vectorized.ExpressionEvaluator
-import java.util
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -105,13 +111,14 @@ case class HashAggregateExecTransformer(
 
   override def doValidate(): Boolean = {
     val substraitContext = new SubstraitContext
-    val relNode = try {
-      getAggRel(substraitContext.registeredFunction, null, validation = true)
-    } catch {
-      case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
-        return false
-    }
+    val relNode =
+      try {
+        getAggRel(substraitContext.registeredFunction, null, validation = true)
+      } catch {
+        case e: Throwable =>
+          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          return false
+      }
     val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
@@ -178,11 +185,12 @@ case class HashAggregateExecTransformer(
     }
     val (relNode, inputAttributes, outputAttributes) = if (childCtx != null) {
       if (!GlutenConfig.getConf.isClickHouseBackend) {
-        (getAggRel(context.registeredFunction, childCtx.root),
-          childCtx.outputAttributes, output)
+        (getAggRel(context.registeredFunction, childCtx.root), childCtx.outputAttributes, output)
       } else {
-        (getAggRel(context.registeredFunction, childCtx.root),
-          childCtx.outputAttributes, aggregateResultAttributes)
+        (
+          getAggRel(context.registeredFunction, childCtx.root),
+          childCtx.outputAttributes,
+          aggregateResultAttributes)
       }
     } else {
       // This means the input is just an iterator, so an ReadRel will be created as child.
@@ -195,17 +203,13 @@ case class HashAggregateExecTransformer(
         val readRel = RelBuilder.makeReadRel(attrList, context)
         (getAggRel(context.registeredFunction, readRel), child.output, output)
       } else {
-        val typeList = new util.ArrayList[TypeNode]()
-        val nameList = new util.ArrayList[String]()
-        for (attr <- aggregateResultAttributes) {
-          typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-          nameList.add(ConverterUtils.getShortAttributeName(attr) + "#" + attr.exprId.id)
-        }
         // The iterator index will be added in the path of LocalFiles.
         val inputIter = LocalFilesBuilder.makeLocalFiles(
-          ConverterUtils.ITERATOR_PREFIX.concat(context.getIteratorIndex.toString))
+          ConverterUtils.ITERATOR_PREFIX.concat(context.nextIteratorIndex.toString))
         context.setLocalFilesNode(inputIter)
-        val readRel = RelBuilder.makeReadRel(typeList, nameList, context)
+        val readRel = RelBuilder.makeReadRel(
+          new util.ArrayList[Attribute](aggregateResultAttributes.asJava),
+          context)
 
         (getAggRel(context.registeredFunction, readRel), aggregateResultAttributes, output)
       }
@@ -229,7 +233,7 @@ case class HashAggregateExecTransformer(
     }
   }
 
-  private def needsPreProjection : Boolean = {
+  private def needsPreProjection: Boolean = {
     var needsProjection = false
     breakable {
       for (expr <- groupingExpressions) {
@@ -242,7 +246,7 @@ case class HashAggregateExecTransformer(
     breakable {
       for (expr <- aggregateExpressions) {
         expr.mode match {
-          case Partial  | PartialMerge =>
+          case Partial | PartialMerge =>
             for (aggChild <- expr.aggregateFunction.children) {
               if (!aggChild.isInstanceOf[Attribute] && !aggChild.isInstanceOf[Literal]) {
                 needsProjection = true
@@ -274,7 +278,7 @@ case class HashAggregateExecTransformer(
               // If the result attribute and result expression has different name or type,
               // post-projection is needed.
               if (exprAttr.name != resAttr.name ||
-                exprAttr.dataType != resAttr.dataType) {
+                  exprAttr.dataType != resAttr.dataType) {
                 needsProjection = true
                 break
               }
@@ -290,10 +294,11 @@ case class HashAggregateExecTransformer(
     needsProjection
   }
 
-  private def getAggRelWithPreProjection(args: java.lang.Object,
-                                         originalInputAttributes: Seq[Attribute],
-                                         input: RelNode = null,
-                                         validation: Boolean): RelNode = {
+  private def getAggRelWithPreProjection(
+      args: java.lang.Object,
+      originalInputAttributes: Seq[Attribute],
+      input: RelNode = null,
+      validation: Boolean): RelNode = {
     // Will add a Projection before Aggregate.
     val preExprNodes = new util.ArrayList[ExpressionNode]()
     groupingExpressions.foreach(expr => {
@@ -367,10 +372,11 @@ case class HashAggregateExecTransformer(
     RelBuilder.makeAggregateRel(inputRel, groupingList, aggregateFunctionList)
   }
 
-  private def getAggRelWithoutPreProjection(args: java.lang.Object,
-                                            originalInputAttributes: Seq[Attribute],
-                                            input: RelNode = null,
-                                            validation: Boolean): RelNode = {
+  private def getAggRelWithoutPreProjection(
+      args: java.lang.Object,
+      originalInputAttributes: Seq[Attribute],
+      input: RelNode = null,
+      validation: Boolean): RelNode = {
     // Get the grouping nodes.
     val groupingList = new util.ArrayList[ExpressionNode]()
     groupingExpressions.foreach(expr => {
@@ -430,8 +436,10 @@ case class HashAggregateExecTransformer(
     }
   }
 
-  private def getAggRel(args: java.lang.Object, input: RelNode = null,
-                        validation: Boolean = false): RelNode = {
+  private def getAggRel(
+      args: java.lang.Object,
+      input: RelNode = null,
+      validation: Boolean = false): RelNode = {
     val originalInputAttributes = child.output
     val aggRel = if (needsPreProjection) {
       getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
@@ -489,9 +497,10 @@ case class HashAggregateExecTransformer(
 
   /**
    * This method calculates the output attributes of Aggregation.
-  */
-  def getAttrForAggregateExpr(aggregateExpressions: Seq[AggregateExpression],
-                              aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
+   */
+  def getAttrForAggregateExpr(
+      aggregateExpressions: Seq[AggregateExpression],
+      aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
     var aggregateAttr = new ListBuffer[Attribute]()
     val size = aggregateExpressions.size
     var res_index = 0

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+
+private[glutenproject] class ZippedPartitionsPartition(
+    idx: Int,
+    @transient private val rdds: Seq[RDD[_]])
+    extends Partition {
+
+  override val index: Int = idx
+  var partitionValues = rdds.map(rdd => rdd.partitions(idx))
+
+  def partitions: Seq[Partition] = partitionValues
+}
+
+class WholeStageZippedPartitionsRDD[V: ClassTag](
+    @transient private val sc: SparkContext,
+    var rdds: Seq[RDD[V]],
+    val func: Seq[Iterator[V]] => Iterator[V])
+    extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
+
+  override def compute(split: Partition, context: TaskContext): Iterator[V] = {
+
+    val partitions = split.asInstanceOf[ZippedPartitionsPartition].partitions
+    val inputIterators = (rdds zip partitions).map {
+      case (rdd, partition) => rdd.iterator(partition, context)
+    }
+    func(inputIterators)
+  }
+
+  override def getPartitions: Array[Partition] = {
+    val numParts = rdds.head.partitions.length
+    if (!rdds.forall(rdd => rdd.partitions.length == numParts)) {
+      throw new IllegalArgumentException(
+        s"Can't zip RDDs with unequal numbers of partitions: ${rdds.map(_.partitions.length)}")
+    }
+    Array.tabulate[Partition](numParts) { i => new ZippedPartitionsPartition(i, rdds) }
+  }
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    rdds = null
+  }
+}

--- a/jvm/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
@@ -39,7 +39,8 @@ class IsNotNullTransformer(child: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+    val functionId = ExpressionBuilder.newScalarFunction(
+      functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.IS_NOT_NULL, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
@@ -59,7 +60,8 @@ class IsNullTransformer(child: Expression, original: Expression)
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+    val functionId = ExpressionBuilder.newScalarFunction(
+      functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.IS_NULL, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
@@ -78,7 +80,7 @@ class MonthTransformer(child: Expression, original: Expression)
 }
 
 class DayOfMonthTransformer(child: Expression, original: Expression)
-  extends DayOfMonth(child: Expression)
+    extends DayOfMonth(child: Expression)
     with ExpressionTransformer
     with Logging {
 
@@ -88,7 +90,7 @@ class DayOfMonthTransformer(child: Expression, original: Expression)
 }
 
 class YearTransformer(child: Expression, original: Expression)
-  extends Year(child: Expression)
+    extends Year(child: Expression)
     with ExpressionTransformer
     with Logging {
   override def doTransform(args: java.lang.Object): ExpressionNode = {
@@ -135,12 +137,15 @@ class BitwiseNotTransformer(child: Expression, original: Expression)
   }
 }
 
-class KnownFloatingPointNormalizedTransformer(child: Expression,
-                                              original: KnownFloatingPointNormalized)
-  extends KnownFloatingPointNormalized(child: Expression) with ExpressionTransformer with Logging {
+class KnownFloatingPointNormalizedTransformer(
+    child: Expression,
+    original: KnownFloatingPointNormalized)
+    extends KnownFloatingPointNormalized(child: Expression)
+    with ExpressionTransformer
+    with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    child.asInstanceOf[ExpressionTransformer].doTransform(args)
   }
 }
 
@@ -172,7 +177,8 @@ class CastTransformer(
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val functionId = ExpressionBuilder.newScalarFunction(functionMap,
+    val functionId = ExpressionBuilder.newScalarFunction(
+      functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.CAST, Seq(child.dataType)))
     val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(dataType, nullable = true)
@@ -212,12 +218,17 @@ class NormalizeNaNAndZeroTransformer(child: Expression, original: NormalizeNaNAn
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    // TODO: A Temporary workaround to make shuffle repartition expression
+    // pass with double/float type.
+    // We need to support converting substrait to gandiva expressions in native.
+    child.asInstanceOf[ExpressionTransformer].doTransform(args)
   }
 }
 
 class PromotePrecisionTransformer(child: Expression, original: PromotePrecision)
-  extends PromotePrecision(child: Expression) with ExpressionTransformer with Logging {
+    extends PromotePrecision(child: Expression)
+    with ExpressionTransformer
+    with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     throw new UnsupportedOperationException("Not supported.")
@@ -287,24 +298,26 @@ object UnaryOperatorTransformer {
       new MicrosToTimestampTransformer(child)
     case other =>
       child.dataType match {
-        case _: DateType => other match {
-          case a: DayOfYear =>
-            new DayOfYearTransformer(new CastTransformer(child, TimestampType, None, null))
-          case a: DayOfWeek =>
-            new DayOfWeekTransformer(new CastTransformer(child, TimestampType, None, null))
-          case other =>
-            throw new UnsupportedOperationException(s"not currently supported: $other.")
-        }
-        case _: TimestampType => other match {
-          case a: Hour =>
-            new HourTransformer(child)
-          case a: Minute =>
-            new MinuteTransformer(child)
-          case a: Second =>
-            new SecondTransformer(child)
-          case other =>
-            throw new UnsupportedOperationException(s"not currently supported: $other.")
-        }
+        case _: DateType =>
+          other match {
+            case a: DayOfYear =>
+              new DayOfYearTransformer(new CastTransformer(child, TimestampType, None, null))
+            case a: DayOfWeek =>
+              new DayOfWeekTransformer(new CastTransformer(child, TimestampType, None, null))
+            case other =>
+              throw new UnsupportedOperationException(s"not currently supported: $other.")
+          }
+        case _: TimestampType =>
+          other match {
+            case a: Hour =>
+              new HourTransformer(child)
+            case a: Minute =>
+              new MinuteTransformer(child)
+            case a: Second =>
+              new SecondTransformer(child)
+            case other =>
+              throw new UnsupportedOperationException(s"not currently supported: $other.")
+          }
         case _ =>
           throw new UnsupportedOperationException(s"not currently supported: $other.")
       }

--- a/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -24,6 +24,7 @@ class SubstraitContext extends Serializable {
   private val functionMap = new java.util.HashMap[String, java.lang.Long]()
 
   private var localFilesNode: LocalFilesNode = _
+  private val iteratorNodes = new java.util.HashMap[java.lang.Long, LocalFilesNode]()
   private var extensionTableNode: ExtensionTableNode = _
   private var iteratorIndex: java.lang.Long = new java.lang.Long(0)
 
@@ -31,7 +32,18 @@ class SubstraitContext extends Serializable {
     this.localFilesNode = localFilesNode
   }
 
+  def setIteratorNode(index: java.lang.Long, localFilesNode: LocalFilesNode): Unit = {
+    if (iteratorNodes.containsKey(index)) {
+      throw new IllegalStateException(s"Iterator index ${index} has been used.")
+    }
+    iteratorNodes.put(index, localFilesNode)
+  }
+
   def getLocalFilesNode: LocalFilesNode = this.localFilesNode
+
+  def getInputIteratorNode(index: java.lang.Long): LocalFilesNode = {
+    iteratorNodes.get(index)
+  }
 
   def setExtensionTableNode(extensionTableNode: ExtensionTableNode): Unit = {
     this.extensionTableNode = extensionTableNode
@@ -52,7 +64,7 @@ class SubstraitContext extends Serializable {
 
   def registeredFunction: java.util.HashMap[String, java.lang.Long] = functionMap
 
-  def getIteratorIndex: java.lang.Long = {
+  def nextIteratorIndex: java.lang.Long = {
     val id = this.iteratorIndex
     this.iteratorIndex += 1
     id

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -17,16 +17,12 @@
 
 package org.apache.spark.sql.execution
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution._
+import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -133,9 +129,8 @@ case class ColumnarCollapseCodegenStages(
   private def insertWholeStageTransformer(plan: SparkPlan): SparkPlan = {
     plan match {
       case t: TransformSupport =>
-          WholeStageTransformerExec(
-            t.withNewChildren(t.children.map(insertInputAdapter)))(
-            codegenStageCounter.incrementAndGet())
+        WholeStageTransformerExec(t.withNewChildren(t.children.map(insertInputAdapter)))(
+          codegenStageCounter.incrementAndGet())
       case other =>
         other.withNewChildren(other.children.map(insertWholeStageTransformer))
     }

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
@@ -77,7 +77,7 @@ class IteratorApiImplSuite extends IIteratorApi {
    *
    * @return
    */
-  override def genFinalStageIterator(iter: Iterator[ColumnarBatch],
+  override def genFinalStageIterator(inputIterators: Seq[Iterator[ColumnarBatch]],
                                      numaBindingInfo: GlutenNumaBindingInfo,
                                      listJars: Seq[String], signature: String,
                                      sparkConf: SparkConf, outputAttributes: Seq[Attribute],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable the substrait conversion in `ShuffledHashJoinExecTransformer`. Enable passing multiple input RDDs to native backend.

Add below configuration to force enabling shuffled hash join:
```
# disable BHJ
--conf spark.sql.autoBroadcastJoinThreshold=-1
# disable SMJ
--conf spark.gluten.sql.columnar.forceshuffledhashjoin=true
```

## How was this patch tested?

Verified locally.