### PR TITLE
[OPPRO-111] "Connector with ID 'hive-connector' is already registered" reported after renewing Spark SQL session

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -69,6 +69,9 @@ namespace compute {
 
 class VeloxInitializer {
  public:
+  VeloxInitializer() {
+    Init();
+  }
   void Init();
 };
 

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -69,9 +69,7 @@ namespace compute {
 
 class VeloxInitializer {
  public:
-  VeloxInitializer() {
-    Init();
-  }
+  VeloxInitializer() { Init(); }
   void Init();
 };
 

--- a/cpp/velox/jni/jni_wrapper.cc
+++ b/cpp/velox/jni/jni_wrapper.cc
@@ -47,8 +47,7 @@ Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(
     JNIEnv* env, jobject obj) {
   gluten::SetBackendFactory(
       [] { return std::make_shared<::velox::compute::VeloxPlanConverter>(); });
-  auto veloxInitializer = std::make_shared<::velox::compute::VeloxInitializer>();
-  veloxInitializer->Init();
+  static auto veloxInitializer = std::make_shared<::velox::compute::VeloxInitializer>();
 }
 
 JNIEXPORT jboolean JNICALL


### PR DESCRIPTION
```
E0525 22:59:05.028767   212 Exceptions.h:68] Line: ../../velox/connectors/Connector.cpp:56, Function:registerConnector, Expression: okConnector with ID 'hive-connector' is already registered, Source: RUNTIME, ErrorCode: INVALID_STATE
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Connector with ID 'hive-connector' is already registered
Retriable: False
Expression: ok
Function: registerConnector
File: ../../velox/connectors/Connector.cpp
Line: 56
Stack trace:
# 0
# 1
# 2
# 3
# 4
# 5
# 6
```