### PR TITLE
[OPPRO-167] Add runtime metrics for dynamic filter

### DIFF
--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -254,7 +254,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   metrics_builder_class = CreateGlobalClassReferenceOrError(
       env, "Lio/glutenproject/vectorized/Metrics;");
   metrics_builder_constructor = GetMethodIDOrError(
-      env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[J[J[J)V");
+      env,
+      metrics_builder_class,
+      "<init>",
+      "([J[J[J[J[J[J[J[J[J[J[J[J[J[J[J)V");
 
   serialized_arrow_array_iterator_class = CreateGlobalClassReferenceOrError(
       env, "Lio/glutenproject/vectorized/ArrowInIterator;");
@@ -444,6 +447,9 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(
   auto wallNanos = env->NewLongArray(numMetrics);
   auto peakMemoryBytes = env->NewLongArray(numMetrics);
   auto numMemoryAllocations = env->NewLongArray(numMetrics);
+  auto numDynamicFiltersProduced = env->NewLongArray(numMetrics);
+  auto numDynamicFiltersAccepted = env->NewLongArray(numMetrics);
+  auto numReplacedWithDynamicFilterRows = env->NewLongArray(numMetrics);
 
   if (metrics) {
     env->SetLongArrayRegion(inputRows, 0, numMetrics, metrics->inputRows);
@@ -462,6 +468,21 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(
         peakMemoryBytes, 0, numMetrics, metrics->peakMemoryBytes);
     env->SetLongArrayRegion(
         numMemoryAllocations, 0, numMetrics, metrics->numMemoryAllocations);
+    env->SetLongArrayRegion(
+        numDynamicFiltersProduced,
+        0,
+        numMetrics,
+        metrics->numDynamicFiltersProduced);
+    env->SetLongArrayRegion(
+        numDynamicFiltersAccepted,
+        0,
+        numMetrics,
+        metrics->numDynamicFiltersAccepted);
+    env->SetLongArrayRegion(
+        numReplacedWithDynamicFilterRows,
+        0,
+        numMetrics,
+        metrics->numReplacedWithDynamicFilterRows);
   }
 
   return env->NewObject(
@@ -478,7 +499,10 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(
       count,
       wallNanos,
       peakMemoryBytes,
-      numMemoryAllocations);
+      numMemoryAllocations,
+      numDynamicFiltersProduced,
+      numDynamicFiltersAccepted,
+      numReplacedWithDynamicFilterRows);
   JNI_METHOD_END(nullptr)
 }
 

--- a/cpp/src/utils/metrics.h
+++ b/cpp/src/utils/metrics.h
@@ -29,12 +29,17 @@ struct Metrics {
   long* outputVectors;
   long* outputBytes;
 
-  // CpuWallTiming
+  // CpuWallTiming.
   long* count;
   long* wallNanos;
 
   long* peakMemoryBytes;
   long* numMemoryAllocations;
+
+  // Runtime metrics.
+  long* numDynamicFiltersProduced;
+  long* numDynamicFiltersAccepted;
+  long* numReplacedWithDynamicFilterRows;
 
   Metrics(int size) : numMetrics(size) {
     inputRows = new long[numMetrics]();
@@ -49,6 +54,9 @@ struct Metrics {
     wallNanos = new long[numMetrics]();
     peakMemoryBytes = new long[numMetrics]();
     numMemoryAllocations = new long[numMetrics]();
+    numDynamicFiltersProduced = new long[numMetrics]();
+    numDynamicFiltersAccepted = new long[numMetrics]();
+    numReplacedWithDynamicFilterRows = new long[numMetrics]();
   }
 
   ~Metrics() {

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -140,6 +140,11 @@ class WholeStageResIter {
   /// Collect Velox metrics.
   void collectMetrics();
 
+  /// Return the sum of one runtime metric.
+  int64_t sumOfRuntimeMetric(
+      const std::unordered_map<std::string, RuntimeMetric>& runtimeStats,
+      const std::string& metricId) const;
+
   std::shared_ptr<memory::MemoryPool> pool_;
 
   std::shared_ptr<Metrics> metrics_ = nullptr;

--- a/jvm/src/main/java/io/glutenproject/vectorized/Metrics.java
+++ b/jvm/src/main/java/io/glutenproject/vectorized/Metrics.java
@@ -30,6 +30,9 @@ public class Metrics {
   public long[] wallNanos;
   public long[] peakMemoryBytes;
   public long[] numMemoryAllocations;
+  public long[] numDynamicFiltersProduced;
+  public long[] numDynamicFiltersAccepted;
+  public long[] numReplacedWithDynamicFilterRows;
 
   /**
    * Create an instance for native metrics.
@@ -37,7 +40,9 @@ public class Metrics {
   public Metrics(
       long[] inputRows, long[] inputVectors, long[] inputBytes, long[] rawInputRows,
       long[] rawInputBytes, long[] outputRows, long[] outputVectors, long[] outputBytes,
-      long[] count, long[] wallNanos, long[] peakMemoryBytes, long[] numMemoryAllocations) {
+      long[] count, long[] wallNanos, long[] peakMemoryBytes, long[] numMemoryAllocations,
+      long[] numDynamicFiltersProduced, long[] numDynamicFiltersAccepted,
+      long[] numReplacedWithDynamicFilterRows) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -50,6 +55,9 @@ public class Metrics {
     this.wallNanos = wallNanos;
     this.peakMemoryBytes = peakMemoryBytes;
     this.numMemoryAllocations = numMemoryAllocations;
+    this.numDynamicFiltersProduced = numDynamicFiltersProduced;
+    this.numDynamicFiltersAccepted = numDynamicFiltersAccepted;
+    this.numReplacedWithDynamicFilterRows = numReplacedWithDynamicFilterRows;
   }
 
   public OperatorMetrics getOperatorMetrics(int index) {
@@ -58,17 +66,20 @@ public class Metrics {
     }
 
     return new OperatorMetrics(
-            inputRows[index],
-            inputVectors[index],
-            inputBytes[index],
-            rawInputRows[index],
-            rawInputBytes[index],
-            outputRows[index],
-            outputVectors[index],
-            outputBytes[index],
-            count[index],
-            wallNanos[index],
-            peakMemoryBytes[index],
-            numMemoryAllocations[index]);
+        inputRows[index],
+        inputVectors[index],
+        inputBytes[index],
+        rawInputRows[index],
+        rawInputBytes[index],
+        outputRows[index],
+        outputVectors[index],
+        outputBytes[index],
+        count[index],
+        wallNanos[index],
+        peakMemoryBytes[index],
+        numMemoryAllocations[index],
+        numDynamicFiltersProduced[index],
+        numDynamicFiltersAccepted[index],
+        numReplacedWithDynamicFilterRows[index]);
   }
 }

--- a/jvm/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
+++ b/jvm/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
@@ -30,6 +30,9 @@ public class OperatorMetrics {
   public long wallNanos;
   public long peakMemoryBytes;
   public long numMemoryAllocations;
+  public long numDynamicFiltersProduced;
+  public long numDynamicFiltersAccepted;
+  public long numReplacedWithDynamicFilterRows;
 
   /**
    * Create an instance for operator metrics.
@@ -37,7 +40,9 @@ public class OperatorMetrics {
   public OperatorMetrics(
       long inputRows, long inputVectors, long inputBytes, long rawInputRows,
       long rawInputBytes, long outputRows, long outputVectors, long outputBytes,
-      long count, long wallNanos, long peakMemoryBytes, long numMemoryAllocations) {
+      long count, long wallNanos, long peakMemoryBytes, long numMemoryAllocations,
+      long numDynamicFiltersProduced, long numDynamicFiltersAccepted,
+      long numReplacedWithDynamicFilterRows) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -50,5 +55,8 @@ public class OperatorMetrics {
     this.wallNanos = wallNanos;
     this.peakMemoryBytes = peakMemoryBytes;
     this.numMemoryAllocations = numMemoryAllocations;
+    this.numDynamicFiltersProduced = numDynamicFiltersProduced;
+    this.numDynamicFiltersAccepted = numDynamicFiltersAccepted;
+    this.numReplacedWithDynamicFilterRows = numReplacedWithDynamicFilterRows;
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -47,7 +47,9 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "total scan time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
-      sparkContext, "number of memory allocations"))
+      sparkContext, "number of memory allocations"),
+    "numDynamicFiltersAccepted" -> SQLMetrics.createMetric(
+      sparkContext, "number of dynamic filters accepted"))
 
   val inputRows: SQLMetric = longMetric("inputRows")
   val inputVectors: SQLMetric = longMetric("inputVectors")
@@ -61,6 +63,9 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
   val wallNanos: SQLMetric = longMetric("wallNanos")
   val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
   val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+
+  // Number of dynamic filters received.
+  val numDynamicFiltersAccepted: SQLMetric = longMetric("numDynamicFiltersAccepted")
 
   override def filterExprs(): Seq[Expression] = if (scan.isInstanceOf[FileScan]) {
     scan.asInstanceOf[FileScan].dataFilters ++ pushdownFilters
@@ -128,6 +133,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
       wallNanos += operatorMetrics.wallNanos
       peakMemoryBytes += operatorMetrics.peakMemoryBytes
       numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      numDynamicFiltersAccepted += operatorMetrics.numDynamicFiltersAccepted
     }
   }
 }

--- a/jvm/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -75,7 +75,9 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     "pruningTime" ->
       SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
-      sparkContext, "number of memory allocations"))
+      sparkContext, "number of memory allocations"),
+    "numDynamicFiltersAccepted" -> SQLMetrics.createMetric(
+      sparkContext, "number of dynamic filters accepted"))
 
   val inputRows: SQLMetric = longMetric("inputRows")
   val inputVectors: SQLMetric = longMetric("inputVectors")
@@ -89,6 +91,9 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
   val wallNanos: SQLMetric = longMetric("wallNanos")
   val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
   val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+
+  // Number of dynamic filters received.
+  val numDynamicFiltersAccepted: SQLMetric = longMetric("numDynamicFiltersAccepted")
 
   override lazy val supportsColumnar: Boolean = {
     relation.fileFormat
@@ -162,6 +167,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
       wallNanos += operatorMetrics.wallNanos
       peakMemoryBytes += operatorMetrics.peakMemoryBytes
       numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      numDynamicFiltersAccepted += operatorMetrics.numDynamicFiltersAccepted
     }
   }
 

--- a/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -213,6 +213,10 @@ abstract class HashJoinLikeExecTransformer(leftKeys: Seq[Expression],
       sparkContext, "hash probe peak memory bytes"),
     "hashProbeNumMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of hash probe memory allocations"),
+    "hashProbeReplacedWithDynamicFilterRows" -> SQLMetrics.createMetric(
+      sparkContext, "number of hash probe replaced with dynamic filter rows"),
+    "hashProbeDynamicFiltersProduced" -> SQLMetrics.createMetric(
+      sparkContext, "number of hash probe dynamic filters produced"),
 
     "postProjectionInputRows" -> SQLMetrics.createMetric(
       sparkContext, "number of postProjection input rows"),
@@ -326,6 +330,15 @@ abstract class HashJoinLikeExecTransformer(leftKeys: Seq[Expression],
   val hashProbePeakMemoryBytes: SQLMetric = longMetric("hashProbePeakMemoryBytes")
   val hashProbeNumMemoryAllocations: SQLMetric = longMetric("hashProbeNumMemoryAllocations")
 
+  // The number of rows which were passed through without any processing
+  // after filter was pushed down.
+  val hashProbeReplacedWithDynamicFilterRows: SQLMetric =
+    longMetric("hashProbeReplacedWithDynamicFilterRows")
+
+  // The number of dynamic filters this join generated for push down.
+  val hashProbeDynamicFiltersProduced: SQLMetric =
+    longMetric("hashProbeDynamicFiltersProduced")
+
   val postProjectionInputRows: SQLMetric = longMetric("postProjectionInputRows")
   val postProjectionInputVectors: SQLMetric = longMetric("postProjectionInputVectors")
   val postProjectionInputBytes: SQLMetric = longMetric("postProjectionInputBytes")
@@ -421,6 +434,8 @@ abstract class HashJoinLikeExecTransformer(leftKeys: Seq[Expression],
     hashProbeWallNanos += hashProbeMetrics.wallNanos
     hashProbePeakMemoryBytes += hashProbeMetrics.peakMemoryBytes
     hashProbeNumMemoryAllocations += hashProbeMetrics.numMemoryAllocations
+    hashProbeReplacedWithDynamicFilterRows += hashProbeMetrics.numReplacedWithDynamicFilterRows
+    hashProbeDynamicFiltersProduced += hashProbeMetrics.numDynamicFiltersProduced
     idx += 1
 
     // HashBuild

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -394,7 +394,9 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
     var wallNanos: Long = 0
     var peakMemoryBytes: Long = 0
     var numMemoryAllocations: Long = 0
-
+    var numDynamicFiltersProduced: Long = 0
+    var numDynamicFiltersAccepted: Long = 0
+    var numReplacedWithDynamicFilterRows: Long = 0
 
     val metricsIterator = operatorMetrics.iterator()
     while (metricsIterator.hasNext) {
@@ -403,11 +405,15 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       wallNanos += metrics.wallNanos
       peakMemoryBytes = peakMemoryBytes.max(metrics.peakMemoryBytes)
       numMemoryAllocations += metrics.numMemoryAllocations
+      numDynamicFiltersProduced += metrics.numDynamicFiltersProduced
+      numDynamicFiltersAccepted += metrics.numDynamicFiltersAccepted
+      numReplacedWithDynamicFilterRows += metrics.numReplacedWithDynamicFilterRows
     }
 
     new OperatorMetrics(
       inputRows, inputVectors, inputBytes, rawInputRows, rawInputBytes, outputRows, outputVectors,
-      outputBytes, count, wallNanos, peakMemoryBytes, numMemoryAllocations)
+      outputBytes, count, wallNanos, peakMemoryBytes, numMemoryAllocations,
+      numDynamicFiltersProduced, numDynamicFiltersAccepted, numReplacedWithDynamicFilterRows)
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR added below three runtime metrics into scan and join operator.

```
HashProbe:
* replacedWithDynamicFilterRows - the number of rows which were passed through
  without any processing after filter was pushed down
* dynamicFiltersProduced - number of dynamic filters generated (at most one per
  join key)
TableScan:
* dynamicFiltersAccepted - number of dynamic filters received
```

## How was this patch tested?

under test

