### PR TITLE
[OPPRO-77] install dependency for libhdfs3

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -80,11 +80,18 @@ void VeloxInitializer::Init() {
   filesystems::registerHdfsFileSystem();
   std::unique_ptr<folly::IOThreadPoolExecutor> executor =
       std::make_unique<folly::IOThreadPoolExecutor>(1);
-  // auto hiveConnectorFactory = std::make_shared<hive::HiveConnectorFactory>();
-  // registerConnectorFactory(hiveConnectorFactory);
-  // read hdfs client conf from hdfs-client.xml from LIBHDFS3_CONF
+
+  // TODO(yuan): should read hdfs client conf from hdfs-client.xml from
+  // LIBHDFS3_CONF
+  std::string hdfsUri = "localhost:9000";
+  const char* envHdfsUri = std::getenv("VELOX_HDFS");
+  if (envHdfsUri != nullptr) {
+    hdfsUri = std::string(envHdfsUri);
+  }
+  auto hdfsPort = hdfsUri.substr(hdfsUri.find(":") + 1);
+  auto hdfsHost = hdfsUri.substr(0, hdfsUri.find(":"));
   static const std::unordered_map<std::string, std::string> configurationValues(
-      {{"hive.hdfs.host", "default"}, {"hive.hdfs.port", "0"}});
+      {{"hive.hdfs.host", hdfsHost}, {"hive.hdfs.port", hdfsPort}});
   auto properties =
       std::make_shared<const core::MemConfig>(configurationValues);
   auto hiveConnector =

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -43,11 +43,27 @@ Arrow home can be set as the same of Velox. Without -Darrow_home, arrow is clone
 
 Refer to [build configurations](GlutenUsage.md) for the list of configurations used by mvn command.
 
-## Cluster mode
+## HDFS support
 
-hdfs support is still in progress for Velox backend. Refer to [issue 158](https://github.com/oap-project/gluten/issues/158). We haven't test the cluster mode. The issue is we have to manually install all dependency libraries on each worker node, currently no script available for this yet. The plan is to use conda env to build Velox and gluten.
+Hadoop hdfs support is ready via the [libhdfs3](https://github.com/apache/hawq/tree/master/depends/libhdfs3) library. The libhdfs3 provides native API for Hadoop I/O without the drawbacks of JNI. It also provides advanced authentatication like Kerberos based. Please note this library has serveral depedencies which may require extra installations on Driver and Worker node.
 
-The script still use yarn to start the spark worker, but yarn is configured as single node only. Assumption is that all dependency libraries are installed into system so we needn't to set the LD_LIBRARY_PATH env.
+Gluten HDFS support requires a extra enviorment variable "VELOX_HDFS" to indicate the Hdfs URI. e.g. VELOX_HDFS="host:port". If the env variable is missing, Gluten will try to connect with hdfs://localhost:9000
+
+This env should be exported in both Spark driver and worker.
+e.g., in Spark local mode:
+```
+export VELOX_HDFS="sr595:9000"
+```
+
+If running in Spark Yarn cluster mode, the env variable need to be set on each executor:
+```
+--conf spark.executorEnv.VELOX_HDFS="sr595:9000"
+```
+
+## Yarn Cluster mode
+
+Hadoop Yarn mode is supported. Note libhdfs3 is used to read from HDFS, all its depedencies should be installed on each worker node. Users may requried to setup extra LD_LIBRARY_PATH if the depedencies are not on system's default library path
+
 
 ## Test TPC-H on Gluten with Velox backend
 

--- a/tools/build_velox.sh
+++ b/tools/build_velox.sh
@@ -40,9 +40,16 @@ function process_script {
     sed -i '/libprotobuf-dev/d' scripts/setup-ubuntu.sh
     sed -i '/protobuf-compiler/d' scripts/setup-ubuntu.sh
     sed -i '/^sudo apt install/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
+    sed -i '/^sudo apt install/a\  libxml2-dev \\' scripts/setup-ubuntu.sh
+    sed -i '/^sudo apt install/a\  libkrb5-dev \\' scripts/setup-ubuntu.sh
+    sed -i '/^sudo apt install/a\  libgsasl7-dev \\' scripts/setup-ubuntu.sh
+    sed -i '/^sudo apt install/a\  libuuid1 \\' scripts/setup-ubuntu.sh
+    sed -i '/^sudo apt install/a\  uuid-dev \\' scripts/setup-ubuntu.sh
     sed -i 's/^  liblzo2-dev.*/  liblzo2-dev \\/g' scripts/setup-ubuntu.sh
     sed -i 's/^  ninja -C "${BINARY_DIR}" install/  sudo ninja -C "${BINARY_DIR}" install/g' scripts/setup-helper-functions.sh
+    sed -i '/^function install_folly.*/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n  cmake_install\n}\n' scripts/setup-ubuntu.sh
     sed -i '/^function install_folly.*/i function install_pb {\n  github_checkout protocolbuffers/protobuf v3.13.0\n  git submodule update --init --recursive\n  ./autogen.sh\n  ./configure CFLAGS=-fPIC CXXFLAGS=-fPIC\n  make -j$(nproc)\n  make check\n  sudo make install\n sudo ldconfig\n}\n' scripts/setup-ubuntu.sh
+    sed -i '/^  run_and_time install_folly/i \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
     sed -i '/^  run_and_time install_folly/i \ \ run_and_time install_pb' scripts/setup-ubuntu.sh
     sed -i 's/-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17/-march=native -std=c++17 -mno-avx512f/g' scripts/setup-helper-functions.sh
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update the setup script to install the dependencies for libhdfs3

This patch introduced a env to pass HDFS URI to gluten

`VELOX_HDFS="host:port"`

This env should be exported in both Spark driver and worker.
in Spark local mode: 
`export VELOX_HDFS="sr595:9000"`

in Spark Yarn cluster mode: 
`--conf spark.executorEnv.VELOX_HDFS="sr595:9000" `

If the variable is missing, Gluten will try to connect from hdfs://localhost:9000

closes: #158
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

pass jenkins

