### PR TITLE
[Gluten-438] Avoid to get all Partitions for each BasicScanTransformer every time

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -299,7 +299,7 @@ class CHIteratorApi extends IIteratorApi with Logging {
       genNativeFilePartition(i, Seq(inputPartitions(i)), wsCxt)
     })
     logInfo(
-      s"Generating the Substrait plan took: ${(System.nanoTime() - startTime) / 1000000} ms.")
+      s"Generating the Substrait plan took: ${(System.nanoTime() - startTime)} ns.")
     new NativeFileScanColumnarRDD(
       sparkContext,
       substraitPlanPartition,

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -307,7 +307,50 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
     for (i <- 1 to executedCnt) {
       val startTime = System.nanoTime()
       val df = spark.sql(s"""
-           |select count(l_orderkey) from ch_lineitem where l_shipdate = date'1994-01-01'
+           |SELECT
+           |    s_acctbal,
+           |    s_name,
+           |    n_name,
+           |    p_partkey,
+           |    p_mfgr,
+           |    s_address,
+           |    s_phone,
+           |    s_comment
+           |FROM
+           |    part,
+           |    supplier,
+           |    partsupp,
+           |    nation,
+           |    region
+           |WHERE
+           |    p_partkey = ps_partkey
+           |    AND s_suppkey = ps_suppkey
+           |    AND p_size = 15
+           |    AND p_type LIKE '%BRASS'
+           |    AND s_nationkey = n_nationkey
+           |    AND n_regionkey = r_regionkey
+           |    AND r_name = 'EUROPE'
+           |    AND ps_supplycost = (
+           |        SELECT
+           |            min(ps_supplycost)
+           |        FROM
+           |            partsupp,
+           |            supplier,
+           |            nation,
+           |            region
+           |        WHERE
+           |            p_partkey = ps_partkey
+           |            AND s_suppkey = ps_suppkey
+           |            AND s_nationkey = n_nationkey
+           |            AND n_regionkey = r_regionkey
+           |            AND r_name = 'EUROPE')
+           |ORDER BY
+           |    s_acctbal DESC,
+           |    n_name,
+           |    s_name,
+           |    p_partkey
+           |LIMIT 100;
+           |
            |""".stripMargin) // .show(30, false)
       // df.queryExecution.debug.codegen
       // df.explain(false)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
@@ -216,7 +216,7 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
 
     val spark = sessionBuilder.getOrCreate()
     if (!configed) {
-      spark.sparkContext.setLogLevel("ERROR")
+      spark.sparkContext.setLogLevel("WARN")
     }
 
     val createTbl = false
@@ -270,7 +270,7 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
 
     val tookTimeArr = ArrayBuffer[Long]()
     val sqlFilePath = "/data2/tpcds-data-gen/tpcds10-queries/"
-    val execNum = 21
+    val execNum = 9
     val sqlNum = "q" + execNum + ".sql"
     val sqlFile = sqlFilePath + sqlNum
     val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString

--- a/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -17,11 +17,10 @@
 
 package io.glutenproject.execution
 
+import com.google.common.collect.Lists
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
-import com.google.common.collect.Lists
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
@@ -34,7 +33,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -263,8 +261,9 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
     // If containing scan exec transformer, a new RDD is created.
     if (basicScanExecTransformer.nonEmpty) {
       // the partition size of the all BasicScanExecTransformer must be the same
-      val partitionLength = basicScanExecTransformer(0).getFlattenPartitions.size
-      if (basicScanExecTransformer.exists(_.getFlattenPartitions.length != partitionLength)) {
+      val allScanPartitions = basicScanExecTransformer.map(_.getFlattenPartitions)
+      val partitionLength = allScanPartitions(0).size
+      if (allScanPartitions.exists(_.size != partitionLength)) {
         throw new RuntimeException(
           "The partition length of all the scan transformer are not the same.")
       }
@@ -277,13 +276,13 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
 
       // generate each partition of all scan exec
       val substraitPlanPartition = (0 until partitionLength).map( i => {
-        val currentPartitions = basicScanExecTransformer.map(_.getFlattenPartitions(i))
+        val currentPartitions = allScanPartitions.map(_(i))
         BackendsApiManager.getIteratorApiInstance.genNativeFilePartition(
           i, currentPartitions, wsCxt)
       })
 
       logInfo(
-        s"Generating the Substrait plan took: ${(System.nanoTime() - startTime) / 1000000} ms.")
+        s"Generating the Substrait plan took: ${(System.nanoTime() - startTime)} ns.")
 
       val metricsUpdatingFunction: GeneralOutIterator => Unit = (resIter: GeneralOutIterator) =>
         updateNativeMetrics(
@@ -304,7 +303,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       val startTime = System.nanoTime()
       val resCtx = doWholestageTransform()
       logInfo(
-        s"Generating the Substrait plan took: ${(System.nanoTime() - startTime) / 1000000} ms.")
+        s"Generating the Substrait plan took: ${(System.nanoTime() - startTime)} ns.")
       logDebug(s"Generating substrait plan:\n${resCtx.root.toProtobuf.toString}")
 
       val metricsUpdatingFunction: GeneralOutIterator => Unit = (resIter: GeneralOutIterator) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In WholeStageTransformerExec, there is a step to get all Partitions for each BasicScanTransformer. Currently, it will get all Partitions every time when it's needed, it spends much time. Get all Partitions once to avoid this problem.

Close #438 .

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

