### PR TITLE
[Gluten-414] Manage not supported test case in a centralized way

### DIFF
--- a/gluten-ut/src/test/scala/io/glutenproject/utils/NotSupport.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/NotSupport.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.utils
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.utils.clickhouse.ClickHouseNotSupport
+import io.glutenproject.utils.velox.VeloxNotSupport
+import org.apache.spark.sql.GlutenTestConstants
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, NullExpressionsSuite}
+
+import scala.reflect.ClassTag
+
+abstract class NotSupport {
+  protected def notSupportSuiteList: Map[String, Map[String, ExpressionInfo]]
+  protected def fullSupportSuiteList: Set[String]
+
+  protected def notSupport[T <: Expression: ClassTag](
+      caseMethodName: String,
+      expressionName: String): (String, ExpressionInfo) = {
+    (caseMethodName, FunctionRegistryBase.expressionInfo(expressionName, None))
+  }
+
+  protected def simpleClassName[T: ClassTag](implicit ct: ClassTag[T]) : String =
+    ct.runtimeClass.getSimpleName
+
+  def NotYetSupportCase(suiteName: String): Option[Seq[String]] = {
+    if (fullSupportSuiteList.contains(suiteName)) {
+      Some(Seq.empty)
+    } else {
+      notSupportSuiteList.get(suiteName).map(_.keys.toSeq)
+    }
+  }
+}
+
+object NotSupport {
+  def NotYetSupportCase(suiteName: String): Seq[String] = {
+    val result =
+      if (SystemParameters.getGlutenBackend.equalsIgnoreCase(GlutenConfig.GLUTEN_VELOX_BACKEND)) {
+        VeloxNotSupport.NotYetSupportCase(suiteName)
+    } else {
+        ClickHouseNotSupport.NotYetSupportCase(suiteName)
+    }
+    result.getOrElse(Seq(GlutenTestConstants.IGNORE_ALL))
+  }
+}

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/SystemParameters.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/SystemParameters.scala
@@ -27,19 +27,19 @@ object SystemParameters {
   val TPCDS_DATA_PATH_KEY = "tpcds.data.path"
   val TPCDS_DATA_PATH_DEFAULT_VALUE = "/data/tpcds-data-sf1"
 
-  def getClickHouseLibPath(): String = {
+  def getClickHouseLibPath: String = {
     System.getProperty(
       SystemParameters.CLICKHOUSE_LIB_PATH_KEY,
       SystemParameters.CLICKHOUSE_LIB_PATH_DEFAULT_VALUE)
   }
 
-  def getTpcdsDataPath(): String = {
+  def getTpcdsDataPath: String = {
     System.getProperty(
       SystemParameters.TPCDS_DATA_PATH_KEY,
       SystemParameters.TPCDS_DATA_PATH_DEFAULT_VALUE)
   }
 
-  def getGlutenBackend(): String = {
+  def getGlutenBackend: String = {
     System.getProperty(
       GlutenConfig.GLUTEN_BACKEND_LIB, GlutenConfig.GLUTEN_VELOX_BACKEND)
   }

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseNotSupport.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseNotSupport.scala
@@ -15,9 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.expressions
+package io.glutenproject.utils.clickhouse
 
-import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
+import io.glutenproject.utils.NotSupport
+import org.apache.spark.sql.catalyst.expressions._
 
-class GlutenSortOrderExpressionsSuite extends SortOrderExpressionsSuite with GlutenTestsTrait {
+object ClickHouseNotSupport extends NotSupport {
+
+  override lazy val notSupportSuiteList: Map[String, Map[String, ExpressionInfo]] = Map.empty
+  override lazy val fullSupportSuiteList: Set[String] = Set.empty
 }

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxNotSupport.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxNotSupport.scala
@@ -15,9 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.expressions
+package io.glutenproject.utils.velox
 
-import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
+import io.glutenproject.utils.NotSupport
+import org.apache.spark.sql.catalyst.expressions._
 
-class GlutenSortOrderExpressionsSuite extends SortOrderExpressionsSuite with GlutenTestsTrait {
+object VeloxNotSupport extends NotSupport {
+
+  override lazy val notSupportSuiteList: Map[String, Map[String, ExpressionInfo]] = Map.empty
+
+  override lazy val fullSupportSuiteList: Set[String] = Set(
+    simpleClassName[NullExpressionsSuite]
+  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
@@ -78,10 +78,10 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
-      .set("spark.gluten.sql.columnar.backend.lib", SystemParameters.getGlutenBackend())
+      .set("spark.gluten.sql.columnar.backend.lib", SystemParameters.getGlutenBackend)
       .set("spark.sql.warehouse.dir", warehouse)
 
-    if (SystemParameters.getGlutenBackend().equalsIgnoreCase(
+    if (SystemParameters.getGlutenBackend.equalsIgnoreCase(
       GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
       conf
         .set(GlutenConfig.GLUTEN_LOAD_ARROW, "false")
@@ -89,7 +89,7 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
         .set("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
         .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
         .set("spark.gluten.sql.enable.native.validation", "false")
-        .set(GlutenConfig.GLUTEN_LIB_PATH, SystemParameters.getClickHouseLibPath())
+        .set(GlutenConfig.GLUTEN_LIB_PATH, SystemParameters.getClickHouseLibPath)
         .set("spark.sql.files.openCostInBytes", "134217728")
     } else {
       conf.set("spark.unsafe.exceptionOnMemoryLeak", "false")

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsBaseTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsBaseTrait.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql
 
+import io.glutenproject.utils.NotSupport
+
 trait GlutenTestsBaseTrait {
 
   protected val rootPath: String = getClass.getResource("/").getPath
@@ -28,7 +30,8 @@ trait GlutenTestsBaseTrait {
   def whiteTestNameList: Seq[String] = Seq.empty
 
   // prefer to use blackTestNameList
-  def blackTestNameList: Seq[String] = Seq.empty
+  def blackTestNameList: Seq[String] =
+    NotSupport.NotYetSupportCase(getClass.getSuperclass.getSimpleName)
 
   def whiteBlackCheck(testName: String): Boolean = {
     if (testName.startsWith(GlutenTestConstants.GLUTEN_TEST)) {
@@ -36,7 +39,7 @@ trait GlutenTestsBaseTrait {
     } else if (blackTestNameList.isEmpty && whiteTestNameList.isEmpty) {
       true
     } else if (blackTestNameList.nonEmpty &&
-      blackTestNameList(0).equalsIgnoreCase(GlutenTestConstants.IGNORE_ALL)) {
+      blackTestNameList.head.equalsIgnoreCase(GlutenTestConstants.IGNORE_ALL)) {
       false
     } else if (blackTestNameList.nonEmpty) {
       !blackTestNameList.contains(testName)

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
@@ -90,10 +90,10 @@ trait GlutenTestsTrait extends SparkFunSuite with ExpressionEvalHelper with Glut
         .config("spark.plugins", "io.glutenproject.GlutenPlugin")
         .config("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
         .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
-        .config("spark.gluten.sql.columnar.backend.lib", SystemParameters.getGlutenBackend())
+        .config("spark.gluten.sql.columnar.backend.lib", SystemParameters.getGlutenBackend)
         .config("spark.sql.warehouse.dir", warehouse)
 
-      _spark = if (SystemParameters.getGlutenBackend().equalsIgnoreCase(
+      _spark = if (SystemParameters.getGlutenBackend.equalsIgnoreCase(
         GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
         sparkBuilder
           .config(GlutenConfig.GLUTEN_LOAD_ARROW, "false")
@@ -102,7 +102,7 @@ trait GlutenTestsTrait extends SparkFunSuite with ExpressionEvalHelper with Glut
           .config("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
           .config("spark.gluten.sql.enable.native.validation", "false")
           .config("spark.sql.files.openCostInBytes", "134217728")
-          .config(GlutenConfig.GLUTEN_LIB_PATH, SystemParameters.getClickHouseLibPath())
+          .config(GlutenConfig.GLUTEN_LIB_PATH, SystemParameters.getClickHouseLibPath)
           .getOrCreate()
       } else {
         sparkBuilder

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenAnsiCastSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenAnsiCastSuite.scala
@@ -25,10 +25,6 @@ import java.time.LocalDateTime
 
 class GlutenCastSuiteWithAnsiModeOn extends AnsiCastSuiteBase with GlutenTestsTrait {
 
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
-
   override def beforeAll(): Unit = {
     super.beforeAll()
     SQLConf.get.setConf(SQLConf.ANSI_ENABLED, true)
@@ -51,10 +47,6 @@ class GlutenCastSuiteWithAnsiModeOn extends AnsiCastSuiteBase with GlutenTestsTr
 }
 
 class GlutenAnsiCastSuiteWithAnsiModeOn extends AnsiCastSuiteBase with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -80,10 +72,6 @@ class GlutenAnsiCastSuiteWithAnsiModeOn extends AnsiCastSuiteBase with GlutenTes
 
 class GlutenAnsiCastSuiteWithAnsiModeOff extends AnsiCastSuiteBase with GlutenTestsTrait {
 
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
-
   override def beforeAll(): Unit = {
     super.beforeAll()
     SQLConf.get.setConf(SQLConf.ANSI_ENABLED, false)
@@ -107,12 +95,6 @@ class GlutenAnsiCastSuiteWithAnsiModeOff extends AnsiCastSuiteBase with GlutenTe
 }
 
 class GlutenTryCastSuite extends TryCastSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL,
-    "ANSI mode: Throw exception on casting out-of-range value to decimal type",
-    "cast from invalid string to numeric should throw NumberFormatException"
-  )
 
   private val specialTs = Seq(
     "0001-01-01T00:00:00", // the fist timestamp of Common Era

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenArithmeticExpressionSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenArithmeticExpressionSuite.scala
@@ -17,13 +17,9 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
+import org.apache.spark.sql.GlutenTestsTrait
 
 class GlutenArithmeticExpressionSuite extends ArithmeticExpressionSuite with GlutenTestsTrait {
 
   override def whiteTestNameList: Seq[String] = Seq.empty
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenBitwiseExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenBitwiseExpressionsSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenBitwiseExpressionsSuite extends BitwiseExpressionsSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -20,12 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenCastSuite extends CastSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL,
-    "cast from long #2",
-    "cast from int #2",
-    "SPARK-28470: Cast should honor nullOnOverflow property",
-    "Cast should output null for invalid strings when ANSI is not enabled."
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCollectionExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCollectionExpressionsSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenCollectionExpressionsSuite extends CollectionExpressionsSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenComplexTypeSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenComplexTypeSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenComplexTypeSuite extends ComplexTypeSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenConditionalExpressionSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenConditionalExpressionSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenConditionalExpressionSuite extends ConditionalExpressionSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDecimalExpressionSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDecimalExpressionSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenDecimalExpressionSuite extends DecimalExpressionSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenHashExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenHashExpressionsSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenHashExpressionsSuite extends HashExpressionsSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenIntervalExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenIntervalExpressionsSuite.scala
@@ -21,7 +21,4 @@ import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenIntervalExpressionsSuite extends IntervalExpressionsSuite with GlutenTestsTrait {
 
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenLiteralExpressionSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenLiteralExpressionSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenLiteralExpressionSuite extends LiteralExpressionSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -21,7 +21,4 @@ import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTrait {
 
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMiscExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMiscExpressionsSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenMiscExpressionsSuite extends MiscExpressionsSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenNondeterministicSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenNondeterministicSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenNondeterministicSuite extends NondeterministicSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenNullExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenNullExpressionsSuite.scala
@@ -17,13 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
+import org.apache.spark.sql.GlutenTestsTrait
 
 class GlutenNullExpressionsSuite extends NullExpressionsSuite with GlutenTestsTrait {
-  override def blackTestNameList: Seq[String] = {
-    val backendType = System.getProperty("backend_type", "")
-    if (backendType.equals("velox")) {
-      Seq()
-    } else Seq(GlutenTestConstants.IGNORE_ALL)
-  }
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenPredicateSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenPredicateSuite.scala
@@ -20,9 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenPredicateSuite extends PredicateSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL,
-    "SPARK-29100: InSet with empty input set"
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenRandomSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenRandomSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenRandomSuite extends RandomSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenRegexpExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenRegexpExpressionsSuite.scala
@@ -20,8 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
 class GlutenRegexpExpressionsSuite extends RegexpExpressionsSuite with GlutenTestsTrait {
-
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenStringExpressionsSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenStringExpressionsSuite.scala
@@ -23,10 +23,6 @@ import org.apache.spark.sql.types.IntegerType
 
 class GlutenStringExpressionsSuite extends StringExpressionsSuite with GlutenTestsTrait {
 
-  override def blackTestNameList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
-
   test(GlutenTestConstants.GLUTEN_TEST + "Substring") {
     val row = create_row("example", 1, 1L, 1.0, true, null, false)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is for https://github.com/oap-project/gluten/issues/414

Add an abstract class `NotSupport`,  the design is quite simple, and different backend can fill its not support list. i.e.

### velox
Currently, Velox backend support all case of `NullExpressionsSuite`
``` scala
object VeloxNotSupport extends NotSupport {

  override lazy val notSupportSuiteList: Map[String, Map[String, ExpressionInfo]] = Map.empty

  override lazy val fullSupportSuiteList: Set[String] = Set(
    simpleClassName[NullExpressionsSuite]
  )
}
```
### clickhouse
In this PR,  clickhouse only supports part of `NullExpressionsSuite`

```scala
object ClickHouseNotSupport extends NotSupport {

  override lazy val notSupportSuiteList: Map[String, Map[String, ExpressionInfo]] = Map(
    (simpleClassName[NullExpressionsSuite], Map(
      notSupport[Coalesce]("coalesce", "coalesce")))
  )
  override lazy val fullSupportSuiteList: Set[String] = Set.empty
}
```
Howerver, we can run some cases of ArithmeticExpressionSuite in my local:

``` scala
object ClickHouseNotSupport extends NotSupport {

  override lazy val notSupportSuiteList: Map[String, Map[String, ExpressionInfo]] = Map(
    (simpleClassName[ArithmeticExpressionSuite], Map(
      notSupport[Greatest]("function greatest", "greatest"),
      notSupport[Least]("function least", "least"))),
    (simpleClassName[NullExpressionsSuite], Map(
      notSupport[Coalesce]("coalesce", "coalesce")))
  )
  override lazy val fullSupportSuiteList: Set[String] = Set.empty
}
```



## How was this patch tested?

Using existed test
