### PR TITLE
[Gluten-330] Fix 'Method getXXX is not supported for Nullable(XXX)' when executing TPCH Q9 and add ut

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -38,9 +38,9 @@ object DSV2BenchmarkTest {
     // val libPath = "/usr/local/clickhouse/lib/libch.so"
     val thrdCnt = 12
     val shufflePartitions = 12
-    val shuffleManager = "sort"
-    // val shuffleManager = "org.apache.spark.shuffle.sort.ColumnarShuffleManager"
-    val ioCompressionCodec = "SNAPPY"
+    // val shuffleManager = "sort"
+    val shuffleManager = "org.apache.spark.shuffle.sort.ColumnarShuffleManager"
+    val ioCompressionCodec = "LZ4"
     val columnarColumnToRow = "true"
     val useV2 = "false"
     val separateScanRDD = "true"
@@ -145,6 +145,7 @@ object DSV2BenchmarkTest {
         // .config("spark.gluten.sql.columnar.filescan", "true")
         // .config("spark.sql.optimizeNullAwareAntiJoin", "false")
         // .config("spark.sql.join.preferSortMergeJoin", "false")
+        .config("spark.sql.shuffledHashJoinFactor", "3")
         // .config("spark.sql.planChangeLog.level", "info")
         // .config("spark.sql.optimizer.inSetConversionThreshold", "5")  // IN to INSET
         .config("spark.sql.columnVector.offheap.enabled", "true")
@@ -372,12 +373,12 @@ object DSV2BenchmarkTest {
   def testTPCHAll(spark: SparkSession): Unit = {
     spark.sql(
       s"""
-         |use default;
+         |use tpch_nullable;
          |""".stripMargin).show(1000, false)
     val tookTimeArr = ArrayBuffer[Long]()
     val executedCnt = 1
     val executeExplain = false
-    val sqlFilePath = "/data2/tpch-queries-spark100/"
+    val sqlFilePath = "/data2/tpch-queries-ch100/"
     for (i <- 1 to 22) {
       if (i != 21) {
         val sqlNum = "q" + "%02d".format(i)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
@@ -44,7 +44,7 @@ object DSV2TPCDSBenchmarkTest {
     val useV2 = "false"
     val separateScanRDD = "true"
     val coalesceBatches = "true"
-    val broadcastThreshold = "10MB"
+    val broadcastThreshold = "10MB" // 100KB  10KB
     val sparkLocalDir = "/data1/gazelle-jni-warehouse/spark_local_dirs"
     val (parquetFilesPath, fileFormat,
     executedCnt, configed, sqlFilePath, stopFlagFile,
@@ -144,6 +144,7 @@ object DSV2TPCDSBenchmarkTest {
         // .config("spark.gluten.sql.columnar.filescan", "true")
         // .config("spark.sql.optimizeNullAwareAntiJoin", "false")
         // .config("spark.sql.join.preferSortMergeJoin", "false")
+        .config("spark.sql.shuffledHashJoinFactor", "2")
         // .config("spark.sql.planChangeLog.level", "info")
         // .config("spark.sql.optimizer.inSetConversionThreshold", "5")  // IN to INSET
         .config("spark.sql.columnVector.offheap.enabled", "true")
@@ -242,7 +243,22 @@ object DSV2TPCDSBenchmarkTest {
     val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString
     for (i <- 1 to executedCnt) {
       val startTime = System.nanoTime()
-      val df = spark.sql(sqlStr) // .show(30, false)
+      val df = spark.sql(
+        s"""
+           |select sr_customer_sk as ctr_customer_sk
+           |,sr_store_sk as ctr_store_sk,
+           |count(1) as cnt
+           |from store_returns
+           |,date_dim
+           |where sr_returned_date_sk - 2 = d_date_sk + 1
+           |and d_year = 2000
+           |and sr_customer_sk is not null
+           |and sr_store_sk is not null
+           |group by sr_customer_sk
+           |,sr_store_sk
+           |order by cnt desc
+           |limit 20
+           |""".stripMargin) // .show(30, false)
       df.explain(false)
       val plan = df.queryExecution.executedPlan
       // df.queryExecution.debug.codegen

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -35,8 +35,8 @@ import org.apache.spark.sql.types.DoubleType
 abstract class GlutenClickHouseTPCDSAbstractSuite extends WholeStageTransformerSuite with Logging {
 
   override protected val backend: String = "ch"
-  override protected val resourcePath: String = "/home/changchen/tpcds-sf1-data/"
-  // override protected val resourcePath: String = "/data1/test_output/tpcds-data-sf1/"
+  // override protected val resourcePath: String = "/home/changchen/tpcds-sf1-data/"
+  override protected val resourcePath: String = "/data1/test_output/tpcds-data-sf1/"
   override protected val fileFormat: String = "parquet"
 
   protected val rootPath: String = getClass.getResource("/").getPath

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -35,8 +35,8 @@ import org.apache.spark.sql.types.DoubleType
 abstract class GlutenClickHouseTPCDSAbstractSuite extends WholeStageTransformerSuite with Logging {
 
   override protected val backend: String = "ch"
-  // override protected val resourcePath: String = "/home/changchen/tpcds-sf1-data/"
-  override protected val resourcePath: String = "/data1/test_output/tpcds-data-sf1/"
+  override protected val resourcePath: String = "/home/changchen/tpcds-sf1-data/"
+  // override protected val resourcePath: String = "/data1/test_output/tpcds-data-sf1/"
   override protected val fileFormat: String = "parquet"
 
   protected val rootPath: String = getClass.getResource("/").getPath

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableColumnarShuffleSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableColumnarShuffleSuite.scala
@@ -20,7 +20,7 @@ package io.glutenproject.execution
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
 
-class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuite {
+class GlutenClickHouseTPCHNullableColumnarShuffleSuite extends GlutenClickHouseTPCHAbstractSuite {
 
   override protected val createNullableTables = true
   override protected val resourcePath: String = "tpch-data-ch-nullable"
@@ -34,8 +34,8 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
     */
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set("spark.shuffle.manager", "sort")
-      .set("spark.io.compression.codec", "SNAPPY")
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.io.compression.codec", "LZ4")
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")


### PR DESCRIPTION
Fix 'Method getXXX is not supported for Nullable(XXX)' when executing TPCH Q9 and add ut.

Close #330 .

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

