### PR TITLE
[Gluten-167] Fallback ShuffleExchangeExec with RangePartitioning for ClickHouse backend.

### DIFF
--- a/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -415,11 +415,19 @@ case class HashAggregateExecTransformer(
       val childrenNodeList = new util.ArrayList[ExpressionNode]()
       val childrenNodes = aggExpr.mode match {
         case Partial =>
-          aggregatFunc.children.toList.map(expr => {
-            val aggExpr: Expression = ExpressionConverter
-              .replaceWithExpressionTransformer(expr, originalInputAttributes)
-            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-          })
+          if (!GlutenConfig.getConf.isClickHouseBackend) {
+            aggregatFunc.children.toList.map(expr => {
+              val aggExpr: Expression = ExpressionConverter
+                .replaceWithExpressionTransformer(expr, originalInputAttributes)
+              aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+            })
+          } else {
+            aggregatFunc.children.toList.map(expr => {
+              val aggExpr: Expression = ExpressionConverter
+                .replaceWithExpressionTransformer(expr, child.output)
+              aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+            })
+          }
         case Final =>
           if (!GlutenConfig.getConf.isClickHouseBackend) {
             aggregatFunc.inputAggBufferAttributes.toList.map(attr => {


### PR DESCRIPTION
Fallback ShuffleExchangeExec with RangePartitioning for ClickHouse backend.

Close #167 .


## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

