### PR TITLE
[OPPRO-46] Support Parquet Scan in Gluten

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxIteratorApi.scala
@@ -59,12 +59,13 @@ class VeloxIteratorApi extends IIteratorApi with Logging {
         val paths = new java.util.ArrayList[String]()
         val starts = new java.util.ArrayList[java.lang.Long]()
         val lengths = new java.util.ArrayList[java.lang.Long]()
+        val fileFormat = wsCxt.substraitContext.getFileFormat()
         files.foreach { f =>
           paths.add(f.filePath)
           starts.add(new java.lang.Long(f.start))
           lengths.add(new java.lang.Long(f.length))
         }
-        val localFilesNode = LocalFilesBuilder.makeLocalFiles(index, paths, starts, lengths)
+        val localFilesNode = LocalFilesBuilder.makeLocalFiles(index, paths, starts, lengths, fileFormat)
         wsCxt.substraitContext.setLocalFilesNode(localFilesNode)
         val substraitPlan = wsCxt.root.toProtobuf
         /*

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxTransformerApi.scala
@@ -77,7 +77,8 @@ class VeloxTransformerApi extends ITransformerApi with Logging {
   override def supportsReadFileFormat(fileFormat: FileFormat): Boolean = {
     GlutenConfig.getConf.isGazelleBackend && fileFormat.isInstanceOf[ParquetFileFormat] ||
     GlutenConfig.getConf.isVeloxBackend && fileFormat.isInstanceOf[OrcFileFormat] ||
-      GlutenConfig.getConf.isVeloxBackend && fileFormat.isInstanceOf[DwrfFileFormat]
+      GlutenConfig.getConf.isVeloxBackend && fileFormat.isInstanceOf[DwrfFileFormat] ||
+      GlutenConfig.getConf.isVeloxBackend && fileFormat.isInstanceOf[ParquetFileFormat]
   }
 
   /**

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -118,7 +118,9 @@ macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(common::time "${VELOX_COMPONENTS_PATH}/common/time/libvelox_time.a")
   add_velox_dependency(common::file "${VELOX_COMPONENTS_PATH}/common/file/libvelox_file.a")
   add_velox_dependency(common::process "${VELOX_COMPONENTS_PATH}/common/process/libvelox_process.a")
+  add_velox_dependency(parquet "${VELOX_COMPONENTS_PATH}/dwio/parquet/reader/libvelox_dwio_parquet_reader.a")
 endmacro()
+
 
 # Build Velox backend.
 set(VELOX_SRCS

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -89,6 +89,8 @@ macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(dwio::dwrf::reader "${VELOX_COMPONENTS_PATH}/dwio/dwrf/reader/libvelox_dwio_dwrf_reader.a")
   add_velox_dependency(dwio::dwrf::utils "${VELOX_COMPONENTS_PATH}/dwio/dwrf/utils/libvelox_dwio_dwrf_utils.a")
   add_velox_dependency(dwio::dwrf::common "${VELOX_COMPONENTS_PATH}/dwio/dwrf/common/libvelox_dwio_dwrf_common.a")
+  add_velox_dependency(parquet "${VELOX_COMPONENTS_PATH}/dwio/parquet/reader/libvelox_dwio_parquet_reader.a")
+  add_velox_dependency(parquet::reader::duckdb "${VELOX_COMPONENTS_PATH}/dwio/parquet/reader/duckdb/libvelox_dwio_parquet_reader_duckdb.a")
   add_velox_dependency(dwio::common "${VELOX_COMPONENTS_PATH}/dwio/common/libvelox_dwio_common.a")
 
   add_velox_dependency(expression "${VELOX_COMPONENTS_PATH}/expression/libvelox_expression.a")
@@ -118,7 +120,13 @@ macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(common::time "${VELOX_COMPONENTS_PATH}/common/time/libvelox_time.a")
   add_velox_dependency(common::file "${VELOX_COMPONENTS_PATH}/common/file/libvelox_file.a")
   add_velox_dependency(common::process "${VELOX_COMPONENTS_PATH}/common/process/libvelox_process.a")
-  add_velox_dependency(parquet "${VELOX_COMPONENTS_PATH}/dwio/parquet/reader/libvelox_dwio_parquet_reader.a")
+  
+  add_velox_dependency(duckdb::function "${VELOX_COMPONENTS_PATH}/duckdb/functions/libvelox_duckdb_functions.a")
+  add_velox_dependency(duckdb::conversion "${VELOX_COMPONENTS_PATH}/duckdb/conversion/libvelox_duckdb_conversion.a")
+  add_velox_dependency(duckdb "${VELOX_COMPONENTS_PATH}/external/duckdb/libduckdb.a")
+  add_velox_dependency(duckdb::tpch "${VELOX_COMPONENTS_PATH}/external/duckdb/tpch/libtpch_extension.a")
+  add_velox_dependency(duckdb::tpch::dbgen "${VELOX_COMPONENTS_PATH}/external/duckdb/tpch/dbgen/libdbgen.a")
+
 endmacro()
 
 

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -41,7 +41,7 @@ auto BM = [](::benchmark::State& state, const std::string& datasetPath,
         gluten::CreateBackend());
     state.ResumeTiming();
     backend->ParsePlan(plan->data(), plan->size());
-    auto resultIter = backend->GetResultIterator(paths, starts, lengths);
+    auto resultIter = backend->GetResultIterator(paths, starts, lengths, fileFormat);
 
     while (resultIter->HasNext()) {
       std::cout << resultIter->Next()->ToString() << std::endl;

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -227,7 +227,7 @@ VeloxPlanConverter::GetResultIterator() {
       pool_, planNode, subVeloxPlanConverter_->getPartitionIndex(),
       subVeloxPlanConverter_->getPaths(), subVeloxPlanConverter_->getStarts(),
       subVeloxPlanConverter_->getLengths(), subVeloxPlanConverter_->getFileFormat(),
-       fakeArrowOutput_);
+      fakeArrowOutput_);
   return std::make_shared<gluten::RecordBatchResultIterator>(std::move(wholestageIter));
 }
 
@@ -338,8 +338,7 @@ class VeloxPlanConverter::WholeStageResIterFirstStage : public WholeStageResIter
                               const u_int32_t index,
                               const std::vector<std::string>& paths,
                               const std::vector<u_int64_t>& starts,
-                              const std::vector<u_int64_t>& lengths,
-                              const int fileFormat,
+                              const std::vector<u_int64_t>& lengths, const int fileFormat,
                               const bool fakeArrowOutput)
       : WholeStageResIter(pool, planNode),
         index_(index),
@@ -350,7 +349,7 @@ class VeloxPlanConverter::WholeStageResIterFirstStage : public WholeStageResIter
     auto format = FileFormat::UNKNOWN;
     if (fileFormat == 2) {
       format = FileFormat::ORC;
-    } else if (fileFormat == 1)  {
+    } else if (fileFormat == 1) {
       format = FileFormat::PARQUET;
     }
 
@@ -358,9 +357,9 @@ class VeloxPlanConverter::WholeStageResIterFirstStage : public WholeStageResIter
       auto path = paths[idx];
       auto start = starts[idx];
       auto length = lengths[idx];
-    
-      auto split = std::make_shared<hive::HiveConnectorSplit>(
-          "hive-connector", path, format, start, length);
+
+      auto split = std::make_shared<hive::HiveConnectorSplit>("hive-connector", path,
+                                                              format, start, length);
       connectorSplits.push_back(split);
     }
     splits_.reserve(connectorSplits.size());

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -60,6 +60,7 @@
 #include "velox/substrait/TypeUtils.h"
 #include "velox/type/Filter.h"
 #include "velox/type/Subfield.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -50,6 +50,7 @@
 #include "velox/dwio/dwrf/common/CachedBufferedInput.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/tests/utils/Cursor.h"
@@ -60,7 +61,6 @@
 #include "velox/substrait/TypeUtils.h"
 #include "velox/type/Filter.h"
 #include "velox/type/Subfield.h"
-#include "velox/dwio/parquet/reader/ParquetReader.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -87,7 +87,7 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
   // For unit test and benchmark.
   std::shared_ptr<gluten::RecordBatchResultIterator> GetResultIterator(
       const std::vector<std::string>& paths, const std::vector<u_int64_t>& starts,
-      const std::vector<u_int64_t>& lengths);
+      const std::vector<u_int64_t>& lengths, const std::string& format);
 
   std::shared_ptr<gluten::columnartorow::ColumnarToRowConverterBase> getColumnarConverter(
       std::shared_ptr<arrow::RecordBatch> rb, arrow::MemoryPool* memory_pool,

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/LocalFilesBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/LocalFilesBuilder.java
@@ -23,8 +23,9 @@ public class LocalFilesBuilder {
     private LocalFilesBuilder() {}
 
     public static LocalFilesNode makeLocalFiles(Integer index, ArrayList<String> paths,
-                                                ArrayList<Long> starts, ArrayList<Long> lengths) {
-        return new LocalFilesNode(index, paths, starts, lengths);
+                                                ArrayList<Long> starts, ArrayList<Long> lengths,
+                                                int fileFormat) {
+        return new LocalFilesNode(index, paths, starts, lengths, fileFormat);
     }
 
     public static LocalFilesNode makeLocalFiles(String iterPath) {

--- a/jvm/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -27,14 +27,18 @@ public class LocalFilesNode implements Serializable {
     private final ArrayList<String> paths = new ArrayList<>();
     private final ArrayList<Long> starts = new ArrayList<>();
     private final ArrayList<Long> lengths = new ArrayList<>();
+
+    private int fileFormat = -1;
     private Boolean iterAsInput = false;
 
     LocalFilesNode(Integer index, ArrayList<String> paths,
-                   ArrayList<Long> starts, ArrayList<Long> lengths) {
+                   ArrayList<Long> starts, ArrayList<Long> lengths,
+                   int fileFormat) {
         this.index = index;
         this.paths.addAll(paths);
         this.starts.addAll(starts);
         this.lengths.addAll(lengths);
+        this.fileFormat = fileFormat;
     }
 
     LocalFilesNode(String iterPath) {
@@ -65,8 +69,7 @@ public class LocalFilesNode implements Serializable {
             }
             fileBuilder.setLength(lengths.get(i));
             fileBuilder.setStart(starts.get(i));
-            // TODO: Support multiple file format
-            fileBuilder.setFormat(ReadRel.LocalFiles.FileOrFiles.FileFormat.FILE_FORMAT_PARQUET);
+            fileBuilder.setFormat(ReadRel.LocalFiles.FileOrFiles.FileFormat.forNumber(fileFormat));
             localFilesBuilder.addItems(fileBuilder.build());
         }
         return localFilesBuilder.build();

--- a/jvm/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/jvm/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -103,6 +103,7 @@ message ReadRel {
         FILE_FORMAT_UNSPECIFIED = 0;
         FILE_FORMAT_PARQUET = 1;
         FILE_FORMAT_ORC = 2;
+        FILE_FORMAT_DWRF = 3;
       }
     }
   }

--- a/jvm/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/jvm/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -102,6 +102,7 @@ message ReadRel {
       enum FileFormat {
         FILE_FORMAT_UNSPECIFIED = 0;
         FILE_FORMAT_PARQUET = 1;
+        FILE_FORMAT_ORC = 2;
       }
     }
   }

--- a/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -26,6 +26,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.vectorized.ColumnarBatch

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -327,16 +327,18 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       // Get the file format based on fileScan
       val fileFormat = fileScan match {
         case f: BatchScanExecTransformer => {
-          f.scan match {
-            case orc: OrcScan => 2
-            case parquet: ParquetScan => 1
+          f.scan.getClass.getSimpleName match {
+            case "OrcScan" => 2
+            case "ParquetScan" => 1
+            case "DwrfScan" => 3
             case _ => -1
           }
         }
         case f: FileSourceScanExecTransformer =>
-          f.relation.fileFormat match {
-            case orc: OrcFileFormat => 2
-            case parquet: ParquetFileFormat => 1
+          f.relation.fileFormat.getClass.getSimpleName match {
+            case "OrcFileFormat" => 2
+            case "ParquetFileFormat" => 1
+            case "DwrfFileFormat" => 3
             case _ => -1
           }
       }

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -33,6 +33,10 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.joins.BaseJoinExec
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -320,7 +324,25 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
         s"${execTempDir}/spark-columnar-plugin-codegen-precompile-${signature}.jar"
       })
       val fileScan = current_op.get
+      // Get the file format based on fileScan
+      val fileFormat = fileScan match {
+        case f: BatchScanExecTransformer => {
+          f.scan match {
+            case orc: OrcScan => 2
+            case parquet: ParquetScan => 1
+            case _ => -1
+          }
+        }
+        case f: FileSourceScanExecTransformer =>
+          f.relation.fileFormat match {
+            case orc: OrcFileFormat => 2
+            case parquet: ParquetFileFormat => 1
+            case _ => -1
+          }
+      }
+
       val wsCxt = doWholestageTransform()
+      wsCxt.substraitContext.setFileFormat(fileFormat)
 
       val startTime = System.nanoTime()
       val substraitPlanPartition = fileScan.getPartitions.map(p =>

--- a/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -28,6 +28,13 @@ class SubstraitContext extends Serializable {
   private val iteratorNodes = new java.util.HashMap[java.lang.Long, LocalFilesNode]()
   private var extensionTableNode: ExtensionTableNode = _
   private var iteratorIndex: java.lang.Long = new java.lang.Long(0)
+  private var fileFormat: java.lang.Integer = new Integer(-1)
+
+  def setFileFormat(format: java.lang.Integer): Unit = {
+    this.fileFormat = format
+  }
+
+  def getFileFormat(): java.lang.Integer = this.fileFormat
 
   private var insertOutputNode: InsertOutputNode = _
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
•	Add the parquet read dependencies into Gluten.
•	Parse and store the file format when converting the Substrait plan to Velox plan and then created the corresponding Split according to the specified file format.
•	Set the specified file format to replace the dead code when converting the Spark plan to Substrait plan.


depend on [oap-project/velox PR#13](https://github.com/oap-project/velox/pull/13) 


## How was this patch tested?
Locally test TPCH Q1 and Q6
