### PR TITLE
[OPPRO-10] Hash Join support

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
@@ -18,9 +18,9 @@ package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.backendsapi.ITransformerApi
 import io.glutenproject.GlutenConfig
-
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.datasources.FileFormat
 
 class CHTransformerApi extends ITransformerApi {
 
@@ -32,6 +32,13 @@ class CHTransformerApi extends ITransformerApi {
   override def validateColumnarShuffleExchangeExec(outputPartitioning: Partitioning,
                                                    outputAttributes: Seq[Attribute]
                                                   ) = true
+
+  /**
+   * Used for table scan validation.
+   *
+   * @return true if backend supports reading the file format.
+   */
+  def supportsReadFileFormat(fileFormat: FileFormat): Boolean = true
 
   /**
    * Get the backend api name.

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -106,6 +106,7 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
   void setInputPlanNode(const ::substrait::AggregateRel& sagg);
   void setInputPlanNode(const ::substrait::ProjectRel& sproject);
   void setInputPlanNode(const ::substrait::FilterRel& sfilter);
+  void setInputPlanNode(const ::substrait::JoinRel& sJoin);
   void setInputPlanNode(const ::substrait::ReadRel& sread);
   void setInputPlanNode(const ::substrait::Rel& srel);
   void setInputPlanNode(const ::substrait::RelRoot& sroot);

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.rel;
+
+import io.glutenproject.substrait.expression.ExpressionNode;
+import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
+import io.substrait.proto.Expression;
+import io.substrait.proto.JoinRel;
+import io.substrait.proto.Rel;
+import io.substrait.proto.RelCommon;
+
+import java.io.Serializable;
+
+public class JoinRelNode implements RelNode, Serializable {
+  private final RelNode left;
+  private final RelNode right;
+  private final JoinRel.JoinType joinType;
+  private final ExpressionNode expression;
+  private final ExpressionNode postJoinFilter;
+  private final AdvancedExtensionNode extensionNode;
+
+  JoinRelNode(
+      RelNode left,
+      RelNode right,
+      JoinRel.JoinType joinType,
+      ExpressionNode expression,
+      ExpressionNode postJoinFilter,
+      AdvancedExtensionNode extensionNode) {
+    this.left = left;
+    this.right = right;
+    this.joinType = joinType;
+    this.expression = expression;
+    this.postJoinFilter = postJoinFilter;
+    this.extensionNode = extensionNode;
+  }
+
+  @Override
+  public Rel toProtobuf() {
+    RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
+    relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
+    JoinRel.Builder joinBuilder = JoinRel.newBuilder();
+
+    joinBuilder.setType(joinType);
+
+    if (left != null) {
+      joinBuilder.setLeft(left.toProtobuf());
+    }
+    if (right != null) {
+      joinBuilder.setRight(right.toProtobuf());
+    }
+    if (expression != null) {
+      joinBuilder.setExpression(expression.toProtobuf());
+    }
+    if (postJoinFilter != null) {
+      joinBuilder.setPostJoinFilter(postJoinFilter.toProtobuf());
+    }
+    if (extensionNode != null) {
+      joinBuilder.setAdvancedExtension(extensionNode.toProtobuf());
+    }
+
+    return Rel.newBuilder().setJoin(joinBuilder.build()).build();
+  }
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -11,23 +11,17 @@ import java.util.ArrayList;
 public class ReadRelNode implements RelNode, Serializable {
     private final ArrayList<TypeNode> types = new ArrayList<>();
     private final ArrayList<String> names = new ArrayList<>();
-    private final ExpressionNode filterNode;
     private final SubstraitContext context;
+    private final ExpressionNode filterNode;
+    private final Long iteratorIndex;
 
     ReadRelNode(ArrayList<TypeNode> types, ArrayList<String> names,
-                ExpressionNode filterNode, SubstraitContext context) {
+                SubstraitContext context, ExpressionNode filterNode, Long iteratorIndex) {
         this.types.addAll(types);
         this.names.addAll(names);
+        this.context = context;
         this.filterNode = filterNode;
-        this.context = context;
-    }
-
-    ReadRelNode(ArrayList<TypeNode> types, ArrayList<String> names,
-                SubstraitContext context) {
-        this.types.addAll(types);
-        this.names.addAll(names);
-        this.filterNode = null;
-        this.context = context;
+        this.iteratorIndex = iteratorIndex;
     }
 
     @Override
@@ -50,7 +44,9 @@ public class ReadRelNode implements RelNode, Serializable {
         if (filterNode != null) {
             readBuilder.setFilter(filterNode.toProtobuf());
         }
-        if (context.getLocalFilesNode() != null) {
+        if (this.iteratorIndex != null) {
+            readBuilder.setLocalFiles(context.getInputIteratorNode(iteratorIndex).toProtobuf());
+        } else if (context.getLocalFilesNode() != null) {
             readBuilder.setLocalFiles(context.getLocalFilesNode().toProtobuf());
         } else if (context.getExtensionTableNode() != null) {
             readBuilder.setExtensionTable(context.getExtensionTableNode().toProtobuf());

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -17,70 +17,66 @@
 
 package io.glutenproject.substrait.rel;
 
-import io.glutenproject.expression.ConverterUtils;
 import io.glutenproject.expression.ConverterUtils$;
 import io.glutenproject.substrait.SubstraitContext;
 import io.glutenproject.substrait.expression.AggregateFunctionNode;
 import io.glutenproject.substrait.expression.ExpressionNode;
 import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
 import io.glutenproject.substrait.type.TypeNode;
+import io.substrait.proto.JoinRel;
+
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 
 import java.util.ArrayList;
 
-/**
- * Contains helper functions for constructing substrait relations.
- */
+/** Contains helper functions for constructing substrait relations. */
 public class RelBuilder {
   private RelBuilder() {}
 
-  public static RelNode makeFilterRel(RelNode input,
-                                      ExpressionNode condition) {
+  public static RelNode makeFilterRel(RelNode input, ExpressionNode condition) {
     return new FilterRelNode(input, condition);
   }
 
-  public static RelNode makeFilterRel(RelNode input,
-                                      ExpressionNode condition,
-                                      AdvancedExtensionNode extensionNode) {
+  public static RelNode makeFilterRel(
+      RelNode input, ExpressionNode condition, AdvancedExtensionNode extensionNode) {
     return new FilterRelNode(input, condition, extensionNode);
   }
 
-  public static RelNode makeProjectRel(RelNode input,
-                                       ArrayList<ExpressionNode> expressionNodes) {
+  public static RelNode makeProjectRel(RelNode input, ArrayList<ExpressionNode> expressionNodes) {
     return new ProjectRelNode(input, expressionNodes);
   }
 
-  public static RelNode makeProjectRel(RelNode input,
-                                       ArrayList<ExpressionNode> expressionNodes,
-                                       AdvancedExtensionNode extensionNode) {
+  public static RelNode makeProjectRel(
+      RelNode input,
+      ArrayList<ExpressionNode> expressionNodes,
+      AdvancedExtensionNode extensionNode) {
     return new ProjectRelNode(input, expressionNodes, extensionNode);
   }
 
-  public static RelNode makeAggregateRel(RelNode input,
-                                         ArrayList<ExpressionNode> groupings,
-                                         ArrayList<AggregateFunctionNode> aggregateFunctionNodes) {
+  public static RelNode makeAggregateRel(
+      RelNode input,
+      ArrayList<ExpressionNode> groupings,
+      ArrayList<AggregateFunctionNode> aggregateFunctionNodes) {
     return new AggregateRelNode(input, groupings, aggregateFunctionNodes);
   }
 
-  public static RelNode makeAggregateRel(RelNode input,
-                                         ArrayList<ExpressionNode> groupings,
-                                         ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
-                                         AdvancedExtensionNode extensionNode) {
+  public static RelNode makeAggregateRel(
+      RelNode input,
+      ArrayList<ExpressionNode> groupings,
+      ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
+      AdvancedExtensionNode extensionNode) {
     return new AggregateRelNode(input, groupings, aggregateFunctionNodes, extensionNode);
   }
 
-  public static RelNode makeReadRel(ArrayList<TypeNode> types, ArrayList<String> names,
-                                    ExpressionNode filter, SubstraitContext context) {
-    return new ReadRelNode(types, names, filter, context);
+  public static RelNode makeReadRel(
+      ArrayList<TypeNode> types,
+      ArrayList<String> names,
+      ExpressionNode filter,
+      SubstraitContext context) {
+    return new ReadRelNode(types, names, context, filter, null);
   }
 
-  public static RelNode makeReadRel(ArrayList<TypeNode> types, ArrayList<String> names,
-                                    SubstraitContext context) {
-    return new ReadRelNode(types, names, context);
-  }
-
-  public static RelNode makeReadRel(ArrayList<Attribute> attributes,
-                                    SubstraitContext context) {
+  public static RelNode makeReadRel(ArrayList<Attribute> attributes, SubstraitContext context) {
     ArrayList<TypeNode> typeList = new ArrayList<>();
     ArrayList<String> nameList = new ArrayList<>();
     ConverterUtils$ converter = ConverterUtils$.MODULE$;
@@ -90,8 +86,30 @@ public class RelBuilder {
     }
 
     // The iterator index will be added in the path of LocalFiles.
-    context.setLocalFilesNode(LocalFilesBuilder.makeLocalFiles(
-            converter.ITERATOR_PREFIX().concat(context.getIteratorIndex().toString())));
-    return new ReadRelNode(typeList, nameList, context);
+    Long iteratorIndex = context.nextIteratorIndex();
+    context.setIteratorNode(
+        iteratorIndex,
+        LocalFilesBuilder.makeLocalFiles(
+            converter.ITERATOR_PREFIX().concat(iteratorIndex.toString())));
+    return new ReadRelNode(typeList, nameList, context, null, iteratorIndex);
+  }
+
+  public static RelNode makeJoinRel(
+      RelNode left,
+      RelNode right,
+      JoinRel.JoinType joinType,
+      ExpressionNode expression,
+      ExpressionNode postJoinFilter) {
+    return makeJoinRel(left, right, joinType, expression, postJoinFilter, null);
+  }
+
+  public static RelNode makeJoinRel(
+      RelNode left,
+      RelNode right,
+      JoinRel.JoinType joinType,
+      ExpressionNode expression,
+      ExpressionNode postJoinFilter,
+      AdvancedExtensionNode extensionNode) {
+    return new JoinRelNode(left, right, joinType, expression, postJoinFilter, extensionNode);
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -104,7 +104,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   val forceShuffledHashJoin: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.forceshuffledhashjoin", "false").toBoolean &&
-        enableCpu
+      enableCpu
 
   // enable or disable columnar sortmergejoin
   // this should be set with preferSortMergeJoin=false

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -70,7 +70,7 @@ trait IIteratorApi extends IBackendsApi {
    *
    * @return
    */
-  def genFinalStageIterator(iter: Iterator[ColumnarBatch],
+  def genFinalStageIterator(inputIterators: Seq[Iterator[ColumnarBatch]],
                             numaBindingInfo: GlutenNumaBindingInfo, listJars: Seq[String],
                             signature: String, sparkConf: SparkConf,
                             outputAttributes: Seq[Attribute], rootNode: PlanNode,

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
@@ -18,6 +18,7 @@ package io.glutenproject.backendsapi
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.datasources.FileFormat
 
 trait ITransformerApi extends IBackendsApi {
 
@@ -28,4 +29,11 @@ trait ITransformerApi extends IBackendsApi {
    */
   def validateColumnarShuffleExchangeExec(outputPartitioning: Partitioning,
                                           outputAttributes: Seq[Attribute]): Boolean
+
+  /**
+   * Used for table scan validation.
+   *
+   * @return true if backend supports reading the file format.
+   */
+  def supportsReadFileFormat(fileFormat: FileFormat): Boolean
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -17,9 +17,13 @@
 
 package io.glutenproject.execution
 
+import com.google.common.collect.Lists
+import io.glutenproject.GlutenConfig
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter, ExpressionTransformer}
-import io.glutenproject.substrait.rel.RelBuilder
 import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.plan.PlanBuilder
+import io.glutenproject.substrait.rel.RelBuilder
+import io.glutenproject.vectorized.ExpressionEvaluator
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.InputPartition
@@ -40,14 +44,34 @@ trait BasicScanExecTransformer extends TransformSupport {
       nameList.add(attr.name)
     }
     // Will put all filter expressions into an AND expression
-    val transformer = filterExprs().reduceLeftOption(And).map(
-      ExpressionConverter.replaceWithExpressionTransformer(_, output)
-    )
+    val transformer = filterExprs()
+      .reduceLeftOption(And)
+      .map(ExpressionConverter.replaceWithExpressionTransformer(_, output))
     val filterNodes = transformer.map(
       _.asInstanceOf[ExpressionTransformer].doTransform(context.registeredFunction))
     val exprNode = filterNodes.orNull
 
     val relNode = RelBuilder.makeReadRel(typeNodes, nameList, exprNode, context)
     TransformContext(output, output, relNode)
+  }
+
+  override def doValidate(): Boolean = {
+    val substraitContext = new SubstraitContext
+    val relNode =
+      try {
+        doTransform(substraitContext).root
+      } catch {
+        case e: Throwable =>
+          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          return false
+      }
+
+    if (GlutenConfig.getConf.enableNativeValidation) {
+      val validator = new ExpressionEvaluator()
+      val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
+      validator.doValidate(planNode.toProtobuf.toByteArray)
+    } else {
+      true
+    }
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -80,22 +80,4 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     null
   }
 
-  override def doValidate(): Boolean = {
-    val substraitContext = new SubstraitContext
-    val relNode = try {
-      doTransform(substraitContext).root
-    } catch {
-      case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
-        return false
-    }
-    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-
-    if (GlutenConfig.getConf.enableNativeValidation) {
-      val validator = new ExpressionEvaluator()
-      validator.doValidate(planNode.toProtobuf.toByteArray)
-    } else {
-      true
-    }
-  }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -23,22 +23,26 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.datasources.{FilePartition, HadoopFsRelation}
 import org.apache.spark.sql.execution.{FileSourceScanExec, PartitionedFileUtil, SparkPlan}
+import org.apache.spark.sql.execution.datasources.{FilePartition, HadoopFsRelation}
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.collection.BitSet
 
-class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
-                                    output: Seq[Attribute],
-                                    requiredSchema: StructType,
-                                    partitionFilters: Seq[Expression],
-                                    optionalBucketSet: Option[BitSet],
-                                    optionalNumCoalescedBuckets: Option[Int],
-                                    dataFilters: Seq[Expression],
-                                    tableIdentifier: Option[TableIdentifier],
-                                    disableBucketedScan: Boolean = false)
-    extends FileSourceScanExec(relation,
+class FileSourceScanExecTransformer(
+    @transient relation: HadoopFsRelation,
+    output: Seq[Attribute],
+    requiredSchema: StructType,
+    partitionFilters: Seq[Expression],
+    optionalBucketSet: Option[BitSet],
+    optionalNumCoalescedBuckets: Option[Int],
+    dataFilters: Seq[Expression],
+    tableIdentifier: Option[TableIdentifier],
+    disableBucketedScan: Boolean = false)
+    extends FileSourceScanExec(
+      relation,
       output,
       requiredSchema,
       partitionFilters,
@@ -46,7 +50,15 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
       optionalNumCoalescedBuckets,
       dataFilters,
       tableIdentifier,
-      disableBucketedScan) with BasicScanExecTransformer {
+      disableBucketedScan)
+    with BasicScanExecTransformer {
+
+  lazy val isFileFormatSupported: Boolean = {
+    GlutenConfig.getConf.isGazelleBackend &&
+    relation.fileFormat.isInstanceOf[ParquetFileFormat] ||
+    GlutenConfig.getConf.isVeloxBackend &&
+    relation.fileFormat.isInstanceOf[OrcFileFormat]
+  }
 
   override def filterExprs(): Seq[Expression] = dataFilters
 
@@ -57,32 +69,34 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     val openCostInBytes = relation.sparkSession.sessionState.conf.filesOpenCostInBytes
     val maxSplitBytes =
       FilePartition.maxSplitBytes(relation.sparkSession, selectedPartitions)
-    logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-      s"open cost is considered as scanning $openCostInBytes bytes.")
+    logInfo(
+      s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+        s"open cost is considered as scanning $openCostInBytes bytes.")
 
-    val splitFiles = selectedPartitions.flatMap { partition =>
-      partition.files.flatMap { file =>
-        // getPath() is very expensive so we only want to call it once in this block:
-        val filePath = file.getPath
-        val isSplitable = relation.fileFormat.isSplitable(
-          relation.sparkSession, relation.options, filePath)
-        PartitionedFileUtil.splitFiles(
-          sparkSession = relation.sparkSession,
-          file = file,
-          filePath = filePath,
-          isSplitable = isSplitable,
-          maxSplitBytes = maxSplitBytes,
-          partitionValues = partition.values
-        )
+    val splitFiles = selectedPartitions
+      .flatMap { partition =>
+        partition.files.flatMap { file =>
+          // getPath() is very expensive so we only want to call it once in this block:
+          val filePath = file.getPath
+          val isSplitable =
+            relation.fileFormat.isSplitable(relation.sparkSession, relation.options, filePath)
+          PartitionedFileUtil.splitFiles(
+            sparkSession = relation.sparkSession,
+            file = file,
+            filePath = filePath,
+            isSplitable = isSplitable,
+            maxSplitBytes = maxSplitBytes,
+            partitionValues = partition.values)
+        }
       }
-    }.sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+      .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
 
     FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
   }
 
   override lazy val supportsColumnar: Boolean = {
-    relation.fileFormat.supportBatch(
-      relation.sparkSession, schema) && GlutenConfig.getConf.enableColumnarIterator
+    relation.fileFormat
+      .supportBatch(relation.sparkSession, schema) && GlutenConfig.getConf.enableColumnarIterator
   }
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
@@ -96,6 +110,8 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
       (that canEqual this) && super.equals(that)
     case _ => false
   }
+
+  override def hashCode(): Int = super.hashCode()
 
   override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
     null
@@ -113,5 +129,11 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     null
   }
 
-  override def doValidate(): Boolean = false
+  override def doValidate(): Boolean = {
+    if (isFileFormatSupported) {
+      super.doValidate()
+    } else {
+      false
+    }
+  }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
@@ -17,19 +17,33 @@
 
 package io.glutenproject.execution
 
+import java.util
+
+import scala.collection.JavaConverters._
+
+import com.google.common.collect.Lists
+import com.google.protobuf.Any
+import io.glutenproject.GlutenConfig
+import io.glutenproject.expression._
+import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+import io.glutenproject.substrait.extensions.ExtensionBuilder
+import io.glutenproject.substrait.plan.PlanBuilder
+import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+import io.glutenproject.vectorized.ExpressionEvaluator
+import io.substrait.proto.JoinRel
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.metric.SQLMetrics
-
-import org.apache.spark.sql.vectorized.ColumnarBatch
-
-import io.glutenproject.substrait.SubstraitContext
-import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.execution.joins.{BaseJoinExec, HashJoin, ShuffledJoin}
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * Performs a hash join of two child relations by first shuffling the data using the join keys.
@@ -46,8 +60,6 @@ case class ShuffledHashJoinExecTransformer(
     extends BaseJoinExec
     with TransformSupport
     with ShuffledJoin {
-
-  val sparkConf = sparkContext.getConf
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
@@ -73,23 +85,38 @@ case class ShuffledHashJoinExecTransformer(
     }
   }
 
+  private val joinExpression = (streamedKeyExprs zip buildKeyExprs)
+    .map { case (l, r) => EqualTo(l, r) }
+    .reduce(And)
+
+  // Direct output order of substrait join operation
+  private val joinOutput = streamedPlan.output ++ buildPlan.output
+
+  private val substraitJoinType = joinType match {
+    case Inner =>
+      JoinRel.JoinType.JOIN_TYPE_INNER
+    case FullOuter =>
+      JoinRel.JoinType.JOIN_TYPE_OUTER
+    case LeftOuter | RightOuter =>
+      JoinRel.JoinType.JOIN_TYPE_LEFT
+    case LeftSemi =>
+      JoinRel.JoinType.JOIN_TYPE_SEMI
+    case LeftAnti =>
+      JoinRel.JoinType.JOIN_TYPE_ANTI
+    case _ =>
+      // TODO: Support cross join with Cross Rel
+      JoinRel.JoinType.UNRECOGNIZED
+  }
+
   override def output: Seq[Attribute] =
     if (projectList == null || projectList.isEmpty) super.output
     else projectList.map(_.toAttribute)
-
-
-  def getBuildPlan: SparkPlan = buildPlan
 
   override def updateMetrics(out_num_rows: Long, process_time: Long): Unit = {
     val numOutputRows = longMetric("numOutputRows")
     val procTime = longMetric("processTime")
     procTime.set(process_time / 1000000)
     numOutputRows += out_num_rows
-  }
-
-  override protected def doExecute(): RDD[InternalRow] = {
-    throw new UnsupportedOperationException(
-      s"ColumnarShuffledHashJoinExec doesn't support doExecute")
   }
 
   override def outputPartitioning: Partitioning = buildSide match {
@@ -112,14 +139,19 @@ case class ShuffledHashJoinExecTransformer(
 
   override def supportsColumnar: Boolean = true
 
-  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = streamedPlan match {
-    case c: TransformSupport =>
-      c.columnarInputRDDs
-    case _ =>
-      Seq(streamedPlan.executeColumnar())
+  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
+    val getInputRDDs = (plan: SparkPlan) => {
+      plan match {
+        case c: TransformSupport =>
+          c.columnarInputRDDs
+        case _ =>
+          Seq(plan.executeColumnar())
+      }
+    }
+    getInputRDDs(streamedPlan) ++ getInputRDDs(buildPlan)
   }
 
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = streamedPlan match {
+  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = buildPlan match {
     case c: TransformSupport =>
       val childPlans = c.getBuildPlans
       childPlans :+ (this, null)
@@ -136,11 +168,142 @@ case class ShuffledHashJoinExecTransformer(
 
   override def getChild: SparkPlan = streamedPlan
 
-  override def doTransform(context: SubstraitContext): TransformContext = {
-    throw new UnsupportedOperationException(s"This operator doesn't support doTransform.")
+  override def doValidate(): Boolean = {
+    val substraitContext = new SubstraitContext
+    // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
+    val supportedJoinType =
+      JoinRel.JoinType.JOIN_TYPE_INNER :: JoinRel.JoinType.JOIN_TYPE_OUTER :: Nil
+    if (!supportedJoinType.contains(substraitJoinType)) {
+      return false
+    }
+    val relNode =
+      try {
+        getJoinRel(null, null, substraitContext, validation = true)
+      } catch {
+        case e: Throwable =>
+          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          return false
+      }
+    // Then, validate the generated plan in native engine.
+    if (GlutenConfig.getConf.enableNativeValidation) {
+      val validator = new ExpressionEvaluator()
+      val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
+      validator.doValidate(planNode.toProtobuf.toByteArray)
+    } else {
+      true
+    }
   }
 
-  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    throw new UnsupportedOperationException(s"This operator doesn't support doExecuteColumnar().")
+  override def doTransform(substraitContext: SubstraitContext): TransformContext = {
+    def transformAndGetOutput(plan: SparkPlan): (RelNode, Seq[Attribute]) = {
+      plan match {
+        case p: TransformSupport =>
+          val transformContext = p.doTransform(substraitContext)
+          (transformContext.root, transformContext.outputAttributes)
+        case _ =>
+          val readRel =
+            RelBuilder.makeReadRel(
+              new util.ArrayList[Attribute](plan.output.asJava),
+              substraitContext)
+          (readRel, plan.output)
+      }
+    }
+
+    val (streamedRelNode, streamedOutput) = transformAndGetOutput(streamedPlan)
+    val (buildRelNode, buildOutput) = transformAndGetOutput(buildPlan)
+    val joinRel = getJoinRel(streamedRelNode, buildRelNode, substraitContext)
+
+    val (inputAttributes, outputAttributes, resultProjection) = buildSide match {
+      case BuildLeft =>
+        val (leftOutput, rightOutput) = getNewOutput(buildOutput, streamedOutput)
+        val resultOutput = leftOutput ++ rightOutput
+        val resultProjection = leftOutput.indices.map(idx =>
+          ExpressionBuilder.makeSelection(idx + streamedOutput.size)) ++
+          rightOutput.indices
+            .map(ExpressionBuilder.makeSelection(_))
+        (buildOutput ++ streamedOutput, resultOutput, resultProjection)
+      case BuildRight =>
+        val (leftOutput, rightOutput) = getNewOutput(streamedOutput, buildOutput)
+        val resultOutput = leftOutput ++ rightOutput
+        val resultProjection =
+          resultOutput.indices.map(ExpressionBuilder.makeSelection(_))
+        (streamedOutput ++ buildOutput, resultOutput, resultProjection)
+    }
+
+    val resultProjectRel =
+      RelBuilder.makeProjectRel(
+        joinRel,
+        new java.util.ArrayList[ExpressionNode](resultProjection.asJava))
+
+    TransformContext(inputAttributes, outputAttributes, resultProjectRel)
+  }
+
+  private def getJoinRel(
+      streamedRelNode: RelNode,
+      buildRelNode: RelNode,
+      substraitContext: SubstraitContext,
+      validation: Boolean = false): RelNode = {
+    val joinExpressionNode = ExpressionConverter
+      .replaceWithExpressionTransformer(joinExpression, joinOutput)
+      .asInstanceOf[ExpressionTransformer]
+      .doTransform(substraitContext.registeredFunction)
+
+    val postJoinFilter = condition.map { expr =>
+      ExpressionConverter
+        .replaceWithExpressionTransformer(expr, joinOutput)
+        .asInstanceOf[ExpressionTransformer]
+        .doTransform(substraitContext.registeredFunction)
+    }
+
+    if (!validation) {
+      RelBuilder.makeJoinRel(
+        streamedRelNode,
+        buildRelNode,
+        substraitJoinType,
+        joinExpressionNode,
+        postJoinFilter.orNull)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val inputTypeNodes = joinOutput.map { attr =>
+        ConverterUtils.getTypeNode(attr.dataType, attr.nullable)
+      }
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        Any.pack(
+          TypeBuilder.makeStruct(new util.ArrayList[TypeNode](inputTypeNodes.asJava)).toProtobuf))
+      RelBuilder.makeJoinRel(
+        streamedRelNode,
+        buildRelNode,
+        substraitJoinType,
+        joinExpressionNode,
+        postJoinFilter.orNull,
+        extensionNode)
+    }
+  }
+
+  private def getNewOutput(
+      leftOutput: Seq[Attribute],
+      rightOutput: Seq[Attribute]): (Seq[Attribute], Seq[Attribute]) = {
+    joinType match {
+      case _: InnerLike =>
+        (leftOutput, rightOutput)
+      case LeftOuter =>
+        (leftOutput, rightOutput.map(_.withNullability(true)))
+      case RightOuter =>
+        (leftOutput.map(_.withNullability(true)), rightOutput)
+      case FullOuter =>
+        (leftOutput.map(_.withNullability(true)), rightOutput.map(_.withNullability(true)))
+      case j: ExistenceJoin =>
+        (leftOutput :+ j.exists, Nil)
+      case LeftExistence(_) =>
+        (leftOutput, Nil)
+      case x =>
+        throw new IllegalArgumentException(
+          s"${getClass.getSimpleName} not take $x as the JoinType")
+    }
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} doesn't support doExecute")
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
@@ -171,9 +171,7 @@ case class ShuffledHashJoinExecTransformer(
   override def doValidate(): Boolean = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
-    val supportedJoinType =
-      JoinRel.JoinType.JOIN_TYPE_INNER :: JoinRel.JoinType.JOIN_TYPE_OUTER :: Nil
-    if (!supportedJoinType.contains(substraitJoinType)) {
+    if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
       return false
     }
     val relNode =

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+
+private[glutenproject] class ZippedPartitionsPartition(
+    idx: Int,
+    @transient private val rdds: Seq[RDD[_]])
+    extends Partition {
+
+  override val index: Int = idx
+  var partitionValues = rdds.map(rdd => rdd.partitions(idx))
+
+  def partitions: Seq[Partition] = partitionValues
+}
+
+class WholeStageZippedPartitionsRDD[V: ClassTag](
+    @transient private val sc: SparkContext,
+    var rdds: Seq[RDD[V]],
+    val func: Seq[Iterator[V]] => Iterator[V])
+    extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
+
+  override def compute(split: Partition, context: TaskContext): Iterator[V] = {
+
+    val partitions = split.asInstanceOf[ZippedPartitionsPartition].partitions
+    val inputIterators = (rdds zip partitions).map {
+      case (rdd, partition) => rdd.iterator(partition, context)
+    }
+    func(inputIterators)
+  }
+
+  override def getPartitions: Array[Partition] = {
+    val numParts = rdds.head.partitions.length
+    if (!rdds.forall(rdd => rdd.partitions.length == numParts)) {
+      throw new IllegalArgumentException(
+        s"Can't zip RDDs with unequal numbers of partitions: ${rdds.map(_.partitions.length)}")
+    }
+    Array.tabulate[Partition](numParts) { i => new ZippedPartitionsPartition(i, rdds) }
+  }
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    rdds = null
+  }
+}

--- a/jvm/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
@@ -135,12 +135,15 @@ class BitwiseNotTransformer(child: Expression, original: Expression)
   }
 }
 
-class KnownFloatingPointNormalizedTransformer(child: Expression,
-                                              original: KnownFloatingPointNormalized)
-  extends KnownFloatingPointNormalized(child: Expression) with ExpressionTransformer with Logging {
+class KnownFloatingPointNormalizedTransformer(
+    child: Expression,
+    original: KnownFloatingPointNormalized)
+    extends KnownFloatingPointNormalized(child: Expression)
+    with ExpressionTransformer
+    with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    child.asInstanceOf[ExpressionTransformer].doTransform(args)
   }
 }
 
@@ -208,7 +211,10 @@ class NormalizeNaNAndZeroTransformer(child: Expression, original: NormalizeNaNAn
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    // TODO: A Temporary workaround to make shuffle repartition expression
+    // pass with double/float type.
+    // We need to support converting substrait to gandiva expressions in native.
+    child.asInstanceOf[ExpressionTransformer].doTransform(args)
   }
 }
 

--- a/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -24,6 +24,7 @@ class SubstraitContext extends Serializable {
   private val functionMap = new java.util.HashMap[String, java.lang.Long]()
 
   private var localFilesNode: LocalFilesNode = _
+  private val iteratorNodes = new java.util.HashMap[java.lang.Long, LocalFilesNode]()
   private var extensionTableNode: ExtensionTableNode = _
   private var iteratorIndex: java.lang.Long = new java.lang.Long(0)
 
@@ -31,7 +32,18 @@ class SubstraitContext extends Serializable {
     this.localFilesNode = localFilesNode
   }
 
+  def setIteratorNode(index: java.lang.Long, localFilesNode: LocalFilesNode): Unit = {
+    if (iteratorNodes.containsKey(index)) {
+      throw new IllegalStateException(s"Iterator index ${index} has been used.")
+    }
+    iteratorNodes.put(index, localFilesNode)
+  }
+
   def getLocalFilesNode: LocalFilesNode = this.localFilesNode
+
+  def getInputIteratorNode(index: java.lang.Long): LocalFilesNode = {
+    iteratorNodes.get(index)
+  }
 
   def setExtensionTableNode(extensionTableNode: ExtensionTableNode): Unit = {
     this.extensionTableNode = extensionTableNode
@@ -52,7 +64,7 @@ class SubstraitContext extends Serializable {
 
   def registeredFunction: java.util.HashMap[String, java.lang.Long] = functionMap
 
-  def getIteratorIndex: java.lang.Long = {
+  def nextIteratorIndex: java.lang.Long = {
     val id = this.iteratorIndex
     this.iteratorIndex += 1
     id

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -17,16 +17,12 @@
 
 package org.apache.spark.sql.execution
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution._
+import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -133,9 +129,8 @@ case class ColumnarCollapseCodegenStages(
   private def insertWholeStageTransformer(plan: SparkPlan): SparkPlan = {
     plan match {
       case t: TransformSupport =>
-          WholeStageTransformerExec(
-            t.withNewChildren(t.children.map(insertInputAdapter)))(
-            codegenStageCounter.incrementAndGet())
+        WholeStageTransformerExec(t.withNewChildren(t.children.map(insertInputAdapter)))(
+          codegenStageCounter.incrementAndGet())
       case other =>
         other.withNewChildren(other.children.map(insertWholeStageTransformer))
     }

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
@@ -77,7 +77,7 @@ class IteratorApiImplSuite extends IIteratorApi {
    *
    * @return
    */
-  override def genFinalStageIterator(iter: Iterator[ColumnarBatch],
+  override def genFinalStageIterator(inputIterators: Seq[Iterator[ColumnarBatch]],
                                      numaBindingInfo: GlutenNumaBindingInfo,
                                      listJars: Seq[String], signature: String,
                                      sparkConf: SparkConf, outputAttributes: Seq[Attribute],

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/TransformerApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/TransformerApiImplSuite.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.datasources.FileFormat
 
 class TransformerApiImplSuite extends ITransformerApi {
 
@@ -30,6 +31,13 @@ class TransformerApiImplSuite extends ITransformerApi {
   override def validateColumnarShuffleExchangeExec(outputPartitioning: Partitioning,
                                                    outputAttributes: Seq[Attribute]
                                                   ): Boolean = false
+
+  /**
+   * Used for table scan validation.
+   *
+   * @return true if backend supports reading the file format.
+   */
+  override def supportsReadFileFormat(fileFormat: FileFormat): Boolean = false
 
   /**
    * Get the backend api name.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable the substrait conversion in `ShuffledHashJoinExecTransformer`. Enable passing multiple input RDDs to native backend.

Add below configuration to force enabling shuffled hash join:
```
# disable BHJ
--conf spark.sql.autoBroadcastJoinThreshold=-1
# disable SMJ
--conf spark.gluten.sql.columnar.forceshuffledhashjoin=true
```

## How was this patch tested?

Verified locally.