### PR TITLE
[OPPRO-159] Remove alias for Velox backend

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/expression/VeloxAliasTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/expression/VeloxAliasTransformer.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.expression
+
+import io.glutenproject.substrait.expression.ExpressionNode
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types._
+
+class VeloxAliasTransformer(child: Expression, name: String)(
+  override val exprId: ExprId,
+  override val qualifier: Seq[String],
+  override val explicitMetadata: Option[Metadata])
+  extends AliasBaseTransformer(child, name)(exprId, qualifier, explicitMetadata) {
+
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    val childNode = child.asInstanceOf[ExpressionTransformer].doTransform(args)
+    if (!childNode.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet")
+    }
+    childNode
+  }
+}

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
@@ -18,13 +18,13 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.execution.{FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
-
+import io.glutenproject.expression.AliasBaseTransformer
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.{SparkSession, Strategy}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 import org.apache.spark.sql.execution.joins.BuildSideRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{Metadata, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 trait ISparkPlanExecApi extends IBackendsApi {
@@ -81,6 +81,20 @@ trait ISparkPlanExecApi extends IBackendsApi {
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     child: SparkPlan): HashAggregateExecBaseTransformer
+
+  /**
+   * Generate Alias transformer.
+   *
+   * @param child The computation being performed
+   * @param name The name to be associated with the result of computing.
+   * @param exprId
+   * @param qualifier
+   * @param explicitMetadata
+   * @return a transformer for alias
+   */
+  def genAliasTransformer(child: Expression, name: String, exprId: ExprId,
+                          qualifier: Seq[String], explicitMetadata: Option[Metadata])
+  : AliasBaseTransformer
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.

--- a/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -33,11 +33,12 @@ object ExpressionConverter extends Logging {
     expr match {
       case a: Alias =>
         logInfo(s"${expr.getClass} ${expr} is supported")
-        new AliasTransformer(
-          replaceWithExpressionTransformer(
-            a.child,
-            attributeSeq),
-          a.name)(a.exprId, a.qualifier, a.explicitMetadata)
+        BackendsApiManager.getSparkPlanExecApiInstance.genAliasTransformer(
+          replaceWithExpressionTransformer(a.child, attributeSeq),
+          a.name,
+          a.exprId,
+          a.qualifier,
+          a.explicitMetadata)
       case a: AttributeReference =>
         logInfo(s"${expr.getClass} ${expr} is supported")
         if (attributeSeq == null) {

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
@@ -18,13 +18,13 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.execution.{FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
-
+import io.glutenproject.expression.AliasBaseTransformer
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.{SparkSession, Strategy}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 import org.apache.spark.sql.execution.joins.BuildSideRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{Metadata, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
@@ -83,6 +83,20 @@ class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
      initialInputBufferOffset: Int,
      resultExpressions: Seq[NamedExpression],
      child: SparkPlan): HashAggregateExecBaseTransformer = null
+
+  /**
+   * Generate Alias transformer.
+   *
+   * @param child The computation being performed
+   * @param name The name to be associated with the result of computing.
+   * @param exprId
+   * @param qualifier
+   * @param explicitMetadata
+   * @return a transformer for alias
+   */
+  def genAliasTransformer(child: Expression, name: String, exprId: ExprId,
+                          qualifier: Seq[String], explicitMetadata: Option[Metadata])
+  : AliasBaseTransformer = null
 
   /**
    * Generate ShuffleDependency for ColumnarShuffleExchangeExec.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Alias is not needed for Velox backend because the plan generation is index-based.


## How was this patch tested?

under test

