### PR TITLE
[Gluten-207] Support MergeTree DataSource V1 for ClickHouse backend

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/utils/SnowflakeIdWorker.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/utils/SnowflakeIdWorker.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.utils;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseConfig;
+
+/**
+ * An object that generates IDs.
+ * This is broken into a separate class in case
+ * we ever want to support multiple worker threads per process.
+ * Refer to twitter-archive Snowflake.
+ */
+public class SnowflakeIdWorker {
+
+  // ==============================Fields===========================================
+  private final long twepoch = 1640966400L;
+
+  private final long workerIdBits = 6L;
+
+  private final long maxWorkerId = -1L ^ (-1L << workerIdBits);
+
+  private final long sequenceBits = 16L;
+
+  private final long workerIdShift = sequenceBits;
+
+  private final long timestampLeftShift = sequenceBits + workerIdBits;
+
+  private final long sequenceMask = -1L ^ (-1L << sequenceBits);
+
+  private long workerId;
+
+  private long sequence = 0L;
+
+  private long lastTimestamp = -1L;
+
+  //==============================Singleton=====================================
+  private static volatile SnowflakeIdWorker INSTANCE;
+
+  public static SnowflakeIdWorker getInstance() {
+    if (INSTANCE == null) {
+      synchronized (SnowflakeIdWorker.class) {
+        if (INSTANCE == null) {
+          if (!SparkEnv.get().conf().contains(ClickHouseConfig.CLICKHOUSE_WORKER_ID())) {
+            throw new IllegalArgumentException("Please set an unique value to " +
+                ClickHouseConfig.CLICKHOUSE_WORKER_ID());
+          }
+          INSTANCE = new SnowflakeIdWorker(
+              SparkEnv.get().conf()
+                  .getLong(ClickHouseConfig.CLICKHOUSE_WORKER_ID(), 0));
+        }
+      }
+    }
+    return INSTANCE;
+  }
+
+  //==============================Constructors=====================================
+
+  public SnowflakeIdWorker(long workerId) {
+    if (workerId > maxWorkerId || workerId < 0) {
+      throw new IllegalArgumentException(
+          String.format("worker Id can't be greater than %d or less than 0", maxWorkerId));
+    }
+    this.workerId = workerId;
+  }
+
+  // ==============================Methods==========================================
+  public synchronized long nextId() {
+    long timestamp = timeGen();
+
+    if (timestamp < lastTimestamp) {
+      throw new RuntimeException(
+          String.format("Clock moved backwards.  Refusing to generate id for %d milliseconds",
+              lastTimestamp - timestamp));
+    }
+
+    if (lastTimestamp == timestamp) {
+      sequence = (sequence + 1) & sequenceMask;
+      if (sequence == 0) {
+        timestamp = tilNextMillis(lastTimestamp);
+      }
+    }
+    else {
+      sequence = 0L;
+    }
+
+    lastTimestamp = timestamp;
+
+    return ((timestamp - twepoch) << timestampLeftShift) //
+        | (workerId << workerIdShift) //
+        | sequence;
+  }
+
+  protected long tilNextMillis(long lastTimestamp) {
+    long timestamp = timeGen();
+    while (timestamp <= lastTimestamp) {
+      timestamp = timeGen();
+    }
+    return timestamp;
+  }
+
+  protected long timeGen() {
+    return System.currentTimeMillis() / 1000L;
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.utils
+
+import io.glutenproject.execution.NativeMergeTreePartition
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.AddMergeTreeParts
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+
+import scala.collection.mutable.ArrayBuffer
+
+object MergeTreePartsPartitionsUtil {
+
+  def getPartsPartitions(sparkSession: SparkSession,
+                         table: ClickHouseTableV2): Seq[InputPartition] = {
+    val maxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
+    val partsFiles = table.listFiles()
+
+    val partitions = new ArrayBuffer[InputPartition]
+    val database = table.catalogTable.get.identifier.database.get
+    val tableName = table.catalogTable.get.identifier.table
+    val engine = table.snapshot.metadata.configuration.get("engine").get
+    val tablePath = table.deltaLog.dataPath.toString.substring(6)
+    var currentMinPartsNum = -1L
+    var currentMaxPartsNum = -1L
+    var currentSize = 0L
+
+    /** Close the current partition and move to the next. */
+    def closePartition(): Unit = {
+      if (currentMinPartsNum > 0L && currentMaxPartsNum >= currentMinPartsNum) {
+        val newPartition = NativeMergeTreePartition(partitions.size, engine, database, tableName,
+          tablePath, currentMinPartsNum, currentMaxPartsNum + 1)
+        partitions += newPartition
+      }
+      currentMinPartsNum = -1L
+      currentMaxPartsNum = -1L
+      currentSize = 0
+    }
+
+    val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
+    // Assign files to partitions using "Next Fit Decreasing"
+    partsFiles.foreach { parts =>
+      if (currentSize + parts.bytesOnDisk > maxSplitBytes) {
+        closePartition()
+      }
+      // Add the given file to the current partition.
+      currentSize += parts.bytesOnDisk + openCostInBytes
+      if (currentMinPartsNum == -1L) {
+        currentMinPartsNum = parts.minBlockNumber
+      }
+      currentMaxPartsNum = parts.maxBlockNumber
+    }
+    closePartition()
+    partitions
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v1/ClickHouseFileIndex.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v1/ClickHouseFileIndex.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v1
+
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, Literal}
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.files.TahoeFileIndex
+import org.apache.spark.sql.execution.datasources.PartitionDirectory
+import org.apache.spark.sql.execution.datasources.utils.MergeTreePartsPartitionsUtil
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.types.StructType
+
+import java.util.Objects
+
+case class ClickHouseFileIndex(override val spark: SparkSession,
+                               override val deltaLog: DeltaLog,
+                               override val path: Path,
+                               table: ClickHouseTableV2,
+                               snapshotAtAnalysis: Snapshot,
+                               partitionFilters: Seq[Expression] = Nil,
+                               isTimeTravelQuery: Boolean = false)
+  extends TahoeFileIndex(spark, deltaLog, path) {
+
+  override def tableVersion: Long = {
+    if (isTimeTravelQuery) snapshotAtAnalysis.version else deltaLog.snapshot.version
+  }
+
+  protected def getSnapshotToScan: Snapshot = {
+    if (isTimeTravelQuery) snapshotAtAnalysis else deltaLog.update(stalenessAcceptable = true)
+  }
+
+  /** Provides the version that's being used as part of the scan if this is a time travel query. */
+  def versionToUse: Option[Long] =
+    if (isTimeTravelQuery) Some(snapshotAtAnalysis.version) else None
+
+  def getSnapshot: Snapshot = {
+    getSnapshotToScan
+  }
+
+  override def matchingFiles(
+                              partitionFilters: Seq[Expression],
+                              dataFilters: Seq[Expression]): Seq[AddFile] = {
+    Seq.empty[AddFile]
+  }
+
+  override def inputFiles: Array[String] = {
+    table.listFiles().map(_.path).toArray
+  }
+
+  override def listFiles(partitionFilters: Seq[Expression],
+                         dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    table.listFiles().map(parts => {
+      val fileStats = new FileStatus(
+        /* length */ parts.bytesOnDisk,
+        /* isDir */ false,
+        /* blockReplication */ 0,
+        /* blockSize */ 1,
+        /* modificationTime */ parts.modificationTime,
+        absolutePath(parts.path))
+      PartitionDirectory(new GenericInternalRow(Array.empty[Any]), Seq(fileStats))
+    })
+  }
+
+  def partsPartitions: Seq[InputPartition] =
+    MergeTreePartsPartitionsUtil.getPartsPartitions(spark, table)
+
+  override def refresh(): Unit = {}
+
+  override val sizeInBytes: Long = table.listFiles().map(_.bytesOnDisk).sum
+
+  override def equals(that: Any): Boolean = that match {
+    case t: ClickHouseFileIndex =>
+      t.path == path && t.deltaLog.isSameLogAs(deltaLog) &&
+        t.versionToUse == versionToUse && t.partitionFilters == partitionFilters
+    case _ => false
+  }
+
+  override def hashCode: scala.Int = {
+    Objects.hashCode(path, deltaLog.tableId -> deltaLog.dataPath, versionToUse, partitionFilters)
+  }
+
+  override def partitionSchema: StructType = snapshotAtAnalysis.metadata.partitionSchema
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
@@ -1,0 +1,331 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+import com.google.common.collect.Lists
+import io.glutenproject.execution.{NativeFilePartition, NativeSubstraitPartition}
+import io.glutenproject.expression.ConverterUtils
+import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.ddlplan.{DllNode, DllTransformContext, InsertOutputBuilder, InsertPlanNode}
+import io.glutenproject.substrait.plan.PlanBuilder
+import io.glutenproject.substrait.rel.{LocalFilesBuilder, RelBuilder}
+import io.glutenproject.utils.SnowflakeIdWorker
+import org.apache.spark.{Partition, SparkEnv, SparkException, TaskContext}
+
+import org.apache.spark.executor.CommitDeniedException
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.catalog.SupportsWrite
+import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, WriterCommitMessage}
+import org.apache.spark.sql.delta.{DeltaOperations, DeltaOptions, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{AddFile, FileAction}
+import org.apache.spark.sql.delta.commands.DeltaCommand
+import org.apache.spark.sql.delta.schema.ImplicitMetadataOperation
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.source.ClickHouseBatchWrite
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, WriteJobStatsTracker}
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.files.ClickHouseCommitProtocol
+import org.apache.spark.util.{LongAccumulator, SerializableConfiguration, Utils}
+
+case class ClickHouseAppendDataExec(
+                                     table: SupportsWrite,
+                                     writeOptions: CaseInsensitiveStringMap,
+                                     query: SparkPlan,
+                                     refreshCache: () => Unit
+                                   ) extends V2TableWriteExec
+  with BatchWriteHelper with ImplicitMetadataOperation with DeltaCommand {
+
+  override protected val canMergeSchema: Boolean = false
+
+  override protected val canOverwriteSchema: Boolean = false
+
+  private val clickhouseTableV2 = table.asInstanceOf[ClickHouseTableV2]
+
+  private val deltaLog = clickhouseTableV2.deltaLog
+
+  private val sparkSession = clickhouseTableV2.spark
+
+  private val configuration = deltaLog.snapshot.metadata.configuration
+
+  private val mode = SaveMode.Append
+
+  private val deltaOptions = new DeltaOptions(mutable.HashMap[String, String](
+    writeOptions.asCaseSensitiveMap().asScala.toSeq: _*).toMap, sparkSession.sessionState.conf)
+
+  override protected def run(): Seq[InternalRow] = {
+    val writtenRows = writeWithV2(newWriteBuilder().buildForBatch())
+    refreshCache()
+    writtenRows
+  }
+
+  override protected def writeWithV2(batchWrite: BatchWrite): Seq[InternalRow] = {
+    val chBatchWrite = batchWrite.asInstanceOf[ClickHouseBatchWrite]
+    val schema = chBatchWrite.querySchema
+    val queryId = chBatchWrite.queryId
+
+    if (schema != clickhouseTableV2.schema()) {
+      throw new SparkException(s"Writing job failed: " +
+        s"the schema of inserting is different from table schema.")
+    }
+
+    try {
+      deltaLog.withNewTransaction { txn =>
+        if (txn.readVersion < 0) {
+          logError(s"Table ${clickhouseTableV2.tableIdentifier} doesn't exists.")
+          throw new SparkException(s"Writing job failed: " +
+            s"table ${clickhouseTableV2.tableIdentifier} doesn't exists.")
+        }
+
+        updateMetadata(sparkSession, txn, schema, Nil, configuration, false,
+          deltaOptions.rearrangeOnly)
+
+        // Validate partition predicates
+        // val replaceWhere = deltaOptions.replaceWhere
+        // val partitionFilters = None
+
+        val rdd: RDD[InternalRow] = {
+          val tempRdd = query.execute()
+          // SPARK-23271 If we are attempting to write a zero partition rdd, create a dummy single
+          // partition rdd to make sure we at least set up one write task to write the metadata.
+          if (tempRdd.partitions.length == 0) {
+            sparkContext.parallelize(Array.empty[InternalRow], 1)
+          } else {
+            tempRdd
+          }
+        }
+        val partitions = rdd.partitions
+        val useCommitCoordinator = batchWrite.useCommitCoordinator
+        val messages = new Array[WriterCommitMessage](partitions.length)
+        val totalNumRowsAccumulator = new LongAccumulator()
+
+        val newFiles = deltaTxnWriteMergeTree(txn,
+          partitions,
+          query.output,
+          messages,
+          useCommitCoordinator,
+          totalNumRowsAccumulator,
+          queryId)
+        logInfo(s"Data source write support $batchWrite is committing.")
+        batchWrite.commit(messages)
+        logInfo(s"Data source write support $batchWrite committed.")
+        commitProgress = Some(StreamWriterCommitProgress(totalNumRowsAccumulator.value))
+        val operation = DeltaOperations.Write(SaveMode.Append, Option(Seq.empty[String]),
+          deltaOptions.replaceWhere, deltaOptions.userMetadata)
+        txn.commit(newFiles, operation)
+      }
+    } catch {
+      case cause: Throwable =>
+        logError(s"Data source write support $batchWrite is aborting.")
+        try {
+          // batchWrite.abort(messages)
+        } catch {
+          case t: Throwable =>
+            logError(s"Data source write support $batchWrite failed to abort.")
+            cause.addSuppressed(t)
+            throw new SparkException("Writing job failed.", cause)
+        }
+        logError(s"Data source write support $batchWrite aborted.")
+        cause match {
+          // Only wrap non fatal exceptions.
+          case NonFatal(e) => throw new SparkException("Writing job aborted.", e)
+          case _ => throw cause
+        }
+    }
+    Seq.empty[InternalRow]
+  }
+
+  private def deltaTxnWriteMergeTree(txn: OptimisticTransaction,
+                                     partitions: Array[Partition],
+                                     queryOutput: Seq[Attribute],
+                                     messages: Array[WriterCommitMessage],
+                                     useCommitCoordinator: Boolean,
+                                     totalNumRowsAccumulator: LongAccumulator,
+                                     queryId: String): Seq[FileAction] = {
+    // write the mergetree data
+    logInfo(s"Start processing data source append support. " +
+      s"The input RDD has ${messages.length} partitions.")
+
+    val database = clickhouseTableV2.catalogTable.get.identifier.database.get
+    val tableName = clickhouseTableV2.catalogTable.get.identifier.table
+    val engine = deltaLog.snapshot.metadata.configuration.get("engine").get
+    val tablePath = deltaLog.dataPath.toString.substring(6)
+    val partitionSchema = deltaLog.snapshot.metadata.partitionSchema
+    val outputPath = deltaLog.dataPath
+    val committer = new ClickHouseCommitProtocol("clickhouse",
+      outputPath.toString,
+      queryId,
+      None)
+    val outputSpec = FileFormatWriter.OutputSpec(
+      outputPath.toString,
+      Map.empty,
+      output)
+    val statsTrackers: ListBuffer[WriteJobStatsTracker] = ListBuffer()
+    if (sparkSession.conf.get(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED)) {
+      val basicWriteJobStatsTracker = new BasicWriteJobStatsTracker(
+        new SerializableConfiguration(sparkSession.sessionState.newHadoopConf()),
+        BasicWriteJobStatsTracker.metrics)
+      txn.registerSQLMetrics(sparkSession, basicWriteJobStatsTracker.metrics)
+      statsTrackers.append(basicWriteJobStatsTracker)
+    }
+
+    // Generate insert substrait plan for per partition
+    val substraitContext = new SubstraitContext
+    val dllCxt = genInsertPlan(substraitContext, queryOutput)
+    val substraitPlanPartition = partitions.map(p => {
+      p match {
+        case NativeSubstraitPartition(index: Int, inputPartition: NativeFilePartition) =>
+          val files = inputPartition.files
+          if (files.length > 1) {
+            throw new SparkException(s"Writing job failed: " +
+              s"can not support multiple input files in one partition.")
+          }
+          if (files.head.start != 0) {
+            throw new SparkException(s"Writing job failed: " +
+              s"can not read a parquet file from non-zero start.")
+          }
+          val paths = new java.util.ArrayList[String]()
+          val starts = new java.util.ArrayList[java.lang.Long]()
+          val lengths = new java.util.ArrayList[java.lang.Long]()
+          paths.add(files.head.filePath)
+          starts.add(files.head.start)
+          lengths.add(files.head.length)
+          val localFilesNode = LocalFilesBuilder.makeLocalFiles(index, paths, starts, lengths)
+          val insertOutputNode = InsertOutputBuilder.makeInsertOutputNode(
+            SnowflakeIdWorker.getInstance().nextId(),
+            database, tableName, tablePath)
+          dllCxt.substraitContext.setLocalFilesNode(localFilesNode)
+          dllCxt.substraitContext.setInsertOutputNode(insertOutputNode)
+          val substraitPlan = dllCxt.root.toProtobuf
+          logWarning(dllCxt.root.toProtobuf.toString)
+        case _ => throw new SparkException(s"Writing job failed: " +
+          s"can not support input partition.")
+      }
+    })
+
+    // committer.setupJob(jobContext = )
+    val newFiles = Nil
+    val addFiles = newFiles.collect { case a: AddFile => a }
+
+    /* sparkContext.runJob(
+          rdd,
+          (context: TaskContext, iter: Iterator[InternalRow]) =>
+            CHDataWritingSparkTask.run(writerFactory, context, iter, useCommitCoordinator),
+          rdd.partitions.indices,
+          (index, result: DataWritingSparkTaskResult) => {
+            val commitMessage = result.writerCommitMessage
+            messages(index) = commitMessage
+            totalNumRowsAccumulator.add(result.numRows)
+            batchWrite.onDataWriterCommit(commitMessage)
+          }
+        ) */
+
+    Nil
+  }
+
+  def genInsertPlan(substraitContext: SubstraitContext,
+                   queryOutput: Seq[Attribute]): DllTransformContext = {
+    val typeNodes = ConverterUtils.getTypeNodeFromAttributes(queryOutput)
+    val nameList = new java.util.ArrayList[String]()
+    for (attr <- queryOutput) {
+      nameList.add(ConverterUtils.getShortAttributeName(attr) + "#" + attr.exprId.id)
+    }
+    val relNode = RelBuilder.makeReadRel(typeNodes, nameList, null, substraitContext)
+
+    val inputPlanNode =
+      PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode), nameList)
+
+    val insertPlanNode = new InsertPlanNode(substraitContext, inputPlanNode)
+
+    val dllNode = new DllNode(Lists.newArrayList(insertPlanNode))
+    DllTransformContext(
+      queryOutput,
+      queryOutput,
+      dllNode,
+      substraitContext)
+  }
+}
+
+object CHDataWritingSparkTask extends Logging {
+  def run(
+           writerFactory: DataWriterFactory,
+           context: TaskContext,
+           iter: Iterator[InternalRow],
+           useCommitCoordinator: Boolean): DataWritingSparkTaskResult = {
+    val stageId = context.stageId()
+    val stageAttempt = context.stageAttemptNumber()
+    val partId = context.partitionId()
+    val taskId = context.taskAttemptId()
+    val attemptId = context.attemptNumber()
+    val dataWriter = writerFactory.createWriter(partId, taskId)
+
+    var count = 0L
+    // write the data and commit this writer.
+    Utils.tryWithSafeFinallyAndFailureCallbacks(block = {
+      while (iter.hasNext) {
+        // Count is here.
+        count += 1
+        // dataWriter.write(iter.next())
+      }
+
+      val msg = if (useCommitCoordinator) {
+        val coordinator = SparkEnv.get.outputCommitCoordinator
+        val commitAuthorized = coordinator.canCommit(stageId, stageAttempt, partId, attemptId)
+        if (commitAuthorized) {
+          logInfo(s"Commit authorized for partition $partId (task $taskId, attempt $attemptId, " +
+            s"stage $stageId.$stageAttempt)")
+          dataWriter.commit()
+        } else {
+          val message = s"Commit denied for partition $partId (task $taskId, attempt $attemptId, " +
+            s"stage $stageId.$stageAttempt)"
+          logInfo(message)
+          // throwing CommitDeniedException will trigger the catch block for abort
+          throw new CommitDeniedException(message, stageId, partId, attemptId)
+        }
+
+      } else {
+        logInfo(s"Writer for partition ${context.partitionId()} is committing.")
+        dataWriter.commit()
+      }
+
+      logInfo(s"Committed partition $partId (task $taskId, attempt $attemptId, " +
+        s"stage $stageId.$stageAttempt)")
+
+      DataWritingSparkTaskResult(count, msg)
+
+    })(catchBlock = {
+      // If there is an error, abort this writer
+      logError(s"Aborting commit for partition $partId (task $taskId, attempt $attemptId, " +
+        s"stage $stageId.$stageAttempt)")
+      dataWriter.abort()
+      logError(s"Aborted commit for partition $partId (task $taskId, attempt $attemptId, " +
+        s"stage $stageId.$stageAttempt)")
+    }, finallyBlock = {
+      dataWriter.close()
+    })
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseConfig.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/ClickHouseConfig.scala
@@ -23,10 +23,19 @@ import java.util
 
 object ClickHouseConfig {
 
+  // MergeTree DataSource name
   val NAME = "clickhouse"
   val ALT_NAME = "clickhouse"
   val METADATA_DIR = "_metadata_log"
   val DEFAULT_ENGINE = "MergeTree"
+
+  // Whether to use MergeTree DataSource V2 API, default is false, fall back to V1.
+  val USE_DATASOURCE_V2 = "spark.gluten.sql.columnar.backend.ch.use.v2"
+  val DEFAULT_USE_DATASOURCE_V2 = "false"
+
+  val CLICKHOUSE_WORKER_ID = "spark.gluten.sql.columnar.backend.ch.worker.id"
+
+  val CLICKHOUSE_WAREHOUSE_DIR = "spark.gluten.sql.columnar.backend.ch.warehouse.dir"
 
   /**
    * Validates specified configurations and returns the normalized key -> value map.

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/files/ClickHouseCommitProtocol.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/files/ClickHouseCommitProtocol.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.files
+
+import java.net.URI
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
+
+import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
+import org.apache.spark.sql.delta.actions.FileAction
+import org.apache.spark.sql.delta.files.DelayedCommitProtocol
+
+class ClickHouseCommitProtocol(jobId: String,
+                               path: String,
+                               queryId: String,
+                               randomPrefixLength: Option[Int])
+  extends DelayedCommitProtocol(jobId, path, randomPrefixLength) {
+
+  override def setupJob(jobContext: JobContext): Unit = {
+    val fs = new Path(path).getFileSystem(jobContext.getConfiguration)
+    val tmpPath = new Path(path, queryId)
+    if (!fs.exists(tmpPath)) {
+      fs.mkdirs(tmpPath)
+    }
+  }
+
+  override def commitJob(jobContext: JobContext,
+                         taskCommits: Seq[FileCommitProtocol.TaskCommitMessage]): Unit =
+    super.commitJob(jobContext, taskCommits)
+
+  override def abortJob(jobContext: JobContext): Unit = super.abortJob(jobContext)
+
+  override def setupTask(taskContext: TaskAttemptContext): Unit = super.setupTask(taskContext)
+
+  override def commitTask(taskContext: TaskAttemptContext
+                         ): FileCommitProtocol.TaskCommitMessage = {
+    if (addedFiles.nonEmpty) {
+      val fs = new Path(path, addedFiles.head._2).getFileSystem(taskContext.getConfiguration)
+      val statuses: Seq[FileAction] = addedFiles.map { f =>
+        val filePath = new Path(path, new Path(new URI(f._2)))
+        val stat = fs.getFileStatus(filePath)
+
+        buildActionFromAddedFile(f, stat, taskContext)
+      }
+
+      new TaskCommitMessage(statuses)
+    } else {
+      new TaskCommitMessage(Nil)
+    }
+  }
+
+  override def abortTask(taskContext: TaskAttemptContext): Unit = super.abortTask(taskContext)
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseBatchWrite.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseBatchWrite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, LogicalWriteInfo, PhysicalWriteInfo, WriterCommitMessage}
+
+class ClickHouseBatchWrite(info: LogicalWriteInfo) extends BatchWrite with Logging {
+
+  def querySchema = info.schema()
+
+  def queryId = info.queryId()
+
+  def options = info.options()
+
+  override def useCommitCoordinator(): Boolean = false
+
+  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+    new ClickHouseWriterFactory()
+  }
+
+  override def commit(messages: Array[WriterCommitMessage]): Unit = {
+  }
+
+  override def abort(messages: Array[WriterCommitMessage]): Unit = {
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseWriteBuilder.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseWriteBuilder.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import org.apache.spark.sql.connector.write.{BatchWrite, LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+
+class ClickHouseWriteBuilder(spark: SparkSession,
+                             table: ClickHouseTableV2,
+                             deltaLog: DeltaLog,
+                             info: LogicalWriteInfo) extends WriteBuilder {
+
+  def querySchema = info.schema()
+
+  def queryId = info.queryId()
+
+  private val options = info.options()
+
+  override def buildForBatch(): BatchWrite = {
+    new ClickHouseBatchWrite(info)
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseWriterFactory.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/ClickHouseWriterFactory.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.write.{DataWriter, DataWriterFactory}
+
+case class ClickHouseWriterFactory() extends DataWriterFactory {
+  override def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = {
+    null
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/extension/CHDataSourceV2Strategy.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/extension/CHDataSourceV2Strategy.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.extension
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.{SparkSession, Strategy}
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CreateTableAsSelect, CreateV2Table, LogicalPlan}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, StagingTableCatalog}
+import org.apache.spark.sql.execution.datasources.v2._
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+case class CHDataSourceV2Strategy(spark: SparkSession) extends Strategy {
+
+  import DataSourceV2Implicits._
+
+  private def refreshCache(r: DataSourceV2Relation)(): Unit = {
+    spark.sharedState.cacheManager.recacheByPlan(spark, r)
+  }
+
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case CreateV2Table(catalog, ident, schema, parts,
+      props, ifNotExists) if catalog.isInstanceOf[ClickHouseSparkCatalog] =>
+      val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)
+      CreateTableExec(catalog, ident, schema, parts, propsWithOwner, ifNotExists) :: Nil
+
+    case CreateTableAsSelect(catalog, ident, parts, query,
+      props, options, ifNotExists) if catalog.isInstanceOf[ClickHouseSparkCatalog] =>
+      val propsWithOwner = CatalogV2Util.withDefaultOwnership(props)
+      val writeOptions = new CaseInsensitiveStringMap(options.asJava)
+      catalog match {
+        case staging: StagingTableCatalog =>
+          //AtomicCreateTableAsSelectExec(staging, ident, parts, query, planLater(query),
+          //  propsWithOwner, writeOptions, ifNotExists) :: Nil
+          Nil
+        case _ =>
+          CreateTableAsSelectExec(catalog, ident, parts, query, planLater(query),
+            propsWithOwner, writeOptions, ifNotExists) :: Nil
+      }
+
+    case AppendData(r: DataSourceV2Relation, query,
+      writeOptions, _) if r.table.isInstanceOf[ClickHouseTableV2] =>
+      r.table.asWritable match {
+        case v2 =>
+          ClickHouseAppendDataExec(v2, writeOptions.asOptions, planLater(query),
+            refreshCache(r)) :: Nil
+      }
+
+    case _ => Nil
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/extension/ClickHouseAnalysis.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/extension/ClickHouseAnalysis.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.extension
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.AnalysisHelper
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseConfig
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class ClickHouseAnalysis(session: SparkSession, conf: SQLConf)
+  extends Rule[LogicalPlan] with AnalysisHelper with DeltaLogging {
+
+  val useDSV2 = session.sessionState.conf.getConfString(
+    ClickHouseConfig.USE_DATASOURCE_V2, ClickHouseConfig.DEFAULT_USE_DATASOURCE_V2).toBoolean
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
+    // This rule falls back to V1 nodes according to 'spark.gluten.sql.columnar.backend.ch.use.v2'
+    case dsv2 @ DataSourceV2Relation(tableV2: ClickHouseTableV2, _, _, _, options) =>
+      if (useDSV2) dsv2
+      else ClickHouseAnalysis.fromV2Relation(tableV2, dsv2, options)
+  }
+}
+
+object ClickHouseAnalysis {
+  def unapply(plan: LogicalPlan): Option[LogicalRelation] = plan match {
+    case dsv2 @ DataSourceV2Relation(d: ClickHouseTableV2, _, _, _, options) =>
+      Some(fromV2Relation(d, dsv2, options))
+    case lr @ ClickHouseTable(_) => Some(lr)
+    case _ => None
+  }
+
+  // convert 'DataSourceV2Relation' to 'LogicalRelation'
+  def fromV2Relation(tableV2: ClickHouseTableV2,
+                     v2Relation: DataSourceV2Relation,
+                     options: CaseInsensitiveStringMap): LogicalRelation = {
+    val relation = tableV2.withOptions(options.asScala.toMap).toBaseRelation
+    val output = v2Relation.output
+
+    val catalogTable = if (tableV2.catalogTable.isDefined) {
+      Some(tableV2.v1Table)
+    } else {
+      None
+    }
+    LogicalRelation(relation, output, catalogTable, isStreaming = false)
+  }
+}
+
+object ClickHouseTable {
+  def unapply(a: LogicalRelation): Option[InputPartition] = a match {
+    case LogicalRelation(HadoopFsRelation(index: InputPartition, _, _, _, _, _), _, _, _) =>
+      Some(index)
+    case _ =>
+      None
+  }
+}

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -18,30 +18,25 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.ISparkPlanExecApi
-import io.glutenproject.execution.{
-  FilterExecBaseTransformer,
-  FilterExecTransformer,
-  NativeColumnarToRowExec,
-  RowToArrowColumnarExec,
-  VeloxFilterExecTransformer,
-  VeloxNativeColumnarToRowExec,
-  VeloxRowToArrowColumnarExec
-}
+import io.glutenproject.execution.{FilterExecBaseTransformer, FilterExecTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxFilterExecTransformer, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
 import io.glutenproject.expression.ArrowConverterUtils
 import io.glutenproject.vectorized.{ArrowColumnarBatchSerializer, ArrowWritableColumnVector}
-
 import org.apache.spark.{ShuffleDependency, SparkException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.shuffle.utils.VeloxShuffleUtil
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{SparkPlan, VeloxBuildSideRelation}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.BuildSideRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.utils.VeloxExecUtil
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -179,6 +174,28 @@ class VeloxSparkPlanExecApi extends ISparkPlanExecApi {
     dataSize += rawSize
 
     VeloxBuildSideRelation(child.output, batches)
+  }
+
+  /**
+   * Generate extended DataSourceV2 Strategy.
+   * Currently only for ClickHouse backend.
+   *
+   * @return
+   */
+  override def genExtendedDataSourceV2Strategy(spark: SparkSession): Strategy = {
+    throw new UnsupportedOperationException(
+      "Cannot support extending DataSourceV2 strategy for Velox backend.")
+  }
+
+  /**
+   * Generate extended Analyzer.
+   * Currently only for ClickHouse backend.
+   *
+   * @return
+   */
+  override def genExtendedAnalyzer(spark: SparkSession, conf: SQLConf): Rule[LogicalPlan] = {
+    throw new UnsupportedOperationException(
+      "Cannot support extending Analyzer for Velox backend.")
   }
 
   /**

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxTransformerApi.scala
@@ -18,18 +18,15 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.ITransformerApi
-import io.glutenproject.expression.{
-  ArrowConverterUtils,
-  ExpressionConverter,
-  ExpressionTransformer
-}
+import io.glutenproject.expression.{ArrowConverterUtils, ExpressionConverter, ExpressionTransformer}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.SelectionNode
-
+import io.glutenproject.utils.InputPartitionsUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
-import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.velox.DwrfFileFormat
@@ -81,6 +78,14 @@ class VeloxTransformerApi extends ITransformerApi with Logging {
     GlutenConfig.getConf.isGazelleBackend && fileFormat.isInstanceOf[ParquetFileFormat] ||
     GlutenConfig.getConf.isVeloxBackend && fileFormat.isInstanceOf[OrcFileFormat] ||
       GlutenConfig.getConf.isVeloxBackend && fileFormat.isInstanceOf[DwrfFileFormat]
+  }
+
+  /**
+   * Generate Seq[InputPartition] for FileSourceScanExecTransformer.
+   */
+  def genInputPartitionSeq(relation: HadoopFsRelation,
+                           selectedPartitions: Array[PartitionDirectory]): Seq[InputPartition] = {
+    InputPartitionsUtil.genInputPartitionSeq(relation, selectedPartitions)
   }
 
   /**

--- a/jvm/src/main/java/io/glutenproject/substrait/ddlplan/DllNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/ddlplan/DllNode.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.ddlplan;
+
+import io.substrait.proto.Dll;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class DllNode implements Serializable {
+
+  private final List<DllPlanNode> dllPlans;
+
+  public DllNode(List<DllPlanNode> dllPlans) {
+    this.dllPlans = dllPlans;
+  }
+
+  public Dll toProtobuf() {
+    Dll.Builder dllBuilder = Dll.newBuilder();
+    for (DllPlanNode dllPlanNode : dllPlans) {
+      dllBuilder.addDllPlan(dllPlanNode.toProtobuf());
+    }
+    return dllBuilder.build();
+  }
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/ddlplan/DllPlanNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/ddlplan/DllPlanNode.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.ddlplan;
+
+import io.substrait.proto.DllPlan;
+
+/**
+ * Contains helper functions for constructing substrait relations.
+ */
+public interface DllPlanNode {
+    /**
+     * Converts a Expression into a protobuf.
+     *
+     * @return A rel protobuf
+     */
+    DllPlan toProtobuf();
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/ddlplan/DllTransformContext.scala
+++ b/jvm/src/main/java/io/glutenproject/substrait/ddlplan/DllTransformContext.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.ddlplan
+
+import io.glutenproject.substrait.SubstraitContext
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class DllTransformContext(
+                                inputAttributes: Seq[Attribute],
+                                outputAttributes: Seq[Attribute],
+                                root: DllNode,
+                                substraitContext: SubstraitContext = null)

--- a/jvm/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.ddlplan;
+
+public class InsertOutputBuilder {
+    private InsertOutputBuilder() {}
+
+    public static InsertOutputNode makeInsertOutputNode(Long partsNum,
+                                                        String database, String tableName,
+                                                        String relativePath) {
+        return new InsertOutputNode(partsNum, database, tableName, relativePath);
+    }
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputNode.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.ddlplan;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import io.substrait.proto.ReadRel;
+
+import java.io.Serializable;
+
+public class InsertOutputNode implements Serializable {
+    private static final String MERGE_TREE = "MergeTree;";
+    private Long partsNum;
+    private String database = null;
+    private String tableName = null;
+    private String relativePath = null;
+    private StringBuffer extensionTableStr = new StringBuffer(MERGE_TREE);
+
+    InsertOutputNode(Long partsNum, String database, String tableName,
+                     String relativePath) {
+        this.partsNum = partsNum;
+        this.database = database;
+        this.tableName = tableName;
+        this.relativePath = relativePath;
+        // MergeTree;{database}\n{table}\n{relative_path}\n{min_part}\n{max_part}\n
+        extensionTableStr.append(database).append("\n").append(tableName).append("\n")
+                .append(relativePath).append("\n")
+                .append(this.partsNum).append("\n");
+    }
+
+    public ReadRel.ExtensionTable toProtobuf() {
+        ReadRel.ExtensionTable.Builder extensionTableBuilder = ReadRel.ExtensionTable.newBuilder();
+        extensionTableBuilder.setDetail(
+                Any.newBuilder().setValue(ByteString.copyFromUtf8(extensionTableStr.toString())));
+        return extensionTableBuilder.build();
+    }
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/ddlplan/InsertPlanNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/ddlplan/InsertPlanNode.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.ddlplan;
+
+import io.glutenproject.substrait.SubstraitContext;
+import io.glutenproject.substrait.plan.PlanNode;
+import io.substrait.proto.DllPlan;
+import io.substrait.proto.Expression;
+import io.substrait.proto.InsertPlan;
+
+import java.io.Serializable;
+
+public class InsertPlanNode implements DllPlanNode, Serializable {
+
+  private final PlanNode inputNode;
+
+  private final SubstraitContext context;
+
+  public InsertPlanNode(SubstraitContext context, PlanNode inputNode) {
+    this.inputNode = inputNode;
+    this.context = context;
+  }
+
+  @Override
+  public DllPlan toProtobuf() {
+    InsertPlan.Builder insertBuilder = InsertPlan.newBuilder();
+    insertBuilder.setInput(inputNode.toProtobuf());
+    if (context.getInsertOutputNode() != null) {
+      insertBuilder.setOutput(context.getInsertOutputNode().toProtobuf());
+    }
+
+    DllPlan.Builder dllBuilder = DllPlan.newBuilder();
+    dllBuilder.setInsertPlan(insertBuilder.build());
+    return dllBuilder.build();
+  }
+}

--- a/jvm/src/main/resources/substrait/proto/substrait/ddl.proto
+++ b/jvm/src/main/resources/substrait/proto/substrait/ddl.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package substrait;
+
+import "substrait/plan.proto";
+import "substrait/algebra.proto";
+
+option java_multiple_files = true;
+option java_package = "io.substrait.proto";
+option csharp_namespace = "Substrait.Protobuf";
+
+message DllPlan {
+  oneof dll_type {
+    InsertPlan insert_plan = 1;
+  }
+}
+
+message InsertPlan {
+  Plan input = 1;
+  ReadRel.ExtensionTable output = 2;
+}
+
+message Dll {
+  repeated DllPlan dll_plan = 1;
+}

--- a/jvm/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/jvm/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -23,7 +23,7 @@ import scala.language.implicitConversions
 
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.extension.{ColumnarOverrides, StrategyOverrides}
+import io.glutenproject.extension.{ColumnarOverrides, OthersExtensionOverrides, StrategyOverrides}
 import io.glutenproject.vectorized.ExpressionEvaluator
 import java.util
 import org.apache.spark.{SparkConf, SparkContext}
@@ -125,7 +125,8 @@ private[glutenproject] object GlutenPlugin {
    */
   val DEFAULT_INJECTORS: List[GlutenSparkExtensionsInjector] = List(
     ColumnarOverrides,
-    StrategyOverrides
+    StrategyOverrides,
+    OthersExtensionOverrides
   )
 
   implicit def sparkConfImplicit(conf: SparkConf): SparkConfImplicits = {

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
@@ -22,12 +22,16 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.BuildSideRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.{SparkSession, Strategy}
 
 trait ISparkPlanExecApi extends IBackendsApi {
 
@@ -93,4 +97,19 @@ trait ISparkPlanExecApi extends IBackendsApi {
       child: SparkPlan,
       numOutputRows: SQLMetric,
       dataSize: SQLMetric): BuildSideRelation
+
+  /**
+   * Generate extended DataSourceV2 Strategy.
+   * Currently only for ClickHouse backend.
+   * @return
+   */
+  def genExtendedDataSourceV2Strategy(spark: SparkSession): Strategy
+
+  /**
+   * Generate extended Analyzer.
+   * Currently only for ClickHouse backend.
+   *
+   * @return
+   */
+  def genExtendedAnalyzer(spark: SparkSession, conf: SQLConf): Rule[LogicalPlan]
 }

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
@@ -18,7 +18,8 @@ package io.glutenproject.backendsapi
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
 
 trait ITransformerApi extends IBackendsApi {
 
@@ -36,4 +37,10 @@ trait ITransformerApi extends IBackendsApi {
    * @return true if backend supports reading the file format.
    */
   def supportsReadFileFormat(fileFormat: FileFormat): Boolean
+
+  /**
+   * Generate Seq[InputPartition] for FileSourceScanExecTransformer.
+   */
+  def genInputPartitionSeq(relation: HadoopFsRelation,
+                           selectedPartitions: Array[PartitionDirectory]): Seq[InputPartition]
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -403,8 +403,10 @@ case class HashAggregateExecTransformer(
     // Get the grouping nodes.
     val groupingList = new util.ArrayList[ExpressionNode]()
     groupingExpressions.foreach(expr => {
+      // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
+      // may be different for each backend.
       val groupingExpr: Expression = ExpressionConverter
-        .replaceWithExpressionTransformer(expr, originalInputAttributes)
+        .replaceWithExpressionTransformer(expr, child.output)
       val exprNode = groupingExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
       groupingList.add(exprNode)
     })

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -327,6 +327,7 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
       !plan.isInstanceOf[SerializeFromObjectExec] &&
       !plan.isInstanceOf[ObjectHashAggregateExec] &&
       !plan.isInstanceOf[V2CommandExec]
+
     val otherSupported = !isCH && nativeEngineEnabled
     if (chSupported || otherSupported) {
       isSupportAdaptive = supportAdaptive(plan)
@@ -344,6 +345,7 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
       !plan.isInstanceOf[SerializeFromObjectExec] &&
       !plan.isInstanceOf[ObjectHashAggregateExec] &&
       !plan.isInstanceOf[V2CommandExec]
+
     val otherSupported = !isCH && nativeEngineEnabled
     if (chSupported || otherSupported) {
       val rule = postOverrides

--- a/jvm/src/main/scala/io/glutenproject/extension/OthersExtensionOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/OthersExtensionOverrides.scala
@@ -1,0 +1,23 @@
+package io.glutenproject.extension
+
+import io.glutenproject.{GlutenConfig, GlutenSparkExtensionsInjector}
+import io.glutenproject.backendsapi.BackendsApiManager
+import org.apache.spark.SparkEnv
+
+import org.apache.spark.sql.SparkSessionExtensions
+
+object OthersExtensionOverrides extends GlutenSparkExtensionsInjector {
+  override def inject(extensions: SparkSessionExtensions): Unit = {
+    // Spark extension rules for ClickHouse backend.
+    if (SparkEnv.get.conf.get(GlutenConfig.GLUTEN_BACKEND_LIB)
+      .equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+      extensions.injectResolutionRule { session =>
+        BackendsApiManager.getSparkPlanExecApiInstance
+          .genExtendedAnalyzer(session, session.sessionState.conf)
+      }
+      extensions.injectPlannerStrategy { spark =>
+        BackendsApiManager.getSparkPlanExecApiInstance.genExtendedDataSourceV2Strategy(spark)
+      }
+    }
+  }
+}

--- a/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
@@ -192,7 +192,7 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
       }
     } catch {
       case e: UnsupportedOperationException =>
-        System.out.println(
+        logError(
           s"Fall back to use row-based operators, error is ${e.getMessage}," +
             s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
         false

--- a/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -17,6 +17,7 @@
 
 package io.glutenproject.substrait
 
+import io.glutenproject.substrait.ddlplan.InsertOutputNode
 import io.glutenproject.substrait.rel.{ExtensionTableNode, LocalFilesNode}
 
 class SubstraitContext extends Serializable {
@@ -27,6 +28,8 @@ class SubstraitContext extends Serializable {
   private val iteratorNodes = new java.util.HashMap[java.lang.Long, LocalFilesNode]()
   private var extensionTableNode: ExtensionTableNode = _
   private var iteratorIndex: java.lang.Long = new java.lang.Long(0)
+
+  private var insertOutputNode: InsertOutputNode = _
 
   def setLocalFilesNode(localFilesNode: LocalFilesNode): Unit = {
     this.localFilesNode = localFilesNode
@@ -50,6 +53,12 @@ class SubstraitContext extends Serializable {
   }
 
   def getExtensionTableNode: ExtensionTableNode = this.extensionTableNode
+
+  def setInsertOutputNode(insertOutputNode: InsertOutputNode): Unit = {
+    this.insertOutputNode = insertOutputNode
+  }
+
+  def getInsertOutputNode: InsertOutputNode = this.insertOutputNode
 
   def registerFunction(funcName: String): java.lang.Long = {
     if (!functionMap.containsKey(funcName)) {

--- a/jvm/src/main/scala/io/glutenproject/utils/InputPartitionsUtil.scala
+++ b/jvm/src/main/scala/io/glutenproject/utils/InputPartitionsUtil.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.utils
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.PartitionedFileUtil
+import org.apache.spark.sql.execution.datasources.{FilePartition, HadoopFsRelation, PartitionDirectory}
+
+object InputPartitionsUtil extends Logging {
+
+  def genInputPartitionSeq(relation: HadoopFsRelation,
+                           selectedPartitions: Array[PartitionDirectory]): Seq[InputPartition] = {
+    // TODO: Support bucketed reads
+    val openCostInBytes = relation.sparkSession.sessionState.conf.filesOpenCostInBytes
+    val maxSplitBytes =
+      FilePartition.maxSplitBytes(relation.sparkSession, selectedPartitions)
+    logInfo(
+      s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+        s"open cost is considered as scanning $openCostInBytes bytes.")
+
+    val splitFiles = selectedPartitions
+      .flatMap { partition =>
+        partition.files.flatMap { file =>
+          // getPath() is very expensive so we only want to call it once in this block:
+          val filePath = file.getPath
+          val isSplitable =
+            relation.fileFormat.isSplitable(relation.sparkSession, relation.options, filePath)
+          PartitionedFileUtil.splitFiles(
+            sparkSession = relation.sparkSession,
+            file = file,
+            filePath = filePath,
+            isSplitable = isSplitable,
+            maxSplitBytes = maxSplitBytes,
+            partitionValues = partition.values)
+        }
+      }
+      .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+
+    FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
+  }
+}

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
@@ -23,12 +23,16 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.BuildSideRelation
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.{SparkSession, Strategy}
 
 class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
   /**
@@ -88,6 +92,15 @@ class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
                                              readBatchNumRows: SQLMetric,
                                              numOutputRows: SQLMetric): Serializer = null
 
+
+  /**
+   * Generate extended DataSourceV2 Strategy.
+   * Currently only for ClickHouse backend.
+   *
+   * @return
+   */
+  override def genExtendedDataSourceV2Strategy(spark: SparkSession): Strategy = null
+
   /**
    * Get the backend api name.
    *
@@ -101,4 +114,12 @@ class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
   override def createBroadcastRelation(child: SparkPlan,
                                        numOutputRows: SQLMetric,
                                        dataSize: SQLMetric): BuildSideRelation = null
+
+  /**
+   * Generate extended Analyzer.
+   * Currently only for ClickHouse backend.
+   *
+   * @return
+   */
+  override def genExtendedAnalyzer(spark: SparkSession, conf: SQLConf): Rule[LogicalPlan] = null
 }

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/TransformerApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/TransformerApiImplSuite.scala
@@ -19,7 +19,8 @@ package io.glutenproject.backendsapi
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
 
 class TransformerApiImplSuite extends ITransformerApi {
 
@@ -38,6 +39,13 @@ class TransformerApiImplSuite extends ITransformerApi {
    * @return true if backend supports reading the file format.
    */
   override def supportsReadFileFormat(fileFormat: FileFormat): Boolean = false
+
+  /**
+   * Generate Seq[InputPartition] for FileSourceScanExecTransformer.
+   */
+  override def genInputPartitionSeq(relation: HadoopFsRelation,
+                                    selectedPartitions: Array[PartitionDirectory]
+                                   ): Seq[InputPartition] = Seq.empty[InputPartition]
 
   /**
    * Get the backend api name.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, there are some column pruning bugs in DataSource V2, so add this feature for ClickHouse backend to execute sql with DataSource V1.

Close #207 .
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

