### PR TITLE
[OPPRO-123] Support dwrf format in Gluten's velox backend

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DwrfDatasourceJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DwrfDatasourceJniWrapper.java
@@ -15,19 +15,21 @@
  * limitations under the License.
  */
 
-#pragma once
+package io.glutenproject.spark.sql.execution.datasources.velox;
 
-#include <arrow/type_fwd.h>
+import java.io.IOException;
 
-#include "velox/type/Type.h"
+import io.glutenproject.vectorized.JniLibLoader;
+import io.glutenproject.vectorized.JniWorkspace;
 
-using namespace facebook::velox;
+public class DwrfDatasourceJniWrapper {
 
-std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& type_name);
-
-std::shared_ptr<arrow::DataType> toArrowType(const TypePtr& type);
-
-const char* arrowTypeIdToFormatStr(arrow::Type::type typeId);
-
-std::shared_ptr<arrow::Schema> toArrowSchema(
-    const std::shared_ptr<const RowType>& row_type);
+    public DwrfDatasourceJniWrapper() throws IOException {
+        final JniLibLoader loader = JniWorkspace.getDefault().libLoader();
+        loader.loadEssentials();
+        loader.mapAndLoad("velox");
+    }
+    public native long nativeInitDwrfDatasource(String filePath);
+    public native byte[] inspectSchema(long instanceId);
+    public native void close(long instanceId);
+}

--- a/backends-velox/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/backends-velox/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+org.apache.spark.sql.execution.datasources.v2.velox.DwrfDatasourceV2

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxDatasourceUtil.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxDatasourceUtil.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.utils
+
+import io.glutenproject.spark.sql.execution.datasources.velox.DwrfDatasourceJniWrapper
+import org.apache.hadoop.fs.FileStatus
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.datasources.v2.arrow.SparkSchemaUtils
+import org.apache.spark.sql.execution.datasources.v2.arrow.SparkMemoryUtils
+
+import org.apache.arrow.vector.util.SchemaUtility
+
+object VeloxDatasourceUtil {
+  def readSchema(file: FileStatus): Option[StructType] = {
+    val dwrfDatasourceJniWrapper = new DwrfDatasourceJniWrapper()
+    val instanceId = dwrfDatasourceJniWrapper.nativeInitDwrfDatasource(file.getPath.toString)
+    val buffer = dwrfDatasourceJniWrapper.inspectSchema(instanceId)
+    val schema = SchemaUtility.deserialize(buffer, SparkMemoryUtils.contextAllocator())
+    try {
+      Option(SparkSchemaUtils.fromArrowSchema(schema))
+    } finally {
+      dwrfDatasourceJniWrapper.close(instanceId)
+    }
+  }
+
+  def readSchema(files: Seq[FileStatus]): Option[StructType] = {
+    if (files.isEmpty) {
+      throw new IllegalArgumentException("No input file specified")
+    }
+    readSchema(files.toList.head)
+  }
+}

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfDatasourceV2.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfDatasourceV2.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.velox
+
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
+import org.apache.spark.sql.execution.datasources.velox.DwrfFileFormat
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class DwrfDatasourceV2 extends FileDataSourceV2 {
+  private val format = classOf[DwrfFileFormat]
+
+  override def fallbackFileFormat: Class[_ <: FileFormat] = {
+    format
+  }
+
+  override def getTable(options: CaseInsensitiveStringMap): Table = {
+    val paths = getPaths(options)
+    val tableName = getTableName(options, paths)
+    DwrfTable(tableName, sparkSession, options, paths, None, fallbackFileFormat)
+  }
+
+  override def shortName(): String = "dwrf"
+
+}

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfScan.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfScan.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.velox
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class DwrfScan(
+                      sparkSession: SparkSession,
+                      fileIndex: PartitioningAwareFileIndex,
+                      readDataSchema: StructType,
+                      readPartitionSchema: StructType,
+                      pushedFilters: Array[Filter],
+                      options: CaseInsensitiveStringMap,
+                      partitionFilters: Seq[Expression] = Seq.empty,
+                      dataFilters: Seq[Expression] = Seq.empty)
+  extends FileScan {
+  override def createReaderFactory(): PartitionReaderFactory = {
+    null
+  }
+
+  override def withFilters(partitionFilters: Seq[Expression],
+                           dataFilters: Seq[Expression]): FileScan =
+    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+}

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfScanBuilder.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfScanBuilder.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.velox
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.{Scan, SupportsPushDownFilters}
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.FileScanBuilder
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class DwrfScanBuilder(
+                             sparkSession: SparkSession,
+                             fileIndex: PartitioningAwareFileIndex,
+                             schema: StructType,
+                             dataSchema: StructType,
+                             options: CaseInsensitiveStringMap)
+  extends FileScanBuilder(sparkSession, fileIndex, dataSchema)
+    with SupportsPushDownFilters {
+
+  private var filters: Array[Filter] = Array.empty
+  private lazy val pushedArrowFilters: Array[Filter] = {
+    filters // todo filter validation & pushdown
+  }
+
+  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    this.filters = filters
+    this.filters
+  }
+
+  override def pushedFilters: Array[Filter] = pushedArrowFilters
+
+  override def build(): Scan = {
+    DwrfScan(
+      sparkSession,
+      fileIndex,
+      readDataSchema(),
+      readPartitionSchema(),
+      pushedFilters,
+      options)
+  }
+}

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfTable.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/v2/velox/DwrfTable.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.velox
+
+import io.glutenproject.utils.VeloxDatasourceUtil
+import org.apache.hadoop.fs.FileStatus
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.FileTable
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class DwrfTable(
+                       name: String,
+                       sparkSession: SparkSession,
+                       options: CaseInsensitiveStringMap,
+                       paths: Seq[String],
+                       userSpecifiedSchema: Option[StructType],
+                       fallbackFileFormat: Class[_ <: FileFormat])
+  extends FileTable(sparkSession, options, paths, userSpecifiedSchema) {
+  override def inferSchema(files: Seq[FileStatus]): Option[StructType] = {
+    VeloxDatasourceUtil.readSchema(files)
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    DwrfScanBuilder(sparkSession, fileIndex, schema, dataSchema, options)
+  }
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    throw new UnsupportedOperationException
+  }
+
+  override def formatName: String = "DWRF"
+}

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/DwrfFileFormat.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/DwrfFileFormat.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.velox
+
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.mapreduce.Job
+import io.glutenproject.utils.VeloxDatasourceUtil
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriterFactory}
+import org.apache.spark.sql.sources.DataSourceRegister
+
+class DwrfFileFormat extends FileFormat with DataSourceRegister with Serializable {
+
+  override def inferSchema(sparkSession: SparkSession,
+                           options: Map[String, String],
+                           files: Seq[FileStatus]): Option[StructType] = {
+    VeloxDatasourceUtil.readSchema(files)
+  }
+
+  override def prepareWrite(sparkSession: SparkSession,
+                            job: Job,
+                            options: Map[String, String],
+                            dataSchema: StructType): OutputWriterFactory = {
+    throw new UnsupportedOperationException
+  }
+
+  override def shortName(): String = "dwrf"
+}

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -126,6 +126,7 @@ set(VELOX_SRCS
     compute/VeloxPlanConverter.cc
     compute/ArrowTypeUtils.cc
     compute/VeloxToRowConverter.cc
+    compute/DwrfDatasource.cc
     )
 add_library(velox SHARED ${VELOX_SRCS})
 

--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -16,6 +16,7 @@
  */
 
 #include "ArrowTypeUtils.h"
+#include <iostream>
 
 using namespace facebook::velox;
 
@@ -48,6 +49,8 @@ std::shared_ptr<arrow::DataType> toArrowType(const TypePtr& type) {
       return arrow::float64();
     case TypeKind::VARCHAR:
       return arrow::utf8();
+    case TypeKind::TIMESTAMP:
+      return arrow::timestamp(arrow::TimeUnit::MICRO);
     default:
       throw std::runtime_error("Type conversion is not supported.");
   }
@@ -69,4 +72,16 @@ const char* arrowTypeIdToFormatStr(arrow::Type::type typeId) {
       // Unsupported types.
       throw std::runtime_error("Arrow type id not supported.");
   }
+}
+
+std::shared_ptr<arrow::Schema> toArrowSchema(
+    const std::shared_ptr<const RowType>& row_type) {
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  auto size = row_type->size();
+  fields.reserve(size);
+  for (auto i = 0; i < size; ++i) {
+    fields.push_back(
+        arrow::field(row_type->nameOf(i), toArrowType(row_type->childAt(i))));
+  }
+  return arrow::schema(fields);
 }

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DwrfDatasource.h"
+#include "ArrowTypeUtils.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+namespace velox {
+namespace compute {
+
+void DwrfDatasource::Init() {
+  // Setup and register.
+  filesystems::registerLocalFileSystem();
+  try {
+    dwrf::registerDwrfReaderFactory();
+  } catch (const VeloxRuntimeError& e) {
+    // The reader factory is already registered in local mode and no need to register.
+    return;
+  }
+}
+
+std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
+  dwio::common::ReaderOptions reader_options;
+  auto format = dwio::common::FileFormat::ORC;  // DWRF
+  reader_options.setFileFormat(format);
+
+  if (strncmp(file_path_.c_str(), "file:", 5) == 0) {
+    std::unique_ptr<dwio::common::Reader> reader =
+        dwio::common::getReaderFactory(reader_options.getFileFormat())
+            ->createReader(
+                std::make_unique<dwio::common::FileInputStream>(file_path_.substr(5)),
+                reader_options);
+    return toArrowSchema(reader->rowType());
+  } else {
+    throw std::runtime_error(
+        "The path is not local file path when inspect shcema with DWRF format!");
+  }
+}
+
+void DwrfDatasource::Close() { dwrf::unregisterDwrfReaderFactory; }
+
+}  // namespace compute
+}  // namespace velox

--- a/cpp/velox/compute/DwrfDatasource.h
+++ b/cpp/velox/compute/DwrfDatasource.h
@@ -19,15 +19,28 @@
 
 #include <arrow/type_fwd.h>
 
-#include "velox/type/Type.h"
+#include <folly/executors/IOThreadPoolExecutor.h>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
 
 using namespace facebook::velox;
 
-std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& type_name);
+namespace velox {
+namespace compute {
 
-std::shared_ptr<arrow::DataType> toArrowType(const TypePtr& type);
+class DwrfDatasource {
+ public:
+  DwrfDatasource(const std::string& file_path) : file_path_(file_path) {}
 
-const char* arrowTypeIdToFormatStr(arrow::Type::type typeId);
+  void Init();
+  std::shared_ptr<arrow::Schema> InspectSchema();
+  void Close();
 
-std::shared_ptr<arrow::Schema> toArrowSchema(
-    const std::shared_ptr<const RowType>& row_type);
+ private:
+  std::string file_path_;
+};
+
+}  // namespace compute
+}  // namespace velox


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add DWRF format in Gluten's velox backend.


## How was this patch tested?
test "spark.read.format("dwrf").load(dwrf_path)" locally

