### PR TITLE
[OPPRO-104] support more expressions

### DIFF
--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -436,7 +436,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_VeloxOutIterator_nativeC
   }
   std::cout << "BatchIterator nativeClose." << std::endl;
 #endif
-  batch_iterator_holder_.Erase(id);
+  // batch_iterator_holder_.Erase(id);
   JNI_METHOD_END()
 }
 

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -436,7 +436,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_VeloxOutIterator_nativeC
   }
   std::cout << "BatchIterator nativeClose." << std::endl;
 #endif
-  // batch_iterator_holder_.Erase(id);
+  batch_iterator_holder_.Erase(id);
   JNI_METHOD_END()
 }
 

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -392,8 +392,8 @@ macro(build_velox_exec)
                                    "${BINARY_RELEASE_DIR}/include")
   set_target_properties(facebook::velox::functions::sparksql::lib
                                    PROPERTIES IMPORTED_LOCATION "${VELOX_FUNCTIONS_SPARKSQL_LIB_PATH}"
-                                              INTERFACE_INCLUDE_DIRECTORIES
-                                              "${BINARY_RELEASE_DIR}/include")
+                                   INTERFACE_INCLUDE_DIRECTORIES
+                                   "${BINARY_RELEASE_DIR}/include")
   set_target_properties(facebook::velox::type::tz
                         PROPERTIES IMPORTED_LOCATION "${VELOX_TYPE_TZ_LIB_PATH}"
                                    INTERFACE_INCLUDE_DIRECTORIES

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -71,6 +71,7 @@ set(VELOX_FUNCTIONS_PRESTOSQL_JSON_LIB_PATH "${VELOX_BUILD_PATH}/functions/prest
 set(VELOX_FUNCTIONS_PRESTOSQL_HYPERLOGLOG_LIB_PATH "${VELOX_BUILD_PATH}/functions/prestosql/hyperloglog/libvelox_functions_hyperloglog.a")
 set(VELOX_FUNCTIONS_PRESTOSQL_AGG_LIB_PATH "${VELOX_BUILD_PATH}/functions/prestosql/aggregates/libvelox_aggregates.a")
 set(VELOX_FUNCTIONS_LIB_PATH "${VELOX_BUILD_PATH}/functions/lib/libvelox_functions_lib.a")
+set(VELOX_FUNCTIONS_SPARKSQL_LIB_PATH  "${VELOX_BUILD_PATH}/functions/sparksql/libvelox_functions_spark.a")
 set(VELOX_TYPE_TZ_LIB_PATH "${VELOX_BUILD_PATH}/type/tz/libvelox_type_tz.a")
 set(VELOX_EXTERNAL_MD5_LIB_PATH "${VELOX_BUILD_PATH}/external/md5/libmd5.a")
 set(VELOX_EXPRESSION_LIB_PATH "${VELOX_BUILD_PATH}/expression/libvelox_expression.a")
@@ -208,6 +209,7 @@ macro(build_velox_exec)
   add_library(facebook::velox::functions::hyperloglog STATIC IMPORTED)
   add_library(facebook::velox::functions::prestosql::agg STATIC IMPORTED)
   add_library(facebook::velox::functions::lib STATIC IMPORTED)
+  add_library(facebook::velox::functions::sparksql::lib STATIC IMPORTED)
   add_library(facebook::velox::type::tz STATIC IMPORTED)
   add_library(facebook::velox::external::md5 STATIC IMPORTED)
   add_library(facebook::velox::expression STATIC IMPORTED)
@@ -388,6 +390,10 @@ macro(build_velox_exec)
                         PROPERTIES IMPORTED_LOCATION "${VELOX_FUNCTIONS_LIB_PATH}"
                                    INTERFACE_INCLUDE_DIRECTORIES
                                    "${BINARY_RELEASE_DIR}/include")
+  set_target_properties(facebook::velox::functions::sparksql::lib
+                                   PROPERTIES IMPORTED_LOCATION "${VELOX_FUNCTIONS_SPARKSQL_LIB_PATH}"
+                                              INTERFACE_INCLUDE_DIRECTORIES
+                                              "${BINARY_RELEASE_DIR}/include")
   set_target_properties(facebook::velox::type::tz
                         PROPERTIES IMPORTED_LOCATION "${VELOX_TYPE_TZ_LIB_PATH}"
                                    INTERFACE_INCLUDE_DIRECTORIES
@@ -429,6 +435,7 @@ macro(build_velox_exec)
                         LINK_PUBLIC facebook::velox::functions::prestosql::impl
                         LINK_PUBLIC facebook::velox::functions::json
                         LINK_PUBLIC facebook::velox::functions::hyperloglog
+                        LINK_PUBLIC facebook::velox::functions::sparksql::lib
                         LINK_PUBLIC facebook::velox::functions::lib
                         LINK_PUBLIC facebook::velox::vector
                         LINK_PUBLIC facebook::velox::exec::test::util

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -228,8 +228,8 @@ std::shared_ptr<gluten::RecordBatchResultIterator> VeloxPlanConverter::GetResult
   std::shared_ptr<gluten::RecordBatchResultIterator> resIter;
   arrowInputIters_ = std::move(inputs);
   const std::shared_ptr<const core::PlanNode> planNode = getVeloxPlanNode(plan_);
-  auto wholestageIter = std::make_shared<WholeStageResIterMiddleStage>(
-      planNode, fakeArrowOutput_);
+  auto wholestageIter =
+      std::make_shared<WholeStageResIterMiddleStage>(planNode, fakeArrowOutput_);
   return std::make_shared<gluten::RecordBatchResultIterator>(std::move(wholestageIter));
 }
 
@@ -304,7 +304,7 @@ class VeloxPlanConverter::WholeStageResIter {
   }
 
   arrow::MemoryPool* memoryPool_ = arrow::default_memory_pool();
-  std::unique_ptr<memory::MemoryPool> pool_{memory::getDefaultScopedMemoryPool()};
+  std::unique_ptr<memory::MemoryPool> veloxPool_{memory::getDefaultScopedMemoryPool()};
   std::shared_ptr<const core::PlanNode> planNode_;
   test::CursorParameters params_;
   std::unique_ptr<test::TaskCursor> cursor_;

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -27,6 +27,7 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/functions/prestosql/aggregates/AverageAggregate.h"
 #include "velox/functions/prestosql/aggregates/CountAggregate.h"
+#include "velox/functions/sparksql/Register.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -50,6 +51,7 @@ void VeloxInitializer::Init() {
   dwrf::registerDwrfReaderFactory();
   // Register Velox functions
   functions::prestosql::registerAllScalarFunctions();
+  functions::sparksql::registerFunctions("");
   aggregate::registerSumAggregate<aggregate::SumAggregate>("sum");
   aggregate::registerAverageAggregate("avg");
   aggregate::registerCountAggregate("count");

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -228,8 +228,8 @@ std::shared_ptr<gluten::RecordBatchResultIterator> VeloxPlanConverter::GetResult
   std::shared_ptr<gluten::RecordBatchResultIterator> resIter;
   arrowInputIters_ = std::move(inputs);
   const std::shared_ptr<const core::PlanNode> planNode = getVeloxPlanNode(plan_);
-  auto wholestageIter =
-      std::make_shared<WholeStageResIterMiddleStage>(planNode, fakeArrowOutput_);
+  auto wholestageIter = std::make_shared<WholeStageResIterMiddleStage>(
+      planNode, fakeArrowOutput_);
   return std::make_shared<gluten::RecordBatchResultIterator>(std::move(wholestageIter));
 }
 
@@ -304,7 +304,7 @@ class VeloxPlanConverter::WholeStageResIter {
   }
 
   arrow::MemoryPool* memoryPool_ = arrow::default_memory_pool();
-  std::unique_ptr<memory::MemoryPool> veloxPool_{memory::getDefaultScopedMemoryPool()};
+  std::unique_ptr<memory::MemoryPool> pool_{memory::getDefaultScopedMemoryPool()};
   std::shared_ptr<const core::PlanNode> planNode_;
   test::CursorParameters params_;
   std::unique_ptr<test::TaskCursor> cursor_;

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -93,6 +93,7 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
   }
 
  private:
+  std::unique_ptr<memory::MemoryPool> veloxPool_{memory::getDefaultScopedMemoryPool()};
   int planNodeId_ = 0;
   bool fakeArrowOutput_ = false;
   bool dsAsInput_ = true;
@@ -118,7 +119,8 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
       std::make_shared<facebook::velox::substrait::SubstraitParser>();
   std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter>
       subVeloxPlanConverter_ =
-          std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>();
+          std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(
+              veloxPool_.get());
 
   /* Result Iterator */
   class WholeStageResIter;

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -93,7 +93,6 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
   }
 
  private:
-  std::unique_ptr<memory::MemoryPool> veloxPool_{memory::getDefaultScopedMemoryPool()};
   int planNodeId_ = 0;
   bool fakeArrowOutput_ = false;
   bool dsAsInput_ = true;
@@ -119,8 +118,7 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
       std::make_shared<facebook::velox::substrait::SubstraitParser>();
   std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter>
       subVeloxPlanConverter_ =
-          std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(
-              veloxPool_.get());
+          std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>();
 
   /* Result Iterator */
   class WholeStageResIter;

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/DateListNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/DateListNode.java
@@ -19,14 +19,29 @@ package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;
 
-/**
- * Contains helper functions for constructing Substrait expressions.
- */
-public interface ExpressionNode {
-    /**
-     * Converts a Expression into a protobuf.
-     *
-     * @return A rel protobuf
-     */
-    Expression toProtobuf();
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class DateListNode implements ExpressionNode, Serializable {
+    private final ArrayList<Integer> values = new ArrayList<>();
+
+    public DateListNode(ArrayList<Integer> values) {
+        this.values.addAll(values);
+    }
+
+    @Override
+    public Expression toProtobuf() {
+        Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
+        Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
+        for (Integer value : values) {
+            literalBuilder.setDate(value);
+            listBuilder.addValues(literalBuilder.build());
+        }
+        literalBuilder.setList(listBuilder.build());
+
+        Expression.Builder builder =  Expression.newBuilder();
+        builder.setLiteral(literalBuilder.build());
+
+        return builder.build();
+    }
 }

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/DoubleListNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/DoubleListNode.java
@@ -19,14 +19,29 @@ package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;
 
-/**
- * Contains helper functions for constructing Substrait expressions.
- */
-public interface ExpressionNode {
-    /**
-     * Converts a Expression into a protobuf.
-     *
-     * @return A rel protobuf
-     */
-    Expression toProtobuf();
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class DoubleListNode implements ExpressionNode, Serializable {
+    private final ArrayList<Double> values = new ArrayList<>();
+
+    public DoubleListNode(ArrayList<Double> values) {
+        this.values.addAll(values);
+    }
+
+    @Override
+    public Expression toProtobuf() {
+        Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
+        Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
+        for (Double value : values) {
+            literalBuilder.setFp64(value);
+            listBuilder.addValues(literalBuilder.build());
+        }
+        literalBuilder.setList(listBuilder.build());
+
+        Expression.Builder builder =  Expression.newBuilder();
+        builder.setLiteral(literalBuilder.build());
+
+        return builder.build();
+    }
 }

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -38,24 +38,44 @@ public class ExpressionBuilder {
         }
     }
 
+    public static IntLiteralNode makeIntLiteral(Integer intConstant) {
+        return new IntLiteralNode(intConstant);
+    }
+
+    public static IntListNode makeIntList(ArrayList<Integer> intConstants) {
+        return new IntListNode(intConstants);
+    }
+
+    public static LongLiteralNode makeLongLiteral(Long longConstant) {
+        return new LongLiteralNode(longConstant);
+    }
+
+    public static LongListNode makeLongList(ArrayList<Long> longConstants) {
+        return new LongListNode(longConstants);
+    }
+
     public static DoubleLiteralNode makeDoubleLiteral(Double doubleConstant) {
         return new DoubleLiteralNode(doubleConstant);
+    }
+
+    public static DoubleListNode makeDoubleList(ArrayList<Double> doubleConstants) {
+        return new DoubleListNode(doubleConstants);
     }
 
     public static DateLiteralNode makeDateLiteral(Integer dateConstant) {
         return new DateLiteralNode(dateConstant);
     }
 
+    public static DateListNode makeDateList(ArrayList<Integer> dateConstants) {
+        return new DateListNode(dateConstants);
+    }
+
     public static StringLiteralNode makeStringLiteral(String strConstant) {
         return new StringLiteralNode(strConstant);
     }
 
-    public static IntLiteralNode makeIntLiteral(Integer intConstant) {
-        return new IntLiteralNode(intConstant);
-    }
-
-    public static LongLiteralNode makeLongLiteral(Long longConstant) {
-        return new LongLiteralNode(longConstant);
+    public static StringListNode makeStringList(ArrayList<String> strConstants) {
+        return new StringListNode(strConstants);
     }
 
     public static ScalarFunctionNode makeScalarFunction(

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/IntListNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/IntListNode.java
@@ -19,14 +19,29 @@ package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;
 
-/**
- * Contains helper functions for constructing Substrait expressions.
- */
-public interface ExpressionNode {
-    /**
-     * Converts a Expression into a protobuf.
-     *
-     * @return A rel protobuf
-     */
-    Expression toProtobuf();
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class IntListNode implements ExpressionNode, Serializable {
+    private final ArrayList<Integer> values = new ArrayList<>();
+
+    public IntListNode(ArrayList<Integer> values) {
+        this.values.addAll(values);
+    }
+
+    @Override
+    public Expression toProtobuf() {
+        Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
+        Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
+        for (Integer value : values) {
+            literalBuilder.setI32(value);
+            listBuilder.addValues(literalBuilder.build());
+        }
+        literalBuilder.setList(listBuilder.build());
+
+        Expression.Builder builder =  Expression.newBuilder();
+        builder.setLiteral(literalBuilder.build());
+
+        return builder.build();
+    }
 }

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/LongListNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/LongListNode.java
@@ -19,14 +19,29 @@ package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;
 
-/**
- * Contains helper functions for constructing Substrait expressions.
- */
-public interface ExpressionNode {
-    /**
-     * Converts a Expression into a protobuf.
-     *
-     * @return A rel protobuf
-     */
-    Expression toProtobuf();
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class LongListNode implements ExpressionNode, Serializable {
+    private final ArrayList<Long> values = new ArrayList<>();
+
+    public LongListNode(ArrayList<Long> values) {
+        this.values.addAll(values);
+    }
+
+    @Override
+    public Expression toProtobuf() {
+        Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
+        Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
+        for (Long value : values) {
+            literalBuilder.setI64(value);
+            listBuilder.addValues(literalBuilder.build());
+        }
+        literalBuilder.setList(listBuilder.build());
+
+        Expression.Builder builder =  Expression.newBuilder();
+        builder.setLiteral(literalBuilder.build());
+
+        return builder.build();
+    }
 }

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/StringListNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/StringListNode.java
@@ -19,14 +19,29 @@ package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;
 
-/**
- * Contains helper functions for constructing Substrait expressions.
- */
-public interface ExpressionNode {
-    /**
-     * Converts a Expression into a protobuf.
-     *
-     * @return A rel protobuf
-     */
-    Expression toProtobuf();
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class StringListNode implements ExpressionNode, Serializable {
+    private final ArrayList<String> values = new ArrayList<>();
+
+    public StringListNode(ArrayList<String> values) {
+        this.values.addAll(values);
+    }
+
+    @Override
+    public Expression toProtobuf() {
+        Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
+        Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
+        for (String value : values) {
+            literalBuilder.setString(value);
+            listBuilder.addValues(literalBuilder.build());
+        }
+        literalBuilder.setList(listBuilder.build());
+
+        Expression.Builder builder =  Expression.newBuilder();
+        builder.setLiteral(literalBuilder.build());
+
+        return builder.build();
+    }
 }

--- a/jvm/src/main/scala/io/glutenproject/expression/ArithmeticTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ArithmeticTransformer.scala
@@ -33,13 +33,13 @@ class AddTransformer(left: Expression, right: Expression, original: Expression)
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
 
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
 
@@ -47,12 +47,12 @@ class AddTransformer(left: Expression, right: Expression, original: Expression)
     val functionName = ConverterUtils.makeFuncName(
       ConverterUtils.ADD, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(left.dataType, nullable = true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -62,13 +62,13 @@ class SubtractTransformer(left: Expression, right: Expression, original: Express
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
 
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
 
@@ -76,12 +76,12 @@ class SubtractTransformer(left: Expression, right: Expression, original: Express
     val functionName = ConverterUtils.makeFuncName(
       ConverterUtils.SUBTRACT, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(left.dataType, nullable = true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -91,13 +91,13 @@ class MultiplyTransformer(left: Expression, right: Expression, original: Express
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
 
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
 
@@ -105,12 +105,12 @@ class MultiplyTransformer(left: Expression, right: Expression, original: Express
     val functionName = ConverterUtils.makeFuncName(
       ConverterUtils.MULTIPLY, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(left.dataType, nullable = true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -121,13 +121,13 @@ class DivideTransformer(left: Expression, right: Expression,
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
 
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
 
@@ -135,12 +135,12 @@ class DivideTransformer(left: Expression, right: Expression,
     val functionName = ConverterUtils.makeFuncName(
       ConverterUtils.DIVIDE, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(left.dataType, nullable = true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 

--- a/jvm/src/main/scala/io/glutenproject/expression/BinaryExpressionTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/BinaryExpressionTransformer.scala
@@ -18,9 +18,9 @@
 package io.glutenproject.expression
 
 import com.google.common.collect.Lists
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
-
 import io.glutenproject.expression.DateTimeExpressionsTransformer.{DateDiffTransformer, UnixTimestampTransformer}
 import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
@@ -51,7 +51,26 @@ class EndsWithTransformer(left: Expression, right: Expression, original: Express
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    val leftNode =
+      left.asInstanceOf[ExpressionTransformer].doTransform(args)
+    val rightNode =
+      right.asInstanceOf[ExpressionTransformer].doTransform(args)
+
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet.")
+    }
+
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionName = ConverterUtils.makeFuncName(
+      ConverterUtils.ENDS_WITH, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
+    val typeNode = TypeBuilder.makeBoolean(false)
+
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -61,7 +80,26 @@ class StartsWithTransformer(left: Expression, right: Expression, original: Expre
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    val leftNode =
+      left.asInstanceOf[ExpressionTransformer].doTransform(args)
+    val rightNode =
+      right.asInstanceOf[ExpressionTransformer].doTransform(args)
+
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet.")
+    }
+
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionName = ConverterUtils.makeFuncName(
+      ConverterUtils.STARTS_WITH, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
+    val typeNode = TypeBuilder.makeBoolean(false)
+
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -71,24 +109,25 @@ class LikeTransformer(left: Expression, right: Expression, original: Expression)
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
+
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.LIKE, Seq(left.dataType, right.dataType)))
 
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -98,7 +137,28 @@ class ContainsTransformer(left: Expression, right: Expression, original: Express
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    val leftNode =
+      left.asInstanceOf[ExpressionTransformer].doTransform(args)
+    val rightNode =
+      right.asInstanceOf[ExpressionTransformer].doTransform(args)
+
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet.")
+    }
+
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionName = ConverterUtils.makeFuncName(
+      ConverterUtils.CONTAINS, Seq(left.dataType, right.dataType), FunctionConfig.OPT)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
+    val typeNode = TypeBuilder.makeBoolean(false)
+
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
+
+
   }
 }
 

--- a/jvm/src/main/scala/io/glutenproject/expression/BinaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/BinaryOperatorTransformer.scala
@@ -30,12 +30,12 @@ class AndTransformer(left: Expression, right: Expression, original: Expression)
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
@@ -43,8 +43,8 @@ class AndTransformer(left: Expression, right: Expression, original: Expression)
       ConverterUtils.makeFuncName(ConverterUtils.AND, Seq(left.dataType, right.dataType)))
 
     val expressionNodes = new java.util.ArrayList[ExpressionNode]()
-    expressionNodes.add(left_node.asInstanceOf[ExpressionNode])
-    expressionNodes.add(right_node.asInstanceOf[ExpressionNode])
+    expressionNodes.add(leftNode.asInstanceOf[ExpressionNode])
+    expressionNodes.add(rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
     ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
@@ -57,12 +57,12 @@ class OrTransformer(left: Expression, right: Expression, original: Expression)
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
@@ -70,8 +70,8 @@ class OrTransformer(left: Expression, right: Expression, original: Expression)
       ConverterUtils.makeFuncName(ConverterUtils.OR, Seq(left.dataType, right.dataType)))
 
     val expressionNodes = new java.util.ArrayList[ExpressionNode]()
-    expressionNodes.add(left_node.asInstanceOf[ExpressionNode])
-    expressionNodes.add(right_node.asInstanceOf[ExpressionNode])
+    expressionNodes.add(leftNode.asInstanceOf[ExpressionNode])
+    expressionNodes.add(rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
     ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
@@ -84,24 +84,24 @@ class EqualToTransformer(left: Expression, right: Expression, original: Expressi
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.EQUAL, Seq(left.dataType, right.dataType)))
 
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -121,24 +121,24 @@ class LessThanTransformer(left: Expression, right: Expression, original: Express
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.LESS_THAN, Seq(left.dataType, right.dataType)))
 
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -148,24 +148,24 @@ class LessThanOrEqualTransformer(left: Expression, right: Expression, original: 
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, ConverterUtils.makeFuncName(
         ConverterUtils.LESS_THAN_OR_EQUAL, Seq(left.dataType, right.dataType)))
 
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -175,24 +175,24 @@ class GreaterThanTransformer(left: Expression, right: Expression, original: Expr
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.GREATER_THAN, Seq(left.dataType, right.dataType)))
 
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -202,24 +202,24 @@ class GreaterThanOrEqualTransformer(left: Expression, right: Expression, origina
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val left_node =
+    val leftNode =
       left.asInstanceOf[ExpressionTransformer].doTransform(args)
-    val right_node =
+    val rightNode =
       right.asInstanceOf[ExpressionTransformer].doTransform(args)
-    if (!left_node.isInstanceOf[ExpressionNode] ||
-        !right_node.isInstanceOf[ExpressionNode]) {
+    if (!leftNode.isInstanceOf[ExpressionNode] ||
+        !rightNode.isInstanceOf[ExpressionNode]) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, ConverterUtils.makeFuncName(
         ConverterUtils.GREATER_THAN_OR_EQUAL, Seq(left.dataType, right.dataType)))
 
-    val expressNodes = Lists.newArrayList(
-      left_node.asInstanceOf[ExpressionNode],
-      right_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(
+      leftNode.asInstanceOf[ExpressionNode],
+      rightNode.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 

--- a/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -281,4 +281,11 @@ object ConverterUtils extends Logging {
   final val ALIAS = "alias"
   final val IS_NOT_NULL = "is_not_null"
   final val IS_NULL = "is_null"
+  // Below names are not in Substrait yaml.
+  final val ENDS_WITH = "ends_with"
+  final val CONTAINS = "contains"
+  final val IN = "in"
+  final val NOT = "not"
+  final val STARTS_WITH = "starts_with"
+  final val SUBSTRING = "substring"
 }

--- a/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -128,11 +128,12 @@ object ExpressionConverter extends Logging {
         CoalesceOperatorTransformer.create(exprs, expr)
       case i: In =>
         logInfo(s"${expr.getClass} ${expr} is supported")
-        InOperatorTransformer.create(
+        InExpressionTransformer.create(
           replaceWithExpressionTransformer(
             i.value,
             attributeSeq),
-          i.list,
+          i.list.map(value => {
+            replaceWithExpressionTransformer(value, attributeSeq)}),
           expr)
       case i: InSet =>
         logInfo(s"${expr.getClass} ${expr} is supported")

--- a/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -132,8 +132,7 @@ object ExpressionConverter extends Logging {
           replaceWithExpressionTransformer(
             i.value,
             attributeSeq),
-          i.list.map(value => {
-            replaceWithExpressionTransformer(value, attributeSeq)}),
+          i.list,
           expr)
       case i: InSet =>
         logInfo(s"${expr.getClass} ${expr} is supported")

--- a/jvm/src/main/scala/io/glutenproject/expression/InExpressionTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/InExpressionTransformer.scala
@@ -17,12 +17,16 @@
 
 package io.glutenproject.expression
 
+import java.util
+
+import scala.collection.JavaConverters._
 import com.google.common.collect.Lists
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types.{DateType, DoubleType, IntegerType, LongType, StringType}
 
 class InTransformer(value: Expression, list: Seq[Expression], original: Expression)
     extends In(value: Expression, list: Seq[Expression])
@@ -36,17 +40,35 @@ class InTransformer(value: Expression, list: Seq[Expression], original: Expressi
     }
     val expressionNodes = Lists.newArrayList(leftNode.asInstanceOf[ExpressionNode])
 
-    for (expression <- list) {
-      // Only Literal is supported currently.
-      if (!expression.isInstanceOf[Literal]) {
-        throw new UnsupportedOperationException(s"not supported yet.")
-      }
-      val expressionNode = expression.asInstanceOf[ExpressionTransformer].doTransform(args)
-      if (!expressionNode.isInstanceOf[ExpressionNode]) {
-        throw new UnsupportedOperationException(s"not supported yet.")
-      }
-      expressionNodes.add(expressionNode)
+    // Stores the values in a List Literal.
+    val values : Seq[Any] = list.map(value => {
+      value.asInstanceOf[Literal].value
+    })
+    val listNode = value.dataType match {
+      case _: IntegerType =>
+        val valueList = new util.ArrayList[java.lang.Integer](values.map(value =>
+            value.asInstanceOf[java.lang.Integer]).asJava)
+        ExpressionBuilder.makeIntList(valueList)
+      case _: LongType =>
+        val valueList = new util.ArrayList[java.lang.Long](values.map(value =>
+         value.asInstanceOf[java.lang.Long]).asJava)
+        ExpressionBuilder.makeLongList(valueList)
+      case _: DoubleType =>
+        val valueList = new util.ArrayList[java.lang.Double](values.map(value =>
+          value.asInstanceOf[java.lang.Double]).asJava)
+        ExpressionBuilder.makeDoubleList(valueList)
+      case _: DateType =>
+        val valueList = new util.ArrayList[java.lang.Integer](values.map(value =>
+          value.asInstanceOf[java.lang.Integer]).asJava)
+        ExpressionBuilder.makeDateList(valueList)
+      case _: StringType =>
+        val valueList = new util.ArrayList[java.lang.String](values.map(value =>
+          value.toString).asJava)
+        ExpressionBuilder.makeStringList(valueList)
+      case other =>
+        throw new UnsupportedOperationException(s"$other is not supported.")
     }
+    expressionNodes.add(listNode)
 
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionName = ConverterUtils.makeFuncName(

--- a/jvm/src/main/scala/io/glutenproject/expression/NamedExpressionsTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/NamedExpressionsTransformer.scala
@@ -38,10 +38,10 @@ class AliasTransformer(child: Expression, name: String)(
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.ALIAS, Seq(child.dataType)))
-    val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = ConverterUtils.getTypeNode(child.dataType, child.nullable)
 
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 

--- a/jvm/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
@@ -18,10 +18,10 @@
 package io.glutenproject.expression
 
 import com.google.common.collect.Lists
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.expression.DateTimeExpressionsTransformer._
 import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer._
@@ -41,9 +41,9 @@ class IsNotNullTransformer(child: Expression, original: Expression)
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.IS_NOT_NULL, Seq(child.dataType)))
-    val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -61,9 +61,9 @@ class IsNullTransformer(child: Expression, original: Expression)
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
       ConverterUtils.makeFuncName(ConverterUtils.IS_NULL, Seq(child.dataType)))
-    val expressNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
+    val expressionNodes = Lists.newArrayList(child_node.asInstanceOf[ExpressionNode])
     val typeNode = TypeBuilder.makeBoolean(true)
-    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
   }
 }
 
@@ -102,7 +102,19 @@ class NotTransformer(child: Expression, original: Expression)
     with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    throw new UnsupportedOperationException("Not supported.")
+    val childNode = child.asInstanceOf[ExpressionTransformer].doTransform(args)
+    if (!childNode.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet.")
+    }
+
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionName = ConverterUtils.makeFuncName(
+      ConverterUtils.NOT, Seq(child.dataType), FunctionConfig.OPT)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+    val expressNodes = Lists.newArrayList(childNode.asInstanceOf[ExpressionNode])
+    val typeNode = TypeBuilder.makeBoolean(false)
+
+    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR supported below expressions to be transformed into Substrait.
```
EndsWith, EqualTo, Or, Contains, In, Not, Like, StartsWith, Substring
```

Depends on: https://github.com/oap-project/velox/pull/14.

## How was this patch tested?

locally tested

