### PR TITLE
[OPPRO-244] Change options in SingularOrList

### DIFF
--- a/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/jvm/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -174,5 +174,4 @@ public class ExpressionBuilder {
                                                           List<ExpressionNode> expressionNodes) {
     return new SingularOrListNode(value, expressionNodes);
   }
-
 }

--- a/jvm/src/main/scala/io/glutenproject/expression/InSetOperatorTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/expression/InSetOperatorTransformer.scala
@@ -54,32 +54,35 @@ object InSetOperatorTransformer {
   def toTransformer(value: Expression,
                     leftNode: ExpressionNode,
                     values: Set[Any]): ExpressionNode = {
-    val expressionNodes = new util.ArrayList[ExpressionNode]()
-    val listNode = value.dataType match {
+    val expressionNodes = value.dataType match {
       case _: IntegerType =>
-        val valueList = new util.ArrayList[java.lang.Integer](values.map(value =>
-          value.asInstanceOf[java.lang.Integer]).asJava)
-        ExpressionBuilder.makeIntList(valueList)
+        new util.ArrayList[ExpressionNode](values.map({
+          value =>
+            ExpressionBuilder.makeIntLiteral(value.asInstanceOf[java.lang.Integer])
+        }).asJava)
       case _: LongType =>
-        val valueList = new util.ArrayList[java.lang.Long](values.map(value =>
-          value.asInstanceOf[java.lang.Long]).asJava)
-        ExpressionBuilder.makeLongList(valueList)
+        new util.ArrayList[ExpressionNode](values.map({
+          value =>
+            ExpressionBuilder.makeLongLiteral(value.asInstanceOf[java.lang.Long])
+        }).asJava)
       case _: DoubleType =>
-        val valueList = new util.ArrayList[java.lang.Double](values.map(value =>
-          value.asInstanceOf[java.lang.Double]).asJava)
-        ExpressionBuilder.makeDoubleList(valueList)
+        new util.ArrayList[ExpressionNode](values.map({
+          value =>
+            ExpressionBuilder.makeDoubleLiteral(value.asInstanceOf[java.lang.Double])
+        }).asJava)
       case _: DateType =>
-        val valueList = new util.ArrayList[java.lang.Integer](values.map(value =>
-          value.asInstanceOf[java.lang.Integer]).asJava)
-        ExpressionBuilder.makeDateList(valueList)
+        new util.ArrayList[ExpressionNode](values.map({
+          value =>
+            ExpressionBuilder.makeDateLiteral(value.asInstanceOf[java.lang.Integer])
+        }).asJava)
       case _: StringType =>
-        val valueList = new util.ArrayList[java.lang.String](values.map(value =>
-          value.toString).asJava)
-        ExpressionBuilder.makeStringList(valueList)
+        new util.ArrayList[ExpressionNode](values.map({
+          value =>
+            ExpressionBuilder.makeStringLiteral(value.toString)
+        }).asJava)
       case other =>
         throw new UnsupportedOperationException(s"$other is not supported.")
     }
-    expressionNodes.add(listNode)
 
     ExpressionBuilder.makeSingularOrListNode(leftNode, expressionNodes)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR changed the way of using SingularOrList options. Instead of putting all literals into a single list, each option was changed to be a literal.

Quoted from Substrait community on how to use options in SingularOrList:
> The design is that the output type of each repeated option should be the same as the value expression. So if value expression c0 is of type i32, then each of the individual expressions' output type in the options repeated field should be the same i32.

Depends on: https://github.com/oap-project/velox/pull/48, https://github.com/oap-project/arrow/pull/170.

## How was this patch tested?

Verified on Jenkins.
