### PR TITLE
[OPPRO-105] Fix the early release of memory pool

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -27,6 +27,7 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/functions/prestosql/aggregates/AverageAggregate.h"
 #include "velox/functions/prestosql/aggregates/CountAggregate.h"
+#include "velox/functions/prestosql/aggregates/MinMaxAggregates.h"
 #include "velox/functions/sparksql/Register.h"
 
 using namespace facebook::velox;
@@ -55,6 +56,10 @@ void VeloxInitializer::Init() {
   aggregate::registerSumAggregate<aggregate::SumAggregate>("sum");
   aggregate::registerAverageAggregate("avg");
   aggregate::registerCountAggregate("count");
+  aggregate::registerMinMaxAggregate<aggregate::MinAggregate,
+                                     aggregate::NonNumericMinAggregate>("min");
+  aggregate::registerMinMaxAggregate<aggregate::MaxAggregate,
+                                     aggregate::NonNumericMaxAggregate>("max");
 }
 
 void VeloxPlanConverter::setInputPlanNode(const ::substrait::AggregateRel& sagg) {

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -93,6 +93,7 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
   }
 
  private:
+  std::unique_ptr<memory::MemoryPool> veloxPool_{memory::getDefaultScopedMemoryPool()};
   int planNodeId_ = 0;
   bool fakeArrowOutput_ = false;
   bool dsAsInput_ = true;
@@ -118,7 +119,8 @@ class VeloxPlanConverter : public gluten::ExecBackendBase {
       std::make_shared<facebook::velox::substrait::SubstraitParser>();
   std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter>
       subVeloxPlanConverter_ =
-          std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>();
+          std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(
+              veloxPool_.get());
 
   /* Result Iterator */
   class WholeStageResIter;

--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -79,7 +79,6 @@ void VeloxToRowConverter::ResumeVeloxVector() {
       throw std::runtime_error("Failed to export from Arrow record batch");
     }
     VectorPtr vec = importFromArrowAsViewer(c_schema, c_array);
-    // auto& pool = *velox_pool_;
     vecs_.push_back(vec);
   }
 }

--- a/cpp/velox/compute/VeloxToRowConverter.h
+++ b/cpp/velox/compute/VeloxToRowConverter.h
@@ -41,11 +41,10 @@ class VeloxToRowConverter : public gluten::columnartorow::ColumnarToRowConverter
   arrow::Status Write() override;
 
  private:
+  void ResumeVeloxVector();
+
   std::vector<VectorPtr> vecs_;
   std::shared_ptr<arrow::Schema> schema_;
-  std::unique_ptr<memory::MemoryPool> velox_pool_{memory::getDefaultScopedMemoryPool()};
-
-  void ResumeVeloxVector();
 };
 
 }  // namespace compute

--- a/cpp/velox/jni/jni_wrapper.cc
+++ b/cpp/velox/jni/jni_wrapper.cc
@@ -59,8 +59,18 @@ Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
   auto planSize = env->GetArrayLength(planArray);
   ::substrait::Plan subPlan;
   ParseProtobuf(planData, planSize, &subPlan);
+
+  // A query context used for function validation.
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  // A memory pool used for function validation.
+  std::unique_ptr<memory::MemoryPool> pool_ = memory::getDefaultScopedMemoryPool();
+  // An execution context used for function validation.
+  std::unique_ptr<core::ExecCtx> execCtx_ =
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
+
   auto planValidator =
-      std::make_shared<facebook::velox::substrait::SubstraitToVeloxPlanValidator>();
+      std::make_shared<facebook::velox::substrait::SubstraitToVeloxPlanValidator>(
+          pool_.get(), execCtx_.get());
   return planValidator->validate(subPlan);
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found segfault in Velox's pool free. Fixed this issue by expanding the life time of Velox's memory pool.
Register min and max.

Depends on: https://github.com/oap-project/velox/pull/14.


## How was this patch tested?

Verified TPC-H on Jenkins.
