### PR TITLE
[OPPRO-182] Change the Substrait plan for avg

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -25,7 +25,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.shuffle.utils.CHShuffleUtil
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -72,6 +73,27 @@ class CHSparkPlanExecApi extends ISparkPlanExecApi {
    */
   override def genFilterExecTransformer(condition: Expression, child: SparkPlan)
     : FilterExecBaseTransformer = FilterExecTransformer(condition, child)
+
+
+  /**
+   * Generate HashAggregateExecTransformer.
+   */
+  override def genHashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan): HashAggregateExecBaseTransformer =
+    CHHashAggregateExecTransformer(
+      requiredChildDistributionExpressions,
+      groupingExpressions,
+      aggregateExpressions,
+      aggregateAttributes,
+      initialInputBufferOffset,
+      resultExpressions,
+      child)
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import scala.util.control.Breaks.{break, breakable}
+
+import com.google.common.collect.Lists
+import com.google.protobuf.Any
+import io.glutenproject.GlutenConfig
+import io.glutenproject.expression._
+import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
+import io.glutenproject.substrait.extensions.ExtensionBuilder
+import io.glutenproject.substrait.plan.PlanBuilder
+import io.glutenproject.substrait.rel.{LocalFilesBuilder, RelBuilder, RelNode}
+import io.glutenproject.vectorized.ExpressionEvaluator
+import java.util
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.aggregate._
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+case class CHHashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan) extends HashAggregateExecBaseTransformer(
+    requiredChildDistributionExpressions,
+    groupingExpressions,
+    aggregateExpressions,
+    aggregateAttributes,
+    initialInputBufferOffset,
+    resultExpressions,
+    child) {
+
+  override def doValidate(): Boolean = {
+    val substraitContext = new SubstraitContext
+    val relNode =
+      try {
+        getAggRel(substraitContext.registeredFunction, null, validation = true)
+      } catch {
+        case e: Throwable =>
+          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          return false
+      }
+    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
+    // Then, validate the generated plan in native engine.
+    if (GlutenConfig.getConf.enableNativeValidation) {
+      val validator = new ExpressionEvaluator()
+      validator.doValidate(planNode.toProtobuf.toByteArray)
+    } else {
+      if (GlutenConfig.getConf.enableColumnarFinalAgg) {
+        true
+      } else {
+        var isPartial = true
+        aggregateExpressions.foreach(aggExpr => {
+          aggExpr.mode match {
+            case Partial =>
+            case _ => isPartial = false
+          }
+        })
+        isPartial
+      }
+    }
+  }
+
+  override def doTransform(context: SubstraitContext): TransformContext = {
+    val childCtx = child match {
+      case c: TransformSupport =>
+        c.doTransform(context)
+      case _ =>
+        null
+    }
+    val (relNode, inputAttributes, outputAttributes) = if (childCtx != null) {
+      (
+        getAggRel(context.registeredFunction, childCtx.root),
+        childCtx.outputAttributes,
+        aggregateResultAttributes)
+    } else {
+      // This means the input is just an iterator, so an ReadRel will be created as child.
+      // Prepare the input schema.
+      // Notes: Currently, ClickHouse backend uses the output attributes of
+      // aggregateResultAttributes as Shuffle output,
+      // which is different from the Velox and Gazelle.
+      val typeList = new util.ArrayList[TypeNode]()
+      val nameList = new util.ArrayList[String]()
+      for (attr <- aggregateResultAttributes) {
+        typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+        nameList.add(ConverterUtils.genColumnNameWithExprId(attr))
+      }
+      // The iterator index will be added in the path of LocalFiles.
+      val inputIter = LocalFilesBuilder.makeLocalFiles(
+        ConverterUtils.ITERATOR_PREFIX.concat(context.nextIteratorIndex.toString))
+      context.setLocalFilesNode(inputIter)
+      val readRel = RelBuilder.makeReadRel(typeList, nameList, null, context)
+
+      (getAggRel(context.registeredFunction, readRel), aggregateResultAttributes, output)
+    }
+    TransformContext(inputAttributes, outputAttributes, relNode)
+  }
+
+  override def getAggRelWithoutPreProjection(args: java.lang.Object,
+                                             originalInputAttributes: Seq[Attribute],
+                                             input: RelNode = null,
+                                             validation: Boolean): RelNode = {
+    // Get the grouping nodes.
+    val groupingList = new util.ArrayList[ExpressionNode]()
+    groupingExpressions.foreach(expr => {
+      // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
+      // may be different for each backend.
+      val groupingExpr: Expression = ExpressionConverter
+        .replaceWithExpressionTransformer(expr, child.output)
+      val exprNode = groupingExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+      groupingList.add(exprNode)
+    })
+    // Get the aggregate function nodes.
+    val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
+    aggregateExpressions.foreach(aggExpr => {
+      val aggregatFunc = aggExpr.aggregateFunction
+      val childrenNodeList = new util.ArrayList[ExpressionNode]()
+      val childrenNodes = aggExpr.mode match {
+        case Partial =>
+          aggregatFunc.children.toList.map(expr => {
+            val aggExpr: Expression = ExpressionConverter
+              .replaceWithExpressionTransformer(expr, child.output)
+            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+          })
+        case Final =>
+          val aggTypesExpr: Expression = ExpressionConverter
+            .replaceWithExpressionTransformer(aggExpr.resultAttribute, originalInputAttributes)
+          Seq(aggTypesExpr.asInstanceOf[ExpressionTransformer].doTransform(args))
+        case other =>
+          throw new UnsupportedOperationException(s"$other not supported.")
+      }
+      for (node <- childrenNodes) {
+        childrenNodeList.add(node)
+      }
+      val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
+        AggregateFunctionsBuilder.create(args, aggregatFunc),
+        childrenNodeList,
+        modeToKeyWord(aggExpr.mode),
+        ConverterUtils.getTypeNode(aggregatFunc.dataType, aggregatFunc.nullable))
+      aggregateFunctionList.add(aggFunctionNode)
+    })
+    if (!validation) {
+      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
+      for (attr <- originalInputAttributes) {
+        inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+      }
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
+      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList, extensionNode)
+    }
+  }
+
+  override def getAggRel(args: java.lang.Object,
+                         input: RelNode = null,
+                         validation: Boolean = false): RelNode = {
+    val originalInputAttributes = child.output
+    val aggRel = if (needsPreProjection) {
+      getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
+    } else {
+      getAggRelWithoutPreProjection(args, aggregateResultAttributes, input, validation)
+    }
+    applyPostProjection(args, aggRel, validation)
+  }
+}

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -143,11 +143,11 @@ case class CHHashAggregateExecTransformer(
     // Get the aggregate function nodes.
     val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
     aggregateExpressions.foreach(aggExpr => {
-      val aggregatFunc = aggExpr.aggregateFunction
+      val aggregateFunc = aggExpr.aggregateFunction
       val childrenNodeList = new util.ArrayList[ExpressionNode]()
       val childrenNodes = aggExpr.mode match {
         case Partial =>
-          aggregatFunc.children.toList.map(expr => {
+          aggregateFunc.children.toList.map(expr => {
             val aggExpr: Expression = ExpressionConverter
               .replaceWithExpressionTransformer(expr, child.output)
             aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
@@ -163,10 +163,10 @@ case class CHHashAggregateExecTransformer(
         childrenNodeList.add(node)
       }
       val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
-        AggregateFunctionsBuilder.create(args, aggregatFunc),
+        AggregateFunctionsBuilder.create(args, aggregateFunc),
         childrenNodeList,
         modeToKeyWord(aggExpr.mode),
-        ConverterUtils.getTypeNode(aggregatFunc.dataType, aggregatFunc.nullable))
+        ConverterUtils.getTypeNode(aggregateFunc.dataType, aggregateFunc.nullable))
       aggregateFunctionList.add(aggFunctionNode)
     })
     if (!validation) {

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -19,7 +19,7 @@ package io.glutenproject.backendsapi.velox
 import com.intel.oap.spark.sql.DwrfWriteExtension.{DummyRule, DwrfWritePostRule, SimpleColumnarRule, SimpleStrategy}
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.ISparkPlanExecApi
-import io.glutenproject.execution.{FilterExecBaseTransformer, FilterExecTransformer, HashAggregateExecBaseTransformer, HashAggregateExecTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxFilterExecTransformer, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, FilterExecTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxFilterExecTransformer, VeloxHashAggregateExecTransformer, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
 import io.glutenproject.expression.ArrowConverterUtils
 import io.glutenproject.vectorized.{ArrowColumnarBatchSerializer, ArrowWritableColumnVector}
 import org.apache.spark.{ShuffleDependency, SparkException}
@@ -92,7 +92,7 @@ class VeloxSparkPlanExecApi extends ISparkPlanExecApi {
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     child: SparkPlan): HashAggregateExecBaseTransformer =
-    HashAggregateExecTransformer(
+    VeloxHashAggregateExecTransformer(
       requiredChildDistributionExpressions,
       groupingExpressions,
       aggregateExpressions,

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -19,7 +19,7 @@ package io.glutenproject.backendsapi.velox
 import com.intel.oap.spark.sql.DwrfWriteExtension.{DummyRule, DwrfWritePostRule, SimpleColumnarRule, SimpleStrategy}
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.ISparkPlanExecApi
-import io.glutenproject.execution.{FilterExecBaseTransformer, FilterExecTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxFilterExecTransformer, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, FilterExecTransformer, HashAggregateExecBaseTransformer, HashAggregateExecTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, VeloxFilterExecTransformer, VeloxNativeColumnarToRowExec, VeloxRowToArrowColumnarExec}
 import io.glutenproject.expression.ArrowConverterUtils
 import io.glutenproject.vectorized.{ArrowColumnarBatchSerializer, ArrowWritableColumnVector}
 import org.apache.spark.{ShuffleDependency, SparkException}
@@ -27,7 +27,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.shuffle.utils.VeloxShuffleUtil
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.{SparkSession, Strategy}
@@ -79,6 +80,26 @@ class VeloxSparkPlanExecApi extends ISparkPlanExecApi {
     } else {
       VeloxFilterExecTransformer(condition, child)
     }
+
+  /**
+   * Generate HashAggregateExecTransformer.
+   */
+  override def genHashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan): HashAggregateExecBaseTransformer =
+    HashAggregateExecTransformer(
+      requiredChildDistributionExpressions,
+      groupingExpressions,
+      aggregateExpressions,
+      aggregateAttributes,
+      initialInputBufferOffset,
+      resultExpressions,
+      child)
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashAggregateExecTransformer.scala
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import scala.collection.JavaConverters._
+import scala.util.control.Breaks.{break, breakable}
+import com.google.common.collect.Lists
+import com.google.protobuf.Any
+import io.glutenproject.expression._
+import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode, ScalarFunctionNode}
+import io.glutenproject.substrait.extensions.ExtensionBuilder
+import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+import java.util
+
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.types.LongType
+
+case class VeloxHashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan) extends HashAggregateExecBaseTransformer(
+    requiredChildDistributionExpressions,
+    groupingExpressions,
+    aggregateExpressions,
+    aggregateAttributes,
+    initialInputBufferOffset,
+    resultExpressions,
+    child) {
+
+  // Create aggregate function node and add to list.
+  override protected def addFunctionNode(
+    args: java.lang.Object,
+    aggregateFunction: AggregateFunction,
+    childrenNodeList: util.ArrayList[ExpressionNode],
+    aggregateMode: AggregateMode,
+    aggregateNodeList: util.ArrayList[AggregateFunctionNode]): Unit = {
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    aggregateFunction match {
+      case _: Average =>
+        aggregateMode match {
+          case Partial =>
+            // Will use sum and count to replace partial avg.
+            assert(childrenNodeList.size() == 1, "Partial Average expects one child node.")
+            val inputType = aggregateFunction.inputAggBufferAttributes.head.dataType
+            val inputNullable = aggregateFunction.inputAggBufferAttributes.head.nullable
+
+            val sumNode = ExpressionBuilder.makeAggregateFunction(
+              ExpressionBuilder.newScalarFunction(
+                functionMap,
+                ConverterUtils
+                  .makeFuncName(ConverterUtils.SUM, Seq(inputType), FunctionConfig.OPT)),
+              childrenNodeList,
+              modeToKeyWord(aggregateMode),
+              ConverterUtils.getTypeNode(inputType, inputNullable))
+            aggregateNodeList.add(sumNode)
+
+            val countNode = ExpressionBuilder.makeAggregateFunction(
+              ExpressionBuilder.newScalarFunction(
+                functionMap,
+                ConverterUtils
+                  .makeFuncName(ConverterUtils.COUNT, Seq(inputType), FunctionConfig.OPT)),
+              childrenNodeList,
+              modeToKeyWord(aggregateMode),
+              ConverterUtils.getTypeNode(LongType, nullable = true) /* return type for count */)
+            aggregateNodeList.add(countNode)
+          case Final =>
+            val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
+              AggregateFunctionsBuilder.create(args, aggregateFunction),
+              childrenNodeList,
+              modeToKeyWord(aggregateMode),
+              ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable))
+            aggregateNodeList.add(aggFunctionNode)
+          case other =>
+            throw new UnsupportedOperationException(s"$other is not supported.")
+        }
+      case _ =>
+        val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
+          AggregateFunctionsBuilder.create(args, aggregateFunction),
+          childrenNodeList,
+          modeToKeyWord(aggregateMode),
+          ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable))
+        aggregateNodeList.add(aggFunctionNode)
+    }
+  }
+
+  // Return whether the outputs partial aggregation should be combined for Velox computing.
+  // When the partial outputs are multiple-column, row construct is needed.
+  private def rowConstructNeeded: Boolean = {
+    for (aggregateExpression <- aggregateExpressions) {
+      aggregateExpression.mode match {
+        case PartialMerge | Final =>
+          if (aggregateExpression.aggregateFunction.inputAggBufferAttributes.size > 1) {
+            return true
+          }
+        case _ =>
+      }
+    }
+    false
+  }
+
+
+  // Return a scalar function node representing row construct function in Velox.
+  private def getRowConstructNode(
+    args: java.lang.Object,
+    childNodes: util.ArrayList[ExpressionNode],
+    rowConstructAttributes: Seq[Attribute]): ScalarFunctionNode = {
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionName = ConverterUtils.makeFuncName(
+      ConverterUtils.ROW_CONSTRUCTOR,
+      rowConstructAttributes.map(attr => attr.dataType),
+      FunctionConfig.NON)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+
+    // Use struct type to represent Velox RowType.
+    val structTypeNodes = new util.ArrayList[TypeNode](rowConstructAttributes.map(attr =>
+      ConverterUtils.getTypeNode(attr.dataType, attr.nullable)
+    ).asJava)
+
+    ExpressionBuilder.makeScalarFunction(
+      functionId, childNodes, TypeBuilder.makeStruct(structTypeNodes))
+  }
+
+  // Add a projection node before aggregation for row constructing.
+  // Currently mainly used for final average.
+  // Pre-projection is always not required for final stage.
+  private def getAggRelWithRowConstruct(args: java.lang.Object,
+                                        originalInputAttributes: Seq[Attribute],
+                                        inputRel: RelNode,
+                                        validation: Boolean): RelNode = {
+    // Create a projection for row construct.
+    val exprNodes = new util.ArrayList[ExpressionNode]()
+    groupingExpressions.foreach(expr => {
+      exprNodes.add(ExpressionConverter
+        .replaceWithExpressionTransformer(expr, originalInputAttributes)
+        .asInstanceOf[ExpressionTransformer].doTransform(args))
+    })
+
+    for (aggregateExpression <- aggregateExpressions) {
+      val functionInputAttributes = aggregateExpression.aggregateFunction.inputAggBufferAttributes
+      aggregateExpression.aggregateFunction match {
+        case Average(_) =>
+          aggregateExpression.mode match {
+            case Final =>
+              assert(
+                functionInputAttributes.size == 2, "Final Average expects two input attributes.")
+              // Use a Velox function to combine sum and count.
+              val childNodes = new util.ArrayList[ExpressionNode](
+                functionInputAttributes.toList.map(attr => {
+                val aggExpr: Expression = ExpressionConverter
+                  .replaceWithExpressionTransformer(attr, originalInputAttributes)
+                aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+                }).asJava)
+              exprNodes.add(getRowConstructNode(args, childNodes, functionInputAttributes))
+            case other =>
+              throw new UnsupportedOperationException(s"$other is not supported.")
+          }
+        case _ =>
+          assert(functionInputAttributes.size == 1, "Only one input attribute is expected.")
+          val childNodes = new util.ArrayList[ExpressionNode](
+            functionInputAttributes.toList.map(attr => {
+            val aggExpr: Expression = ExpressionConverter
+              .replaceWithExpressionTransformer(attr, originalInputAttributes)
+            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+          }).asJava)
+          exprNodes.addAll(childNodes)
+      }
+    }
+
+    // Create a project rel.
+    val projectRel = if (!validation) {
+      RelBuilder.makeProjectRel(inputRel, exprNodes)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
+      for (attr <- originalInputAttributes) {
+        inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+      }
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
+      RelBuilder.makeProjectRel(inputRel, exprNodes, extensionNode)
+    }
+
+    // Create aggregation rel.
+    val groupingList = new util.ArrayList[ExpressionNode]()
+    var colIdx = 0
+    groupingExpressions.foreach(_ => {
+      groupingList.add(ExpressionBuilder.makeSelection(colIdx))
+      colIdx += 1
+    })
+
+    val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
+    aggregateExpressions.foreach(aggExpr => {
+      val aggregateFunc = aggExpr.aggregateFunction
+      val childrenNodes = new util.ArrayList[ExpressionNode]()
+      aggregateFunc match {
+        case Average(_) =>
+          // Only occupies one column due to sum and count are combined by previous projection.
+          childrenNodes.add(ExpressionBuilder.makeSelection(colIdx))
+          colIdx += 1
+        case _ =>
+          aggregateFunc.children.toList.map(_ => {
+            childrenNodes.add(ExpressionBuilder.makeSelection(colIdx))
+            colIdx += 1
+            aggExpr
+          })
+      }
+      addFunctionNode(args, aggregateFunc, childrenNodes, aggExpr.mode, aggregateFunctionList)
+    })
+    RelBuilder.makeAggregateRel(projectRel, groupingList, aggregateFunctionList)
+  }
+
+  override protected def getAggRel(args: java.lang.Object,
+                                   input: RelNode = null,
+                                   validation: Boolean = false): RelNode = {
+    val originalInputAttributes = child.output
+    val preProjectionNeeded = needsPreProjection
+
+    val aggRel = if (preProjectionNeeded) {
+      getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
+    } else {
+      if (rowConstructNeeded) {
+        getAggRelWithRowConstruct(args, originalInputAttributes, input, validation)
+      } else {
+        getAggRelWithoutPreProjection(args, originalInputAttributes, input, validation)
+      }
+    }
+
+    applyPostProjection(args, aggRel, validation)
+  }
+}

--- a/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -48,11 +48,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   val enableColumnarHashAgg: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.hashagg", "true").toBoolean
 
-  // A tmp config used to fallback Final Aggregation.
-  // Can be removed after Final Aggregation is fully supported.
-  val enableColumnarFinalAgg: Boolean = conf.getConfString(
-    "spark.gluten.sql.columnar.hashagg.enablefinal", "true").toBoolean
-
   // enable or disable columnar project
   val enableColumnarProject: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.project", "true").toBoolean

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
@@ -16,12 +16,13 @@
 
 package io.glutenproject.backendsapi
 
-import io.glutenproject.execution.{FilterExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -60,6 +61,18 @@ trait ISparkPlanExecApi extends IBackendsApi {
    */
   def genFilterExecTransformer(condition: Expression, child: SparkPlan)
     : FilterExecBaseTransformer
+
+  /**
+   * Generate HashAggregateExecTransformer.
+   */
+  def genHashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan): HashAggregateExecBaseTransformer
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -20,7 +20,6 @@ package io.glutenproject.execution
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.util.control.Breaks.{break, breakable}
-
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
@@ -221,7 +220,7 @@ abstract class HashAggregateExecBaseTransformer(
       input: RelNode = null,
       validation: Boolean): RelNode = {
     // Will add a Projection before Aggregate.
-    // Logic was added to prevent selecting the same column for more than one times,
+    // Logic was added to prevent selecting the same column for more than once,
     // so the expression in preExpressions will be unique.
     var preExpressions: Seq[Expression] = Seq()
     var selections: Seq[Int] = Seq()
@@ -243,10 +242,10 @@ abstract class HashAggregateExecBaseTransformer(
 
     // Get the needed expressions from aggregation expressions.
     aggregateExpressions.foreach(aggExpr => {
-      val aggregatFunc = aggExpr.aggregateFunction
+      val aggregateFunc = aggExpr.aggregateFunction
       aggExpr.mode match {
         case Partial =>
-          aggregatFunc.children.toList.map(childExpr => {
+          aggregateFunc.children.toList.map(childExpr => {
             val foundExpr = preExpressions.find(e => e.semanticEquals(childExpr)).orNull
             if (foundExpr != null) {
               selections = selections :+ preExpressions.indexOf(foundExpr)
@@ -282,6 +281,11 @@ abstract class HashAggregateExecBaseTransformer(
 
     // Handle the pure Aggregate after Projection. Both grouping and Aggregate expressions are
     // selections.
+    getAggRelAfterProject(args, selections, inputRel)
+  }
+
+  protected def getAggRelAfterProject(
+    args: java.lang.Object, selections: Seq[Int], inputRel: RelNode): RelNode = {
     val groupingList = new util.ArrayList[ExpressionNode]()
     var colIdx = 0
     while (colIdx < groupingExpressions.size) {
@@ -293,9 +297,9 @@ abstract class HashAggregateExecBaseTransformer(
     // Create Aggregation functions.
     val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
     aggregateExpressions.foreach(aggExpr => {
-      val aggregatFunc = aggExpr.aggregateFunction
+      val aggregateFunc = aggExpr.aggregateFunction
       val childrenNodeList = new util.ArrayList[ExpressionNode]()
-      val childrenNodes = aggregatFunc.children.toList.map(_ => {
+      val childrenNodes = aggregateFunc.children.toList.map(_ => {
         val aggExpr = ExpressionBuilder.makeSelection(selections(colIdx))
         colIdx += 1
         aggExpr
@@ -303,15 +307,33 @@ abstract class HashAggregateExecBaseTransformer(
       for (node <- childrenNodes) {
         childrenNodeList.add(node)
       }
-      val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
-        AggregateFunctionsBuilder.create(args, aggregatFunc),
-        childrenNodeList,
-        modeToKeyWord(aggExpr.mode),
-        ConverterUtils.getTypeNode(aggregatFunc.dataType, aggregatFunc.nullable))
-      aggregateFunctionList.add(aggFunctionNode)
+      addFunctionNode(args, aggregateFunc, childrenNodeList, aggExpr.mode, aggregateFunctionList)
     })
 
     RelBuilder.makeAggregateRel(inputRel, groupingList, aggregateFunctionList)
+  }
+
+  protected def addFunctionNode(args: java.lang.Object,
+                                aggregateFunction: AggregateFunction,
+                                childrenNodeList: util.ArrayList[ExpressionNode],
+                                aggregateMode: AggregateMode,
+                                aggregateNodeList: util.ArrayList[AggregateFunctionNode]): Unit = {
+    aggregateNodeList.add(
+      ExpressionBuilder.makeAggregateFunction(
+          AggregateFunctionsBuilder.create(args, aggregateFunction),
+          childrenNodeList,
+          modeToKeyWord(aggregateMode),
+          ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable)))
+  }
+
+  // The direct outputs of Aggregation.
+  protected val allAggregateResultAttributes: List[Attribute] = {
+    val groupingAttributes = groupingExpressions.map(expr => {
+      ConverterUtils.getAttrFromExpr(expr).toAttribute
+    })
+    groupingAttributes.toList ::: getAttrForAggregateExpr(
+      aggregateExpressions,
+      aggregateAttributes)
   }
 
   protected def applyPostProjection(args: java.lang.Object,
@@ -319,14 +341,6 @@ abstract class HashAggregateExecBaseTransformer(
                                     validation: Boolean): RelNode = {
     // Will check if post-projection is needed. If yes, a ProjectRel will be added after the
     // AggregateRel.
-    val groupingAttributes = groupingExpressions.map(expr => {
-      ConverterUtils.getAttrFromExpr(expr).toAttribute
-    })
-    // This is the direct outputs of this Aggregation.
-    val allAggregateResultAttributes: List[Attribute] =
-      groupingAttributes.toList ::: getAttrForAggregateExpr(
-        aggregateExpressions,
-        aggregateAttributes)
     if (!needsPostProjection(allAggregateResultAttributes)) {
       aggRel
     } else {
@@ -356,7 +370,7 @@ abstract class HashAggregateExecBaseTransformer(
    * This method calculates the output attributes of Aggregation.
    */
   protected def getAttrForAggregateExpr(aggregateExpressions: Seq[AggregateExpression],
-                               aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
+                                        aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
     var aggregateAttr = new ListBuffer[Attribute]()
     val size = aggregateExpressions.size
     var res_index = 0
@@ -490,34 +504,70 @@ abstract class HashAggregateExecBaseTransformer(
   }
 
   protected def getAggRelWithoutPreProjection(args: java.lang.Object,
-                                    originalInputAttributes: Seq[Attribute],
-                                    input: RelNode = null,
-                                    validation: Boolean): RelNode
+                                              originalInputAttributes: Seq[Attribute],
+                                              input: RelNode = null,
+                                              validation: Boolean): RelNode = {
+    // Get the grouping nodes.
+    val groupingList = new util.ArrayList[ExpressionNode]()
+    groupingExpressions.foreach(expr => {
+    // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
+    // may be different for each backend.
+    val groupingExpr: Expression = ExpressionConverter
+      .replaceWithExpressionTransformer(expr, child.output)
+    val exprNode = groupingExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+      groupingList.add(exprNode)
+    })
+    // Get the aggregate function nodes.
+    val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
+    aggregateExpressions.foreach(aggExpr => {
+      val aggregateFunc = aggExpr.aggregateFunction
+      val childrenNodeList = new util.ArrayList[ExpressionNode]()
+      val childrenNodes = aggExpr.mode match {
+        case Partial =>
+          aggregateFunc.children.toList.map(expr => {
+            val aggExpr: Expression = ExpressionConverter
+              .replaceWithExpressionTransformer(expr, originalInputAttributes)
+            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+          })
+        case Final =>
+          aggregateFunc.inputAggBufferAttributes.toList.map(attr => {
+            val aggExpr: Expression = ExpressionConverter
+              .replaceWithExpressionTransformer(attr, originalInputAttributes)
+            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+          })
+        case other =>
+          throw new UnsupportedOperationException(s"$other not supported.")
+      }
+      for (node <- childrenNodes) {
+        childrenNodeList.add(node)
+      }
+      addFunctionNode(args, aggregateFunc, childrenNodeList, aggExpr.mode, aggregateFunctionList)
+    })
+    if (!validation) {
+      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
+      for (attr <- originalInputAttributes) {
+        inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+      }
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
+      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList, extensionNode)
+    }
+  }
 
   protected def getAggRel(args: java.lang.Object,
-                input: RelNode = null,
-                validation: Boolean = false): RelNode
-
-  def doValidate(): Boolean
-
-  def doTransform(context: SubstraitContext): TransformContext
-}
-
-case class HashAggregateExecTransformer(
-    requiredChildDistributionExpressions: Option[Seq[Expression]],
-    groupingExpressions: Seq[NamedExpression],
-    aggregateExpressions: Seq[AggregateExpression],
-    aggregateAttributes: Seq[Attribute],
-    initialInputBufferOffset: Int,
-    resultExpressions: Seq[NamedExpression],
-    child: SparkPlan) extends HashAggregateExecBaseTransformer(
-    requiredChildDistributionExpressions,
-    groupingExpressions,
-    aggregateExpressions,
-    aggregateAttributes,
-    initialInputBufferOffset,
-    resultExpressions,
-    child) {
+                          input: RelNode = null,
+                          validation: Boolean = false): RelNode = {
+    val originalInputAttributes = child.output
+    val aggRel = if (needsPreProjection) {
+      getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
+    } else {
+      getAggRelWithoutPreProjection(args, originalInputAttributes, input, validation)
+    }
+    applyPostProjection(args, aggRel, validation)
+  }
 
   override def doValidate(): Boolean = {
     val substraitContext = new SubstraitContext
@@ -559,76 +609,5 @@ case class HashAggregateExecTransformer(
       (getAggRel(context.registeredFunction, readRel), child.output, output)
     }
     TransformContext(inputAttributes, outputAttributes, relNode)
-  }
-
-  override protected def getAggRelWithoutPreProjection(args: java.lang.Object,
-                                                       originalInputAttributes: Seq[Attribute],
-                                                       input: RelNode = null,
-                                                       validation: Boolean): RelNode = {
-    // Get the grouping nodes.
-    val groupingList = new util.ArrayList[ExpressionNode]()
-    groupingExpressions.foreach(expr => {
-      // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
-      // may be different for each backend.
-      val groupingExpr: Expression = ExpressionConverter
-        .replaceWithExpressionTransformer(expr, child.output)
-      val exprNode = groupingExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-      groupingList.add(exprNode)
-    })
-    // Get the aggregate function nodes.
-    val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
-    aggregateExpressions.foreach(aggExpr => {
-      val aggregatFunc = aggExpr.aggregateFunction
-      val childrenNodeList = new util.ArrayList[ExpressionNode]()
-      val childrenNodes = aggExpr.mode match {
-        case Partial =>
-          aggregatFunc.children.toList.map(expr => {
-            val aggExpr: Expression = ExpressionConverter
-              .replaceWithExpressionTransformer(expr, originalInputAttributes)
-            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-          })
-        case Final =>
-          aggregatFunc.inputAggBufferAttributes.toList.map(attr => {
-            val aggExpr: Expression = ExpressionConverter
-              .replaceWithExpressionTransformer(attr, originalInputAttributes)
-            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-          })
-        case other =>
-          throw new UnsupportedOperationException(s"$other not supported.")
-      }
-      for (node <- childrenNodes) {
-        childrenNodeList.add(node)
-      }
-      val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
-        AggregateFunctionsBuilder.create(args, aggregatFunc),
-        childrenNodeList,
-        modeToKeyWord(aggExpr.mode),
-        ConverterUtils.getTypeNode(aggregatFunc.dataType, aggregatFunc.nullable))
-      aggregateFunctionList.add(aggFunctionNode)
-    })
-    if (!validation) {
-      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList)
-    } else {
-      // Use a extension node to send the input types through Substrait plan for validation.
-      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
-      for (attr <- originalInputAttributes) {
-        inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-      }
-      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
-        Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
-      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList, extensionNode)
-    }
-  }
-
-  override protected def getAggRel(args: java.lang.Object,
-                                   input: RelNode = null,
-                                   validation: Boolean = false): RelNode = {
-    val originalInputAttributes = child.output
-    val aggRel = if (needsPreProjection) {
-      getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
-    } else {
-      getAggRelWithoutPreProjection(args, originalInputAttributes, input, validation)
-    }
-    applyPostProjection(args, aggRel, validation)
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 /**
  * Columnar Based HashAggregateExec.
  */
-case class HashAggregateExecTransformer(
+abstract class HashAggregateExecBaseTransformer(
     requiredChildDistributionExpressions: Option[Seq[Expression]],
     groupingExpressions: Seq[NamedExpression],
     aggregateExpressions: Seq[AggregateExpression],
@@ -104,37 +104,6 @@ case class HashAggregateExecTransformer(
     })
   }
 
-  override def doValidate(): Boolean = {
-    val substraitContext = new SubstraitContext
-    val relNode =
-      try {
-        getAggRel(substraitContext.registeredFunction, null, validation = true)
-      } catch {
-        case e: Throwable =>
-          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
-          return false
-      }
-    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-    // Then, validate the generated plan in native engine.
-    if (GlutenConfig.getConf.enableNativeValidation) {
-      val validator = new ExpressionEvaluator()
-      validator.doValidate(planNode.toProtobuf.toByteArray)
-    } else {
-      if (GlutenConfig.getConf.enableColumnarFinalAgg) {
-        true
-      } else {
-        var isPartial = true
-        aggregateExpressions.foreach(aggExpr => {
-          aggExpr.mode match {
-            case Partial =>
-            case _ => isPartial = false
-          }
-        })
-        isPartial
-      }
-    }
-  }
-
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     throw new UnsupportedOperationException(s"This operator doesn't support doExecuteColumnar().")
   }
@@ -169,54 +138,6 @@ case class HashAggregateExecTransformer(
 
   // override def canEqual(that: Any): Boolean = false
 
-  override def doTransform(context: SubstraitContext): TransformContext = {
-    val childCtx = child match {
-      case c: TransformSupport =>
-        c.doTransform(context)
-      case _ =>
-        null
-    }
-    val (relNode, inputAttributes, outputAttributes) = if (childCtx != null) {
-      if (!GlutenConfig.getConf.isClickHouseBackend) {
-        (getAggRel(context.registeredFunction, childCtx.root), childCtx.outputAttributes, output)
-      } else {
-        (
-          getAggRel(context.registeredFunction, childCtx.root),
-          childCtx.outputAttributes,
-          aggregateResultAttributes)
-      }
-    } else {
-      // This means the input is just an iterator, so an ReadRel will be created as child.
-      // Prepare the input schema.
-      if (!GlutenConfig.getConf.isClickHouseBackend) {
-        val attrList = new util.ArrayList[Attribute]()
-        for (attr <- child.output) {
-          attrList.add(attr)
-        }
-        val readRel = RelBuilder.makeReadRel(attrList, context)
-        (getAggRel(context.registeredFunction, readRel), child.output, output)
-      } else {
-        // Notes: Currently, ClickHouse backend uses the output attributes of
-        // aggregateResultAttributes as Shuffle output,
-        // which is different from the Velox and Gazelle.
-        val typeList = new util.ArrayList[TypeNode]()
-        val nameList = new util.ArrayList[String]()
-        for (attr <- aggregateResultAttributes) {
-          typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-          nameList.add(ConverterUtils.genColumnNameWithExprId(attr))
-        }
-        // The iterator index will be added in the path of LocalFiles.
-        val inputIter = LocalFilesBuilder.makeLocalFiles(
-          ConverterUtils.ITERATOR_PREFIX.concat(context.nextIteratorIndex.toString))
-        context.setLocalFilesNode(inputIter)
-        val readRel = RelBuilder.makeReadRel(typeList, nameList, null, context)
-
-        (getAggRel(context.registeredFunction, readRel), aggregateResultAttributes, output)
-      }
-    }
-    TransformContext(inputAttributes, outputAttributes, relNode)
-  }
-
   override def verboseString(maxFields: Int): String = toString(verbose = true, maxFields)
 
   override def simpleString(maxFields: Int): String = toString(verbose = false, maxFields)
@@ -233,7 +154,7 @@ case class HashAggregateExecTransformer(
     }
   }
 
-  private def needsPreProjection: Boolean = {
+  protected def needsPreProjection: Boolean = {
     var needsProjection = false
     breakable {
       for (expr <- groupingExpressions) {
@@ -261,7 +182,7 @@ case class HashAggregateExecTransformer(
     needsProjection
   }
 
-  private def needsPostProjection(aggOutAttributes: List[Attribute]): Boolean = {
+  protected def needsPostProjection(aggOutAttributes: List[Attribute]): Boolean = {
     // Check if Post-Projection is needed after the Aggregation.
     var needsProjection = false
     // If the result expressions has different size with output attribute,
@@ -294,7 +215,7 @@ case class HashAggregateExecTransformer(
     needsProjection
   }
 
-  private def getAggRelWithPreProjection(
+  protected def getAggRelWithPreProjection(
       args: java.lang.Object,
       originalInputAttributes: Seq[Attribute],
       input: RelNode = null,
@@ -393,94 +314,9 @@ case class HashAggregateExecTransformer(
     RelBuilder.makeAggregateRel(inputRel, groupingList, aggregateFunctionList)
   }
 
-  private def getAggRelWithoutPreProjection(
-      args: java.lang.Object,
-      originalInputAttributes: Seq[Attribute],
-      input: RelNode = null,
-      validation: Boolean): RelNode = {
-    // Get the grouping nodes.
-    val groupingList = new util.ArrayList[ExpressionNode]()
-    groupingExpressions.foreach(expr => {
-      // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
-      // may be different for each backend.
-      val groupingExpr: Expression = ExpressionConverter
-        .replaceWithExpressionTransformer(expr, child.output)
-      val exprNode = groupingExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-      groupingList.add(exprNode)
-    })
-    // Get the aggregate function nodes.
-    val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
-    aggregateExpressions.foreach(aggExpr => {
-      val aggregatFunc = aggExpr.aggregateFunction
-      val childrenNodeList = new util.ArrayList[ExpressionNode]()
-      val childrenNodes = aggExpr.mode match {
-        case Partial =>
-          if (!GlutenConfig.getConf.isClickHouseBackend) {
-            aggregatFunc.children.toList.map(expr => {
-              val aggExpr: Expression = ExpressionConverter
-                .replaceWithExpressionTransformer(expr, originalInputAttributes)
-              aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-            })
-          } else {
-            aggregatFunc.children.toList.map(expr => {
-              val aggExpr: Expression = ExpressionConverter
-                .replaceWithExpressionTransformer(expr, child.output)
-              aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-            })
-          }
-        case Final =>
-          if (!GlutenConfig.getConf.isClickHouseBackend) {
-            aggregatFunc.inputAggBufferAttributes.toList.map(attr => {
-              val aggExpr: Expression = ExpressionConverter
-                .replaceWithExpressionTransformer(attr, originalInputAttributes)
-              aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
-            })
-          } else {
-            val aggTypesExpr: Expression = ExpressionConverter
-              .replaceWithExpressionTransformer(aggExpr.resultAttribute, originalInputAttributes)
-            Seq(aggTypesExpr.asInstanceOf[ExpressionTransformer].doTransform(args))
-          }
-        case other =>
-          throw new UnsupportedOperationException(s"$other not supported.")
-      }
-      for (node <- childrenNodes) {
-        childrenNodeList.add(node)
-      }
-      val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
-        AggregateFunctionsBuilder.create(args, aggregatFunc),
-        childrenNodeList,
-        modeToKeyWord(aggExpr.mode),
-        ConverterUtils.getTypeNode(aggregatFunc.dataType, aggregatFunc.nullable))
-      aggregateFunctionList.add(aggFunctionNode)
-    })
-    if (!validation) {
-      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList)
-    } else {
-      // Use a extension node to send the input types through Substrait plan for validation.
-      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
-      for (attr <- originalInputAttributes) {
-        inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-      }
-      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
-        Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
-      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList, extensionNode)
-    }
-  }
-
-  private def getAggRel(
-      args: java.lang.Object,
-      input: RelNode = null,
-      validation: Boolean = false): RelNode = {
-    val originalInputAttributes = child.output
-    val aggRel = if (needsPreProjection) {
-      getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
-    } else {
-      if (!GlutenConfig.getConf.isClickHouseBackend) {
-        getAggRelWithoutPreProjection(args, originalInputAttributes, input, validation)
-      } else {
-        getAggRelWithoutPreProjection(args, aggregateResultAttributes, input, validation)
-      }
-    }
+  protected def applyPostProjection(args: java.lang.Object,
+                                    aggRel: RelNode,
+                                    validation: Boolean): RelNode = {
     // Will check if post-projection is needed. If yes, a ProjectRel will be added after the
     // AggregateRel.
     val groupingAttributes = groupingExpressions.map(expr => {
@@ -516,22 +352,11 @@ case class HashAggregateExecTransformer(
     }
   }
 
-  private def modeToKeyWord(aggregateMode: AggregateMode): String = {
-    aggregateMode match {
-      case Partial => "PARTIAL"
-      case PartialMerge => "PARTIAL_MERGE"
-      case Final => "FINAL"
-      case other =>
-        throw new UnsupportedOperationException(s"not currently supported: $other.")
-    }
-  }
-
   /**
    * This method calculates the output attributes of Aggregation.
    */
-  def getAttrForAggregateExpr(
-      aggregateExpressions: Seq[AggregateExpression],
-      aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
+  protected def getAttrForAggregateExpr(aggregateExpressions: Seq[AggregateExpression],
+                               aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
     var aggregateAttr = new ListBuffer[Attribute]()
     val size = aggregateExpressions.size
     var res_index = 0
@@ -652,5 +477,158 @@ case class HashAggregateExecTransformer(
       }
     }
     aggregateAttr.toList
+  }
+
+  protected def modeToKeyWord(aggregateMode: AggregateMode): String = {
+    aggregateMode match {
+      case Partial => "PARTIAL"
+      case PartialMerge => "PARTIAL_MERGE"
+      case Final => "FINAL"
+      case other =>
+        throw new UnsupportedOperationException(s"not currently supported: $other.")
+    }
+  }
+
+  protected def getAggRelWithoutPreProjection(args: java.lang.Object,
+                                    originalInputAttributes: Seq[Attribute],
+                                    input: RelNode = null,
+                                    validation: Boolean): RelNode
+
+  protected def getAggRel(args: java.lang.Object,
+                input: RelNode = null,
+                validation: Boolean = false): RelNode
+
+  def doValidate(): Boolean
+
+  def doTransform(context: SubstraitContext): TransformContext
+}
+
+case class HashAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan) extends HashAggregateExecBaseTransformer(
+    requiredChildDistributionExpressions,
+    groupingExpressions,
+    aggregateExpressions,
+    aggregateAttributes,
+    initialInputBufferOffset,
+    resultExpressions,
+    child) {
+
+  override def doValidate(): Boolean = {
+    val substraitContext = new SubstraitContext
+    val relNode =
+      try {
+        getAggRel(substraitContext.registeredFunction, null, validation = true)
+      } catch {
+        case e: Throwable =>
+          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          return false
+      }
+    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
+    // Then, validate the generated plan in native engine.
+    if (GlutenConfig.getConf.enableNativeValidation) {
+      val validator = new ExpressionEvaluator()
+      validator.doValidate(planNode.toProtobuf.toByteArray)
+    } else {
+      true
+    }
+  }
+
+  override def doTransform(context: SubstraitContext): TransformContext = {
+    val childCtx = child match {
+      case c: TransformSupport =>
+        c.doTransform(context)
+      case _ =>
+        null
+    }
+    val (relNode, inputAttributes, outputAttributes) = if (childCtx != null) {
+      (getAggRel(context.registeredFunction, childCtx.root), childCtx.outputAttributes, output)
+    } else {
+      // This means the input is just an iterator, so an ReadRel will be created as child.
+      // Prepare the input schema.
+      val attrList = new util.ArrayList[Attribute]()
+      for (attr <- child.output) {
+        attrList.add(attr)
+      }
+      val readRel = RelBuilder.makeReadRel(attrList, context)
+      (getAggRel(context.registeredFunction, readRel), child.output, output)
+    }
+    TransformContext(inputAttributes, outputAttributes, relNode)
+  }
+
+  override protected def getAggRelWithoutPreProjection(args: java.lang.Object,
+                                                       originalInputAttributes: Seq[Attribute],
+                                                       input: RelNode = null,
+                                                       validation: Boolean): RelNode = {
+    // Get the grouping nodes.
+    val groupingList = new util.ArrayList[ExpressionNode]()
+    groupingExpressions.foreach(expr => {
+      // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
+      // may be different for each backend.
+      val groupingExpr: Expression = ExpressionConverter
+        .replaceWithExpressionTransformer(expr, child.output)
+      val exprNode = groupingExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+      groupingList.add(exprNode)
+    })
+    // Get the aggregate function nodes.
+    val aggregateFunctionList = new util.ArrayList[AggregateFunctionNode]()
+    aggregateExpressions.foreach(aggExpr => {
+      val aggregatFunc = aggExpr.aggregateFunction
+      val childrenNodeList = new util.ArrayList[ExpressionNode]()
+      val childrenNodes = aggExpr.mode match {
+        case Partial =>
+          aggregatFunc.children.toList.map(expr => {
+            val aggExpr: Expression = ExpressionConverter
+              .replaceWithExpressionTransformer(expr, originalInputAttributes)
+            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+          })
+        case Final =>
+          aggregatFunc.inputAggBufferAttributes.toList.map(attr => {
+            val aggExpr: Expression = ExpressionConverter
+              .replaceWithExpressionTransformer(attr, originalInputAttributes)
+            aggExpr.asInstanceOf[ExpressionTransformer].doTransform(args)
+          })
+        case other =>
+          throw new UnsupportedOperationException(s"$other not supported.")
+      }
+      for (node <- childrenNodes) {
+        childrenNodeList.add(node)
+      }
+      val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
+        AggregateFunctionsBuilder.create(args, aggregatFunc),
+        childrenNodeList,
+        modeToKeyWord(aggExpr.mode),
+        ConverterUtils.getTypeNode(aggregatFunc.dataType, aggregatFunc.nullable))
+      aggregateFunctionList.add(aggFunctionNode)
+    })
+    if (!validation) {
+      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
+      for (attr <- originalInputAttributes) {
+        inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+      }
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        Any.pack(TypeBuilder.makeStruct(inputTypeNodeList).toProtobuf))
+      RelBuilder.makeAggregateRel(input, groupingList, aggregateFunctionList, extensionNode)
+    }
+  }
+
+  override protected def getAggRel(args: java.lang.Object,
+                                   input: RelNode = null,
+                                   validation: Boolean = false): RelNode = {
+    val originalInputAttributes = child.output
+    val aggRel = if (needsPreProjection) {
+      getAggRelWithPreProjection(args, originalInputAttributes, input, validation)
+    } else {
+      getAggRelWithoutPreProjection(args, originalInputAttributes, input, validation)
+    }
+    applyPostProjection(args, aggRel, validation)
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -333,11 +333,11 @@ object ConverterUtils extends Logging {
   final val IS_NULL = "is_null"
   // Datetime
   final val EXTRACT = "extract"
-  // Below names are not in Substrait yaml.
   final val ENDS_WITH = "ends_with"
   final val CONTAINS = "contains"
-  final val IN = "in"
+  final val IN = "in" // TODO: use OrList in Substrait to replace in.
   final val NOT = "not"
   final val STARTS_WITH = "starts_with"
   final val SUBSTRING = "substring"
+  final val ROW_CONSTRUCTOR = "row_constructor"
 }

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -93,14 +93,15 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
     case plan: HashAggregateExec =>
       val child = replaceWithTransformerPlan(plan.child)
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-      HashAggregateExecTransformer(
-        plan.requiredChildDistributionExpressions,
-        plan.groupingExpressions,
-        plan.aggregateExpressions,
-        plan.aggregateAttributes,
-        plan.initialInputBufferOffset,
-        plan.resultExpressions,
-        child)
+      BackendsApiManager.getSparkPlanExecApiInstance
+        .genHashAggregateExecTransformer(
+          plan.requiredChildDistributionExpressions,
+          plan.groupingExpressions,
+          plan.aggregateExpressions,
+          plan.aggregateAttributes,
+          plan.initialInputBufferOffset,
+          plan.resultExpressions,
+          child)
     case plan: UnionExec =>
       val children = plan.children.map(replaceWithTransformerPlan)
       logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")

--- a/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
@@ -109,14 +109,15 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
           transformer.doValidate()
         case plan: HashAggregateExec =>
           if (!enableColumnarHashAgg) return false
-          val transformer = HashAggregateExecTransformer(
-            plan.requiredChildDistributionExpressions,
-            plan.groupingExpressions,
-            plan.aggregateExpressions,
-            plan.aggregateAttributes,
-            plan.initialInputBufferOffset,
-            plan.resultExpressions,
-            plan.child)
+          val transformer = BackendsApiManager.getSparkPlanExecApiInstance
+            .genHashAggregateExecTransformer(
+              plan.requiredChildDistributionExpressions,
+              plan.groupingExpressions,
+              plan.aggregateExpressions,
+              plan.aggregateAttributes,
+              plan.initialInputBufferOffset,
+              plan.resultExpressions,
+              plan.child)
           transformer.doValidate()
         case plan: UnionExec =>
           if (!enableColumnarUnion) return false

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
@@ -17,12 +17,13 @@
 
 package io.glutenproject.backendsapi
 
-import io.glutenproject.execution.{FilterExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
+import io.glutenproject.execution.{FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -60,6 +61,18 @@ class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
    */
   override def genFilterExecTransformer(condition: Expression, child: SparkPlan)
     : FilterExecBaseTransformer = null
+
+  /**
+   * Generate HashAggregateExecTransformer.
+   */
+  override def genHashAggregateExecTransformer(
+     requiredChildDistributionExpressions: Option[Seq[Expression]],
+     groupingExpressions: Seq[NamedExpression],
+     aggregateExpressions: Seq[AggregateExpression],
+     aggregateAttributes: Seq[Attribute],
+     initialInputBufferOffset: Int,
+     resultExpressions: Seq[NamedExpression],
+     child: SparkPlan): HashAggregateExecBaseTransformer = null
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changed the Substrait plan for avg to avoid special handling in native. Changes are:

- Used sum and count to replace partial avg in Substrait plan.

- Added a row_constructor projection before aggregation for final avg.

- Seperated module for aggregation transformer.

Depends on: https://github.com/oap-project/velox/pull/31.


## How was this patch tested?

Verified on Jenkins.

