### PR TITLE
[OPPRO-213]update build_velox.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Memory management is an essential feature in Spark. It's even more important to 
 
 Spark's RDD cache is columnar batch based. In Gazelle-plugin, we use the arrow record batch directly without any memcpy. We can build the same functionality in Gluten.
 
-pyspark support needs to be ported as well. If input data format is Arrow, we can send the data to pyspark directly. No memcpy
+Pyspark support needs to be ported as well. If input data format is Arrow, we can send the data to pyspark directly. No memcpy
 
-UDF support. We need to create the interface which use columnar batch as inptu. So customer can port their current UDF to columnar batch based. If it's Arrow record batch based, user can utilize Arrow's JAVA or C++ API to implement their UDF, debug without Spark, then register to Spark.
+UDF support. We need to create the interface which use columnar batch as input. So customer can port their current UDF to columnar batch based. If it's Arrow record batch based, user can utilize Arrow's JAVA or C++ API to implement their UDF, debug without Spark, then register to Spark.
 
 Ideally if all native library can return arrow record batch, we can share much features in Spark's JVM. Spark already have Apache arrow dependency, we can make arrow format as Spark's basic columnar format. The problem is that native library may not be 100% compitable with Arrow format, then there will be a transform between their native format and Arrow, usually it's not cheap.
 

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -31,6 +31,7 @@
         <velox.build_gazelle_cpp>${build_gazelle_cpp}</velox.build_gazelle_cpp>
         <velox.build_velox>${build_velox}</velox.build_velox>
         <velox.build_velox_from_source>${build_velox_from_source}</velox.build_velox_from_source>
+        <velox.compile_velox>${compile_velox}</velox.compile_velox>
         <velox.velox_home>${velox_home}</velox.velox_home>
         <velox.velox_build_type>${velox_build_type}</velox.velox_build_type>
         <velox.debug_build>${debug_build}</velox.debug_build>
@@ -274,6 +275,10 @@
                                 <argument>
                                     --build_velox_from_source=${velox.build_velox_from_source}
                                 </argument>
+                                <argument>
+                                    --compile_velox=${velox.compile_velox}
+                                </argument>
+                                <argument>${velox.velox_home}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/docs/GlutenUsage.md
+++ b/docs/GlutenUsage.md
@@ -16,7 +16,7 @@ If you wish to automatically build velox from source. The default velox installa
 -Dbuild_velox=ON -Dbuild_velox_from_source=ON
 ```
 
-If you wish to enable Velox backend and you have an existing compiled Velox, please use velox_home to set the path.
+If you wish to enable Velox backend and you have an existing compiled Velox or Velox repo, please use velox_home to set the path.
 
 ```shell script
 -Dbuild_velox=ON -Dvelox_home=${VELOX_HOME}
@@ -56,6 +56,7 @@ Based on the different environment, there are some parameters can be set via -D 
 | backends-clickhouse | Add -Pbackends-clickhouse in maven command to compile the JVM part of ClickHouse backend | false |
 | build_velox | Enable or Disable building the CPP part of Velox backend | OFF |
 | velox_home (only valid when build_velox is ON) | The path to the compiled Velox project. When building Gluten with Velox, if you have an existing Velox, please set it. | /PATH_TO_GLUTEN/tools/build/velox_ep |
+| compile_velox(only valid when velox_home is assigned) | recompile exising Velox use custom compile parameters| OFF |
 | velox_build_type | The build type Velox was built with from source code. Gluten uses this value to locate the binary path of Velox's binary libraries. | release |
 | debug_build | Whether to generate debug binary library from Gluten's C++ codes. | OFF |
 

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -17,13 +17,13 @@ export PATH=$JAVA_HOME/bin:$PATH
 
 ## Velox home directory
 
-### The command below clones velox source code from [OAP-project/velox](https://github.com/oap-project/velox) to tools/build/velox_ep. Then it applies some patches to Velox build script and builds the velox library.
+The command below clones velox source code from [OAP-project/velox](https://github.com/oap-project/velox) to tools/build/velox_ep. Then it applies some patches to Velox build script and builds the velox library.
 
 ```shell script
 mvn clean package -DskipTests -Dcheckstyle.skip -Pbackends-velox -Dbuild_protobuf=OFF -Dbuild_cpp=ON -Dbuild_velox=ON -Dbuild_velox_from_source=ON -Dbuild_arrow=ON
 ```
 
-### You can also clone the Velox source to some other folder then specify it by -Dvelox_home as below. With -Dbuild_velox=ON, the script applies the patches and build the Velox library. With -Dbuild_velox=OFF, script skips the velox build steps and reuse the existed library. It's useful if Velox isn't changed.
+You can also clone the Velox source to some other folder then specify it by -Dvelox_home as below. With -Dbuild_velox=ON, the script applies the patches and build the Velox library. With -Dbuild_velox=OFF, script skips the velox build steps and reuse the existed library. It's useful if Velox isn't changed.
 
 ```shell script
 mvn clean package -DskipTests -Dcheckstyle.skip -Pbackends-velox -Dbuild_protobuf=OFF -Dbuild_cpp=ON -Dbuild_velox=ON -Dvelox_home=${VELOX_HOME} -Dbuild_arrow=ON -Dcompile_velox=ON

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -15,20 +15,24 @@ export PATH=$JAVA_HOME/bin:$PATH
 ```
 
 
-## There are two ways to build Velox backend jars. 
+## Velox home directory
 
-### Use velox source code from [OAP-project/velox](https://github.com/oap-project/velox). The script is shown below.
+### The command below clones velox source code from [OAP-project/velox](https://github.com/oap-project/velox) to tools/build/velox_ep. Then it applies some patches to Velox build script and builds the velox library.
 
 ```shell script
 mvn clean package -DskipTests -Dcheckstyle.skip -Pbackends-velox -Dbuild_protobuf=OFF -Dbuild_cpp=ON -Dbuild_velox=ON -Dbuild_velox_from_source=ON -Dbuild_arrow=ON
 ```
 
-### Build velox from source code manually. This script will preprocess script named setup-ubuntu.sh in your source code and compile velox. 
-Default Value of compile_velox option is off to avoid compile code repeatedly. Please set 'compile_velox=ON' when you need recompile.
+### You can also clone the Velox source to some other folder then specify it by -Dvelox_home as below. With -Dbuild_velox=ON, the script applies the patches and build the Velox library. With -Dbuild_velox=OFF, script skips the velox build steps and reuse the existed library. It's useful if Velox isn't changed.
 
 ```shell script
 mvn clean package -DskipTests -Dcheckstyle.skip -Pbackends-velox -Dbuild_protobuf=OFF -Dbuild_cpp=ON -Dbuild_velox=ON -Dvelox_home=${VELOX_HOME} -Dbuild_arrow=ON -Dcompile_velox=ON
 ```
+
+## Arrow home directory
+
+Arrow home can be set as the same of Velox. Without -Darrow_home, arrow is cloned to toos/build/arrow_ep. You can specify the arrow home directory by -Darrow_home and then use -Dbuild_arrow to control arrow build or not.
+
 
 In Gluten, all 22 queries can be fully offloaded into Velox for computing.  
 

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -15,10 +15,19 @@ export PATH=$JAVA_HOME/bin:$PATH
 ```
 
 
-The script to build Velox backend jars:
+## There are two ways to build Velox backend jars. 
+
+### Use velox source code from [OAP-project/velox](https://github.com/oap-project/velox). The script is shown below.
 
 ```shell script
 mvn clean package -DskipTests -Dcheckstyle.skip -Pbackends-velox -Dbuild_protobuf=OFF -Dbuild_cpp=ON -Dbuild_velox=ON -Dbuild_velox_from_source=ON -Dbuild_arrow=ON
+```
+
+### Build velox from source code manually. This script will preprocess script named setup-ubuntu.sh in your source code and compile velox. 
+Default Value of compile_velox option is off to avoid compile code repeatedly. Please set 'compile_velox=ON' when you need recompile.
+
+```shell script
+mvn clean package -DskipTests -Dcheckstyle.skip -Pbackends-velox -Dbuild_protobuf=OFF -Dbuild_cpp=ON -Dbuild_velox=ON -Dvelox_home=${VELOX_HOME} -Dbuild_arrow=ON -Dcompile_velox=ON
 ```
 
 In Gluten, all 22 queries can be fully offloaded into Velox for computing.  

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -36,7 +36,7 @@ Arrow home can be set as the same of Velox. Without -Darrow_home, arrow is clone
 
 In Gluten, all 22 queries can be fully offloaded into Velox for computing.  
 
-## Test TPC-H Q1 and Q6 on Gluten with Velox backend
+## Test TPC-H on Gluten with Velox backend
 
 ### Data preparation
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <build_gazelle_cpp>OFF</build_gazelle_cpp>
     <build_velox>OFF</build_velox>
     <build_velox_from_source>OFF</build_velox_from_source>
+    <compile_velox>OFF</compile_velox>
     <velox_home>${project.basedir}/../tools/build/velox_ep</velox_home>
     <velox_build_type>release</velox_build_type>
     <debug_build>OFF</debug_build>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update velox_build.sh script. If we compile gluten with an existing repo, we need apply our change and compile option of the repo.

## How was this patch tested?
Test this script in two ways.

one way is build gluten with option " -Dbuild_velox_from_source=ON " 
 The full compiling command is 
`mvn clean package -Pbackends-velox -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip -Dbuild_cpp=ON -Dbuild_velox=ON -Dbuild_velox_from_source=ON -Dbuild_arrow=OFF -D build_protobuf=OFF`

another is  build gluten with option " -Dvelox_home=$VELOX_HOME  "
The full compiling command is 
`mvn clean package -Pbackends-velox -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip -Dbuild_cpp=ON -Dbuild_velox=ON -Dvelox_home=$VELOX_HOME   -Dbuild_arrow=OFF -Dbuild_protobuf=OFF  -Dcompile_velox=OFF/ON` 



