### PR TITLE
[OPPRO-196] Fix the result type of sum in partial avg

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashAggregateExecTransformer.scala
@@ -64,7 +64,12 @@ case class VeloxHashAggregateExecTransformer(
           case Partial =>
             // Will use sum and count to replace partial avg.
             assert(childrenNodeList.size() == 1, "Partial Average expects one child node.")
-            val inputType = aggregateFunction.inputAggBufferAttributes.head.dataType
+            val inputType = if (aggregateFunction.children.head.isInstanceOf[Cast]) {
+              aggregateFunction.children.head.dataType
+            } else {
+              aggregateFunction.inputAggBufferAttributes.head.dataType
+            }
+
             val inputNullable = aggregateFunction.inputAggBufferAttributes.head.nullable
 
             val sumNode = ExpressionBuilder.makeAggregateFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the result type of sum. If pre-projection is conducted, the input type should be the type after pre-projection, and the result type should be the accumulated type for int-like types.


## How was this patch tested?

Verified on Jenkins.
