### PR TITLE
[CH-158] Support functions for clickhouse backend: ltrim/rtrim

### DIFF
--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenStringFunctionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenStringFunctionsSuite.scala
@@ -17,9 +17,20 @@
 
 package org.apache.spark.sql
 
-class GlutenStringFunctionsSuite extends StringFunctionsSuite with GlutenSQLTestsTrait {
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.ExpressionEvalHelper
+import org.apache.spark.sql.catalyst.expressions.Lower
+import org.apache.spark.sql.catalyst.expressions.Upper
+
+class GlutenStringFunctionsSuite extends StringFunctionsSuite
+  with GlutenSQLTestsTrait
+  with ExpressionEvalHelper {
+  override def whiteTestNameList: Seq[String] = Seq(
+    "string trim functions"
+  )
 
   override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
   )
 }

--- a/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -338,6 +338,7 @@ object ConverterUtils extends Logging {
   final val ENDS_WITH = "ends_with"
   final val CONTAINS = "contains"
   final val NOT = "not"
+  // Strings
   final val STARTS_WITH = "starts_with"
   final val SUBSTRING = "substring"
   final val ROW_CONSTRUCTOR = "row_constructor"
@@ -345,4 +346,6 @@ object ConverterUtils extends Logging {
   final val CHR = "chr"
   // SparkSQL Math fucctions of Velox
   final val ABS = "abs"
+  final val LTRIM = "ltrim"
+  final val RTRIM = "rtrim"
 }

--- a/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -206,6 +206,23 @@ object ExpressionConverter extends Logging {
             r.scale,
             attributeSeq),
           expr)
+      case l: StringTrimLeft =>
+        if (l.trimStr != None) {
+          throw new UnsupportedOperationException(s"not supported yet.")
+        }
+        logInfo(s"${expr.getClass} ${expr} is supported")
+        TrimOperatorTransformer.create(
+          replaceWithExpressionTransformer(l.srcStr, attributeSeq),
+          expr)
+      case r: StringTrimRight =>
+        if (r.trimStr != None) {
+          throw new UnsupportedOperationException(s"not supported yet.")
+        }
+        logInfo(s"${expr.getClass} ${expr} is supported")
+        TrimOperatorTransformer.create(
+          replaceWithExpressionTransformer(r.srcStr, attributeSeq),
+          expr)
+
       case expr =>
         logDebug(s"${expr.getClass} or ${expr} is not currently supported.")
         throw new UnsupportedOperationException(

--- a/jvm/src/main/scala/io/glutenproject/expression/TrimOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/TrimOperatorTransformer.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.expression
+
+import com.google.common.collect.Lists
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.internal.Logging
+import io.glutenproject.substrait.expression._
+import io.glutenproject.substrait.`type`.TypeBuilder
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
+
+
+class StringTrimLeftTransformer(srcStr: Expression, original: Expression)
+    extends StringTrimLeft(srcStr: Expression, None: Option[Expression])
+    with ExpressionTransformer
+    with Logging {
+
+    override def doTransform(args: java.lang.Object): ExpressionNode = {
+      val srcStrNode = srcStr.asInstanceOf[ExpressionTransformer].doTransform(args)
+      if (!srcStrNode.isInstanceOf[ExpressionNode]) {
+        throw new UnsupportedOperationException(s"not supported yet.")
+      }
+
+      val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+      val functionName =
+        ConverterUtils.makeFuncName(ConverterUtils.LTRIM, Seq(srcStr.dataType), FunctionConfig.OPT)
+      val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+      val expressNodes = Lists.newArrayList(srcStrNode.asInstanceOf[ExpressionNode])
+      val typeNode = TypeBuilder.makeString(original.nullable)
+      ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+  }
+}
+
+
+class StringTrimRightTransformer(srcStr: Expression, original: Expression)
+    extends StringTrimRight(srcStr: Expression, None: Option[Expression])
+    with ExpressionTransformer
+    with Logging {
+
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    val srcStrNode = srcStr.asInstanceOf[ExpressionTransformer].doTransform(args)
+    if (!srcStrNode.isInstanceOf[ExpressionNode]) {
+      throw new UnsupportedOperationException(s"not supported yet.")
+    }
+
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionName =
+      ConverterUtils.makeFuncName(ConverterUtils.RTRIM, Seq(srcStr.dataType), FunctionConfig.OPT)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+    val expressNodes = Lists.newArrayList(srcStrNode.asInstanceOf[ExpressionNode])
+    val typeNode = TypeBuilder.makeString(original.nullable)
+    ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
+  }
+}
+
+object TrimOperatorTransformer {
+  def create(srcStr: Expression, original: Expression): Expression =
+    original match {
+      case l: StringTrimLeft =>
+        new StringTrimLeftTransformer(srcStr, l)
+      case r: StringTrimRight =>
+        new StringTrimRightTransformer(srcStr, r)
+      case other =>
+        throw new UnsupportedOperationException(s"not currently supported: $other.")
+    }
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
Close https://github.com/Kyligence/ClickHouse/issues/158
Related PR: https://github.com/Kyligence/ClickHouse/pull/117

Support more functions 
- ltrim(when trimStr is None)
- rtrim(when trimStr is None)

## How was this patch tested?

ltrim: 
```
0: jdbc:hive2://localhost:10000> explain formatted select ltrim(l_comment) from lineitem where l_comment like '%sly%' 
. . . . . . . . . . . . . . . .> ;
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (6)
+- * Project (5)
   +- BlockNativeColumnarToRowExec (4)
      +- * FilterExecTransformer (2)
         +- Scan parquet  (1)


(1) Scan parquet 
Output [1]: [l_comment#224]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
PushedFilters: [IsNotNull(l_comment), StringContains(l_comment,sly)]
ReadSchema: struct<l_comment:string>

(2) FilterExecTransformer
Input [1]: [l_comment#224]
Arguments: (isnotnull(l_comment#224) AND Contains(l_comment#224, sly))

(3) WholeStageCodegenTransformer (1)
Input [1]: [l_comment#224]

(4) BlockNativeColumnarToRowExec
Input [1]: [l_comment#224]

(5) Project [codegen id : 1]
Output [1]: [lower(l_comment#224) AS lower(l_comment)#338]
Input [1]: [l_comment#224]

(6) CollectLimit
Input [1]: [lower(l_comment)#338]
Arguments: 10
```

rtrim
``` 
0: jdbc:hive2://localhost:10000> explain formatted select rtrim(l_comment) from lineitem where l_comment like '%sly%' limit 10  ;  
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (6)
+- BlockNativeColumnarToRowExec (5)
   +- * ProjectExecTransformer (3)
      +- * FilterExecTransformer (2)
         +- Scan parquet  (1)


(1) Scan parquet 
Output [1]: [l_comment#15]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
PushedFilters: [IsNotNull(l_comment), StringContains(l_comment,sly)]
ReadSchema: struct<l_comment:string>

(2) FilterExecTransformer
Input [1]: [l_comment#15]
Arguments: (isnotnull(l_comment#15) AND Contains(l_comment#15, sly))

(3) ProjectExecTransformer
Input [1]: [l_comment#15]
Arguments: [rtrim(l_comment#15, None) AS rtrim(l_comment)#46]

(4) WholeStageCodegenTransformer (1)
Input [1]: [rtrim(l_comment)#46]

(5) BlockNativeColumnarToRowExec
Input [1]: [rtrim(l_comment)#46]

(6) CollectLimit
Input [1]: [rtrim(l_comment)#46]
Arguments: 10
```

