### PR TITLE
[OPPRO-104] Separate and push down filter conditions

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -18,15 +18,14 @@ package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.backendsapi.ISparkPlanExecApi
 import io.glutenproject.GlutenConfig
-import io.glutenproject.execution.{NativeColumnarToRowExec, RowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, FilterExecTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
 import io.glutenproject.vectorized.CHColumnarBatchSerializer
 import org.apache.spark.ShuffleDependency
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.shuffle.utils.CHShuffleUtil
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -56,6 +55,16 @@ class CHSparkPlanExecApi extends ISparkPlanExecApi {
   override def genRowToArrowColumnarExec(child: SparkPlan): RowToArrowColumnarExec =
     throw new UnsupportedOperationException(
       "Cannot support RowToArrowColumnarExec operation with ClickHouse backend.")
+
+  /**
+   * Generate FilterExecTransformer.
+   *
+   * @param condition: the filter condition
+   * @param child: the chid of FilterExec
+   * @return the transformer of FilterExec
+   */
+  override def genFilterExecTransformer(condition: Expression, child: SparkPlan)
+    : FilterExecBaseTransformer = FilterExecTransformer(condition, child)
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -17,18 +17,16 @@
 package io.glutenproject.backendsapi.velox
 
 import scala.collection.JavaConverters._
-
 import io.glutenproject.backendsapi.ISparkPlanExecApi
 import io.glutenproject.GlutenConfig
-import io.glutenproject.execution.{NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxFilterExecTransformer, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
 import io.glutenproject.vectorized.ArrowColumnarBatchSerializer
 import org.apache.spark.ShuffleDependency
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.shuffle.utils.VeloxShuffleUtil
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -55,6 +53,16 @@ class VeloxSparkPlanExecApi extends ISparkPlanExecApi {
    */
   override def genRowToArrowColumnarExec(child: SparkPlan): RowToArrowColumnarExec =
     new VeloxRowToArrowColumnarExec(child)
+
+  /**
+   * Generate FilterExecTransformer.
+   *
+   * @param condition: the filter condition
+   * @param child: the chid of FilterExec
+   * @return the transformer of FilterExec
+   */
+  override def genFilterExecTransformer(condition: Expression, child: SparkPlan)
+    : FilterExecBaseTransformer = VeloxFilterExecTransformer(condition, child)
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxFilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxFilterExecTransformer.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import java.util
+
+import com.google.common.collect.Lists
+import io.glutenproject.GlutenConfig
+import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.plan.PlanBuilder
+import io.glutenproject.substrait.rel.RelBuilder
+import io.glutenproject.vectorized.ExpressionEvaluator
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Expression}
+import org.apache.spark.sql.execution.SparkPlan
+
+import scala.collection.JavaConverters._
+
+case class VeloxFilterExecTransformer(condition: Expression,
+                                      child: SparkPlan)
+  extends FilterExecBaseTransformer(condition, child) {
+
+  def getLeftCondition : Expression = {
+    val scanFilters = child match {
+      // Get the filters including the manually pushed down ones.
+      case batchScanTransformer: BatchScanExecTransformer =>
+        batchScanTransformer.filterExprs()
+      case fileScanTransformer: FileSourceScanExecTransformer =>
+        fileScanTransformer.filterExprs()
+      // In ColumnarGuardRules, the child is still row-based. Need to get the original filters.
+      case _ =>
+        FilterHandler.getScanFilters(child)
+    }
+    if (scanFilters.isEmpty) {
+      condition
+    } else {
+      val leftFilters = FilterHandler.getLeftFilters(
+        scanFilters, FilterHandler.flattenCondition(condition))
+      leftFilters.reduceLeftOption(And).orNull
+    }
+  }
+
+  override def doValidate(): Boolean = {
+    val leftCondition = getLeftCondition
+    if (leftCondition == null) {
+      // All the filters can be pushed down and the computing of this Filter
+      // is not needed.
+      return true
+    }
+    val substraitContext = new SubstraitContext
+    // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
+    val relNode = try {
+      getRelNode(substraitContext.registeredFunction, leftCondition, child.output,
+        null, validation = true)
+    } catch {
+      case e: Throwable =>
+        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        return false
+    }
+    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
+    // Then, validate the generated plan in native engine.
+    if (GlutenConfig.getConf.enableNativeValidation) {
+      val validator = new ExpressionEvaluator()
+      validator.doValidate(planNode.toProtobuf.toByteArray)
+    } else {
+      true
+    }
+  }
+
+  override def doTransform(context: SubstraitContext): TransformContext = {
+    val leftCondition = getLeftCondition
+    val childCtx = child match {
+      case c: TransformSupport =>
+        c.doTransform(context)
+      case _ =>
+        null
+    }
+    if (leftCondition == null) {
+      // The computing for this filter is not needed.
+      return childCtx
+    }
+    val currRel = if (childCtx != null) {
+      getRelNode(context.registeredFunction, leftCondition, child.output,
+        childCtx.root, validation = false)
+    } else {
+      // This means the input is just an iterator, so an ReadRel will be created as child.
+      // Prepare the input schema.
+      val attrList = new util.ArrayList[Attribute](child.output.asJava)
+      getRelNode(context.registeredFunction, leftCondition, child.output,
+        RelBuilder.makeReadRel(attrList, context), validation = false)
+    }
+    if (currRel == null) {
+      return childCtx
+    }
+    val inputAttributes = if (childCtx != null) {
+      // Use the outputAttributes of child context as inputAttributes.
+      childCtx.outputAttributes
+    } else {
+      child.output
+    }
+    TransformContext(inputAttributes, output, currRel)
+  }
+}

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
@@ -16,13 +16,12 @@
 
 package io.glutenproject.backendsapi
 
-import io.glutenproject.execution.{NativeColumnarToRowExec, RowToArrowColumnarExec}
-
+import io.glutenproject.execution.{FilterExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -46,6 +45,16 @@ trait ISparkPlanExecApi extends IBackendsApi {
    * @return
    */
   def genRowToArrowColumnarExec(child: SparkPlan): RowToArrowColumnarExec
+
+  /**
+   * Generate FilterExecTransformer.
+   *
+   * @param condition: the filter condition
+   * @param child: the chid of FilterExec
+   * @return the transformer of FilterExec
+   */
+  def genFilterExecTransformer(condition: Expression, child: SparkPlan)
+    : FilterExecBaseTransformer
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/jvm/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -26,7 +26,6 @@ import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.GlutenConfig
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter, ExpressionTransformer}
-import io.glutenproject.extension.filterSeparator
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
@@ -43,7 +42,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.collection.JavaConverters._
 
-case class FilterExecTransformer(
+abstract class FilterExecBaseTransformer(
     condition: Expression,
     child: SparkPlan) extends UnaryExecNode
     with TransformSupport
@@ -61,52 +60,7 @@ case class FilterExecTransformer(
     "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "input_batches"),
     "processTime" -> SQLMetrics.createTimingMetric(sparkContext, "totaltime_filter"))
 
-  def getLeftCondition : Expression = {
-    val scanFilters = child match {
-      // Get the filters including the manually pushed down ones.
-      case batchScanTransformer: BatchScanExecTransformer =>
-        batchScanTransformer.filterExprs()
-      case fileScanTransformer: FileSourceScanExecTransformer =>
-        fileScanTransformer.filterExprs()
-      // In ColumnarGuardRules, the child is still row-based. Need to get the original filters.
-      case _ =>
-        filterSeparator.getScanFilters(child)
-    }
-    if (scanFilters.isEmpty) {
-      condition
-    } else {
-      val leftFilters = filterSeparator.getLeftFilters(
-        scanFilters, filterSeparator.flattenCondition(condition))
-      leftFilters.reduceLeftOption(And).orNull
-    }
-  }
-
-  override def doValidate(): Boolean = {
-    val leftCondition = getLeftCondition
-    if (leftCondition == null) {
-      // All the filters can be pushed down and the computing of this Filter
-      // is not needed.
-      return true
-    }
-    val substraitContext = new SubstraitContext
-    // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
-    val relNode = try {
-      getRelNode(substraitContext.registeredFunction, leftCondition, child.output,
-        null, validation = true)
-    } catch {
-      case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
-        return false
-    }
-    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-    // Then, validate the generated plan in native engine.
-    if (GlutenConfig.getConf.enableNativeValidation) {
-      val validator = new ExpressionEvaluator()
-      validator.doValidate(planNode.toProtobuf.toByteArray)
-    } else {
-      true
-    }
-  }
+  def doValidate(): Boolean
 
   def isNullIntolerant(expr: Expression): Boolean = expr match {
     case e: NullIntolerant => e.children.forall(isNullIntolerant)
@@ -166,39 +120,7 @@ case class FilterExecTransformer(
 
   // override def canEqual(that: Any): Boolean = false
 
-  override def doTransform(context: SubstraitContext): TransformContext = {
-    val leftCondition = getLeftCondition
-    val childCtx = child match {
-      case c: TransformSupport =>
-        c.doTransform(context)
-      case _ =>
-        null
-    }
-    if (leftCondition == null) {
-      // The computing for this filter is not needed.
-      return childCtx
-    }
-    val currRel = if (childCtx != null) {
-      getRelNode(context.registeredFunction, leftCondition, child.output,
-        childCtx.root, validation = false)
-    } else {
-      // This means the input is just an iterator, so an ReadRel will be created as child.
-      // Prepare the input schema.
-      val attrList = new util.ArrayList[Attribute](child.output.asJava)
-      getRelNode(context.registeredFunction, leftCondition, child.output,
-        RelBuilder.makeReadRel(attrList, context), validation = false)
-    }
-    if (currRel == null) {
-      return childCtx
-    }
-    val inputAttributes = if (childCtx != null) {
-      // Use the outputAttributes of child context as inputAttributes.
-      childCtx.outputAttributes
-    } else {
-      child.output
-    }
-    TransformContext(inputAttributes, output, currRel)
-  }
+  def doTransform(context: SubstraitContext): TransformContext
 
   protected override def doExecute()
       : org.apache.spark.rdd.RDD[org.apache.spark.sql.catalyst.InternalRow] = {
@@ -233,6 +155,68 @@ case class FilterExecTransformer(
         Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
       RelBuilder.makeFilterRel(input, condExprNode, extensionNode)
     }
+  }
+}
+
+case class FilterExecTransformer(condition: Expression, child: SparkPlan)
+  extends FilterExecBaseTransformer(condition, child) {
+
+  override def doValidate(): Boolean = {
+    if (condition == null) {
+      // The computing of this Filter is not needed.
+      return true
+    }
+    val substraitContext = new SubstraitContext
+    // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
+    val relNode = try {
+      getRelNode(substraitContext.registeredFunction, condition, child.output,
+        null, validation = true)
+    } catch {
+      case e: Throwable =>
+        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        return false
+    }
+    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
+    // Then, validate the generated plan in native engine.
+    if (GlutenConfig.getConf.enableNativeValidation) {
+      val validator = new ExpressionEvaluator()
+      validator.doValidate(planNode.toProtobuf.toByteArray)
+    } else {
+      true
+    }
+  }
+
+  override def doTransform(context: SubstraitContext): TransformContext = {
+    val childCtx = child match {
+      case c: TransformSupport =>
+        c.doTransform(context)
+      case _ =>
+        null
+    }
+    if (condition == null) {
+      // The computing for this filter is not needed.
+      return childCtx
+    }
+    val currRel = if (childCtx != null) {
+      getRelNode(context.registeredFunction, condition, child.output,
+        childCtx.root, validation = false)
+    } else {
+      // This means the input is just an iterator, so an ReadRel will be created as child.
+      // Prepare the input schema.
+      val attrList = new util.ArrayList[Attribute](child.output.asJava)
+      getRelNode(context.registeredFunction, condition, child.output,
+        RelBuilder.makeReadRel(attrList, context), validation = false)
+    }
+    if (currRel == null) {
+      return childCtx
+    }
+    val inputAttributes = if (childCtx != null) {
+      // Use the outputAttributes of child context as inputAttributes.
+      childCtx.outputAttributes
+    } else {
+      child.output
+    }
+    TransformContext(inputAttributes, output, currRel)
   }
 }
 
@@ -437,5 +421,98 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
 
   override def doTransform(context: SubstraitContext): TransformContext = {
     throw new UnsupportedOperationException(s"This operator doesn't support doTransform.")
+  }
+}
+
+/** Contains functions for the comparision and separation of the filter conditions
+ * in Scan and Filter.
+ * Contains the function to manually push down the conditions into Scan.
+ */
+object FilterHandler {
+  /** Get the original filter conditions in Scan for the comparison with those in Filter.
+   *
+   * @param plan: the Spark plan
+   * @return If the plan is FileSourceScanExec or BatchScanExec, return the filter conditions in it.
+   *         Otherwise, return empty sequence.
+   */
+  def getScanFilters(plan: SparkPlan): Seq[Expression] = {
+    plan match {
+      case fileSourceScan: FileSourceScanExec =>
+        fileSourceScan.dataFilters
+      case batchScan: BatchScanExec =>
+        batchScan.scan match {
+          case scan: FileScan =>
+            scan.dataFilters
+          case _ =>
+            throw new UnsupportedOperationException(
+              s"${batchScan.scan.getClass.toString} is not supported")
+        }
+      case _ =>
+        Seq()
+    }
+  }
+
+  /** Flatten the condition connected with 'And'. Return the filter conditions with sequence.
+   *
+   * @param condition: the condition connected with 'And'
+   * @return flattened conditions in sequence
+   */
+  def flattenCondition(condition: Expression) : Seq[Expression] = {
+    var expressions: Seq[Expression] = Seq()
+    condition match {
+      case and: And =>
+        and.children.foreach(expression => {
+          expressions ++= flattenCondition(expression)
+        })
+      case _ =>
+        expressions = expressions :+ condition
+    }
+    expressions
+  }
+
+  /** Compare the semantics of the filter conditions pushed down to Scan and in the Filter.
+   *
+   * @param scanFilters: the conditions pushed down into Scan
+   * @param filters: the conditions in the Filter after the Scan
+   * @return the filter conditions not pushed down into Scan.
+   */
+  def getLeftFilters(scanFilters: Seq[Expression], filters: Seq[Expression]): Seq[Expression] = {
+    var leftFilters: Seq[Expression] = Seq()
+    for (expression <- filters) {
+      if (!scanFilters.exists(_.semanticEquals(expression))) {
+        leftFilters = leftFilters :+ expression.clone()
+      }
+    }
+    leftFilters
+  }
+
+  // Separate and compare the filter conditions in Scan and Filter.
+  // Push down the left conditions in Filter into Scan.
+  def applyFilterPushdownToScan(plan: FilterExec): SparkPlan = plan.child match {
+    case fileSourceScan: FileSourceScanExec =>
+      val leftFilters =
+        getLeftFilters(fileSourceScan.dataFilters, flattenCondition(plan.condition))
+      new FileSourceScanExecTransformer(
+        fileSourceScan.relation,
+        fileSourceScan.output,
+        fileSourceScan.requiredSchema,
+        fileSourceScan.partitionFilters,
+        fileSourceScan.optionalBucketSet,
+        fileSourceScan.optionalNumCoalescedBuckets,
+        fileSourceScan.dataFilters ++ leftFilters,
+        fileSourceScan.tableIdentifier,
+        fileSourceScan.disableBucketedScan)
+    case batchScan: BatchScanExec =>
+      batchScan.scan match {
+        case scan: FileScan =>
+          val leftFilters =
+            getLeftFilters(scan.dataFilters, flattenCondition(plan.condition))
+          new BatchScanExecTransformer(batchScan.output, batchScan.scan, leftFilters)
+        case _ =>
+          throw new UnsupportedOperationException(
+            s"${batchScan.scan.getClass.toString} is not supported.")
+      }
+    case other =>
+      throw new UnsupportedOperationException(s"${other.getClass.toString} is not supported.")
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -30,11 +30,12 @@ import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan: Scan)
+class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan: Scan,
+                               pushdownFilters: Seq[Expression] = Seq())
     extends BatchScanExec(output, scan) with BasicScanExecTransformer {
 
   override def filterExprs(): Seq[Expression] = if (scan.isInstanceOf[FileScan]) {
-    scan.asInstanceOf[FileScan].dataFilters
+    scan.asInstanceOf[FileScan].dataFilters ++ pushdownFilters
   } else {
     throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
   }

--- a/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -33,7 +33,7 @@ object ConverterUtils extends Logging {
       case a: Cast =>
         getAttrFromExpr(a.child)
       case a: AggregateExpression =>
-        getAttrFromExpr(a.aggregateFunction.children(0))
+        getAttrFromExpr(a.aggregateFunction.children.head)
       case a: AttributeReference =>
         a
       case a: Alias =>
@@ -48,7 +48,7 @@ object ConverterUtils extends Logging {
       case a: NormalizeNaNAndZero =>
         getAttrFromExpr(a.child)
       case c: Coalesce =>
-        getAttrFromExpr(c.children(0))
+        getAttrFromExpr(c.children.head)
       case i: IsNull =>
         getAttrFromExpr(i.child)
       case a: Add =>
@@ -62,7 +62,7 @@ object ConverterUtils extends Logging {
       case u: Upper =>
         getAttrFromExpr(u.child)
       case ss: Substring =>
-        getAttrFromExpr(ss.children(0))
+        getAttrFromExpr(ss.children.head)
       case other =>
         throw new UnsupportedOperationException(
           s"makeStructField is unable to parse from $other (${other.getClass}).")
@@ -158,13 +158,13 @@ object ConverterUtils extends Logging {
 
   def ifEquals(left: Seq[AttributeReference], right: Seq[NamedExpression]): Boolean = {
     if (left.size != right.size) return false
-    for (i <- 0 until left.size) {
+    for (i <- left.indices) {
       if (left(i).exprId != right(i).exprId) return false
     }
     true
   }
 
-  override def toString(): String = {
+  override def toString: String = {
     s"ConverterUtils"
   }
 

--- a/jvm/src/main/scala/io/glutenproject/expression/ScalarSubqueryTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ScalarSubqueryTransformer.scala
@@ -17,7 +17,6 @@
 
 package io.glutenproject.expression
 
-import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.InternalRow

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -77,9 +77,10 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
       ProjectExecTransformer(plan.projectList, columnarChild)
     case plan: FilterExec =>
-      val child = replaceWithTransformerPlan(plan.child)
+      // Push down the left conditions in Filter into Scan.
+      val newChild = applyFilterPushdownToScan(plan)
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-      FilterExecTransformer(plan.condition, child)
+      FilterExecTransformer(plan.condition, newChild)
     case plan: HashAggregateExec =>
       val child = replaceWithTransformerPlan(plan.child)
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
@@ -189,6 +190,38 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
       p.withNewChildren(children)
   }
   def setAdaptiveSupport(enable: Boolean): Unit = { isSupportAdaptive = enable }
+
+  // Separate and compare the filter conditions in Scan and Filter.
+  // Push down the left conditions in Filter into Scan.
+  def applyFilterPushdownToScan(plan: FilterExec): SparkPlan = plan.child match {
+    case fileSourceScan: FileSourceScanExec =>
+      val leftFilters = filterSeparator.getLeftFilters(
+          fileSourceScan.dataFilters,
+          filterSeparator.flattenCondition(plan.condition))
+      new FileSourceScanExecTransformer(
+        fileSourceScan.relation,
+        fileSourceScan.output,
+        fileSourceScan.requiredSchema,
+        fileSourceScan.partitionFilters,
+        fileSourceScan.optionalBucketSet,
+        fileSourceScan.optionalNumCoalescedBuckets,
+        fileSourceScan.dataFilters ++ leftFilters,
+        fileSourceScan.tableIdentifier,
+        fileSourceScan.disableBucketedScan)
+    case batchScan: BatchScanExec =>
+      batchScan.scan match {
+        case scan: FileScan =>
+          val leftFilters = filterSeparator.getLeftFilters(
+            scan.dataFilters,
+            filterSeparator.flattenCondition(plan.condition))
+          new BatchScanExecTransformer(batchScan.output, batchScan.scan, leftFilters)
+        case _ =>
+          throw new UnsupportedOperationException(
+            s"${batchScan.scan.getClass.toString} is not supported.")
+      }
+    case _ =>
+      replaceWithTransformerPlan(plan.child)
+  }
 
   def apply(plan: SparkPlan): SparkPlan = {
     replaceWithTransformerPlan(plan)
@@ -344,5 +377,53 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
 object ColumnarOverrides extends GlutenSparkExtensionsInjector {
   override def inject(extensions: SparkSessionExtensions): Unit = {
     extensions.injectColumnar(ColumnarOverrideRules)
+  }
+}
+
+object filterSeparator {
+  // Get the original filter conditions in Scan for the comparison with those in Filter.
+  def getScanFilters(child: SparkPlan): Seq[Expression] = {
+    child match {
+      case fileSourceScan: FileSourceScanExec =>
+        fileSourceScan.dataFilters
+      case batchScan: BatchScanExec =>
+        batchScan.scan match {
+          case scan: FileScan =>
+            scan.dataFilters
+          case _ =>
+            throw new UnsupportedOperationException(
+              s"${batchScan.scan.getClass.toString} is not supported")
+        }
+      case _ =>
+        Seq()
+    }
+  }
+
+  // Flatten the condition connected with 'And'. Return the filter conditions with sequence.
+  def flattenCondition(condition: Expression) : Seq[Expression] = {
+    var expressions: Seq[Expression] = Seq()
+    condition match {
+      case and: And =>
+        and.children.foreach(expression => {
+          expressions ++= flattenCondition(expression)
+        })
+      case _ =>
+        expressions = expressions :+ condition
+    }
+    expressions
+  }
+
+  // Compare the semantics of the filter conditions pushed down to Scan and in the Filter.
+  // scanFilters: the conditions pushed down into Scan.
+  // filters: the conditions in the Filter after the Scan.
+  // Return the filter conditions not pushed down into Scan.
+  def getLeftFilters(scanFilters: Seq[Expression], filters: Seq[Expression]): Seq[Expression] = {
+    var leftFilters: Seq[Expression] = Seq()
+    for (expression <- filters) {
+      if (!scanFilters.exists(_.semanticEquals(expression))) {
+        leftFilters = leftFilters :+ expression.clone()
+      }
+    }
+    leftFilters
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
@@ -19,7 +19,6 @@ package io.glutenproject.extension.columnar
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution._
-import io.glutenproject.extension.filterSeparator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._

--- a/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
@@ -18,6 +18,7 @@
 package io.glutenproject.extension.columnar
 
 import io.glutenproject.GlutenConfig
+import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -102,7 +103,8 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
           transformer.doValidate()
         case plan: FilterExec =>
           if (!enableColumnarFilter) return false
-          val transformer = FilterExecTransformer(plan.condition, plan.child)
+          val transformer = BackendsApiManager.getSparkPlanExecApiInstance
+            .genFilterExecTransformer(plan.condition, plan.child)
           transformer.doValidate()
         case plan: HashAggregateExec =>
           if (!enableColumnarHashAgg) return false

--- a/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension.columnar
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution._
-
+import io.glutenproject.extension.filterSeparator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -29,7 +29,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.window.WindowExec
@@ -103,16 +103,6 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
           transformer.doValidate()
         case plan: FilterExec =>
           if (!enableColumnarFilter) return false
-          plan.child match {
-            case batchScan: BatchScanExec =>
-              val childTransformer = new BatchScanExecTransformer(batchScan.output, batchScan.scan)
-              if (childTransformer.doValidate()) {
-                // If the BatchScan passes validation, all the filters can be pushed down and
-                // the computing of this Filter is not needed.
-                return true
-              }
-            case _ =>
-          }
           val transformer = FilterExecTransformer(plan.condition, plan.child)
           transformer.doValidate()
         case plan: HashAggregateExec =>

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
@@ -17,13 +17,12 @@
 
 package io.glutenproject.backendsapi
 
-import io.glutenproject.execution.{NativeColumnarToRowExec, RowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
 import org.apache.spark.ShuffleDependency
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.SparkPlan
@@ -46,6 +45,16 @@ class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
    * @return
    */
   override def genRowToArrowColumnarExec(child: SparkPlan): RowToArrowColumnarExec = null
+
+  /**
+   * Generate FilterExecTransformer.
+   *
+   * @param condition: the filter condition
+   * @param child: the chid of FilterExec
+   * @return the transformer of FilterExec
+   */
+  override def genFilterExecTransformer(condition: Expression, child: SparkPlan)
+    : FilterExecBaseTransformer = null
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Compare and separate the filter conditions in Scan and Filter.
Manually push down the left conditions in Filter into Scan.

## How was this patch tested?

Verified on TPC-H.

