### PR TITLE
[CH-120] Unify cross-JNI memory management for ClickHouse backends

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/CHMemoryConsumer.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/CHMemoryConsumer.java
@@ -17,29 +17,33 @@
 
 package io.glutenproject.memory;
 
-import java.io.IOException;
-
 import io.glutenproject.memory.alloc.Spiller;
 
-import org.apache.spark.memory.MemoryConsumer;
-import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.memory.TaskMemoryManager;
 
-public abstract class GlutenMemoryConsumer extends MemoryConsumer {
+public class CHMemoryConsumer extends GlutenMemoryConsumer {
 
-  protected final Spiller spiller;
-
-  public GlutenMemoryConsumer(TaskMemoryManager taskMemoryManager, Spiller spiller) {
-    super(taskMemoryManager, taskMemoryManager.pageSizeBytes(), MemoryMode.OFF_HEAP);
-    this.spiller = spiller;
+  public CHMemoryConsumer(TaskMemoryManager taskMemoryManager, Spiller spiller) {
+    super(taskMemoryManager, spiller);
   }
 
   @Override
-  public long spill(long size, MemoryConsumer trigger) throws IOException {
-    return spiller.spill(size, trigger);
+  public void acquire(long size) {
+    if (size == 0) {
+      return;
+    }
+    long granted = acquireMemory(size);
+    if (granted < size) {
+      freeMemory(granted);
+      throw new UnsupportedOperationException("Not enough spark off-heap execution memory. " +
+          "Acquired: " + size + ", granted: " + granted + ". " +
+          "Try tweaking config option spark.memory.offHeap.size to " +
+          "get larger space to run this application. ");
+    }
   }
 
-  public abstract void acquire(long size);
-
-  public abstract void free(long size);
+  @Override
+  public void free(long size) {
+    freeMemory(size);
+  }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHManagedReservationListener.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHManagedReservationListener.java
@@ -61,16 +61,18 @@ public class CHManagedReservationListener implements ReservationListener {
       if (!open) {
         return;
       }
+      long memoryToFree = size;
       if ((currentMemory.get() - size) < 0L) {
-        throw new UnsupportedOperationException(
-            "The 'currentMemory' " + currentMemory.get() +
-                " value will be less than 0 after free " + size
+        LOG.warn(
+            "The current used memory' " + currentMemory.get() +
+                " will be less than 0 after free " + size
         );
+        memoryToFree = currentMemory.get();
       }
-      LOG.debug("unreserve memory size from native: " + size);
-      consumer.free(size);
-      currentMemory.addAndGet(-size);
-      metrics.inc(-size);
+      LOG.debug("unreserve memory size from native: " + memoryToFree);
+      consumer.free(memoryToFree);
+      currentMemory.addAndGet(-memoryToFree);
+      metrics.inc(-memoryToFree);
     }
   }
 

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHManagedReservationListener.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHManagedReservationListener.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.memory.alloc;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.glutenproject.memory.GlutenMemoryConsumer;
+import io.glutenproject.memory.TaskMemoryMetrics;
+
+public class CHManagedReservationListener implements ReservationListener {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CHManagedReservationListener.class);
+
+  private GlutenMemoryConsumer consumer;
+  private TaskMemoryMetrics metrics;
+  private volatile boolean open = true;
+
+  private final AtomicLong currentMemory = new AtomicLong(0L);
+
+  public CHManagedReservationListener(GlutenMemoryConsumer consumer,
+                                      TaskMemoryMetrics metrics) {
+    this.consumer = consumer;
+    this.metrics = metrics;
+  }
+
+  @Override
+  public void reserve(long size) {
+    synchronized (this) {
+      if (!open) {
+        return;
+      }
+      LOG.debug("reserve memory size from native: " + size);
+      consumer.acquire(size);
+      currentMemory.addAndGet(size);
+      metrics.inc(size);
+    }
+  }
+
+  @Override
+  public void unreserve(long size) {
+    synchronized (this) {
+      if (!open) {
+        return;
+      }
+      if ((currentMemory.get() - size) < 0L) {
+        throw new UnsupportedOperationException(
+            "The 'currentMemory' " + currentMemory.get() +
+                " value will be less than 0 after free " + size
+        );
+      }
+      LOG.debug("unreserve memory size from native: " + size);
+      consumer.free(size);
+      currentMemory.addAndGet(-size);
+      metrics.inc(-size);
+    }
+  }
+
+  @Override
+  public void inactivate() {
+    synchronized (this) {
+      consumer = null; // make it gc reachable
+      open = false;
+    }
+  }
+
+  @Override
+  public long currentMemory() {
+    return currentMemory.get();
+  }
+}

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHMemoryAllocatorManager.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHMemoryAllocatorManager.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.memory.alloc;
+
+import java.util.List;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.util.memory.TaskMemoryResourceManager;
+
+public class CHMemoryAllocatorManager implements TaskMemoryResourceManager,
+    NativeMemoryAllocatorManager {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(CHMemoryAllocatorManager.class);
+
+  private static final List<NativeMemoryAllocator> LEAKED = new Vector<>();
+  private final NativeMemoryAllocator managed;
+
+  private static AtomicLong ACCUMULATED_LEAK_BYTES = new AtomicLong(0L);
+
+  public CHMemoryAllocatorManager(NativeMemoryAllocator managed) {
+    this.managed = managed;
+  }
+
+  private void close() throws Exception {
+    managed.close();
+  }
+
+  @Override
+  public void release() throws Exception {
+    // close native allocator first
+    close();
+    // detect whether there is the memory leak
+    long currentMemory = managed.listener().currentMemory();
+    managed.listener().inactivate();
+    if (currentMemory > 0L) {
+      long accumulated = ACCUMULATED_LEAK_BYTES.addAndGet(currentMemory);
+      String errMsg = String.format("Detected leaked native allocator, size: %d, " +
+          "process accumulated leaked size: %d...", currentMemory, accumulated);
+      LOGGER.error(errMsg);
+      throw new UnsupportedOperationException(errMsg);
+    }
+  }
+
+  @Override
+  public NativeMemoryAllocator getManaged() {
+    return managed;
+  }
+}

--- a/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
+++ b/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
@@ -80,7 +80,7 @@ public class TestTaskMemoryManagerSuite {
     Assert.assertEquals(0L, taskMemoryManager.getMemoryConsumptionForThisTask());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testMemoryFreeLessThanMalloc() {
     listener.reserve(100L);
     Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
@@ -115,6 +115,6 @@ public class TestTaskMemoryManagerSuite {
     listener.reserve(100L);
     Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
 
-    listener.unreserve(1000L);
+    listener.reserve(1000L);
   }
 }

--- a/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
+++ b/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.memory;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.glutenproject.memory.CHMemoryConsumer;
+import io.glutenproject.memory.TaskMemoryMetrics;
+import io.glutenproject.memory.alloc.CHManagedReservationListener;
+import io.glutenproject.memory.alloc.CHMemoryAllocatorManager;
+import io.glutenproject.memory.alloc.NativeMemoryAllocator;
+import io.glutenproject.memory.alloc.Spiller;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.internal.config.package$;
+
+public class TestTaskMemoryManagerSuite {
+  static {
+    // for skip loading lib in NativeMemoryAllocator
+    System.setProperty("spark.sql.testkey", "true");
+  }
+
+  protected TaskMemoryManager taskMemoryManager;
+  protected CHManagedReservationListener listener;
+  protected CHMemoryAllocatorManager manager;
+
+  @Before
+  public void initMemoryManager() {
+    final SparkConf conf = new SparkConf()
+        .set(package$.MODULE$.MEMORY_OFFHEAP_ENABLED(), true)
+        .set(package$.MODULE$.MEMORY_OFFHEAP_SIZE(), 1000L);
+    taskMemoryManager = new TaskMemoryManager(
+        new UnifiedMemoryManager(
+            conf,
+            1000L,
+            500L,
+            1),
+        0);
+
+    listener = new CHManagedReservationListener(
+        new CHMemoryConsumer(taskMemoryManager, Spiller.NO_OP),
+        new TaskMemoryMetrics()
+    );
+
+    manager = new CHMemoryAllocatorManager(
+        new NativeMemoryAllocator(-1L, listener));
+  }
+
+  @After
+  public void destroyMemoryManager() {
+    taskMemoryManager = null;
+    listener = null;
+    manager = null;
+  }
+
+  @Test
+  public void testCHNativeMemoryManager() {
+    listener.reserve(100L);
+    Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    listener.unreserve(100L);
+    Assert.assertEquals(0L, taskMemoryManager.getMemoryConsumptionForThisTask());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testMemoryFreeLessThanMalloc() {
+    listener.reserve(100L);
+    Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    listener.unreserve(200L);
+    Assert.assertEquals(0L, taskMemoryManager.getMemoryConsumptionForThisTask());
+  }
+
+  @Test
+  public void testMemoryLeak() {
+    listener.reserve(100L);
+    Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    listener.unreserve(100L);
+    Assert.assertEquals(0L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    listener.reserve(100L);
+    Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    listener.reserve(100L);
+    Assert.assertEquals(200L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    try {
+      manager.release();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof UnsupportedOperationException);
+    }
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testAcquireLessMemory() {
+    listener.reserve(100L);
+    Assert.assertEquals(100L, taskMemoryManager.getMemoryConsumptionForThisTask());
+
+    listener.unreserve(1000L);
+  }
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -304,69 +304,74 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
     spark.sql(s"""
          |use default;
          |""".stripMargin).show(1000, false)
-    val tookTimeArr = ArrayBuffer[Long]()
-    for (i <- 1 to executedCnt) {
-      val startTime = System.nanoTime()
-      val df = spark.sql(s"""
-           |SELECT
-           |    o_year,
-           |    sum(
-           |        CASE WHEN nation = 'BRAZIL' THEN
-           |            volume
-           |        ELSE
-           |            0
-           |        END) / sum(volume) AS mkt_share
-           |FROM (
-           |    SELECT
-           |        extract(year FROM o_orderdate) AS o_year,
-           |        l_extendedprice * (1 - l_discount) AS volume,
-           |        n2.n_name AS nation
-           |    FROM
-           |        part01,
-           |        supplier01,
-           |        lineitem01,
-           |        orders01,
-           |        customer01,
-           |        nation01 n1,
-           |        nation01 n2,
-           |        region01
-           |    WHERE
-           |        p_partkey = l_partkey
-           |        AND s_suppkey = l_suppkey
-           |        AND l_orderkey = o_orderkey
-           |        AND o_custkey = c_custkey
-           |        AND c_nationkey = n1.n_nationkey
-           |        AND n1.n_regionkey = r_regionkey
-           |        AND r_name = 'AMERICA'
-           |        AND s_nationkey = n2.n_nationkey
-           |        AND o_orderdate BETWEEN date'1995-01-01' AND date'1996-12-31'
-           |        AND p_type = 'ECONOMY ANODIZED STEEL') AS all_nations
-           |GROUP BY
-           |    o_year
-           |ORDER BY
-           |    o_year;
-           |
-           |""".stripMargin) // .show(30, false)
-      // df.queryExecution.debug.codegen
-      // df.explain(false)
-      val result = df.collect() // .show(100, false)  //.collect()
-      df.explain(false)
-      val plan = df.queryExecution.executedPlan
-      collectAllJoinSide(plan)
-      println(result.size)
-      result.foreach(r => println(r.mkString(",")))
-      val tookTime = (System.nanoTime() - startTime) / 1000000
-      println(s"Execute ${i} time, time: ${tookTime}")
-      tookTimeArr += tookTime
-      // Thread.sleep(5000)
-    }
+    try {
+      val tookTimeArr = ArrayBuffer[Long]()
+      for (i <- 1 to executedCnt) {
+        val startTime = System.nanoTime()
+        val df = spark.sql(
+          s"""
+             |SELECT
+             |    supp_nation,
+             |    cust_nation,
+             |    l_year,
+             |    sum(volume) AS revenue
+             |FROM (
+             |    SELECT
+             |        n1.n_name AS supp_nation,
+             |        n2.n_name AS cust_nation,
+             |        extract(year FROM l_shipdate) AS l_year,
+             |        l_extendedprice * (1 - l_discount) AS volume
+             |    FROM
+             |        supplier100,
+             |        lineitem100,
+             |        orders100,
+             |        customer100,
+             |        nation100 n1,
+             |        nation100 n2
+             |    WHERE
+             |        s_suppkey = l_suppkey
+             |        AND o_orderkey = l_orderkey
+             |        AND c_custkey = o_custkey
+             |        AND s_nationkey = n1.n_nationkey
+             |        AND c_nationkey = n2.n_nationkey
+             |        AND ((n1.n_name = 'FRANCE'
+             |                AND n2.n_name = 'GERMANY')
+             |            OR (n1.n_name = 'GERMANY'
+             |                AND n2.n_name = 'FRANCE'))
+             |        AND l_shipdate BETWEEN date'1995-01-01' AND date'1996-12-31') AS shipping
+             |GROUP BY
+             |    supp_nation,
+             |    cust_nation,
+             |    l_year
+             |ORDER BY
+             |    supp_nation,
+             |    cust_nation,
+             |    l_year;
+             |
+             |""".stripMargin) // .show(30, false)
+        // df.queryExecution.debug.codegen
+        // df.explain(false)
+        val result = df.collect() // .show(100, false)  //.collect()
+        df.explain(false)
+        val plan = df.queryExecution.executedPlan
+        collectAllJoinSide(plan)
+        println(result.size)
+        result.foreach(r => println(r.mkString(",")))
+        val tookTime = (System.nanoTime() - startTime) / 1000000
+        println(s"Execute ${i} time, time: ${tookTime}")
+        tookTimeArr += tookTime
+        // Thread.sleep(5000)
+      }
 
-    println(tookTimeArr.mkString(","))
+      println(tookTimeArr.mkString(","))
 
-    if (executedCnt >= 10) {
-      import spark.implicits._
-      val df = spark.sparkContext.parallelize(tookTimeArr.toSeq, 1).toDF("time")
-      df.summary().show(100, false)
+      if (executedCnt >= 10) {
+        import spark.implicits._
+        val df = spark.sparkContext.parallelize(tookTimeArr.toSeq, 1).toDF("time")
+        df.summary().show(100, false)
+      }
+    } catch {
+      case e: Exception => e.printStackTrace()
     }
   }
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -45,9 +45,9 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
 
   def main(args: Array[String]): Unit = {
 
-    val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
-      "cmake-build-release/utils/local-engine/libch.so"
-    // val libPath = "/usr/local/clickhouse/lib/libch.so"
+    // val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
+    //   "cmake-build-release/utils/local-engine/libch.so"
+    val libPath = "/usr/local/clickhouse/lib/libch.so"
     val thrdCnt = 12
     val shufflePartitions = 12
     val shuffleManager = "sort"
@@ -189,12 +189,13 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
         // .config("spark.sql.optimizeNullAwareAntiJoin", "false")
         // .config("spark.sql.join.preferSortMergeJoin", "false")
         .config("spark.sql.shuffledHashJoinFactor", "3")
-        .config("spark.sql.planChangeLog.level", "debug")
+        // .config("spark.sql.planChangeLog.level", "warn")
+        // .config("spark.sql.planChangeLog.batches", "ApplyColumnarRulesAndInsertTransitions")
         // .config("spark.sql.optimizer.inSetConversionThreshold", "5")  // IN to INSET
         .config("spark.sql.columnVector.offheap.enabled", "true")
         .config("spark.sql.parquet.columnarReaderBatchSize", "4096")
         .config("spark.memory.offHeap.enabled", "true")
-        .config("spark.memory.offHeap.size", "21474836480")
+        .config("spark.memory.offHeap.size", "20G")
         .config("spark.shuffle.sort.bypassMergeThreshold", "200")
         .config("spark.local.dir", sparkLocalDir)
         .config("spark.executor.heartbeatInterval", "30s")
@@ -308,48 +309,42 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
       val startTime = System.nanoTime()
       val df = spark.sql(s"""
            |SELECT
-           |    s_acctbal,
-           |    s_name,
-           |    n_name,
-           |    p_partkey,
-           |    p_mfgr,
-           |    s_address,
-           |    s_phone,
-           |    s_comment
-           |FROM
-           |    part,
-           |    supplier,
-           |    partsupp,
-           |    nation,
-           |    region
-           |WHERE
-           |    p_partkey = ps_partkey
-           |    AND s_suppkey = ps_suppkey
-           |    AND p_size = 15
-           |    AND p_type LIKE '%BRASS'
-           |    AND s_nationkey = n_nationkey
-           |    AND n_regionkey = r_regionkey
-           |    AND r_name = 'EUROPE'
-           |    AND ps_supplycost = (
-           |        SELECT
-           |            min(ps_supplycost)
-           |        FROM
-           |            partsupp,
-           |            supplier,
-           |            nation,
-           |            region
-           |        WHERE
-           |            p_partkey = ps_partkey
-           |            AND s_suppkey = ps_suppkey
-           |            AND s_nationkey = n_nationkey
-           |            AND n_regionkey = r_regionkey
-           |            AND r_name = 'EUROPE')
+           |    o_year,
+           |    sum(
+           |        CASE WHEN nation = 'BRAZIL' THEN
+           |            volume
+           |        ELSE
+           |            0
+           |        END) / sum(volume) AS mkt_share
+           |FROM (
+           |    SELECT
+           |        extract(year FROM o_orderdate) AS o_year,
+           |        l_extendedprice * (1 - l_discount) AS volume,
+           |        n2.n_name AS nation
+           |    FROM
+           |        part01,
+           |        supplier01,
+           |        lineitem01,
+           |        orders01,
+           |        customer01,
+           |        nation01 n1,
+           |        nation01 n2,
+           |        region01
+           |    WHERE
+           |        p_partkey = l_partkey
+           |        AND s_suppkey = l_suppkey
+           |        AND l_orderkey = o_orderkey
+           |        AND o_custkey = c_custkey
+           |        AND c_nationkey = n1.n_nationkey
+           |        AND n1.n_regionkey = r_regionkey
+           |        AND r_name = 'AMERICA'
+           |        AND s_nationkey = n2.n_nationkey
+           |        AND o_orderdate BETWEEN date'1995-01-01' AND date'1996-12-31'
+           |        AND p_type = 'ECONOMY ANODIZED STEEL') AS all_nations
+           |GROUP BY
+           |    o_year
            |ORDER BY
-           |    s_acctbal DESC,
-           |    n_name,
-           |    s_name,
-           |    p_partkey
-           |LIMIT 100;
+           |    o_year;
            |
            |""".stripMargin) // .show(30, false)
       // df.queryExecution.debug.codegen

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
@@ -33,9 +33,9 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
 
   def main(args: Array[String]): Unit = {
 
-    val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
-      "cmake-build-release/utils/local-engine/libch.so"
-    // val libPath = "/usr/local/clickhouse/lib/libch.so"
+    // val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
+    //   "cmake-build-release/utils/local-engine/libch.so"
+    val libPath = "/usr/local/clickhouse/lib/libch.so"
     val thrdCnt = 12
     val shufflePartitions = 12
     val shuffleManager = "sort"
@@ -178,11 +178,12 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
         // .config("spark.sql.join.preferSortMergeJoin", "false")
         .config("spark.sql.shuffledHashJoinFactor", "3")
         // .config("spark.sql.planChangeLog.level", "warn")
+        // .config("spark.sql.planChangeLog.batches", "ApplyColumnarRulesAndInsertTransitions")
         // .config("spark.sql.optimizer.inSetConversionThreshold", "5")  // IN to INSET
         .config("spark.sql.columnVector.offheap.enabled", "true")
         .config("spark.sql.parquet.columnarReaderBatchSize", "4096")
         .config("spark.memory.offHeap.enabled", "true")
-        .config("spark.memory.offHeap.size", "21474836480")
+        .config("spark.memory.offHeap.size", "20G")
         .config("spark.shuffle.sort.bypassMergeThreshold", "200")
         .config("spark.local.dir", sparkLocalDir)
         .config("spark.executor.heartbeatInterval", "30s")
@@ -270,7 +271,7 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
 
     val tookTimeArr = ArrayBuffer[Long]()
     val sqlFilePath = "/data2/tpcds-data-gen/tpcds10-queries/"
-    val execNum = 9
+    val execNum = 21
     val sqlNum = "q" + execNum + ".sql"
     val sqlFile = sqlFilePath + sqlNum
     val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString

--- a/backends-velox/src/main/java/io/glutenproject/memory/alloc/VeloxManagedReservationListener.java
+++ b/backends-velox/src/main/java/io/glutenproject/memory/alloc/VeloxManagedReservationListener.java
@@ -23,13 +23,13 @@ import io.glutenproject.memory.TaskMemoryMetrics;
 /**
  * Reserve Spark managed memory.
  */
-public class SparkManagedReservationListener implements ReservationListener {
+public class VeloxManagedReservationListener implements ReservationListener {
 
   private GlutenMemoryConsumer consumer;
   private TaskMemoryMetrics metrics;
   private volatile boolean open = true;
 
-  public SparkManagedReservationListener(GlutenMemoryConsumer consumer,
+  public VeloxManagedReservationListener(GlutenMemoryConsumer consumer,
                                          TaskMemoryMetrics metrics) {
     this.consumer = consumer;
     this.metrics = metrics;
@@ -63,5 +63,10 @@ public class SparkManagedReservationListener implements ReservationListener {
       consumer = null; // make it gc reachable
       open = false;
     }
+  }
+
+  @Override
+  public long currentMemory() {
+    return consumer.getUsed();
   }
 }

--- a/backends-velox/src/main/java/io/glutenproject/memory/alloc/VeloxMemoryAllocatorManager.java
+++ b/backends-velox/src/main/java/io/glutenproject/memory/alloc/VeloxMemoryAllocatorManager.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.memory.alloc;
+
+import java.util.List;
+import java.util.Vector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.spark.util.memory.TaskMemoryResourceManager;
+import org.apache.spark.util.memory.TaskMemoryResources;
+
+public class VeloxMemoryAllocatorManager implements TaskMemoryResourceManager,
+    NativeMemoryAllocatorManager {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(VeloxMemoryAllocatorManager.class);
+  private static final List<NativeMemoryAllocator> LEAKED = new Vector<>();
+  private final NativeMemoryAllocator managed;
+
+  public VeloxMemoryAllocatorManager(NativeMemoryAllocator managed) {
+    this.managed = managed;
+  }
+
+  private void close() throws Exception {
+    managed.close();
+  }
+
+  private void softClose() throws Exception {
+    // move to leaked list
+    long leakBytes = managed.getBytesAllocated();
+    long accumulated = TaskMemoryResources.ACCUMULATED_LEAK_BYTES().addAndGet(leakBytes);
+    LOGGER.warn(String.format("Detected leaked native allocator, size: %d, " +
+        "process accumulated leaked size: %d...", leakBytes, accumulated));
+    managed.listener().inactivate();
+    if (TaskMemoryResources.DEBUG()) {
+      LEAKED.add(managed);
+    }
+  }
+
+  @Override
+  public void release() throws Exception {
+    if (managed.getBytesAllocated() != 0L) {
+      softClose();
+    } else {
+      close();
+    }
+  }
+
+  @Override
+  public NativeMemoryAllocator getManaged() {
+    return managed;
+  }
+}

--- a/backends-velox/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/backends-velox/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -17,7 +17,8 @@
 
 package io.glutenproject.memory.arrowalloc;
 
-import io.glutenproject.memory.GlutenMemoryConsumer;
+import io.glutenproject.memory.VeloxMemoryConsumer;
+import io.glutenproject.memory.alloc.NativeMemoryAllocator;
 import io.glutenproject.memory.alloc.Spiller;
 import org.apache.arrow.memory.AllocationListener;
 import org.apache.arrow.memory.BufferAllocator;
@@ -33,7 +34,6 @@ import java.util.Vector;
 public class ArrowBufferAllocators {
 
   private ArrowBufferAllocators() {
-
   }
 
   private static final long MAX_ALLOCATION_SIZE = TaskMemoryResources.OFFHEAP_SIZE();
@@ -54,14 +54,14 @@ public class ArrowBufferAllocators {
     }
     return ((ArrowBufferAllocatorManager) TaskMemoryResources.getResourceManager(id)).managed;
   }
+
   public static class ArrowBufferAllocatorManager implements TaskMemoryResourceManager {
     private static Logger LOGGER = LoggerFactory.getLogger(ArrowBufferAllocatorManager.class);
     private static final List<BufferAllocator> LEAKED = new Vector<>();
     private final AllocationListener listener = new SparkManagedAllocationListener(
-        new GlutenMemoryConsumer(TaskMemoryResources.getSparkMemoryManager(), Spiller.NO_OP),
+        new VeloxMemoryConsumer(TaskMemoryResources.getSparkMemoryManager(), Spiller.NO_OP),
         TaskMemoryResources.getSharedMetrics());
     private final BufferAllocator managed = new RootAllocator(listener, Long.MAX_VALUE);
-
 
     public ArrowBufferAllocatorManager() {
     }
@@ -89,6 +89,14 @@ public class ArrowBufferAllocators {
       } else {
         close();
       }
+    }
+
+    /**
+     * Not support for ArrowBufferAllocatorManager
+     * @return
+     */
+    public NativeMemoryAllocator getManaged() {
+      throw new UnsupportedOperationException("Not support for ArrowBufferAllocatorManager");
     }
   }
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
@@ -78,7 +78,8 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
       .set("spark.sql.adaptive.enabled", "true")
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.sql.files.maxPartitionBytes", "134217728")
-      .set("spark.memory.offHeap.size", "2g")
+      .set("spark.memory.offHeap.enabled", "true")
+      .set("spark.memory.offHeap.size", "1024MB")
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
@@ -94,6 +95,7 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
         .set("spark.gluten.sql.enable.native.validation", "false")
         .set(GlutenConfig.GLUTEN_LIB_PATH, SystemParameters.getClickHouseLibPath)
         .set("spark.sql.files.openCostInBytes", "134217728")
+        .set("spark.unsafe.exceptionOnMemoryLeak", "true")
     } else {
       conf.set("spark.unsafe.exceptionOnMemoryLeak", "false")
     }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
@@ -105,7 +105,8 @@ trait GlutenTestsTrait extends SparkFunSuite with ExpressionEvalHelper with Glut
         .config("spark.sql.adaptive.enabled", "true")
         .config("spark.sql.shuffle.partitions", "1")
         .config("spark.sql.files.maxPartitionBytes", "134217728")
-        .config("spark.memory.offHeap.size", "2g")
+        .config("spark.memory.offHeap.enabled", "true")
+        .config("spark.memory.offHeap.size", "1024MB")
         .config("spark.plugins", "io.glutenproject.GlutenPlugin")
         .config("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
         .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
@@ -121,6 +122,7 @@ trait GlutenTestsTrait extends SparkFunSuite with ExpressionEvalHelper with Glut
           .config("spark.gluten.sql.enable.native.validation", "false")
           .config("spark.sql.files.openCostInBytes", "134217728")
           .config(GlutenConfig.GLUTEN_LIB_PATH, SystemParameters.getClickHouseLibPath)
+          .config("spark.unsafe.exceptionOnMemoryLeak", "true")
           .getOrCreate()
       } else {
         sparkBuilder

--- a/jvm/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocatorManager.java
+++ b/jvm/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocatorManager.java
@@ -17,31 +17,8 @@
 
 package io.glutenproject.memory.alloc;
 
-public interface ReservationListener {
-  ReservationListener NOOP = new ReservationListener() {
-    @Override
-    public void reserve(long size) {
-    }
-
-    @Override
-    public void unreserve(long size) {
-    }
-
-    @Override
-    public void inactivate() {
-    }
-
-    @Override
-    public long currentMemory() {
-      return 0L;
-    }
-  };
-
-  void reserve(long size);
-
-  void unreserve(long size);
-
-  void inactivate();
-
-  long currentMemory();
+/**
+ * It's a black interface for the native memory allocator manager
+ */
+public interface NativeMemoryAllocatorManager {
 }

--- a/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/jvm/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -19,15 +19,20 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.GlutenNumaBindingInfo
 import io.glutenproject.execution.{BaseNativeFilePartition, WholestageTransformContext}
+import io.glutenproject.memory.TaskMemoryMetrics
+import io.glutenproject.memory.alloc.Spiller
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.vectorized.{ExpressionEvaluator, ExpressionEvaluatorJniWrapper, GeneralInIterator, GeneralOutIterator}
+
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
+import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.memory.TaskMemoryResourceManager
 
 trait IIteratorApi extends IBackendsApi {
 
@@ -112,11 +117,21 @@ trait IIteratorApi extends IBackendsApi {
                           ): RDD[ColumnarBatch]
 
   /**
+   * Generate NativeMemoryAllocatorManager.
+   * @return
+   */
+  def genNativeMemoryAllocatorManager(taskMemoryManager: TaskMemoryManager,
+                                      spiller: Spiller,
+                                      taskMemoryMetrics: TaskMemoryMetrics
+                                     ): TaskMemoryResourceManager
+
+  /**
    * Generate BatchIterator for ExpressionEvaluator.
    *
    * @return
    */
-  def genBatchIterator(wsPlan: Array[Byte], iterList: Seq[GeneralInIterator],
+  def genBatchIterator(allocId: java.lang.Long, wsPlan: Array[Byte],
+                       iterList: Seq[GeneralInIterator],
                        jniWrapper: ExpressionEvaluatorJniWrapper,
                        outAttrs: Seq[Attribute]): GeneralOutIterator
 }

--- a/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/jvm/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -345,9 +345,11 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
 
     if (supportedGluten) {
       var overridden: SparkPlan = plan
+      val startTime = System.nanoTime()
       preOverrides.foreach { r =>
         overridden = r(session)(overridden)
       }
+      logInfo(s"preTransform SparkPlan took: ${System.nanoTime() - startTime} ns.")
       overridden
     } else {
       plan
@@ -361,9 +363,11 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
 
     if (supportedGluten) {
       var overridden: SparkPlan = plan
+      val startTime = System.nanoTime()
       postOverrides.foreach { r =>
         overridden = r(session)(overridden)
       }
+      logInfo(s"postTransform SparkPlan took: ${System.nanoTime() - startTime} ns.")
       overridden
     } else {
       plan

--- a/jvm/src/main/scala/org/apache/spark/util/memory/TaskMemoryResourceManager.scala
+++ b/jvm/src/main/scala/org/apache/spark/util/memory/TaskMemoryResourceManager.scala
@@ -17,7 +17,11 @@
 
 package org.apache.spark.util.memory
 
+import io.glutenproject.memory.alloc.NativeMemoryAllocator
+
 trait TaskMemoryResourceManager {
   @throws(classOf[Exception])
   def release(): Unit
+
+  def getManaged(): NativeMemoryAllocator
 }

--- a/jvm/src/main/scala/org/apache/spark/util/memory/TaskMemoryResources.scala
+++ b/jvm/src/main/scala/org/apache/spark/util/memory/TaskMemoryResources.scala
@@ -17,19 +17,20 @@
 
 package org.apache.spark.util.memory
 
+import java.util.concurrent.atomic.AtomicLong
+import java.util.UUID
+
+import scala.collection.JavaConverters._
+
 import io.glutenproject.memory.TaskMemoryMetrics
 
 import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.internal.config.MEMORY_OFFHEAP_SIZE
+import org.apache.spark.internal.Logging
 import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.TaskCompletionListener
 import org.apache.spark.util.memory.TaskMemoryResources._
-import scala.collection.JavaConverters._
-import java.util.concurrent.atomic.AtomicLong
-import java.util.UUID
-
-import org.apache.spark.internal.config.MEMORY_OFFHEAP_SIZE
-import org.apache.spark.internal.Logging
 
 object TaskMemoryResources {
   val DEBUG: Boolean = {

--- a/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/backendsapi/IteratorApiImplSuite.scala
@@ -19,15 +19,20 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.GlutenNumaBindingInfo
 import io.glutenproject.execution.{BaseNativeFilePartition, WholestageTransformContext}
+import io.glutenproject.memory.TaskMemoryMetrics
+import io.glutenproject.memory.alloc.Spiller
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.vectorized.{ExpressionEvaluator, ExpressionEvaluatorJniWrapper, GeneralInIterator, GeneralOutIterator}
+
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
+import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.memory.TaskMemoryResourceManager
 
 class IteratorApiImplSuite extends IIteratorApi {
   /**
@@ -101,11 +106,21 @@ class IteratorApiImplSuite extends IIteratorApi {
                                         ): GeneralInIterator = null
 
   /**
+   * Generate NativeMemoryAllocatorManager.
+   *
+   * @return
+   */
+  override def genNativeMemoryAllocatorManager(taskMemoryManager: TaskMemoryManager,
+                                               spiller: Spiller,
+                                               taskMemoryMetrics: TaskMemoryMetrics
+                                              ): TaskMemoryResourceManager = null
+
+  /**
    * Generate BatchIterator for ExpressionEvaluator.
    *
    * @return
    */
-  override def genBatchIterator(wsPlan: Array[Byte],
+  override def genBatchIterator(allocId: java.lang.Long, wsPlan: Array[Byte],
                                 iterList: Seq[GeneralInIterator],
                                 jniWrapper: ExpressionEvaluatorJniWrapper,
                                 outAttrs: Seq[Attribute]): GeneralOutIterator = null

--- a/jvm/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/jvm/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -60,6 +60,8 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
     super.sparkConf
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.default.parallelism", "1")
+      .set("spark.memory.offHeap.enabled", "true")
+      .set("spark.memory.offHeap.size", "1024MB")
   }
 
   protected def compareResultStr(


### PR DESCRIPTION
Unify cross-JNI memory management for ClickHouse backends.

Refer to:
1. [PR-251](https://github.com/oap-project/gluten/pull/251);
2. [PR-311](https://github.com/oap-project/gluten/pull/311);
3. [PR-325](https://github.com/oap-project/gluten/pull/325);
4. [PR-344](https://github.com/oap-project/gluten/pull/344);
5. [PR-440](https://github.com/oap-project/gluten/pull/440);

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

