### PR TITLE
[Gluten-302] Add parameter for separating ClickHouse Scan RDD

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -120,7 +120,6 @@ object DSV2BenchmarkTest {
         .config("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
         .config("spark.gluten.sql.enable.native.validation", "false")
         .config("spark.gluten.sql.columnar.separate.scan.rdd.for.ch", "true")
-        // .config("spark.gluten.sql.columnar.extension.scan.rdd", "false")
         // .config("spark.gluten.sql.columnar.sort", "false")
         // .config("spark.sql.codegen.wholeStage", "false")
         .config("spark.sql.autoBroadcastJoinThreshold", "10MB")

--- a/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/jvm/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -258,6 +258,10 @@ object GlutenConfig {
   val GLUTEN_CLICKHOUSE_BACKEND = "ch"
   val GLUTEN_GAZELLE_BACKEND = "gazelle_cpp"
 
+  // For ClickHouse Backends.
+  val GLUTEN_CLICKHOUSE_SEP_SCAN_RDD = "spark.gluten.sql.columnar.separate.scan.rdd.for.ch"
+  val GLUTEN_CLICKHOUSE_SEP_SCAN_RDD_DEFAULT = true
+
   var ins: GlutenConfig = _
   var random_temp_dir_path: String = _
 

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -299,6 +299,9 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
   val isCH: Boolean = conf
     .get(GlutenConfig.GLUTEN_BACKEND_LIB, "")
     .equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
+  val separateScanRDDForCH: Boolean = isCH && conf
+    .getBoolean(GlutenConfig.GLUTEN_CLICKHOUSE_SEP_SCAN_RDD,
+      GlutenConfig.GLUTEN_CLICKHOUSE_SEP_SCAN_RDD_DEFAULT)
   var isSupportAdaptive: Boolean = true
 
   def conf: SparkConf = session.sparkContext.getConf
@@ -356,7 +359,7 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
   def postOverrides: TransformPostOverrides = TransformPostOverrides()
 
   def collapseOverrides: ColumnarCollapseCodegenStages =
-    ColumnarCollapseCodegenStages(columnarWholeStageEnabled, isCH)
+    ColumnarCollapseCodegenStages(columnarWholeStageEnabled, separateScanRDDForCH)
 
   private def supportAdaptive(plan: SparkPlan): Boolean = {
     // TODO migrate dynamic-partition-pruning onto adaptive execution.

--- a/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
+++ b/jvm/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseCodegenStages.scala
@@ -107,7 +107,7 @@ class ColumnarInputAdapter(child: SparkPlan) extends InputAdapter(child) {
  */
 case class ColumnarCollapseCodegenStages(
                                           columnarWholeStageEnabled: Boolean,
-                                          isCH: Boolean,
+                                          separateScanRDDForCH: Boolean,
                                           codegenStageCounter: AtomicInteger =
                                           new AtomicInteger(0))
   extends Rule[SparkPlan] {
@@ -125,7 +125,7 @@ case class ColumnarCollapseCodegenStages(
    * BasicScanExecTransformer will not be included in WholeStageTransformerExec.
    */
   private def isSeparateBasicScanExecTransformer(plan: SparkPlan): Boolean = plan match {
-    case f: BasicScanExecTransformer if isCH => true
+    case f: BasicScanExecTransformer if separateScanRDDForCH => true
     case _ => false
   }
 


### PR DESCRIPTION
Add a parameter 'spark.gluten.sql.columnar.separate.scan.rdd.for.ch' to control whether to separate scan rdd for ClickHouse Backend.

Close #302 .

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

