### PR TITLE
[Gluten-279] Separate Scan Operator as independent node for ClickHouse Backend and add metrics.

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
@@ -48,8 +48,6 @@ public class CHNativeBlock {
     return blockAddress;
   }
 
-  ;
-
   private native int nativeNumColumns(long blockAddress);
 
   public int numColumns() {

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -28,8 +28,9 @@ import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.{ExtensionTableBuilder, LocalFilesBuilder}
 import io.glutenproject.vectorized._
 
-import org.apache.spark.{InterruptibleIterator, SparkConf, TaskContext}
+import org.apache.spark.{InterruptibleIterator, SparkConf, SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
@@ -111,6 +112,7 @@ class CHIteratorApi extends IIteratorApi with Logging {
           CHNativeBlock.fromColumnarBatch(res).ifPresent(block => {
             numOutputRows += block.numRows();
             numOutputBatches += 1;
+            concatTime += System.nanoTime() - beforeConcat
           })
           res
         }
@@ -142,16 +144,17 @@ class CHIteratorApi extends IIteratorApi with Logging {
   : Iterator[ColumnarBatch] = {
     var resIter: GeneralOutIterator = null
     if (loadNative) {
+      val beforeBuild = System.nanoTime()
       val transKernel = new ExpressionEvaluator()
       val inBatchIters = new java.util.ArrayList[GeneralInIterator](inputIterators.map { iter =>
         new ColumnarNativeIterator(genCloseableColumnBatchIterator(iter).asJava)
       }.asJava)
       resIter = transKernel.createKernelWithBatchIterator(
         inputPartition.substraitPlan, inBatchIters, outputAttributes.asJava)
+      pipelineTime += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - beforeBuild)
       TaskContext.get().addTaskCompletionListener[Unit] { _ => resIter.close() }
     }
     val iter = new Iterator[Any] {
-      // private val inputMetrics = TaskContext.get().taskMetrics().inputMetrics
 
       override def hasNext: Boolean = {
         if (loadNative) {
@@ -196,13 +199,13 @@ class CHIteratorApi extends IIteratorApi with Logging {
                                     ): Iterator[ColumnarBatch] = {
      // scalastyle:on argcount
     GlutenConfig.getConf
+    val beforeBuild = System.nanoTime()
     val transKernel = new ExpressionEvaluator()
     val columnarNativeIterator =
       new java.util.ArrayList[GeneralInIterator](inputIterators.map { iter =>
         new ColumnarNativeIterator(genCloseableColumnBatchIterator(iter).asJava)
       }.asJava)
     // we need to complete dependency RDD's firstly
-    val beforeBuild = System.nanoTime()
     val nativeIterator = transKernel.createKernelWithBatchIterator(rootNode, columnarNativeIterator,
       outputAttributes.asJava)
     pipelineTime += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - beforeBuild)
@@ -275,6 +278,35 @@ class CHIteratorApi extends IIteratorApi with Logging {
     val batchIteratorInstance = jniWrapper.nativeCreateKernelWithIterator(
       0L, wsPlan, iterList.toArray)
     new BatchIterator(batchIteratorInstance, outAttrs.asJava)
+  }
+
+  /**
+    * Generate Native FileScanRDD, currently only for ClickHouse Backend.
+    */
+  override def genNativeFileScanRDD(sparkContext: SparkContext,
+                                    wsCxt: WholestageTransformContext,
+                                    fileFormat: java.lang.Integer,
+                                    inputPartitions: Seq[InputPartition],
+                                    numOutputRows: SQLMetric,
+                                    numOutputBatches: SQLMetric,
+                                    scanTime: SQLMetric): RDD[ColumnarBatch] = {
+    val startTime = System.nanoTime()
+    // the file format for each scan exec
+    wsCxt.substraitContext.setFileFormat(Seq(fileFormat).asJava)
+
+    // generate each partition of all scan exec
+    val substraitPlanPartition = (0 until inputPartitions.size).map( i => {
+      genNativeFilePartition(i, Seq(inputPartitions(i)), wsCxt)
+    })
+    logInfo(
+      s"Generating the Substrait plan took: ${(System.nanoTime() - startTime) / 1000000} ms.")
+    new NativeFileScanColumnarRDD(
+      sparkContext,
+      substraitPlanPartition,
+      wsCxt.outputAttributes,
+      numOutputRows,
+      numOutputBatches,
+      scanTime)
   }
 
   /**

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/NativeFileScanColumnarRDD.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/NativeFileScanColumnarRDD.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import scala.collection.JavaConverters._
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.vectorized.{ExpressionEvaluator, GeneralInIterator, GeneralOutIterator}
+
+import org.apache.spark.{Partition, SparkContext, SparkException, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class NativeFileScanColumnarRDD(sc: SparkContext,
+                                @transient private val inputPartitions: Seq[InputPartition],
+                                outputAttributes: Seq[Attribute],
+                                numOutputRows: SQLMetric,
+                                numOutputBatches: SQLMetric,
+                                scanTime: SQLMetric)
+  extends RDD[ColumnarBatch](sc, Nil) {
+
+  val loadNative: Boolean = GlutenConfig.getConf.loadNative
+
+  override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
+    val inputPartition = castNativePartition(split)
+    var scanTotalTime = 0L
+
+    var resIter: GeneralOutIterator = null
+    if (loadNative) {
+      val startNs = System.nanoTime()
+      val transKernel = new ExpressionEvaluator()
+      val inBatchIters = new java.util.ArrayList[GeneralInIterator]()
+      resIter = transKernel.createKernelWithBatchIterator(
+        inputPartition.substraitPlan, inBatchIters, outputAttributes.asJava)
+      scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+      TaskContext.get().addTaskCompletionListener[Unit] { _ => resIter.close() }
+    }
+    val iter = new Iterator[Any] {
+      override def hasNext: Boolean = {
+        if (loadNative) {
+          val startNs = System.nanoTime()
+          val res = resIter.hasNext
+          scanTotalTime += System.nanoTime() - startNs
+          if (!res) {
+            scanTime += NANOSECONDS.toMillis(scanTotalTime)
+          }
+          res
+        } else {
+          false
+        }
+      }
+
+      override def next(): Any = {
+        val startNs = System.nanoTime()
+        if (!hasNext) {
+          throw new java.util.NoSuchElementException("End of stream")
+        }
+        val cb = resIter.next()
+        numOutputRows += cb.numRows()
+        numOutputBatches += 1
+        scanTotalTime += System.nanoTime() - startNs
+        cb
+      }
+    }
+    iter.asInstanceOf[Iterator[ColumnarBatch]]
+  }
+
+  private def castNativePartition(split: Partition): BaseNativeFilePartition = split match {
+    case FirstZippedPartitionsPartition(_, p: BaseNativeFilePartition, _) => p
+    case _ => throw new SparkException(s"[BUG] Not a NativeSubstraitPartition: $split")
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = {
+    castPartition(split).inputPartition.preferredLocations()
+  }
+
+  private def castPartition(split: Partition): FirstZippedPartitionsPartition = split match {
+    case p: FirstZippedPartitionsPartition => p
+    case _ => throw new SparkException(s"[BUG] Not a NativeSubstraitPartition: $split")
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    inputPartitions.zipWithIndex.map {
+      case (inputPartition, index) => FirstZippedPartitionsPartition(index, inputPartition)
+    }.toArray
+  }
+}

--- a/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CHColumnarBatchSerializer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CHColumnarBatchSerializer.scala
@@ -86,6 +86,7 @@ private class CHColumnarBatchSerializerInstance(readBatchNumRows: SQLMetric,
             cb = nativeBlock.toColumnarBatch
             cb.asInstanceOf[T]
           } else {
+            nativeBlock.close()
             this.close()
             throw new EOFException
           }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDSV2ColumnarShuffleSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDSV2ColumnarShuffleSuite.scala
@@ -21,6 +21,10 @@ import org.apache.spark.SparkConf
 
 class GlutenClickHouseDSV2ColumnarShuffleSuite extends GlutenClickHouseTPCHAbstractSuite {
 
+  override protected val tablesPath: String = basePath + "/tpch-data-ch"
+  override protected val tpchQueries: String = rootPath + "queries/tpch-queries-ch"
+  override protected val queriesResults: String = rootPath + "queries-output"
+
   /**
     * Run Gluten + ClickHouse Backend with ColumnarShuffleManager
     */
@@ -34,107 +38,107 @@ class GlutenClickHouseDSV2ColumnarShuffleSuite extends GlutenClickHouseTPCHAbstr
   }
 
   test("TPCH Q1") {
-    runTPCHQuery(1, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(1) { df =>
     }
   }
 
   test("TPCH Q2") {
-    runTPCHQuery(2, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(2) { df =>
     }
   }
 
   test("TPCH Q3") {
-    runTPCHQuery(3, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(3) { df =>
     }
   }
 
   test("TPCH Q4") {
-    runTPCHQuery(4, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(4) { df =>
     }
   }
 
   test("TPCH Q5") {
-    runTPCHQuery(5, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(5) { df =>
     }
   }
 
   test("TPCH Q6") {
-    runTPCHQuery(6, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(6) { df =>
     }
   }
 
   test("TPCH Q7") {
-    runTPCHQuery(7, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(7) { df =>
     }
   }
 
   test("TPCH Q8") {
-    runTPCHQuery(8, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(8) { df =>
     }
   }
 
   test("TPCH Q9") {
-    runTPCHQuery(9, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(9) { df =>
     }
   }
 
   test("TPCH Q10") {
-    runTPCHQuery(10, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(10) { df =>
     }
   }
 
   test("TPCH Q11") {
-    runTPCHQuery(11, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(11) { df =>
     }
   }
 
   test("TPCH Q12") {
-    runTPCHQuery(12, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(12) { df =>
     }
   }
 
   test("TPCH Q13") {
-    runTPCHQuery(13, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(13) { df =>
     }
   }
 
   test("TPCH Q14") {
-    runTPCHQuery(14, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(14) { df =>
     }
   }
 
   test("TPCH Q15") {
-    runTPCHQuery(15, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(15) { df =>
     }
   }
 
   test("TPCH Q16") {
-    runTPCHQuery(16, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(16) { df =>
     }
   }
 
   test("TPCH Q17") {
-    runTPCHQuery(17, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(17) { df =>
     }
   }
 
   test("TPCH Q18") {
-    runTPCHQuery(18, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(18) { df =>
     }
   }
 
   test("TPCH Q19") {
-    runTPCHQuery(19, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(19) { df =>
     }
   }
 
   test("TPCH Q20") {
-    runTPCHQuery(20, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(20) { df =>
     }
   }
 
   test("TPCH Q22") {
-    runTPCHQuery(22, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(22) { df =>
     }
   }
 }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDSV2Suite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDSV2Suite.scala
@@ -21,6 +21,10 @@ import org.apache.spark.SparkConf
 
 class GlutenClickHouseDSV2Suite extends GlutenClickHouseTPCHAbstractSuite {
 
+  override protected val tablesPath: String = basePath + "/tpch-data-ch"
+  override protected val tpchQueries: String = rootPath + "queries/tpch-queries-ch"
+  override protected val queriesResults: String = rootPath + "queries-output"
+
   /**
     * Run Gluten + ClickHouse Backend with ColumnarShuffleManager
     */
@@ -34,107 +38,115 @@ class GlutenClickHouseDSV2Suite extends GlutenClickHouseTPCHAbstractSuite {
   }
 
   test("TPCH Q1") {
-    runTPCHQuery(1, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(1) { df =>
+      val scanExec = df.queryExecution.executedPlan.collect {
+        case scanExec: BasicScanExecTransformer => true
+      }
+      assert(scanExec.size == 1)
     }
   }
 
   test("TPCH Q2") {
-    runTPCHQuery(2, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(2) { df =>
+      val scanExec = df.queryExecution.executedPlan.collect {
+        case scanExec: BasicScanExecTransformer => scanExec
+      }
+      assert(scanExec.size == 9)
     }
   }
 
   test("TPCH Q3") {
-    runTPCHQuery(3, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(3) { df =>
     }
   }
 
   test("TPCH Q4") {
-    runTPCHQuery(4, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(4) { df =>
     }
   }
 
   test("TPCH Q5") {
-    runTPCHQuery(5, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(5) { df =>
     }
   }
 
   test("TPCH Q6") {
-    runTPCHQuery(6, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(6) { df =>
     }
   }
 
   test("TPCH Q7") {
-    runTPCHQuery(7, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(7) { df =>
     }
   }
 
   test("TPCH Q8") {
-    runTPCHQuery(8, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(8) { df =>
     }
   }
 
   test("TPCH Q9") {
-    runTPCHQuery(9, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(9) { df =>
     }
   }
 
   test("TPCH Q10") {
-    runTPCHQuery(10, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(10) { df =>
     }
   }
 
   test("TPCH Q11") {
-    runTPCHQuery(11, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(11) { df =>
     }
   }
 
   test("TPCH Q12") {
-    runTPCHQuery(12, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(12) { df =>
     }
   }
 
   test("TPCH Q13") {
-    runTPCHQuery(13, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(13) { df =>
     }
   }
 
   test("TPCH Q14") {
-    runTPCHQuery(14, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(14) { df =>
     }
   }
 
   test("TPCH Q15") {
-    runTPCHQuery(15, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(15) { df =>
     }
   }
 
   test("TPCH Q16") {
-    runTPCHQuery(16, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(16) { df =>
     }
   }
 
   test("TPCH Q17") {
-    runTPCHQuery(17, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(17) { df =>
     }
   }
 
   test("TPCH Q18") {
-    runTPCHQuery(18, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(18) { df =>
     }
   }
 
   test("TPCH Q19") {
-    runTPCHQuery(19, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(19) { df =>
     }
   }
 
   test("TPCH Q20") {
-    runTPCHQuery(20, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(20) { df =>
     }
   }
 
   test("TPCH Q22") {
-    runTPCHQuery(22, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(22) { df =>
     }
   }
 }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.optimizer.BuildLeft
+
+class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite {
+
+  override protected val resourcePath: String =
+    "../../../../jvm/src/test/resources/tpch-data"
+
+  override protected val tablesPath: String = basePath + "/tpch-data"
+  override protected val tpchQueries: String =
+    rootPath + "../../../../jvm/src/test/resources/queries"
+  override protected val queriesResults: String = rootPath + "queries-output"
+
+  /**
+    * Run Gluten + ClickHouse Backend with SortShuffleManager
+    */
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", "sort")
+      .set("spark.io.compression.codec", "snappy")
+      .set("spark.sql.shuffle.partitions", "5")
+      .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
+      .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
+  }
+
+  override protected def createTPCHTables(): Unit = {
+    val customerData = tablesPath + "/customer"
+    spark.sql(s"DROP TABLE IF EXISTS customer")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS customer (
+         | c_custkey    bigint,
+         | c_name       string,
+         | c_address    string,
+         | c_nationkey  bigint,
+         | c_phone      string,
+         | c_acctbal    double,
+         | c_mktsegment string,
+         | c_comment    string)
+         | USING PARQUET LOCATION '${customerData}'
+         |""".stripMargin)
+
+    val lineitemData = tablesPath + "/lineitem"
+    spark.sql(s"DROP TABLE IF EXISTS lineitem")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS lineitem (
+         | l_orderkey      bigint,
+         | l_partkey       bigint,
+         | l_suppkey       bigint,
+         | l_linenumber    bigint,
+         | l_quantity      double,
+         | l_extendedprice double,
+         | l_discount      double,
+         | l_tax           double,
+         | l_returnflag    string,
+         | l_linestatus    string,
+         | l_shipdate      date,
+         | l_commitdate    date,
+         | l_receiptdate   date,
+         | l_shipinstruct  string,
+         | l_shipmode      string,
+         | l_comment       string)
+         | USING PARQUET LOCATION '${lineitemData}'
+         |""".stripMargin)
+
+    val nationData = tablesPath + "/nation"
+    spark.sql(s"DROP TABLE IF EXISTS nation")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS nation (
+         | n_nationkey bigint,
+         | n_name      string,
+         | n_regionkey bigint,
+         | n_comment   string)
+         | USING PARQUET LOCATION '${nationData}'
+         |""".stripMargin)
+
+    val regionData = tablesPath + "/region"
+    spark.sql(s"DROP TABLE IF EXISTS region")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS region (
+         | r_regionkey bigint,
+         | r_name      string,
+         | r_comment   string)
+         | USING PARQUET LOCATION '${regionData}'
+         |""".stripMargin)
+
+    val ordersData = tablesPath + "/order"
+    spark.sql(s"DROP TABLE IF EXISTS orders")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS orders (
+         | o_orderkey      bigint,
+         | o_custkey       bigint,
+         | o_orderstatus   string,
+         | o_totalprice    double,
+         | o_orderdate     date,
+         | o_orderpriority string,
+         | o_clerk         string,
+         | o_shippriority  bigint,
+         | o_comment       string)
+         | USING PARQUET LOCATION '${ordersData}'
+         |""".stripMargin)
+
+    val partData = tablesPath + "/part"
+    spark.sql(s"DROP TABLE IF EXISTS part")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS part (
+         | p_partkey     bigint,
+         | p_name        string,
+         | p_mfgr        string,
+         | p_brand       string,
+         | p_type        string,
+         | p_size        bigint,
+         | p_container   string,
+         | p_retailprice double,
+         | p_comment     string)
+         | USING PARQUET LOCATION '${partData}'
+         |""".stripMargin)
+
+    val partsuppData = tablesPath + "/partsupp"
+    spark.sql(s"DROP TABLE IF EXISTS partsupp")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS partsupp (
+         | ps_partkey    bigint,
+         | ps_suppkey    bigint,
+         | ps_availqty   bigint,
+         | ps_supplycost double,
+         | ps_comment    string)
+         | USING PARQUET LOCATION '${partsuppData}'
+         |""".stripMargin)
+
+    val supplierData = tablesPath + "/supplier"
+    spark.sql(s"DROP TABLE IF EXISTS supplier")
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS supplier (
+         | s_suppkey   bigint,
+         | s_name      string,
+         | s_address   string,
+         | s_nationkey bigint,
+         | s_phone     string,
+         | s_acctbal   double,
+         | s_comment   string)
+         | USING PARQUET LOCATION '${supplierData}'
+         |""".stripMargin)
+
+    val result = spark.sql(
+      s"""
+         | show tables;
+         |""".stripMargin).collect()
+    assert(result.size == 8)
+  }
+
+  test("TPCH Q1") {
+    runTPCHQuery(1) { df =>
+      val scanExec = df.queryExecution.executedPlan.collect {
+        case scanExec: BasicScanExecTransformer => true
+      }
+      assert(scanExec.size == 1)
+    }
+  }
+
+  test("TPCH Q2") {
+    runTPCHQuery(2) { df =>
+      val scanExec = df.queryExecution.executedPlan.collect {
+        case scanExec: BasicScanExecTransformer => scanExec
+      }
+      assert(scanExec.size == 8)
+    }
+  }
+
+  test("TPCH Q3") {
+    withSQLConf(
+      ("spark.sql.autoBroadcastJoinThreshold", "-1")) {
+      runTPCHQuery(3) { df =>
+        val shjBuildLeft = df.queryExecution.executedPlan.collect {
+          case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
+        }
+        assert(shjBuildLeft.size == 1)
+      }
+    }
+  }
+
+  test("TPCH Q4") {
+    runTPCHQuery(4) { df =>
+    }
+  }
+
+  test("TPCH Q5") {
+    withSQLConf(
+      ("spark.sql.autoBroadcastJoinThreshold", "-1")) {
+      runTPCHQuery(5) { df =>
+        val bhjRes = df.queryExecution.executedPlan.collect {
+          case bhj: BroadcastHashJoinExecTransformer => bhj
+        }
+        assert(bhjRes.isEmpty)
+      }
+    }
+  }
+
+  test("TPCH Q6") {
+    runTPCHQuery(6) { df =>
+    }
+  }
+
+  test("TPCH Q7") {
+    withSQLConf(
+      ("spark.sql.shuffle.partitions", "1"),
+      ("spark.sql.autoBroadcastJoinThreshold", "-1"),
+      ("spark.gluten.sql.columnar.backend.ch.use.v2", "true")) {
+      runTPCHQuery(7) { df =>
+      }
+    }
+  }
+
+  test("TPCH Q8") {
+    withSQLConf(
+      ("spark.sql.shuffle.partitions", "1"),
+      ("spark.sql.autoBroadcastJoinThreshold", "-1"),
+      ("spark.gluten.sql.columnar.backend.ch.use.v2", "true")) {
+      runTPCHQuery(8) { df =>
+      }
+    }
+  }
+
+  test("TPCH Q9") {
+    runTPCHQuery(9, compareResult = false) { df =>
+    }
+  }
+
+  test("TPCH Q10") {
+    runTPCHQuery(10) { df =>
+    }
+  }
+
+  test("TPCH Q11") {
+    runTPCHQuery(11, compareResult = false) { df =>
+    }
+  }
+
+  test("TPCH Q12") {
+    runTPCHQuery(12) { df =>
+    }
+  }
+
+  test("TPCH Q13") {
+    runTPCHQuery(13) { df =>
+    }
+  }
+
+  test("TPCH Q14") {
+    withSQLConf(
+      ("spark.sql.shuffle.partitions", "1"),
+      ("spark.sql.autoBroadcastJoinThreshold", "-1"),
+      ("spark.gluten.sql.columnar.backend.ch.use.v2", "true")) {
+      runTPCHQuery(14) { df =>
+      }
+    }
+  }
+
+  test("TPCH Q15") {
+    runTPCHQuery(15) { df =>
+    }
+  }
+
+  test("TPCH Q16") {
+    runTPCHQuery(16) { df =>
+    }
+  }
+
+  test("TPCH Q17") {
+    withSQLConf(
+      ("spark.shuffle.sort.bypassMergeThreshold", "2")) {
+      runTPCHQuery(17) { df =>
+      }
+    }
+  }
+
+  test("TPCH Q18") {
+    withSQLConf(
+      ("spark.shuffle.sort.bypassMergeThreshold", "2")) {
+      runTPCHQuery(18) { df =>
+      }
+    }
+  }
+
+  test("TPCH Q19") {
+    runTPCHQuery(19) { df =>
+    }
+  }
+
+  test("TPCH Q20") {
+    runTPCHQuery(20) { df =>
+    }
+  }
+
+  test("TPCH Q22") {
+    runTPCHQuery(22) { df =>
+    }
+  }
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
@@ -22,6 +22,10 @@ import org.apache.spark.sql.catalyst.optimizer.BuildLeft
 
 class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
 
+  override protected val tablesPath: String = basePath + "/tpch-data-ch"
+  override protected val tpchQueries: String = rootPath + "queries/tpch-queries-ch"
+  override protected val queriesResults: String = rootPath + "queries-output"
+
   /**
     * Run Gluten + ClickHouse Backend with SortShuffleManager
     */
@@ -35,19 +39,27 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
   }
 
   test("TPCH Q1") {
-    runTPCHQuery(1, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(1) { df =>
+      val scanExec = df.queryExecution.executedPlan.collect {
+        case scanExec: BasicScanExecTransformer => true
+      }
+      assert(scanExec.size == 1)
     }
   }
 
   test("TPCH Q2") {
-    runTPCHQuery(2, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(2) { df =>
+      val scanExec = df.queryExecution.executedPlan.collect {
+        case scanExec: BasicScanExecTransformer => scanExec
+      }
+      assert(scanExec.size == 8)
     }
   }
 
   test("TPCH Q3") {
     withSQLConf(
       ("spark.sql.autoBroadcastJoinThreshold", "-1")) {
-      runTPCHQuery(3, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(3) { df =>
         val shjBuildLeft = df.queryExecution.executedPlan.collect {
           case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
         }
@@ -57,14 +69,14 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
   }
 
   test("TPCH Q4") {
-    runTPCHQuery(4, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(4) { df =>
     }
   }
 
   test("TPCH Q5") {
     withSQLConf(
       ("spark.sql.autoBroadcastJoinThreshold", "-1")) {
-      runTPCHQuery(5, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(5) { df =>
         val bhjRes = df.queryExecution.executedPlan.collect {
           case bhj: BroadcastHashJoinExecTransformer => bhj
         }
@@ -74,7 +86,7 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
   }
 
   test("TPCH Q6") {
-    runTPCHQuery(6, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(6) { df =>
     }
   }
 
@@ -83,7 +95,7 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
       ("spark.sql.shuffle.partitions", "1"),
       ("spark.sql.autoBroadcastJoinThreshold", "-1"),
       ("spark.gluten.sql.columnar.backend.ch.use.v2", "true")) {
-      runTPCHQuery(7, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(7) { df =>
       }
     }
   }
@@ -93,33 +105,33 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
       ("spark.sql.shuffle.partitions", "1"),
       ("spark.sql.autoBroadcastJoinThreshold", "-1"),
       ("spark.gluten.sql.columnar.backend.ch.use.v2", "true")) {
-      runTPCHQuery(8, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(8) { df =>
       }
     }
   }
 
   test("TPCH Q9") {
-    runTPCHQuery(9, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(9) { df =>
     }
   }
 
   test("TPCH Q10") {
-    runTPCHQuery(10, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(10) { df =>
     }
   }
 
   test("TPCH Q11") {
-    runTPCHQuery(11, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(11) { df =>
     }
   }
 
   test("TPCH Q12") {
-    runTPCHQuery(12, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(12) { df =>
     }
   }
 
   test("TPCH Q13") {
-    runTPCHQuery(13, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(13) { df =>
     }
   }
 
@@ -128,25 +140,25 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
       ("spark.sql.shuffle.partitions", "1"),
       ("spark.sql.autoBroadcastJoinThreshold", "-1"),
       ("spark.gluten.sql.columnar.backend.ch.use.v2", "true")) {
-      runTPCHQuery(14, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(14) { df =>
       }
     }
   }
 
   test("TPCH Q15") {
-    runTPCHQuery(15, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(15) { df =>
     }
   }
 
   test("TPCH Q16") {
-    runTPCHQuery(16, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(16) { df =>
     }
   }
 
   test("TPCH Q17") {
     withSQLConf(
       ("spark.shuffle.sort.bypassMergeThreshold", "2")) {
-      runTPCHQuery(17, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(17) { df =>
       }
     }
   }
@@ -154,23 +166,23 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
   test("TPCH Q18") {
     withSQLConf(
       ("spark.shuffle.sort.bypassMergeThreshold", "2")) {
-      runTPCHQuery(18, chTpchQueries, queriesResults) { df =>
+      runTPCHQuery(18) { df =>
       }
     }
   }
 
   test("TPCH Q19") {
-    runTPCHQuery(19, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(19) { df =>
     }
   }
 
   test("TPCH Q20") {
-    runTPCHQuery(20, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(20) { df =>
     }
   }
 
   test("TPCH Q22") {
-    runTPCHQuery(22, chTpchQueries, queriesResults) { df =>
+    runTPCHQuery(22) { df =>
     }
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxIteratorApi.scala
@@ -25,8 +25,10 @@ import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.InterruptibleIterator
 import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
@@ -367,6 +369,20 @@ class VeloxIteratorApi extends IIteratorApi with Logging {
     val batchIteratorInstance =
       jniWrapper.nativeCreateKernelWithIterator(allocId, wsPlan, iterList.toArray)
     new ArrowOutIterator(batchIteratorInstance, outAttrs.asJava)
+  }
+
+  /**
+   * Generate Native FileScanRDD, currently only for ClickHouse Backend.
+   */
+  override def genNativeFileScanRDD(sparkContext: SparkContext,
+                                    wsCxt: WholestageTransformContext,
+                                    fileFormat: java.lang.Integer,
+                                    inputPartitions: Seq[InputPartition],
+                                    numOutputRows: SQLMetric,
+                                    numOutputBatches: SQLMetric,
+                                    scanTime: SQLMetric): RDD[ColumnarBatch] = {
+    throw new UnsupportedOperationException(
+      "Cannot support to generate Native FileScanRDD.")
   }
 
   /**

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -22,7 +22,8 @@ import io.glutenproject.execution.{BaseNativeFilePartition, WholestageTransformC
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.vectorized.{ExpressionEvaluator, ExpressionEvaluatorJniWrapper, GeneralInIterator, GeneralOutIterator}
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.{SparkConf, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
@@ -99,6 +100,18 @@ trait IIteratorApi extends IBackendsApi {
    * @return
    */
   def genColumnarNativeIterator(delegated: Iterator[ColumnarBatch]): GeneralInIterator
+
+  /**
+   * Generate Native FileScanRDD, currently only for ClickHouse Backend.
+   */
+  def genNativeFileScanRDD(sparkContext: SparkContext,
+                           wsCxt: WholestageTransformContext,
+                           fileFormat: java.lang.Integer,
+                           inputPartitions: Seq[InputPartition],
+                           numOutputRows: SQLMetric,
+                           numOutputBatches: SQLMetric,
+                           scanTime: SQLMetric
+                          ): RDD[ColumnarBatch]
 
   /**
    * Generate BatchIterator for ExpressionEvaluator.

--- a/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -19,6 +19,7 @@ package io.glutenproject.execution
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.vectorized.OperatorMetrics
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
@@ -44,6 +45,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu wall nanos"),
     "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu nanos"),
     "blockedWallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "block wall nanos"),
+    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "total scan time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -76,7 +78,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
   override def supportsColumnar(): Boolean = GlutenConfig.getConf.enableColumnarIterator
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    throw new UnsupportedOperationException(s"This operator doesn't support doExecuteColumnar().")
+    doExecuteColumnarInternal()
   }
 
   override def equals(other: Any): Boolean = other match {

--- a/jvm/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -20,6 +20,7 @@ package io.glutenproject.execution
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.vectorized.OperatorMetrics
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
@@ -65,6 +66,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu wall nanos"),
     "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu nanos"),
     "blockedWallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "block wall nanos"),
+    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "total scan time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -131,7 +133,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
   }
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    throw new UnsupportedOperationException(s"This operator doesn't support doExecuteColumnar().")
+    doExecuteColumnarInternal()
   }
 
   override def updateMetrics(outNumBatches: Long, outNumRows: Long): Unit = {

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -261,7 +261,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
     // If containing scan exec transformer, a new RDD is created.
     if (basicScanExecTransformer.nonEmpty) {
       // the partition size of the all BasicScanExecTransformer must be the same
-      val partitionLength = basicScanExecTransformer.head.getPartitions.length
+      val partitionLength = basicScanExecTransformer(0).getPartitions.size
       if (basicScanExecTransformer.exists(_.getPartitions.length != partitionLength)) {
         throw new RuntimeException(
           "The partition length of all the scan transformer are not the same.")

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -356,7 +356,7 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
   def postOverrides: TransformPostOverrides = TransformPostOverrides()
 
   def collapseOverrides: ColumnarCollapseCodegenStages =
-    ColumnarCollapseCodegenStages(columnarWholeStageEnabled)
+    ColumnarCollapseCodegenStages(columnarWholeStageEnabled, isCH)
 
   private def supportAdaptive(plan: SparkPlan): Boolean = {
     // TODO migrate dynamic-partition-pruning onto adaptive execution.

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
@@ -22,7 +22,8 @@ import io.glutenproject.execution.{BaseNativeFilePartition, WholestageTransformC
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.vectorized.{ExpressionEvaluator, ExpressionEvaluatorJniWrapper, GeneralInIterator, GeneralOutIterator}
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.{SparkConf, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
@@ -109,6 +110,17 @@ class IteratorApiImplSuite extends IIteratorApi {
                                 iterList: Seq[GeneralInIterator],
                                 jniWrapper: ExpressionEvaluatorJniWrapper,
                                 outAttrs: Seq[Attribute]): GeneralOutIterator = null
+
+  /**
+   * Generate Native FileScanRDD, currently only for ClickHouse Backend.
+   */
+  override def genNativeFileScanRDD(sparkContext: SparkContext,
+                                    wsCxt: WholestageTransformContext,
+                                    fileFormat: Integer,
+                                    inputPartitions: Seq[InputPartition],
+                                    numOutputRows: SQLMetric,
+                                    numOutputBatches: SQLMetric,
+                                    scanTime: SQLMetric): RDD[ColumnarBatch] = null
 
   /**
    * Get the backend api name.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Separate Scan Operator as independent node for ClickHouse Backend and add metrics.

Close #279 .

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

