### PR TITLE
[Gluten-410] Fix issue: Can not get the config 'spark.gluten.sql.columnar.libpath' when executing task for ClickHouse backend

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxIteratorApi.scala
@@ -29,7 +29,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.datasources.v2.arrow.SparkMemoryUtils
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -287,7 +286,6 @@ class VeloxIteratorApi extends IIteratorApi with Logging {
                                      sparkConf: SparkConf,
                                      outputAttributes: Seq[Attribute],
                                      rootNode: PlanNode,
-                                     streamedSortPlan: SparkPlan,
                                      pipelineTime: SQLMetric,
                                      updateMetrics: (Long, Long) => Unit,
                                      updateNativeMetrics: GeneralOutIterator => Unit,

--- a/jvm/src/main/java/io/glutenproject/vectorized/ExpressionEvaluator.java
+++ b/jvm/src/main/java/io/glutenproject/vectorized/ExpressionEvaluator.java
@@ -47,7 +47,7 @@ public class ExpressionEvaluator implements AutoCloseable {
   public ExpressionEvaluator(List<String> listJars, String libName) throws IOException,
       IllegalAccessException, IllegalStateException {
     this(listJars, libName,
-        GlutenConfig.getSessionConf().nativeLibPath(),
+        GlutenConfig.getConf().nativeLibPath(),
         GlutenConfig.getConf().glutenBackendLib(),
         GlutenConfig.getConf().loadArrow());
   }

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -26,7 +26,6 @@ import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -85,7 +84,6 @@ trait IIteratorApi extends IBackendsApi {
                             sparkConf: SparkConf,
                             outputAttributes: Seq[Attribute],
                             rootNode: PlanNode,
-                            streamedSortPlan: SparkPlan,
                             pipelineTime: SQLMetric,
                             updateMetrics: (Long, Long) => Unit,
                             updateNativeMetrics: GeneralOutIterator => Unit,

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -248,7 +248,6 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
 
     // we should zip all dependent RDDs to current main RDD
     // TODO: Does it still need these parameters?
-    val streamedSortPlan = getStreamedLeafPlan
     val dependentKernels: mutable.ListBuffer[ExpressionEvaluator] = mutable.ListBuffer()
     val dependentKernelIterators: mutable.ListBuffer[GeneralOutIterator] = mutable.ListBuffer()
     val buildRelationBatchHolder: mutable.ListBuffer[ColumnarBatch] = mutable.ListBuffer()
@@ -319,7 +318,6 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
             sparkConf,
             resCtx.outputAttributes,
             resCtx.root,
-            streamedSortPlan,
             pipelineTime,
             updateMetrics,
             metricsUpdatingFunction,

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -84,7 +83,7 @@ class IteratorApiImplSuite extends IIteratorApi {
                                      numaBindingInfo: GlutenNumaBindingInfo,
                                      listJars: Seq[String], signature: String,
                                      sparkConf: SparkConf, outputAttributes: Seq[Attribute],
-                                     rootNode: PlanNode, streamedSortPlan: SparkPlan,
+                                     rootNode: PlanNode,
                                      pipelineTime: SQLMetric,
                                      updateMetrics: (Long, Long) => Unit,
                                      updateNativeMetrics: GeneralOutIterator => Unit,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix issue: Can not get the config 'spark.gluten.sql.columnar.libpath' when executing task for ClickHouse backend

Close #410 .


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

