### PR TITLE
[OPPRO-278] Fix split coredump

### DIFF
--- a/cpp/src/operators/shuffle/splitter.cc
+++ b/cpp/src/operators/shuffle/splitter.cc
@@ -836,7 +836,8 @@ arrow::Status Splitter::SpillPartition(int32_t partition_id) {
       partition_buffers_.begin(),
       partition_buffers_.end(),
       [partition_id](std::vector<arrow::BufferVector>& bufs) {
-        if (bufs[partition_id].size() != 0 && bufs[partition_id][0] != nullptr) {
+        if (bufs[partition_id].size() != 0 &&
+            bufs[partition_id][0] != nullptr) {
           // initialize all true once allocated
           auto addr = bufs[partition_id][0]->mutable_data();
           memset(addr, 0xff, bufs[partition_id][0]->capacity());

--- a/cpp/src/operators/shuffle/splitter.cc
+++ b/cpp/src/operators/shuffle/splitter.cc
@@ -836,7 +836,7 @@ arrow::Status Splitter::SpillPartition(int32_t partition_id) {
       partition_buffers_.begin(),
       partition_buffers_.end(),
       [partition_id](std::vector<arrow::BufferVector>& bufs) {
-        if (bufs[partition_id][0] != nullptr) {
+        if (bufs[partition_id].size() != 0 && bufs[partition_id][0] != nullptr) {
           // initialize all true once allocated
           auto addr = bufs[partition_id][0]->mutable_data();
           memset(addr, 0xff, bufs[partition_id][0]->capacity());


### PR DESCRIPTION
The `bufs[pid]` length may be 0
```
#6  <signal handler called>
#7  0x00007f19d92f84a4 in std::__shared_ptr<arrow::Buffer, (__gnu_cxx::_Lock_policy)2>::operator bool (this=0x0)
    at /usr/include/c++/9/bits/shared_ptr_base.h:1313
#8  0x00007f19d94d7cf2 in std::operator!=<arrow::Buffer>(std::shared_ptr<arrow::Buffer> const&, decltype(nullptr)) (
    __a=<error reading variable: Cannot access memory at address 0x8>) at /usr/include/c++/9/bits/shared_ptr.h:404
#9  0x00007f19d94ce123 in gluten::shuffle::Splitter::SpillPartition (this=0x7f16e828e580, partition_id=0)
    at /mnt/DP_disk1/code/gluten/cpp/src/operators/shuffle/splitter.cc:836
#10 0x00007f19d94cf105 in gluten::shuffle::Splitter::DoSplit (this=0x7f16e828e580, rb=...)
    at /mnt/DP_disk1/code/gluten/cpp/src/operators/shuffle/splitter.cc:1002
#11 0x00007f19d94ca37b in gluten::shuffle::Splitter::Split (this=0x7f16e828e580, rb=...)
    at /mnt/DP_disk1/code/gluten/cpp/src/operators/shuffle/splitter.cc:425
#12 0x00007f19d92edff6 in Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_split (env=0x7f17c002ea58, splitter_id=10,
    num_rows=32602, c_array=139727338145840, first_record_batch=0 '\000') at /mnt/DP_disk1/code/gluten/cpp/src/jni/jni_wrapper.cc:871
#13 0x00007f1a31feb102 in ?? ()
#14 0x00000005c9004710 in ?? ()
#15 0x0000000035cca7f6 in ?? ()
#16 0x00000005c906ce40 in ?? ()
#17 0x506e5c98cc2bc600 in ?? ()
#18 0x00007f19c9137010 in ?? ()
#19 0x00007f1a3107097c in ?? ()
#20 0x00000005c906bee8 in ?? ()
#21 0x00000005c906be90 in ?? ()
#22 0x00007f19c9137070 in ?? ()
#23 0x00007f1a31007b90 in ?? ()
#24 0x00007f1a31007b90 in ?? ()
#25 0x0000000000000000 in ?? ()

(gdb) f 9
#9  0x00007f19d94ce123 in gluten::shuffle::Splitter::SpillPartition (this=0x7f16e828e580, partition_id=0)
    at /mnt/DP_disk1/code/gluten/cpp/src/operators/shuffle/splitter.cc:836
836         if (bufs[partition_id][0] != nullptr) {
(gdb) p bufs
$1 = std::vector of length 1, capacity 1 = {std::vector of length 0, capacity 0}
(gdb) p bufs[0]
$3 = std::vector of length 0, capacity 0
```