### PR TITLE
[CH-132] Automatically identify which backend

### DIFF
--- a/backends-clickhouse/src/main/resources/META-INF/services/io.glutenproject.backendsapi.IBackendsApi
+++ b/backends-clickhouse/src/main/resources/META-INF/services/io.glutenproject.backendsapi.IBackendsApi
@@ -1,0 +1,1 @@
+io.glutenproject.backendsapi.clickhouse.CHBackend

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.backendsapi.clickhouse
+
+import io.glutenproject.backendsapi.IBackendsApi
+import io.glutenproject.GlutenConfig
+
+class CHBackend extends IBackendsApi {
+
+  /**
+   * Get the backend api name.
+   */
+  override def getBackendName: String = GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -168,7 +168,7 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
         .config("spark.databricks.delta.stalenessLimit", 3600 * 1000)
         // .config("spark.sql.execution.arrow.maxRecordsPerBatch", "20000")
         .config("spark.gluten.sql.columnar.columnartorow", columnarColumnToRow)
-        .config("spark.gluten.sql.columnar.backend.lib", "ch")
+        // .config("spark.gluten.sql.columnar.backend.lib", "ch")
         .config("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
         .config("spark.gluten.sql.columnar.backend.ch.use.v2", useV2)
         .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2Q1ColumnarBenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2Q1ColumnarBenchmarkTest.scala
@@ -123,7 +123,6 @@ object DSV2Q1ColumnarBenchmarkTest {
         .config("spark.memory.offHeap.enabled", "true")
         .config("spark.memory.offHeap.size", "6442450944")
         .config("spark.io.compression.codec", "LZ4")
-        .config("spark.gluten.sql.columnar.backend.lib", "clickhouse")
 
       if (!warehouse.isEmpty) {
         sessionBuilderTmp1

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
@@ -156,7 +156,7 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
         .config("spark.databricks.delta.stalenessLimit", 3600 * 1000)
         // .config("spark.sql.execution.arrow.maxRecordsPerBatch", "20000")
         .config("spark.gluten.sql.columnar.columnartorow", columnarColumnToRow)
-        .config("spark.gluten.sql.columnar.backend.lib", "ch")
+        // .config("spark.gluten.sql.columnar.backend.lib", "ch")
         .config("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
         .config("spark.gluten.sql.columnar.backend.ch.use.v2", useV2)
         .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")

--- a/backends-velox/src/main/resources/META-INF/services/io.glutenproject.backendsapi.IBackendsApi
+++ b/backends-velox/src/main/resources/META-INF/services/io.glutenproject.backendsapi.IBackendsApi
@@ -1,0 +1,1 @@
+io.glutenproject.backendsapi.velox.VeloxBackend

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.backendsapi.clickhouse
+
+import io.glutenproject.backendsapi.IBackendsApi
+import io.glutenproject.GlutenConfig
+
+class VeloxBackend extends IBackendsApi {
+
+  /**
+   * Get the backend api name.
+   */
+  override def getBackendName: String = GlutenConfig.GLUTEN_VELOX_BACKEND
+}

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.glutenproject.backendsapi.clickhouse
+package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.backendsapi.IBackendsApi
 import io.glutenproject.GlutenConfig

--- a/gluten-ut/pom.xml
+++ b/gluten-ut/pom.xml
@@ -170,9 +170,6 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
-            <properties>
-                <spark.gluten.sql.columnar.backend.lib>ch</spark.gluten.sql.columnar.backend.lib>
-            </properties>
         </profile>
         <profile>
             <id>backends-velox</id>
@@ -188,7 +185,6 @@
                 </dependency>
             </dependencies>
             <properties>
-                <spark.gluten.sql.columnar.backend.lib>velox</spark.gluten.sql.columnar.backend.lib>
                 <clickhouse.lib.path></clickhouse.lib.path>
             </properties>
         </profile>
@@ -206,7 +202,6 @@
                 </dependency>
             </dependencies>
             <properties>
-                <spark.gluten.sql.columnar.backend.lib>velox</spark.gluten.sql.columnar.backend.lib>
                 <clickhouse.lib.path></clickhouse.lib.path>
             </properties>
         </profile>
@@ -343,7 +338,6 @@
                             <systemProperties>
                                 <clickhouse.lib.path>${clickhouse.lib.path}</clickhouse.lib.path>
                                 <tpcds.data.path>${tpcds.data.path}</tpcds.data.path>
-                                <spark.gluten.sql.columnar.backend.lib>${spark.gluten.sql.columnar.backend.lib}</spark.gluten.sql.columnar.backend.lib>
                             </systemProperties>
                         </configuration>
                     </execution>

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/SystemParameters.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/SystemParameters.scala
@@ -18,11 +18,14 @@
 package io.glutenproject.utils
 
 import io.glutenproject.GlutenConfig
+import io.glutenproject.backendsapi.BackendsApiManager
 
 object SystemParameters {
 
+  lazy val GLUTEN_BACKEND = BackendsApiManager.initialize()
+
   val CLICKHOUSE_LIB_PATH_KEY = "clickhouse.lib.path"
-  val CLICKHOUSE_LIB_PATH_DEFAULT_VALUE = ""
+  val CLICKHOUSE_LIB_PATH_DEFAULT_VALUE = "/usr/local/clickhouse/lib/libch.so"
 
   val TPCDS_DATA_PATH_KEY = "tpcds.data.path"
   val TPCDS_DATA_PATH_DEFAULT_VALUE = "/data/tpcds-data-sf1"
@@ -41,6 +44,6 @@ object SystemParameters {
 
   def getGlutenBackend: String = {
     System.getProperty(
-      GlutenConfig.GLUTEN_BACKEND_LIB, GlutenConfig.GLUTEN_VELOX_BACKEND)
+      GlutenConfig.GLUTEN_BACKEND_LIB, GLUTEN_BACKEND)
   }
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
@@ -82,7 +82,6 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
-      .set("spark.gluten.sql.columnar.backend.lib", SystemParameters.getGlutenBackend)
       .set("spark.sql.warehouse.dir", warehouse)
 
     if (SystemParameters.getGlutenBackend.equalsIgnoreCase(

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
@@ -90,7 +90,6 @@ trait GlutenTestsTrait extends SparkFunSuite with ExpressionEvalHelper with Glut
         .config("spark.plugins", "io.glutenproject.GlutenPlugin")
         .config("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
         .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
-        .config("spark.gluten.sql.columnar.backend.lib", SystemParameters.getGlutenBackend)
         .config("spark.sql.warehouse.dir", warehouse)
 
       _spark = if (SystemParameters.getGlutenBackend.equalsIgnoreCase(

--- a/jvm/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/jvm/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -49,11 +49,14 @@ class GlutenPlugin extends SparkPlugin {
 private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
     val conf = pluginContext.conf()
+    // Initialize Backends API
+    val glutenBackenLibName = BackendsApiManager.initialize
+    // Automatically set the 'spark.gluten.sql.columnar.backend.lib'
+    if (conf.get(GlutenConfig.GLUTEN_BACKEND_LIB, "").isEmpty) {
+      conf.set(GlutenConfig.GLUTEN_BACKEND_LIB, glutenBackenLibName)
+    }
     GlutenPlugin.initNative(conf)
     setPredefinedConfigs(conf)
-    // Initialize Backends API
-    BackendsApiManager.initialize(pluginContext.conf()
-      .get(GlutenConfig.GLUTEN_BACKEND_LIB, ""))
     Collections.emptyMap()
   }
 
@@ -72,8 +75,14 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
    * Initialize the executor plugin.
    */
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
+    val conf = ctx.conf()
+    // Initialize Backends API
+    val glutenBackenLibName = BackendsApiManager.initialize
+    // Automatically set the 'spark.gluten.sql.columnar.backend.lib'
+    if (conf.get(GlutenConfig.GLUTEN_BACKEND_LIB, "").isEmpty) {
+      conf.set(GlutenConfig.GLUTEN_BACKEND_LIB, glutenBackenLibName)
+    }
     GlutenPlugin.initNative(ctx.conf())
-    BackendsApiManager.initialize(ctx.conf().get(GlutenConfig.GLUTEN_BACKEND_LIB, ""))
   }
 
   /**

--- a/jvm/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -59,7 +59,6 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
-      .set("spark.gluten.sql.columnar.backend.lib", backend)
       .set("spark.default.parallelism", "1")
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <!-- For unit tests -->
     <clickhouse.lib.path>/usr/local/clickhouse/lib/libch.so</clickhouse.lib.path>
     <tpcds.data.path>/data/tpcds-data-sf1</tpcds.data.path>
-    <spark.gluten.sql.columnar.backend.lib>velox</spark.gluten.sql.columnar.backend.lib>
     <fasterxml.spark33.version>2.13.3</fasterxml.spark33.version>
     <fasterxml.version>${fasterxml.spark33.version}</fasterxml.version>
     <spark32bundle.version>3.2</spark32bundle.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Automatically identify which backend when starting Gluten by BackendsAPI, and don't need to config the 'spark.gluten.sql.columnar.backend.lib' manually, specially for running ut.

Issue: [CH-132](https://github.com/Kyligence/ClickHouse/issues/132)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

