### PR TITLE
Vanilla Spark's data source types not found when running in a boundled jar

### DIFF
--- a/backends-clickhouse/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/backends-clickhouse/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,12 @@
+org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2
+org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
+org.apache.spark.sql.execution.datasources.v2.json.JsonDataSourceV2
+org.apache.spark.sql.execution.datasources.noop.NoopDataSource
+org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
+org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
+org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
+org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
+org.apache.spark.sql.execution.streaming.sources.TextSocketSourceProvider
+org.apache.spark.sql.execution.datasources.binaryfile.BinaryFileFormat
 org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseDataSource

--- a/backends-velox/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/backends-velox/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,12 @@
+org.apache.spark.sql.execution.datasources.v2.csv.CSVDataSourceV2
+org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider
+org.apache.spark.sql.execution.datasources.v2.json.JsonDataSourceV2
+org.apache.spark.sql.execution.datasources.noop.NoopDataSource
+org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+org.apache.spark.sql.execution.datasources.v2.parquet.ParquetDataSourceV2
+org.apache.spark.sql.execution.datasources.v2.text.TextDataSourceV2
+org.apache.spark.sql.execution.streaming.ConsoleSinkProvider
+org.apache.spark.sql.execution.streaming.sources.RateStreamProvider
+org.apache.spark.sql.execution.streaming.sources.TextSocketSourceProvider
+org.apache.spark.sql.execution.datasources.binaryfile.BinaryFileFormat
 org.apache.spark.sql.execution.datasources.v2.velox.DwrfDatasourceV2


### PR DESCRIPTION
To fix error like
```
java.lang.ClassNotFoundException: Failed to find data source: parquet. Please find packages at http://spark.apache.org/third-party-projects.html
        at org.apache.spark.sql.execution.datasources.DataSource$.lookupDataSource(DataSource.scala:689)
        at org.apache.spark.sql.execution.datasources.DataSource$.lookupDataSourceV2(DataSource.scala:743)
        at org.apache.spark.sql.DataFrameWriter.lookupV2Provider(DataFrameWriter.scala:993)
        at org.apache.spark.sql.DataFrameWriter.saveInternal(DataFrameWriter.scala:311)
        at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:293)
        at org.apache.spark.sql.DataFrameWriter.parquet(DataFrameWriter.scala:874)
        at io.glutenproject.integration.tpc.h.TpchDataGen.generate(TpchDataGen.scala:346)
        at io.glutenproject.integration.tpc.h.TpchDataGen.gen(TpchDataGen.scala:45)
        at io.glutenproject.integration.tpc.h.TpchSuite.run(TpchSuite.scala:75)
        at io.glutenproject.integration.tpc.h.Tpch.call(Tpch.java:94)
        at io.glutenproject.integration.tpc.h.Tpch.call(Tpch.java:12)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
        at picocli.CommandLine.execute(CommandLine.java:2078)
        at io.glutenproject.integration.tpc.h.Tpch.main(Tpch.java:102)
Caused by: java.lang.ClassNotFoundException: parquet.DefaultSource
        at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at org.apache.spark.sql.execution.datasources.DataSource$.$anonfun$lookupDataSource$5(DataSource.scala:663)
        at scala.util.Try$.apply(Try.scala:213)
        at org.apache.spark.sql.execution.datasources.DataSource$.$anonfun$lookupDataSource$4(DataSource.scala:663)
        at scala.util.Failure.orElse(Try.scala:224)
        at org.apache.spark.sql.execution.datasources.DataSource$.lookupDataSource(DataSource.scala:663)
        ... 19 more
```