### PR TITLE
[OPPRO-242] Implement a workaround for Velox Anti join

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -18,31 +18,23 @@
 package io.glutenproject.backendsapi.clickhouse
 
 import scala.collection.mutable.ArrayBuffer
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.ISparkPlanExecApi
 import io.glutenproject.execution._
 import io.glutenproject.expression.{AliasBaseTransformer, AliasTransformer}
 import io.glutenproject.vectorized.{BlockNativeWriter, CHColumnarBatchSerializer}
-
 import org.apache.spark.{ShuffleDependency, SparkException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.shuffle.utils.CHShuffleUtil
 import org.apache.spark.sql.{SparkSession, Strategy}
-import org.apache.spark.sql.catalyst.expressions.{
-  Alias,
-  Attribute,
-  AttributeReference,
-  BoundReference,
-  Expression,
-  ExprId,
-  NamedExpression
-}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.optimizer.BuildSide
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
+import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.delta.DeltaLogFileIndex
 import org.apache.spark.sql.execution._
@@ -50,11 +42,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
-import org.apache.spark.sql.execution.joins.{
-  BuildSideRelation,
-  ClickHouseBuildSideRelation,
-  HashedRelationBroadcastMode
-}
+import org.apache.spark.sql.execution.joins.{BuildSideRelation, ClickHouseBuildSideRelation, HashedRelationBroadcastMode}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.utils.CHExecUtil
 import org.apache.spark.sql.extension.{CHDataSourceV2Strategy, ClickHouseAnalysis}
@@ -144,6 +132,33 @@ class CHSparkPlanExecApi extends ISparkPlanExecApi with AdaptiveSparkPlanHelper 
       initialInputBufferOffset,
       resultExpressions,
       child)
+
+  /**
+   * Generate ShuffledHashJoinExecTransformer.
+   */
+  def genShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                         rightKeys: Seq[Expression],
+                                         joinType: JoinType,
+                                         buildSide: BuildSide,
+                                         condition: Option[Expression],
+                                         left: SparkPlan,
+                                         right: SparkPlan): ShuffledHashJoinExecTransformer =
+    CHShuffledHashJoinExecTransformer(
+      leftKeys, rightKeys, joinType, buildSide, condition, left, right)
+
+  /**
+   * Generate BroadcastHashJoinExecTransformer.
+   */
+  def genBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                          rightKeys: Seq[Expression],
+                                          joinType: JoinType,
+                                          buildSide: BuildSide,
+                                          condition: Option[Expression],
+                                          left: SparkPlan,
+                                          right: SparkPlan,
+                                          isNullAwareAntiJoin: Boolean = false)
+  : BroadcastHashJoinExecTransformer = CHBroadcastHashJoinExecTransformer(
+    leftKeys, rightKeys, joinType, buildSide, condition, left, right)
 
   /**
    * Generate Alias transformer.

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.optimizer.BuildSide
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.execution.SparkPlan
+
+case class CHShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                             rightKeys: Seq[Expression],
+                                             joinType: JoinType,
+                                             buildSide: BuildSide,
+                                             condition: Option[Expression],
+                                             left: SparkPlan,
+                                             right: SparkPlan)
+  extends ShuffledHashJoinExecTransformer(
+    leftKeys, rightKeys, joinType, buildSide, condition, left, right) {
+
+  override protected def withNewChildrenInternal(
+      newLeft: SparkPlan, newRight: SparkPlan): CHShuffledHashJoinExecTransformer =
+    copy(left = newLeft, right = newRight)
+}
+
+case class CHBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                              rightKeys: Seq[Expression],
+                                              joinType: JoinType,
+                                              buildSide: BuildSide,
+                                              condition: Option[Expression],
+                                              left: SparkPlan,
+                                              right: SparkPlan,
+                                              isNullAwareAntiJoin: Boolean = false)
+  extends BroadcastHashJoinExecTransformer(
+    leftKeys, rightKeys, joinType, buildSide, condition, left, right) {
+
+  override protected def withNewChildrenInternal(
+      newLeft: SparkPlan, newRight: SparkPlan): CHBroadcastHashJoinExecTransformer =
+    copy(left = newLeft, right = newRight)
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -290,8 +290,8 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
 
   def collectAllJoinSide(executedPlan: SparkPlan): Unit = {
     val buildSides = collect(executedPlan) {
-      case s: ShuffledHashJoinExecTransformer => "Shuffle-" + s.buildSide.toString
-      case b: BroadcastHashJoinExecTransformer => "Broadcast-" + b.buildSide.toString
+      case s: ShuffledHashJoinExecTransformer => "Shuffle-" + s.joinBuildSide.toString
+      case b: BroadcastHashJoinExecTransformer => "Broadcast-" + b.joinBuildSide.toString
       case os: ShuffledHashJoinExec => "Shuffle-" + os.buildSide.toString
       case ob: BroadcastHashJoinExec => "Broadcast-" + ob.buildSide.toString
       case sm: SortMergeJoinExec => "SortMerge-Join"

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableColumnarShuffleSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableColumnarShuffleSuite.scala
@@ -63,7 +63,7 @@ class GlutenClickHouseTPCHNullableColumnarShuffleSuite extends GlutenClickHouseT
     withSQLConf(("spark.sql.autoBroadcastJoinThreshold", "-1")) {
       runTPCHQuery(3) { df =>
         val shjBuildLeft = df.queryExecution.executedPlan.collect {
-          case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
+          case shj: ShuffledHashJoinExecTransformer if shj.joinBuildSide == BuildLeft => shj
         }
         assert(shjBuildLeft.size == 2)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHNullableSuite.scala
@@ -63,7 +63,7 @@ class GlutenClickHouseTPCHNullableSuite extends GlutenClickHouseTPCHAbstractSuit
     withSQLConf(("spark.sql.autoBroadcastJoinThreshold", "-1")) {
       runTPCHQuery(3) { df =>
         val shjBuildLeft = df.queryExecution.executedPlan.collect {
-          case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
+          case shj: ShuffledHashJoinExecTransformer if shj.joinBuildSide == BuildLeft => shj
         }
         assert(shjBuildLeft.size == 2)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQESuite.scala
@@ -75,7 +75,7 @@ class GlutenClickHouseTPCHParquetAQESuite
       runTPCHQuery(3) { df =>
         assert(df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
         val shjBuildLeft = collect(df.queryExecution.executedPlan) {
-          case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
+          case shj: ShuffledHashJoinExecTransformer if shj.joinBuildSide == BuildLeft => shj
         }
         assert(shjBuildLeft.size == 2)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -219,7 +219,7 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     withSQLConf(("spark.sql.autoBroadcastJoinThreshold", "-1")) {
       runTPCHQuery(3) { df =>
         val shjBuildLeft = df.queryExecution.executedPlan.collect {
-          case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
+          case shj: ShuffledHashJoinExecTransformer if shj.joinBuildSide == BuildLeft => shj
         }
         assert(shjBuildLeft.size == 1)
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
@@ -60,7 +60,7 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
     withSQLConf(("spark.sql.autoBroadcastJoinThreshold", "-1")) {
       runTPCHQuery(3) { df =>
         val shjBuildLeft = df.queryExecution.executedPlan.collect {
-          case shj: ShuffledHashJoinExecTransformer if shj.buildSide == BuildLeft => shj
+          case shj: ShuffledHashJoinExecTransformer if shj.joinBuildSide == BuildLeft => shj
         }
         assert(shjBuildLeft.size == 2)
       }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import io.glutenproject.execution.HashJoinLikeExecTransformer.{makeAndExpression, makeEqualToExpression, makeIsNullExpression}
+import io.glutenproject.expression._
+import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
+import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+import io.substrait.proto.JoinRel
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.{BooleanType, DataType}
+import java.util
+
+import scala.collection.JavaConverters._
+
+trait VeloxHashJoinLikeExecTransformer extends HashJoinLikeExecTransformer {
+
+  // Direct output order of substrait join operation
+  override protected val substraitJoinType: JoinRel.JoinType = joinType match {
+    case Inner =>
+      JoinRel.JoinType.JOIN_TYPE_INNER
+    case FullOuter =>
+      JoinRel.JoinType.JOIN_TYPE_OUTER
+    case LeftOuter =>
+      JoinRel.JoinType.JOIN_TYPE_LEFT
+    case RightOuter =>
+      JoinRel.JoinType.JOIN_TYPE_RIGHT
+    case LeftSemi =>
+      JoinRel.JoinType.JOIN_TYPE_SEMI
+    case LeftAnti =>
+      if (!antiJoinWorkaroundNeeded) {
+        JoinRel.JoinType.JOIN_TYPE_ANTI
+      } else {
+        // Use Left to replace Anti as a workaround.
+        JoinRel.JoinType.JOIN_TYPE_LEFT
+      }
+    case _ =>
+      // TODO: Support cross join with Cross Rel
+      // TODO: Support existence join
+      JoinRel.JoinType.UNRECOGNIZED
+  }
+
+  /**
+   * Use a workaround for Anti join with 'not exists' semantics.
+   * Firstly, add an aggregation rel over build rel to make the build keys distinct.
+   * Secondly, add a project rel over the aggregation rel to append a column of true constant.
+   * Then, this project rel is returned and will be used as the input rel for join build side.
+   * @param buildInfo: the original build keys, build rel and build outputs.
+   * @param context: Substrait context.
+   * @param operatorId: operator id of this join.
+   * @return original build keys, new build rel and build outputs.
+   */
+  private def createSpecialRelForAntiBuild(
+      buildInfo: (Seq[(ExpressionNode, DataType)], RelNode, Seq[Attribute]),
+      context: SubstraitContext,
+      operatorId: java.lang.Long,
+      validation: Boolean): (Seq[(ExpressionNode, DataType)], RelNode, Seq[Attribute]) = {
+    // Create an Aggregation Rel over build Rel.
+    val groupingNodes = new util.ArrayList[ExpressionNode]()
+    var colIdx = 0
+    buildInfo._3.foreach(_ => {
+      groupingNodes.add(ExpressionBuilder.makeSelection(colIdx))
+      colIdx += 1
+    })
+    val aggNode = RelBuilder.makeAggregateRel(
+      buildInfo._2,
+      groupingNodes,
+      new util.ArrayList[AggregateFunctionNode](),
+      context,
+      operatorId)
+    // Create a Project Rel over Aggregation Rel.
+    val expressionNodes = groupingNodes
+    // Append a new column of true constant.
+    expressionNodes.add(ExpressionBuilder.makeBooleanLiteral(true))
+    val projectNode = RelBuilder.makeProjectRel(
+      aggNode,
+      expressionNodes,
+      createExtensionNode(buildInfo._3, validation),
+      context,
+      operatorId)
+    (
+      buildInfo._1,
+      projectNode,
+      buildInfo._3 :+ AttributeReference(s"constant_true", BooleanType)()
+    )
+  }
+
+  override def createJoinRel(inputStreamedRelNode: RelNode,
+                             inputBuildRelNode: RelNode,
+                             inputStreamedOutput: Seq[Attribute],
+                             inputBuildOutput: Seq[Attribute],
+                             substraitContext: SubstraitContext,
+                             operatorId: java.lang.Long,
+                             validation: Boolean = false): RelNode = {
+    // Create pre-projection for build/streamed plan. Append projected keys to each side.
+    val (streamedKeys, streamedRelNode, streamedOutput) = createPreProjectionIfNeeded(
+      streamedKeyExprs,
+      inputStreamedRelNode,
+      inputStreamedOutput,
+      inputStreamedOutput,
+      substraitContext,
+      operatorId,
+      validation)
+
+    val (buildKeys, buildRelNode, buildOutput) = {
+      val (keys, relNode, output) = createPreProjectionIfNeeded(
+        buildKeyExprs,
+        inputBuildRelNode,
+        inputBuildOutput,
+        streamedOutput ++ inputBuildOutput,
+        substraitContext,
+        operatorId,
+        validation)
+      if (!antiJoinWorkaroundNeeded) {
+        (keys, relNode, output)
+      } else {
+        // Use a workaround for Anti join.
+        createSpecialRelForAntiBuild(
+          (keys, relNode, output), substraitContext, operatorId, validation)
+      }
+    }
+
+    // Combine join keys to make a single expression.
+    val joinExpressionNode = (streamedKeys zip buildKeys).map {
+      case ((leftKey, leftType), (rightKey, rightType)) =>
+        makeEqualToExpression(
+          leftKey, leftType, rightKey, rightType, substraitContext.registeredFunction)
+    }.reduce((l, r) => makeAndExpression(l, r, substraitContext.registeredFunction))
+
+    // Create post-join filter, which will be computed in hash join.
+    val postJoinFilter = condition.map {
+      expr =>
+        ExpressionConverter
+          .replaceWithExpressionTransformer(expr, streamedOutput ++ buildOutput)
+          .asInstanceOf[ExpressionTransformer]
+          .doTransform(substraitContext.registeredFunction)
+    }
+
+    // Create JoinRel.
+    val joinRel = {
+      val joinNode = RelBuilder.makeJoinRel(
+        streamedRelNode,
+        buildRelNode,
+        substraitJoinType,
+        joinExpressionNode,
+        postJoinFilter.orNull,
+        createJoinExtensionNode(streamedOutput ++ buildOutput, validation),
+        substraitContext,
+        operatorId)
+      if (!antiJoinWorkaroundNeeded) {
+        joinNode
+      } else {
+        // Use an isNulll filter to select the rows needed by Anti join from Left join outputs.
+        val isNullFilter = makeIsNullExpression(
+          ExpressionBuilder.makeSelection(streamedOutput.size + buildOutput.size - 1),
+          substraitContext.registeredFunction)
+        RelBuilder.makeFilterRel(
+          joinNode,
+          isNullFilter,
+          createJoinExtensionNode(streamedOutput ++ buildOutput, validation),
+          substraitContext,
+          operatorId)
+      }
+    }
+
+    // Result projection will drop the appended keys, and exchange columns order if BuildLeft.
+    val resultProjection = joinBuildSide match {
+      case BuildLeft =>
+        val (leftOutput, rightOutput) =
+          getResultProjectionOutput(inputBuildOutput, inputStreamedOutput)
+        // Exchange the order of build and streamed.
+        leftOutput.indices.map(idx =>
+          ExpressionBuilder.makeSelection(idx + streamedOutput.size)) ++
+          rightOutput.indices
+            .map(ExpressionBuilder.makeSelection(_))
+      case BuildRight =>
+        val (leftOutput, rightOutput) =
+          getResultProjectionOutput(inputStreamedOutput, inputBuildOutput)
+        leftOutput.indices.map(ExpressionBuilder.makeSelection(_)) ++
+          rightOutput.indices.map(idx => ExpressionBuilder.makeSelection(idx + streamedOutput.size))
+    }
+
+    RelBuilder.makeProjectRel(
+      joinRel,
+      new java.util.ArrayList[ExpressionNode](resultProjection.asJava),
+      createExtensionNode(streamedOutput ++ buildOutput, validation),
+      substraitContext,
+      operatorId)
+  }
+}
+
+case class VeloxShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                                rightKeys: Seq[Expression],
+                                                joinType: JoinType,
+                                                buildSide: BuildSide,
+                                                condition: Option[Expression],
+                                                left: SparkPlan,
+                                                right: SparkPlan)
+  extends ShuffledHashJoinExecTransformer(
+    leftKeys,
+    rightKeys,
+    joinType,
+    buildSide,
+    condition,
+    left,
+    right) with VeloxHashJoinLikeExecTransformer {
+
+  /**
+   * Returns whether a workaround for Anti join is needed. True for 'not exists' semantics.
+   * For SHJ, always returns true for Anti join.
+   */
+  override def antiJoinWorkaroundNeeded: Boolean = {
+    joinType match {
+      case LeftAnti => true
+      case _ => false
+    }
+  }
+
+  override protected def withNewChildrenInternal(
+      newLeft: SparkPlan, newRight: SparkPlan): VeloxShuffledHashJoinExecTransformer =
+    copy(left = newLeft, right = newRight)
+}
+
+case class VeloxBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                                 rightKeys: Seq[Expression],
+                                                 joinType: JoinType,
+                                                 buildSide: BuildSide,
+                                                 condition: Option[Expression],
+                                                 left: SparkPlan,
+                                                 right: SparkPlan,
+                                                 isNullAwareAntiJoin: Boolean = false)
+  extends BroadcastHashJoinExecTransformer(
+    leftKeys,
+    rightKeys,
+    joinType,
+    buildSide,
+    condition,
+    left,
+    right) with VeloxHashJoinLikeExecTransformer {
+
+  /**
+   * Returns whether a workaround for Anti join is needed. True for 'not exists' semantics.
+   * For BHJ, only when isNullAwareAntiJoin is disabled, true is returned.
+   */
+  override def antiJoinWorkaroundNeeded: Boolean = {
+    joinType match {
+      case LeftAnti =>
+        if (isNullAwareAntiJoin) {
+          false
+        } else {
+          // Velox's Anti semantics are matched with the case when isNullAwareAntiJoin is enabled.
+          // So a workaround is needed if isNullAwareAntiJoin is disabled.
+          true
+        }
+      case _ =>
+        false
+    }
+  }
+
+  override protected def withNewChildrenInternal(
+      newLeft: SparkPlan, newRight: SparkPlan): VeloxBroadcastHashJoinExecTransformer =
+    copy(left = newLeft, right = newRight)
+}

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
@@ -40,10 +40,11 @@ trait VeloxHashJoinLikeExecTransformer extends HashJoinLikeExecTransformer {
       JoinRel.JoinType.JOIN_TYPE_INNER
     case FullOuter =>
       JoinRel.JoinType.JOIN_TYPE_OUTER
-    case LeftOuter =>
+    case LeftOuter | RightOuter =>
+      // The right side is required to be used for building hash table in Substrait plan.
+      // Therefore, for RightOuter Join, the left and right relations are exchanged and the
+      // join type is reverted.
       JoinRel.JoinType.JOIN_TYPE_LEFT
-    case RightOuter =>
-      JoinRel.JoinType.JOIN_TYPE_RIGHT
     case LeftSemi =>
       JoinRel.JoinType.JOIN_TYPE_SEMI
     case LeftAnti =>

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/BooleanLiteralNode.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/BooleanLiteralNode.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.substrait.expression;
+
+import io.substrait.proto.Expression;
+
+import java.io.Serializable;
+
+public class BooleanLiteralNode implements ExpressionNode, Serializable {
+  private final Boolean value;
+
+  public BooleanLiteralNode(Boolean value) {
+    this.value = value;
+  }
+
+  @Override
+  public Expression toProtobuf() {
+    Expression.Literal.Builder booleanBuilder =
+        Expression.Literal.newBuilder();
+    booleanBuilder.setBoolean(value);
+
+    Expression.Builder builder = Expression.newBuilder();
+    builder.setLiteral(booleanBuilder.build());
+    return builder.build();
+  }
+}

--- a/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -50,6 +50,10 @@ public class ExpressionBuilder {
     return new NullLiteralNode(typeNode);
   }
 
+  public static BooleanLiteralNode makeBooleanLiteral(Boolean booleanConstant) {
+    return new BooleanLiteralNode(booleanConstant);
+  }
+
   public static IntLiteralNode makeIntLiteral(Integer intConstant) {
     return new IntLiteralNode(intConstant);
   }

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
@@ -17,9 +17,8 @@
 
 package io.glutenproject.backendsapi
 
-import io.glutenproject.execution.{FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
+import io.glutenproject.execution.{BroadcastHashJoinExecTransformer, FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, ShuffledHashJoinExecTransformer}
 import io.glutenproject.expression.AliasBaseTransformer
-
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
@@ -27,8 +26,10 @@ import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriter
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.optimizer.BuildSide
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
+import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 import org.apache.spark.sql.execution.joins.BuildSideRelation
@@ -81,6 +82,30 @@ trait ISparkPlanExecApi extends IBackendsApi {
     initialInputBufferOffset: Int,
     resultExpressions: Seq[NamedExpression],
     child: SparkPlan): HashAggregateExecBaseTransformer
+
+  /**
+   * Generate ShuffledHashJoinExecTransformer.
+   */
+  def genShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                         rightKeys: Seq[Expression],
+                                         joinType: JoinType,
+                                         buildSide: BuildSide,
+                                         condition: Option[Expression],
+                                         left: SparkPlan,
+                                         right: SparkPlan): ShuffledHashJoinExecTransformer
+
+  /**
+   * Generate BroadcastHashJoinExecTransformer.
+   */
+  def genBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                          rightKeys: Seq[Expression],
+                                          joinType: JoinType,
+                                          buildSide: BuildSide,
+                                          condition: Option[Expression],
+                                          left: SparkPlan,
+                                          right: SparkPlan,
+                                          isNullAwareAntiJoin: Boolean = false)
+  : BroadcastHashJoinExecTransformer
 
   /**
    * Generate Alias transformer.

--- a/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -513,10 +513,11 @@ trait HashJoinLikeExecTransformer
       JoinRel.JoinType.JOIN_TYPE_INNER
     case FullOuter =>
       JoinRel.JoinType.JOIN_TYPE_OUTER
-    case LeftOuter =>
+    case LeftOuter | RightOuter =>
+      // The right side is required to be used for building hash table in Substrait plan.
+      // Therefore, for RightOuter Join, the left and right relations are exchanged and the
+      // join type is reverted.
       JoinRel.JoinType.JOIN_TYPE_LEFT
-    case RightOuter =>
-      JoinRel.JoinType.JOIN_TYPE_RIGHT
     case LeftSemi =>
       JoinRel.JoinType.JOIN_TYPE_SEMI
     case LeftAnti =>

--- a/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -20,14 +20,13 @@ package io.glutenproject.execution
 import com.google.common.collect.Lists
 import com.google.protobuf.{Any, ByteString}
 import io.glutenproject.GlutenConfig
-import io.glutenproject.execution.HashJoinLikeExecTransformer.{makeAndExpression, makeEqualToExpression, makeIsNullExpression}
 import io.glutenproject.expression._
 import io.glutenproject.substrait.{JoinParams, SubstraitContext}
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
-import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
+import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.extensions.{AdvancedExtensionNode, ExtensionBuilder}
 import io.glutenproject.substrait.plan.PlanBuilder
-import io.glutenproject.substrait.rel.{AggregateRelNode, ProjectRelNode, RelBuilder, RelNode}
+import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.vectorized.{ExpressionEvaluator, OperatorMetrics}
 import io.glutenproject.vectorized.Metrics.SingleMetric
 import io.substrait.proto.JoinRel
@@ -910,9 +909,10 @@ trait HashJoinLikeExecTransformer
     // Combine join keys to make a single expression.
     val joinExpressionNode = (streamedKeys zip buildKeys).map {
       case ((leftKey, leftType), (rightKey, rightType)) =>
-        makeEqualToExpression(
+        HashJoinLikeExecTransformer.makeEqualToExpression(
           leftKey, leftType, rightKey, rightType, substraitContext.registeredFunction)
-    }.reduce((l, r) => makeAndExpression(l, r, substraitContext.registeredFunction))
+    }.reduce((l, r) =>
+      HashJoinLikeExecTransformer.makeAndExpression(l, r, substraitContext.registeredFunction))
 
     // Create post-join filter, which will be computed in hash join.
     val postJoinFilter = condition.map {

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -145,14 +145,15 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
         val left = replaceWithTransformerPlan(plan.left, isSupportAdaptive)
         val right = replaceWithTransformerPlan(plan.right, isSupportAdaptive)
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-        ShuffledHashJoinExecTransformer(
-          plan.leftKeys,
-          plan.rightKeys,
-          plan.joinType,
-          plan.buildSide,
-          plan.condition,
-          left,
-          right)
+        BackendsApiManager.getSparkPlanExecApiInstance
+          .genShuffledHashJoinExecTransformer(
+            plan.leftKeys,
+            plan.rightKeys,
+            plan.joinType,
+            plan.buildSide,
+            plan.condition,
+            left,
+            right)
       case plan: SortMergeJoinExec =>
         val left = replaceWithTransformerPlan(plan.left, isSupportAdaptive)
         val right = replaceWithTransformerPlan(plan.right, isSupportAdaptive)
@@ -176,15 +177,16 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
       case plan: BroadcastHashJoinExec =>
         val left = replaceWithTransformerPlan(plan.left, isSupportAdaptive)
         val right = replaceWithTransformerPlan(plan.right, isSupportAdaptive)
-        BroadcastHashJoinExecTransformer(
-          plan.leftKeys,
-          plan.rightKeys,
-          plan.joinType,
-          plan.buildSide,
-          plan.condition,
-          left,
-          right,
-          isNullAwareAntiJoin = plan.isNullAwareAntiJoin)
+        BackendsApiManager.getSparkPlanExecApiInstance
+          .genBroadcastHashJoinExecTransformer(
+            plan.leftKeys,
+            plan.rightKeys,
+            plan.joinType,
+            plan.buildSide,
+            plan.condition,
+            left,
+            right,
+            isNullAwareAntiJoin = plan.isNullAwareAntiJoin)
       case plan: AQEShuffleReadExec if columnarConf.enableColumnarShuffle =>
         plan.child match {
           case shuffle: ColumnarShuffleExchangeAdaptor =>

--- a/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/columnar/ColumnarGuardRule.scala
@@ -147,14 +147,15 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
           exec.doValidate()
         case plan: ShuffledHashJoinExec =>
           if (!enableColumnarShuffledHashJoin) return false
-          val transformer = ShuffledHashJoinExecTransformer(
-            plan.leftKeys,
-            plan.rightKeys,
-            plan.joinType,
-            plan.buildSide,
-            plan.condition,
-            plan.left,
-            plan.right)
+          val transformer = BackendsApiManager.getSparkPlanExecApiInstance
+            .genShuffledHashJoinExecTransformer(
+              plan.leftKeys,
+              plan.rightKeys,
+              plan.joinType,
+              plan.buildSide,
+              plan.condition,
+              plan.left,
+              plan.right)
           transformer.doValidate()
         case plan: BroadcastExchangeExec =>
           // columnar broadcast is enabled only when columnar bhj is enabled.
@@ -163,7 +164,8 @@ case class TransformGuardRule() extends Rule[SparkPlan] {
           exec.doValidate()
         case plan: BroadcastHashJoinExec =>
           if (!enableColumnarBroadcastJoin) return false
-          val transformer = BroadcastHashJoinExecTransformer(
+          val transformer = BackendsApiManager.getSparkPlanExecApiInstance
+          .genBroadcastHashJoinExecTransformer(
             plan.leftKeys,
             plan.rightKeys,
             plan.joinType,

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/SparkPlanExecApiImplSuite.scala
@@ -17,9 +17,8 @@
 
 package io.glutenproject.backendsapi
 
-import io.glutenproject.execution.{FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec}
+import io.glutenproject.execution.{BroadcastHashJoinExecTransformer, FilterExecBaseTransformer, HashAggregateExecBaseTransformer, NativeColumnarToRowExec, RowToArrowColumnarExec, ShuffledHashJoinExecTransformer}
 import io.glutenproject.expression.AliasBaseTransformer
-
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
@@ -27,8 +26,10 @@ import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriter
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.optimizer.BuildSide
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
+import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 import org.apache.spark.sql.execution.joins.BuildSideRelation
@@ -83,6 +84,30 @@ class SparkPlanExecApiImplSuite extends ISparkPlanExecApi {
      initialInputBufferOffset: Int,
      resultExpressions: Seq[NamedExpression],
      child: SparkPlan): HashAggregateExecBaseTransformer = null
+
+  /**
+   * Generate ShuffledHashJoinExecTransformer.
+   */
+  def genShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                         rightKeys: Seq[Expression],
+                                         joinType: JoinType,
+                                         buildSide: BuildSide,
+                                         condition: Option[Expression],
+                                         left: SparkPlan,
+                                         right: SparkPlan): ShuffledHashJoinExecTransformer = null
+
+  /**
+   * Generate BroadcastHashJoinExecTransformer.
+   */
+  def genBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
+                                          rightKeys: Seq[Expression],
+                                          joinType: JoinType,
+                                          buildSide: BuildSide,
+                                          condition: Option[Expression],
+                                          left: SparkPlan,
+                                          right: SparkPlan,
+                                          isNullAwareAntiJoin: Boolean = false)
+  : BroadcastHashJoinExecTransformer = null
 
   /**
    * Generate Alias transformer.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since Velox only supports null aware Anti join for now, this PR implements a workaround to reproduce `not exists` semantics in Velox backend. It uses left outer join with aggregation, project, filter to replace anti join.


## How was this patch tested?

Verified on TPC-H and TPC-DS.
