### PR TITLE
[Gluten-343] Fix wrong results when executing avg(int), avg(long), avg(boolean) for ClickHouse backend

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -49,6 +49,7 @@ object CHExecUtil {
     case "Short" => ShortType
     case "String" => StringType
     case "Binary" => BinaryType
+    case "Boolean" => BooleanType
   }
   // scalastyle:off argcount
   def genShuffleDependency(rdd: RDD[ColumnarBatch],

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSParquetSuite.scala
@@ -69,6 +69,17 @@ class GlutenClickHouseTPCDSParquetSuite extends GlutenClickHouseTPCDSAbstractSui
     assert(result(0).getDouble(0) == 379.21313271604936)
   }
 
+  test("test select avg(int), avg(long)") {
+    val testSql =
+      """
+        |select avg(cs_item_sk), avg(cs_order_number)
+        |  from catalog_sales
+        |""".stripMargin
+    val result = spark.sql(testSql).collect()
+    assert(result(0).getDouble(0) == 8998.463336886734)
+    assert(result(0).getDouble(1) == 80037.12727449503)
+  }
+
   test("TPCDS Q9") {
     withSQLConf(
       ("spark.gluten.sql.columnar.columnartorow", "true")) {


### PR DESCRIPTION
Fix wrong results when executing avg(int), avg(long), avg(boolean) for ClickHouse backend

Close #343 .

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

