### PR TITLE
Use reversed order to release TaskMemoryResourceManager

### DIFF
--- a/jvm/src/main/scala/org/apache/spark/util/memory/TaskMemoryResources.scala
+++ b/jvm/src/main/scala/org/apache/spark/util/memory/TaskMemoryResources.scala
@@ -117,10 +117,10 @@ class TaskMemoryResourceRegistry extends Logging {
 
   private val sharedMetrics = new TaskMemoryMetrics()
 
-  private val managers = new java.util.HashMap[String, TaskMemoryResourceManager]()
+  private val managers = new java.util.LinkedHashMap[String, TaskMemoryResourceManager]()
 
   private[memory] def releaseAll(): Unit = {
-    managers.values().asScala.foreach(m => try {
+    managers.values().asScala.toArray.reverse.foreach(m => try {
       m.release()
     } catch {
       case e: Throwable =>


### PR DESCRIPTION
Basically this is to prevent Arrow from reporting sth like "allocator closed with outstanding child allocators"  when debug option `-ea` is specified.

When memory resource are registered in order, e.g.

1. parent resource manager
2. child resource manager 1
3. child resource manager 2

The release order of the above should be 

1. child resource manager 2
2. child resource manager 1
3. parent resource manager

@zzcclp I expect this change doesn't break anything in ch backend's design. Would you please confirm on it? Thanks.