### PR TITLE
[Gluten-161] The children of BaseJoinExec should insert WholeStageTransformerExec separately

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseScan.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseScan.scala
@@ -115,7 +115,11 @@ case class ClickHouseScan(
 
   override def estimateStatistics(): Statistics = {
     new Statistics {
-      override def sizeInBytes(): OptionalLong = OptionalLong.empty()
+      override def sizeInBytes(): OptionalLong = {
+        val compressionFactor = sparkSession.sessionState.conf.fileCompressionFactor
+        val size = (compressionFactor * table.listFiles().map(_.bytesOnDisk).sum).toLong
+        OptionalLong.of(size)
+      }
 
       override def numRows(): OptionalLong = OptionalLong.empty()
     }

--- a/jvm/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
@@ -142,7 +142,7 @@ case class ShuffledHashJoinExecTransformer(
   override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
     val getInputRDDs = (plan: SparkPlan) => {
       plan match {
-        case c: TransformSupport =>
+        case c: TransformSupport if !c.isInstanceOf[WholeStageTransformerExec] =>
           c.columnarInputRDDs
         case _ =>
           Seq(plan.executeColumnar())
@@ -195,7 +195,7 @@ case class ShuffledHashJoinExecTransformer(
   override def doTransform(substraitContext: SubstraitContext): TransformContext = {
     def transformAndGetOutput(plan: SparkPlan): (RelNode, Seq[Attribute]) = {
       plan match {
-        case p: TransformSupport =>
+        case p: TransformSupport if !p.isInstanceOf[WholeStageTransformerExec] =>
           val transformContext = p.doTransform(substraitContext)
           (transformContext.root, transformContext.outputAttributes)
         case _ =>

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -206,7 +206,7 @@ case class TransformPostOverrides() extends Rule[SparkPlan] {
     case plan: RowToColumnarExec =>
       val child = replaceWithTransformerPlan(plan.child)
       logDebug(s"ColumnarPostOverrides RowToArrowColumnarExec(${child.getClass})")
-        BackendsApiManager.getSparkPlanExecApiInstance.genRowToArrowColumnarExec(child)
+      BackendsApiManager.getSparkPlanExecApiInstance.genRowToArrowColumnarExec(child)
     case ColumnarToRowExec(child: ColumnarShuffleExchangeAdaptor) =>
       replaceWithTransformerPlan(child)
     case ColumnarToRowExec(child: CoalesceBatchesExec) =>

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -134,8 +134,7 @@ case class ColumnarCollapseCodegenStages(
   private def insertWholeStageTransformer(plan: SparkPlan): SparkPlan = {
     plan match {
       case t: TransformSupport =>
-        WholeStageTransformerExec(t.withNewChildren(t.children.map(insertInputAdapter)))(
-          codegenStageCounter.incrementAndGet())
+        WholeStageTransformerExec(insertInputAdapter(t))(codegenStageCounter.incrementAndGet())
       case other =>
         other.withNewChildren(other.children.map(insertWholeStageTransformer))
     }

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.sql.execution
 
-import io.glutenproject.GlutenConfig
-import io.glutenproject.execution._
 import java.util.concurrent.atomic.AtomicInteger
+
+import io.glutenproject.execution._
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.joins.BaseJoinExec
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -121,6 +122,10 @@ case class ColumnarCollapseCodegenStages(
     plan match {
       case p if !supportTransform(p) =>
         new ColumnarInputAdapter(insertWholeStageTransformer(p))
+      // The children of BaseJoinExec should do transformer separately.
+      case j if j.isInstanceOf[BaseJoinExec] =>
+        j.withNewChildren(j.children.map(c =>
+          new ColumnarInputAdapter(insertWholeStageTransformer(c))))
       case p =>
         p.withNewChildren(p.children.map(insertInputAdapter))
     }


### PR DESCRIPTION
Currently, the strategy of inserting 'WholeStageTransformer' only meet the shuffle exchange scenario, when there is a join operator, it also needs to insert 'WholeStageTransformer' for the children of the join operator.

Please refer to : [WholeStageCodegenExec.scala](https://github.com/apache/spark/blob/66648e96e4283223003c80a1a997325bbd27f940/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala#L893)

Close #161 .

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

