### PR TITLE
[OPPRO-169] Use the global memory pool when creating TaskCursor to avoid the pool released in velox

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -434,7 +434,7 @@ class VeloxPlanConverter::WholeStageResIterFirstStage : public WholeStageResIter
     }
     params_.planNode = planNode;
     params_.queryCtx = createNewVeloxQueryCtx(pool);
-  
+
     cursor_ = std::make_unique<test::TaskCursor>(params_);
     addSplits_ = [&](Task* task) {
       if (noMoreSplits_) {
@@ -466,7 +466,7 @@ class VeloxPlanConverter::WholeStageResIterMiddleStage : public WholeStageResIte
       : WholeStageResIter(pool, planNode) {
     params_.planNode = planNode;
     params_.queryCtx = createNewVeloxQueryCtx(pool);
-   
+
     cursor_ = std::make_unique<test::TaskCursor>(params_);
     addSplits_ = [&](Task* task) {
       if (noMoreSplits_) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

