### PR TITLE
Use capital letter SNAPSHOT in versioning

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -50,7 +50,7 @@ jobs:
           rm -rf ~/.m2/repository/org/apache/arrow && rm -rf ~/.m2/repository/io/glutenproject/
           mvn clean package -Dhttps.proxyHost=child-prc.intel.com -Dhttps.proxyPort=913 -Pbackends-gazelle -DskipTests -Dbuild_cpp=ON -Dbuild_gazelle_cpp=ON -Dbuild_arrow=ON
           rm -rf /tmp/gluten_jars && mkdir -p /tmp/gluten_jars
-          cp backends-velox/target/gluten-1.0.0-snapshot-jar-with-dependencies.jar /tmp/gluten_jars/
+          cp backends-velox/target/gluten-1.0.0-SNAPSHOT-jar-with-dependencies.jar /tmp/gluten_jars/
       # - name: Run unit tests
       #   run: |
       #     mvn test -Dhttps.proxyHost=child-prc.intel.com -Dhttps.proxyPort=913 -Dcheckstyle.skip -Dexec.skip -Pbackends-gazelle -Dbuild_cpp=OFF -pl backends-gazelle -DwildcardSuites=io.glutenproject.execution.ArrowParquetWriteSuite -DfailIfNoTests=false

--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gluten-parent</artifactId>
         <groupId>io.glutenproject</groupId>
-        <version>1.0.0-snapshot</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backends-gazelle/pom.xml
+++ b/backends-gazelle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gluten-parent</artifactId>
         <groupId>io.glutenproject</groupId>
-        <version>1.0.0-snapshot</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gluten-parent</artifactId>
         <groupId>io.glutenproject</groupId>
-        <version>1.0.0-snapshot</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backends-velox/workload/tpch/gen_data/dwrf_dataset/tpch_convert_parquet_dwrf.sh
+++ b/backends-velox/workload/tpch/gen_data/dwrf_dataset/tpch_convert_parquet_dwrf.sh
@@ -1,7 +1,7 @@
 batchsize=20480
 
 export GLUTEN_HOME=/PATH/TO/gluten/
-export GLUTEN_JVM_JAR=${GLUTEN_HOME}/backends-velox/target/gluten-1.0.0-snapshot-jar-with-dependencies.jar
+export GLUTEN_JVM_JAR=${GLUTEN_HOME}/backends-velox/target/gluten-1.0.0-SNAPSHOT-jar-with-dependencies.jar
 SPARK_HOME=/home/sparkuser/spark/
 
 cat tpch_convert_parquet_dwrf.scala  | ${SPARK_HOME}/bin/spark-shell                            \

--- a/docs/ArrowBackend.md
+++ b/docs/ArrowBackend.md
@@ -53,8 +53,8 @@ ArrowBackend should be added.
 
 | Configuration | Value | Comment |
 | --- | --- | --- |
-| spark.driver.extraClassPath | /path/to/gluten/backends-velox/target/gluten-1.0.0-snapshot-jar-with-dependencies.jar |  |
-| spark.executor.extraClassPath | /path/to/gluten/backends-velox/target/gluten-1.0.0-snapshot-jar-with-dependencies.jar |  |
+| spark.driver.extraClassPath | /path/to/gluten/backends-velox/target/gluten-1.0.0-SNAPSHOT-jar-with-dependencies.jar |  |
+| spark.executor.extraClassPath | /path/to/gluten/backends-velox/target/gluten-1.0.0-SNAPSHOT-jar-with-dependencies.jar |  |
 | spark.plugins | io.glutenproject.GlutenPlugin |  |
 | spark.gluten.sql.columnar.backend.lib | gazelle_cpp |  |
 | spark.shuffle.manager | org.apache.spark.shuffle.sort.ColumnarShuffleManager |  |

--- a/docs/GlutenUsage.md
+++ b/docs/GlutenUsage.md
@@ -72,8 +72,8 @@ spark.plugins io.glutenproject.GlutenPlugin
 spark.gluten.sql.columnar.backend.lib ${BACKEND}
 spark.sql.sources.useV1SourceList avro
 spark.memory.offHeap.size 20g
-spark.driver.extraClassPath ${GLUTEN_HOME}/backends-velox/target/gluten-jvm-<version>-snapshot-jar-with-dependencies.jar
-spark.executor.extraClassPath ${GLUTEN_HOME}/backends-velox/target/gluten-jvm-<version>-snapshot-jar-with-dependencies.jar
+spark.driver.extraClassPath ${GLUTEN_HOME}/backends-velox/target/gluten-jvm-<version>-SNAPSHOT-jar-with-dependencies.jar
+spark.executor.extraClassPath ${GLUTEN_HOME}/backends-velox/target/gluten-jvm-<version>-SNAPSHOT-jar-with-dependencies.jar
 ```
 ${BACKEND} can be velox or clickhouse, refer [Velox.md](https://github.com/oap-project/gluten/blob/main/docs/Velox.md}) and [ClickHouse.md](https://github.com/oap-project/gluten/blob/main/docs/ClickHouse.md) to get more detail.
 

--- a/gluten-ut/pom.xml
+++ b/gluten-ut/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gluten-parent</artifactId>
         <groupId>io.glutenproject</groupId>
-        <version>1.0.0-snapshot</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -17,12 +17,12 @@
     <parent>
         <groupId>io.glutenproject</groupId>
         <artifactId>gluten-parent</artifactId>
-        <version>1.0.0-snapshot</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>gluten-jvm</artifactId>
-    <version>1.0.0-snapshot</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Gluten-JVM</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.glutenproject</groupId>
   <artifactId>gluten-parent</artifactId>
-  <version>1.0.0-snapshot</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gluten Parent Pom</name>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.glutenproject</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.0.0-snapshot</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.glutenproject</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.0.0-snapshot</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/spark32/pom.xml
+++ b/shims/spark32/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.glutenproject</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.0.0-snapshot</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Maven uses upper case `SNAPSHOT` to decide if an artifact is snapshot version or not.

https://github.com/apache/maven/blob/e410a6ce1dea787258e5675e71a672144e3f0419/maven-artifact/src/main/java/org/apache/maven/artifact/Artifact.java#L47