### PR TITLE
[Gluten-349] Bug fix for checkException memory double free error

### DIFF
--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -235,9 +235,9 @@ static inline std::string JStringToCString(JNIEnv* env, jstring string) {
   int32_t jlen, clen;
   clen = env->GetStringUTFLength(string);
   jlen = env->GetStringLength(string);
-  std::vector<char> buffer(clen);
-  env->GetStringUTFRegion(string, 0, jlen, buffer.data());
-  return std::string(buffer.data(), clen);
+  char buffer[clen];
+  env->GetStringUTFRegion(string, 0, jlen, buffer);
+  return std::string(buffer, clen);
 }
 
 static inline jbyteArray ToSchemaByteArray(JNIEnv* env, std::shared_ptr<arrow::Schema> schema) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
bug fix for convert parquet to dwrf memory double free error as describe in #349 


## How was this patch tested?
manual tests
1. run tpch_convert_parquet_dwrf.sh it cause the error describe in #349
2. modfiy the jni_common.h as in pr, and re-run the script, no errors, and the dwrf file was produced.

