### PR TITLE
[OPPRO-223] Change to use partial avg in Velox

### DIFF
--- a/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -145,6 +145,10 @@ public class ExpressionBuilder {
     return new SelectionNode(fieldIdx);
   }
 
+  public static SelectionNode makeSelection(Integer fieldIdx, Integer childFieldIdx) {
+    return new SelectionNode(fieldIdx, childFieldIdx);
+  }
+
   public static AggregateFunctionNode makeAggregateFunction(
       Long functionId,
       ArrayList<ExpressionNode> expressionNodes,

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
@@ -20,19 +20,38 @@ package io.glutenproject.substrait.expression;
 import io.substrait.proto.Expression;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 public class SelectionNode implements ExpressionNode, Serializable {
   private final Integer fieldIdx;
+  private final Integer childFieldIdx;
 
   SelectionNode(Integer fieldIdx) {
     this.fieldIdx = fieldIdx;
+    this.childFieldIdx = null;
+  }
+
+  SelectionNode(Integer fieldIdx, Integer childFieldIdx) {
+    this.fieldIdx = fieldIdx;
+    this.childFieldIdx = childFieldIdx;
   }
 
   @Override
   public Expression toProtobuf() {
     Expression.ReferenceSegment.StructField.Builder structBuilder =
         Expression.ReferenceSegment.StructField.newBuilder();
-    structBuilder.setField(fieldIdx.intValue());
+    structBuilder.setField(fieldIdx);
+
+    // Handle the child field indices.
+    if (childFieldIdx != null) {
+      Expression.ReferenceSegment.StructField.Builder childStructBuilder =
+          Expression.ReferenceSegment.StructField.newBuilder();
+      childStructBuilder.setField(childFieldIdx);
+      Expression.ReferenceSegment.Builder childRefBuilder =
+          Expression.ReferenceSegment.newBuilder();
+      childRefBuilder.setStructField(childStructBuilder.build());
+      structBuilder.setChild(childRefBuilder.build());
+    }
 
     Expression.ReferenceSegment.Builder refBuilder =
         Expression.ReferenceSegment.newBuilder();

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
@@ -20,7 +20,6 @@ package io.glutenproject.substrait.expression;
 import io.substrait.proto.Expression;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 
 public class SelectionNode implements ExpressionNode, Serializable {
   private final Integer fieldIdx;

--- a/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -127,6 +127,31 @@ abstract class HashAggregateExecBaseTransformer(
     "aggNumMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of aggregation memory allocations"),
 
+    "extractionInputRows" -> SQLMetrics.createMetric(
+      sparkContext, "number of extraction input rows"),
+    "extractionInputVectors" -> SQLMetrics.createMetric(
+      sparkContext, "number of extraction input vectors"),
+    "extractionInputBytes" -> SQLMetrics.createSizeMetric(
+      sparkContext, "number of extraction input bytes"),
+    "extractionRawInputRows" -> SQLMetrics.createMetric(
+      sparkContext, "number of extraction raw input rows"),
+    "extractionRawInputBytes" -> SQLMetrics.createSizeMetric(
+      sparkContext, "number of extraction raw input bytes"),
+    "extractionOutputRows" -> SQLMetrics.createMetric(
+      sparkContext, "number of extraction output rows"),
+    "extractionOutputVectors" -> SQLMetrics.createMetric(
+      sparkContext, "number of extraction output vectors"),
+    "extractionOutputBytes" -> SQLMetrics.createSizeMetric(
+      sparkContext, "number of extraction output bytes"),
+    "extractionCount" -> SQLMetrics.createMetric(
+      sparkContext, "extraction cpu wall time count"),
+    "extractionWallNanos" -> SQLMetrics.createNanoTimingMetric(
+      sparkContext, "totaltime_extraction"),
+    "extractionPeakMemoryBytes" -> SQLMetrics.createSizeMetric(
+      sparkContext, "extraction peak memory bytes"),
+    "extractionNumMemoryAllocations" -> SQLMetrics.createMetric(
+      sparkContext, "number of extraction memory allocations"),
+
     "postProjectionInputRows" -> SQLMetrics.createMetric(
       sparkContext, "number of postProjection input rows"),
     "postProjectionInputVectors" -> SQLMetrics.createMetric(
@@ -195,6 +220,20 @@ abstract class HashAggregateExecBaseTransformer(
   val aggWallNanos: SQLMetric = longMetric("aggWallNanos")
   val aggPeakMemoryBytes: SQLMetric = longMetric("aggPeakMemoryBytes")
   val aggNumMemoryAllocations: SQLMetric = longMetric("aggNumMemoryAllocations")
+
+  val extractionInputRows: SQLMetric = longMetric("extractionInputRows")
+  val extractionInputVectors: SQLMetric = longMetric("extractionInputVectors")
+  val extractionInputBytes: SQLMetric = longMetric("extractionInputBytes")
+  val extractionRawInputRows: SQLMetric = longMetric("extractionRawInputRows")
+  val extractionRawInputBytes: SQLMetric = longMetric("extractionRawInputBytes")
+  val extractionOutputRows: SQLMetric = longMetric("extractionOutputRows")
+  val extractionOutputVectors: SQLMetric = longMetric("extractionOutputVectors")
+  val extractionOutputBytes: SQLMetric = longMetric("extractionOutputBytes")
+  val extractionCount: SQLMetric = longMetric("extractionCount")
+  val extractionWallNanos: SQLMetric = longMetric("extractionWallNanos")
+  val extractionPeakMemoryBytes: SQLMetric = longMetric("extractionPeakMemoryBytes")
+  val extractionNumMemoryAllocations: SQLMetric =
+    longMetric("extractionNumMemoryAllocations")
 
   val postProjectionInputRows: SQLMetric = longMetric("postProjectionInputRows")
   val postProjectionInputVectors: SQLMetric = longMetric("postProjectionInputVectors")
@@ -283,6 +322,23 @@ abstract class HashAggregateExecBaseTransformer(
       postProjectionWallNanos += metrics.wallNanos
       postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
       postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
+      idx += 1
+    }
+
+    if (aggParams.extractionNeeded) {
+      val metrics = aggregationMetrics.get(idx)
+      extractionInputRows += metrics.inputRows
+      extractionInputVectors += metrics.inputVectors
+      extractionInputBytes += metrics.inputBytes
+      extractionRawInputRows += metrics.rawInputRows
+      extractionRawInputBytes += metrics.rawInputBytes
+      extractionOutputRows += metrics.outputRows
+      extractionOutputVectors += metrics.outputVectors
+      extractionOutputBytes += metrics.outputBytes
+      extractionCount += metrics.count
+      extractionWallNanos += metrics.wallNanos
+      extractionPeakMemoryBytes += metrics.peakMemoryBytes
+      extractionNumMemoryAllocations += metrics.numMemoryAllocations
       idx += 1
     }
 

--- a/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/jvm/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -48,6 +48,9 @@ case class AggregationParams() {
   // Whether preProjection is needed.
   var preProjectionNeeded = false
 
+  // Whether extraction from intermediate struct is needed.
+  var extractionNeeded = false
+
   // Whether postProjection is needed.
   var postProjectionNeeded = false
 }

--- a/tools/build_velox.sh
+++ b/tools/build_velox.sh
@@ -71,7 +71,7 @@ if [ $BUILD_VELOX_FROM_SOURCE == "ON" ]; then
     echo "VELOX_INSTALL_DIR=${VELOX_INSTALL_DIR}"
     mkdir -p $VELOX_SOURCE_DIR
     mkdir -p $VELOX_INSTALL_DIR
-    git clone https://github.com/oap-project/velox.git -b main $VELOX_SOURCE_DIR
+    git clone https://github.com/rui-mo/velox.git -b wip_fix_avg $VELOX_SOURCE_DIR
     pushd $VELOX_SOURCE_DIR
     #sync submodules
     git submodule sync --recursive

--- a/tools/build_velox.sh
+++ b/tools/build_velox.sh
@@ -71,7 +71,7 @@ if [ $BUILD_VELOX_FROM_SOURCE == "ON" ]; then
     echo "VELOX_INSTALL_DIR=${VELOX_INSTALL_DIR}"
     mkdir -p $VELOX_SOURCE_DIR
     mkdir -p $VELOX_INSTALL_DIR
-    git clone https://github.com/rui-mo/velox.git -b wip_fix_avg $VELOX_SOURCE_DIR
+    git clone https://github.com/oap-project/velox.git -b main $VELOX_SOURCE_DIR
     pushd $VELOX_SOURCE_DIR
     #sync submodules
     git submodule sync --recursive


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously, we use sum and count to replace partial avg. But incompatible intermediate type was found for avg(int). Instead of adding a projection for casting bigint to double, we changed to use partial avg in Velox and extract the subfields from struct.

Depends on https://github.com/oap-project/velox/pull/38.

## How was this patch tested?

Verified on Jenkins.

