### PR TITLE
[OPPRO-113] Improve C++ exception handling

### DIFF
--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -53,7 +53,7 @@ std::shared_ptr<gluten::RecordBatchResultIterator> ArrowExecBackend::GetResultIt
     std::vector<std::shared_ptr<gluten::RecordBatchResultIterator>> inputs) {
   GLUTEN_ASSIGN_OR_THROW(auto decls, arrow::engine::ConvertPlan(plan_));
   if (decls.size() != 1) {
-    throw gluten::JniPendingException("Expected 1 decl, but got " +
+    throw gluten::GlutenException("Expected 1 decl, but got " +
                                       std::to_string(decls.size()));
   }
   decl_ = std::make_shared<arrow::compute::Declaration>(std::move(decls[0]));
@@ -64,7 +64,7 @@ std::shared_ptr<gluten::RecordBatchResultIterator> ArrowExecBackend::GetResultIt
     for (auto i = 0; i < inputs.size(); ++i) {
       auto it = schema_map_.find(i);
       if (it == schema_map_.end()) {
-        throw gluten::JniPendingException("Schema not found for input batch iterator " +
+        throw gluten::GlutenException("Schema not found for input batch iterator " +
                                           std::to_string(i));
       }
       auto batch_it = MakeMapIterator(
@@ -179,7 +179,7 @@ void ArrowExecBackend::FieldPathToName(arrow::compute::Expression* expression,
         *expr =
             arrow::compute::field_ref(schema->field((field_path->indices())[0])->name());
       } else {
-        throw gluten::JniPendingException("Field Ref is not field path: " +
+        throw gluten::GlutenException("Field Ref is not field path: " +
                                           field_ref->ToString());
       }
     }
@@ -207,7 +207,7 @@ void ArrowExecBackend::ReplaceSourceDecls(
   }
 
   if (source_indexes.size() != source_decls.size()) {
-    throw gluten::JniPendingException(
+    throw gluten::GlutenException(
         "Wrong number of source declarations. " + std::to_string(source_indexes.size()) +
         " source(s) needed by source declarations, but got " +
         std::to_string(source_decls.size()) + " from input batches.");

--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -54,7 +54,7 @@ std::shared_ptr<gluten::RecordBatchResultIterator> ArrowExecBackend::GetResultIt
   GLUTEN_ASSIGN_OR_THROW(auto decls, arrow::engine::ConvertPlan(plan_));
   if (decls.size() != 1) {
     throw gluten::GlutenException("Expected 1 decl, but got " +
-                                      std::to_string(decls.size()));
+                                  std::to_string(decls.size()));
   }
   decl_ = std::make_shared<arrow::compute::Declaration>(std::move(decls[0]));
 
@@ -65,7 +65,7 @@ std::shared_ptr<gluten::RecordBatchResultIterator> ArrowExecBackend::GetResultIt
       auto it = schema_map_.find(i);
       if (it == schema_map_.end()) {
         throw gluten::GlutenException("Schema not found for input batch iterator " +
-                                          std::to_string(i));
+                                      std::to_string(i));
       }
       auto batch_it = MakeMapIterator(
           [](const std::shared_ptr<arrow::RecordBatch>& batch) {
@@ -180,7 +180,7 @@ void ArrowExecBackend::FieldPathToName(arrow::compute::Expression* expression,
             arrow::compute::field_ref(schema->field((field_path->indices())[0])->name());
       } else {
         throw gluten::GlutenException("Field Ref is not field path: " +
-                                          field_ref->ToString());
+                                      field_ref->ToString());
       }
     }
   }

--- a/cpp/gazelle-cpp/jni/jni_wrapper.cc
+++ b/cpp/gazelle-cpp/jni/jni_wrapper.cc
@@ -20,6 +20,8 @@
 #include "compute/substrait_arrow.h"
 #include "compute/substrait_utils.h"
 
+#include "jni/jni_errors.h"
+
 static jint JNI_VERSION = JNI_VERSION_1_8;
 
 #ifdef __cplusplus
@@ -31,6 +33,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
     return JNI_ERR;
   }
+  gluten::GetJniErrorsState()->Initialize(env);
   std::cout << "loaded gazelle_cpp" << std::endl;
   return JNI_VERSION;
 }
@@ -43,15 +46,19 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 JNIEXPORT void JNICALL
 Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(
     JNIEnv* env, jobject obj) {
+  JNI_METHOD_START
   gazellecpp::compute::Initialize();
   gluten::SetBackendFactory(
       [] { return std::make_shared<gazellecpp::compute::ArrowExecBackend>(); });
+  JNI_METHOD_END()
 }
 
 JNIEXPORT jboolean JNICALL
 Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
     JNIEnv* env, jobject obj, jbyteArray planArray) {
+  JNI_METHOD_START
   return true;
+  JNI_METHOD_END(false)
 }
 
 #ifdef __cplusplus

--- a/cpp/gazelle-cpp/jni/jni_wrapper.cc
+++ b/cpp/gazelle-cpp/jni/jni_wrapper.cc
@@ -19,7 +19,6 @@
 
 #include "compute/substrait_arrow.h"
 #include "compute/substrait_utils.h"
-
 #include "jni/jni_errors.h"
 
 static jint JNI_VERSION = JNI_VERSION_1_8;

--- a/cpp/src/compute/substrait_utils.h
+++ b/cpp/src/compute/substrait_utils.h
@@ -34,20 +34,20 @@ namespace compute {
 class SubstraitParser : public ExecBackendBase {
  public:
   SubstraitParser();
-  void ParseLiteral(const substrait::Expression::Literal& slit);
-  void ParseScalarFunction(const substrait::Expression::ScalarFunction& sfunc);
-  void ParseReferenceSegment(const substrait::Expression::ReferenceSegment& sref);
-  void ParseFieldReference(const substrait::Expression::FieldReference& sfield);
-  void ParseExpression(const substrait::Expression& sexpr);
-  void ParseType(const substrait::Type& stype);
-  void ParseNamedStruct(const substrait::NamedStruct& named_struct);
-  void ParseAggregateRel(const substrait::AggregateRel& sagg);
-  void ParseProjectRel(const substrait::ProjectRel& sproject);
-  void ParseFilterRel(const substrait::FilterRel& sfilter);
-  void ParseReadRel(const substrait::ReadRel& sread);
-  void ParseRelRoot(const substrait::RelRoot& sroot);
-  void ParseRel(const substrait::Rel& srel);
-  void ParsePlan(const substrait::Plan& splan);
+  void ParseLiteral(const ::substrait::Expression::Literal& slit);
+  void ParseScalarFunction(const ::substrait::Expression::ScalarFunction& sfunc);
+  void ParseReferenceSegment(const ::substrait::Expression::ReferenceSegment& sref);
+  void ParseFieldReference(const ::substrait::Expression::FieldReference& sfield);
+  void ParseExpression(const ::substrait::Expression& sexpr);
+  void ParseType(const ::substrait::Type& stype);
+  void ParseNamedStruct(const ::substrait::NamedStruct& named_struct);
+  void ParseAggregateRel(const ::substrait::AggregateRel& sagg);
+  void ParseProjectRel(const ::substrait::ProjectRel& sproject);
+  void ParseFilterRel(const ::substrait::FilterRel& sfilter);
+  void ParseReadRel(const ::substrait::ReadRel& sread);
+  void ParseRelRoot(const ::substrait::RelRoot& sroot);
+  void ParseRel(const ::substrait::Rel& srel);
+  void ParsePlan(const ::substrait::Plan& splan);
   std::shared_ptr<RecordBatchResultIterator> GetResultIterator() override;
   std::shared_ptr<RecordBatchResultIterator> GetResultIterator(
       std::vector<std::shared_ptr<RecordBatchResultIterator>> inputs) override;

--- a/cpp/src/jni/exec_backend.h
+++ b/cpp/src/jni/exec_backend.h
@@ -93,7 +93,7 @@ class RecordBatchResultIterator : public ResultIteratorBase<arrow::RecordBatch> 
 
   inline void CheckValid() {
     if (iter_ == nullptr) {
-      throw JniPendingException(
+      throw GlutenException(
           "RecordBatchResultIterator: the underlying iterator has expired.");
     }
   }
@@ -139,7 +139,7 @@ class ExecBackendBase : public std::enable_shared_from_this<ExecBackendBase> {
             // TODO: remove arrow::Status
             GLUTEN_THROW_NOT_OK(GetIterInputSchemaFromRel(sroot.input()));
           } else {
-            throw JniPendingException("Expect Rel as input.");
+            throw GlutenException("Expect Rel as input.");
           }
         }
         if (srel.has_rel()) {

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -15,11 +15,16 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <arrow/builder.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/io/memory.h>
 #include <arrow/util/parallel.h>
 #include <gandiva/arrow.h>
 #include <gandiva/gandiva_aliases.h>
@@ -37,43 +42,21 @@
 #include "compute/protobuf_utils.h"
 #include "compute/substrait_utils.h"
 
-static jclass io_exception_class;
-static jclass runtime_exception_class;
-static jclass unsupportedoperation_exception_class;
-static jclass illegal_access_exception_class;
-static jclass illegal_argument_exception_class;
-
 jclass CreateGlobalClassReference(JNIEnv* env, const char* class_name) {
   jclass local_class = env->FindClass(class_name);
   jclass global_class = (jclass)env->NewGlobalRef(local_class);
   env->DeleteLocalRef(local_class);
-  if (global_class == nullptr) {
-    std::string error_message =
-        "Unable to createGlobalClassReference for" + std::string(class_name);
-    env->ThrowNew(illegal_access_exception_class, error_message.c_str());
-  }
   return global_class;
 }
 
 jmethodID GetMethodID(JNIEnv* env, jclass this_class, const char* name, const char* sig) {
   jmethodID ret = env->GetMethodID(this_class, name, sig);
-  if (ret == nullptr) {
-    std::string error_message = "Unable to find method " + std::string(name) +
-                                " within signature" + std::string(sig);
-    env->ThrowNew(illegal_access_exception_class, error_message.c_str());
-  }
-
   return ret;
 }
 
 jmethodID GetStaticMethodID(JNIEnv* env, jclass this_class, const char* name,
                             const char* sig) {
   jmethodID ret = env->GetStaticMethodID(this_class, name, sig);
-  if (ret == nullptr) {
-    std::string error_message = "Unable to find static method " + std::string(name) +
-                                " within signature" + std::string(sig);
-    env->ThrowNew(illegal_access_exception_class, error_message.c_str());
-  }
   return ret;
 }
 
@@ -316,7 +299,7 @@ jbyteArray ToSchemaByteArray(JNIEnv* env, std::shared_ptr<arrow::Schema> schema)
   if (!status.ok()) {
     std::string error_message =
         "Unable to convert schema to byte array, err is " + status.message();
-    env->ThrowNew(io_exception_class, error_message.c_str());
+    throw gluten::GlutenException(error_message);
   }
   auto buffer = *std::move(maybe_buffer);
   jbyteArray out = env->NewByteArray(buffer->size());

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -18,13 +18,13 @@
 #pragma once
 
 #include <arrow/builder.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/ipc/writer.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
-#include <arrow/ipc/reader.h>
-#include <arrow/ipc/writer.h>
-#include <arrow/io/memory.h>
 #include <arrow/util/parallel.h>
 #include <gandiva/arrow.h>
 #include <gandiva/gandiva_aliases.h>

--- a/cpp/src/jni/jni_errors.h
+++ b/cpp/src/jni/jni_errors.h
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+#include "utils/exception.h"
+#include "jni_common.h"
+
+#define JNI_METHOD_START try {
+// macro ended
+
+#define JNI_METHOD_END(fallback_expr)                                               \
+  }                                                                                 \
+  catch (std::exception & e) {                                                      \
+    env->ThrowNew(gluten::GetJniErrorsState()->RuntimeExceptionClass(), e.what());  \
+    return fallback_expr;                                                           \
+  }
+// macro ended
+
+namespace gluten {
+
+class JniPendingException : public std::runtime_error {
+ public:
+  explicit JniPendingException(const std::string& arg) : runtime_error(arg) {}
+};
+
+void ThrowPendingException(const std::string& message) {
+  throw JniPendingException(message);
+}
+
+template <typename T>
+T JniGetOrThrow(arrow::Result<T> result) {
+  if (!result.status().ok()) {
+    ThrowPendingException(result.status().message());
+  }
+  return std::move(result).ValueOrDie();
+}
+
+template <typename T>
+T JniGetOrThrow(arrow::Result<T> result, const std::string& message) {
+  if (!result.status().ok()) {
+    ThrowPendingException(message + " - " + result.status().message());
+  }
+  return std::move(result).ValueOrDie();
+}
+
+void JniAssertOkOrThrow(arrow::Status status) {
+  if (!status.ok()) {
+    ThrowPendingException(status.message());
+  }
+}
+
+void JniAssertOkOrThrow(arrow::Status status, const std::string& message) {
+  if (!status.ok()) {
+    ThrowPendingException(message + " - " + status.message());
+  }
+}
+
+void JniThrow(const std::string& message) { ThrowPendingException(message); }
+
+static struct JniErrorsGlobalState {
+ public:
+  virtual ~JniErrorsGlobalState() = default;
+
+  void Initialize(JNIEnv* env) {
+    std::lock_guard<std::mutex> lock_guard(mtx_);
+    io_exception_class_ = CreateGlobalClassReference(env, "Ljava/io/IOException;");
+    runtime_exception_class_ =
+        CreateGlobalClassReference(env, "Ljava/lang/RuntimeException;");
+    unsupportedoperation_exception_class_ =
+        CreateGlobalClassReference(env, "Ljava/lang/UnsupportedOperationException;");
+    illegal_access_exception_class_ =
+        CreateGlobalClassReference(env, "Ljava/lang/IllegalAccessException;");
+    illegal_argument_exception_class_ =
+        CreateGlobalClassReference(env, "Ljava/lang/IllegalArgumentException;");
+  }
+
+  jclass RuntimeExceptionClass() {
+    std::lock_guard<std::mutex> lock_guard(mtx_);
+    if (runtime_exception_class_ == nullptr) {
+      throw gluten::GlutenException("Fatal: JniGlobalState::Initialize(...) was not called before using the utility");
+    }
+    return runtime_exception_class_;
+  }
+
+  jclass IllegalAccessExceptionClass() {
+    std::lock_guard<std::mutex> lock_guard(mtx_);
+    if (illegal_access_exception_class_ == nullptr) {
+      throw gluten::GlutenException("Fatal: JniGlobalState::Initialize(...) was not called before using the utility");
+    }
+    return illegal_access_exception_class_;
+  }
+
+ private:
+  jclass io_exception_class_ = nullptr;
+  jclass runtime_exception_class_ = nullptr;
+  jclass unsupportedoperation_exception_class_ = nullptr;
+  jclass illegal_access_exception_class_ = nullptr;
+  jclass illegal_argument_exception_class_ = nullptr;
+  std::mutex mtx_;
+
+} jni_errors_state;
+
+static JniErrorsGlobalState* GetJniErrorsState() {
+  return &jni_errors_state;
+}
+
+}  // namespace gluten
+

--- a/cpp/src/jni/jni_errors.h
+++ b/cpp/src/jni/jni_errors.h
@@ -19,17 +19,17 @@
 
 #include <stdexcept>
 
-#include "utils/exception.h"
 #include "jni_common.h"
+#include "utils/exception.h"
 
 #define JNI_METHOD_START try {
 // macro ended
 
-#define JNI_METHOD_END(fallback_expr)                                               \
-  }                                                                                 \
-  catch (std::exception & e) {                                                      \
-    env->ThrowNew(gluten::GetJniErrorsState()->RuntimeExceptionClass(), e.what());  \
-    return fallback_expr;                                                           \
+#define JNI_METHOD_END(fallback_expr)                                              \
+  }                                                                                \
+  catch (std::exception & e) {                                                     \
+    env->ThrowNew(gluten::GetJniErrorsState()->RuntimeExceptionClass(), e.what()); \
+    return fallback_expr;                                                          \
   }
 // macro ended
 
@@ -94,7 +94,9 @@ static struct JniErrorsGlobalState {
   jclass RuntimeExceptionClass() {
     std::lock_guard<std::mutex> lock_guard(mtx_);
     if (runtime_exception_class_ == nullptr) {
-      throw gluten::GlutenException("Fatal: JniGlobalState::Initialize(...) was not called before using the utility");
+      throw gluten::GlutenException(
+          "Fatal: JniGlobalState::Initialize(...) was not called before using the "
+          "utility");
     }
     return runtime_exception_class_;
   }
@@ -102,7 +104,9 @@ static struct JniErrorsGlobalState {
   jclass IllegalAccessExceptionClass() {
     std::lock_guard<std::mutex> lock_guard(mtx_);
     if (illegal_access_exception_class_ == nullptr) {
-      throw gluten::GlutenException("Fatal: JniGlobalState::Initialize(...) was not called before using the utility");
+      throw gluten::GlutenException(
+          "Fatal: JniGlobalState::Initialize(...) was not called before using the "
+          "utility");
     }
     return illegal_access_exception_class_;
   }
@@ -117,9 +121,6 @@ static struct JniErrorsGlobalState {
 
 } jni_errors_state;
 
-static JniErrorsGlobalState* GetJniErrorsState() {
-  return &jni_errors_state;
-}
+static JniErrorsGlobalState* GetJniErrorsState() { return &jni_errors_state; }
 
 }  // namespace gluten
-

--- a/cpp/src/utils/exception.h
+++ b/cpp/src/utils/exception.h
@@ -25,7 +25,7 @@
   do {                                                          \
     ::arrow::Status _s = ::arrow::internal::GenericToStatus(s); \
     if (!_s.ok()) {                                             \
-      throw ::gluten::JniPendingException(_s.ToString());       \
+      throw gluten::GlutenException(_s.ToString());             \
     }                                                           \
   } while (0)
 
@@ -40,9 +40,9 @@
 
 namespace gluten {
 
-class JniPendingException : public std::runtime_error {
+class GlutenException : public std::runtime_error {
  public:
-  explicit JniPendingException(const std::string& arg) : runtime_error(arg) {}
+  explicit GlutenException(const std::string& arg) : runtime_error(arg) {}
 };
 
 }  // namespace gluten

--- a/cpp/src/utils/macros.h
+++ b/cpp/src/utils/macros.h
@@ -42,7 +42,7 @@
     auto start = std::chrono::steady_clock::now();                                      \
     auto __s = (expr);                                                                  \
     if (!__s.ok()) {                                                                    \
-      throw JniPendingException(__s.message());                                         \
+      throw GlutenException(__s.message());                                         \
     }                                                                                   \
     auto end = std::chrono::steady_clock::now();                                        \
     time += std::chrono::duration_cast<std::chrono::microseconds>(end - start).count(); \
@@ -72,7 +72,7 @@
     auto start = std::chrono::steady_clock::now();                                     \
     auto __s = (expr);                                                                 \
     if (!__s.ok()) {                                                                   \
-      throw JniPendingException(__s.message());                                        \
+      throw GlutenException(__s.message());                                        \
     }                                                                                  \
     auto end = std::chrono::steady_clock::now();                                       \
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count(); \
@@ -92,7 +92,7 @@
   do {                                          \
     auto __s = (expr);                          \
     if (!__s.ok()) {                            \
-      throw JniPendingException(__s.message()); \
+      throw GlutenException(__s.message()); \
     }                                           \
   } while (false);
 

--- a/cpp/src/utils/macros.h
+++ b/cpp/src/utils/macros.h
@@ -42,7 +42,7 @@
     auto start = std::chrono::steady_clock::now();                                      \
     auto __s = (expr);                                                                  \
     if (!__s.ok()) {                                                                    \
-      throw GlutenException(__s.message());                                         \
+      throw GlutenException(__s.message());                                             \
     }                                                                                   \
     auto end = std::chrono::steady_clock::now();                                        \
     time += std::chrono::duration_cast<std::chrono::microseconds>(end - start).count(); \
@@ -72,7 +72,7 @@
     auto start = std::chrono::steady_clock::now();                                     \
     auto __s = (expr);                                                                 \
     if (!__s.ok()) {                                                                   \
-      throw GlutenException(__s.message());                                        \
+      throw GlutenException(__s.message());                                            \
     }                                                                                  \
     auto end = std::chrono::steady_clock::now();                                       \
     time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count(); \
@@ -88,12 +88,12 @@
   }                                    \
   std::cout << std::endl;
 
-#define THROW_NOT_OK(expr)                      \
-  do {                                          \
-    auto __s = (expr);                          \
-    if (!__s.ok()) {                            \
+#define THROW_NOT_OK(expr)                  \
+  do {                                      \
+    auto __s = (expr);                      \
+    if (!__s.ok()) {                        \
       throw GlutenException(__s.message()); \
-    }                                           \
+    }                                       \
   } while (false);
 
 #define TIME_TO_STRING(time) \

--- a/cpp/velox/jni/jni_wrapper.cc
+++ b/cpp/velox/jni/jni_wrapper.cc
@@ -18,9 +18,8 @@
 #include <jni.h>
 
 #include "compute/VeloxPlanConverter.h"
-#include "velox/substrait/SubstraitToVeloxPlanValidator.h"
-
 #include "jni/jni_errors.h"
+#include "velox/substrait/SubstraitToVeloxPlanValidator.h"
 
 static jint JNI_VERSION = JNI_VERSION_1_8;
 


### PR DESCRIPTION
Including follow:

1. Catch all std::exception at JNI entrypoints;
2. Let all modules be able to access the exception utils as well as the main module.