### PR TITLE
[OPPRO-277]Add free diskspace step before running velox testing

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,7 +33,12 @@ jobs:
           java-version: '8'
           java-package: jdk
           overwrite-settings: false
-      - run: sudo swapoff -a
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -rf /tmp/
+          sudo apt clean
+          sudo df -h
       - run: free
       - run: sudo apt-get update
       - run: sudo apt-get install -y cmake ccache build-essential


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add free disk space step before running testing.

## How was this patch tested?

No test, must check during GHA testing.



