### PR TITLE
[OPPRO-252] Register SparkSql functions first

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -79,8 +79,6 @@ void VeloxInitializer::Init() {
   filesystems::registerLocalFileSystem();
   std::unique_ptr<folly::IOThreadPoolExecutor> executor =
       std::make_unique<folly::IOThreadPoolExecutor>(1);
-  // auto hiveConnectorFactory = std::make_shared<hive::HiveConnectorFactory>();
-  // registerConnectorFactory(hiveConnectorFactory);
   auto hiveConnector =
       getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -89,9 +87,9 @@ void VeloxInitializer::Init() {
   parquet::registerParquetReaderFactory(ParquetReaderType::NATIVE);
   // parquet::registerParquetReaderFactory(ParquetReaderType::DUCKDB);
   dwrf::registerDwrfReaderFactory();
-  // Register Velox functions
-  functions::prestosql::registerAllScalarFunctions();
+  // Register Velox functions.
   functions::sparksql::registerFunctions("");
+  functions::prestosql::registerAllScalarFunctions();
   aggregate::registerSumAggregate<aggregate::SumAggregate>("sum");
   aggregate::registerAverageAggregate("avg");
   aggregate::registerCountAggregate("count");


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR registered SparkSql functions first. In Velox, the first registered function name and signature will be put into an unordered map, so when the name of SparkSql and PrestoSql function is the same, the firstly registered one will be used.

Depends on: https://github.com/oap-project/velox/pull/49.

## How was this patch tested?

Verified TPC-H locally and on Jenkins.

