### PR TITLE
[OPPRO-284] Remove computing first batch compressed size in shuffle write

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/vectorized/ShuffleSplitterJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/vectorized/ShuffleSplitterJniWrapper.java
@@ -84,12 +84,11 @@ public class ShuffleSplitterJniWrapper {
    * @param splitterId splitter instance id
    * @param numRows Rows per batch
    * @param cArray Addresses of ArrowArray
-   * @param firstRecordBatch whether this record batch is the first
    * record batch in the first partition.
    * @return If the firstRecorBatch is true, return the compressed size, otherwise -1.
    */
   public native long split(
-      long splitterId, int numRows, long cArray, boolean firstRecordBatch) throws IOException;
+      long splitterId, int numRows, long cArray) throws IOException;
 
   /**
    * Update the compress type.

--- a/backends-velox/src/main/scala/org/apache/spark/shuffle/VeloxColumnarShuffleWriter.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/shuffle/VeloxColumnarShuffleWriter.scala
@@ -68,14 +68,8 @@ class VeloxColumnarShuffleWriter[K, V](
 
   private val nativeBufferSize = GlutenConfig.getConf.shuffleSplitDefaultSize
 
-  private val customizedCompressCodecWhitelist = Seq("gzip")
-  private val customizedCompressCodec =
+  private val customizedCompressionCodec =
     GlutenConfig.getConf.columnarShuffleUseCustomizedCompressionCodec
-  private val defaultCompressionCodec = if (conf.getBoolean("spark.shuffle.compress", true)) {
-    conf.get("spark.io.compression.codec", CompressType.LZ4_FRAME.getAlias)
-  } else {
-    CompressType.NO_COMPRESSION.getAlias
-  }
   private val batchCompressThreshold =
     GlutenConfig.getConf.columnarShuffleBatchCompressThreshold;
 
@@ -114,7 +108,7 @@ class VeloxColumnarShuffleWriter[K, V](
         dep.nativePartitioning,
         offheapPerTask,
         nativeBufferSize,
-        defaultCompressionCodec,
+        customizedCompressionCodec,
         batchCompressThreshold,
         dataTmp.getAbsolutePath,
         blockManager.subDirsPerLocalDir,
@@ -150,6 +144,7 @@ class VeloxColumnarShuffleWriter[K, V](
         dep.dataSize.add(rb.getBuffersLayout.asScala.map(buf => buf.getSize).sum)
         schema = if (firstRecordBatch) {
           ArrowConverterUtils.getSchemaFromBytesBuf(dep.nativePartitioning.getSchema)
+          firstRecordBatch = false
         } else schema
         try {
           ArrowAbiUtil.exportFromArrowRecordBatch(allocator, rb, schema,
@@ -159,42 +154,11 @@ class VeloxColumnarShuffleWriter[K, V](
         }
 
         val startTime = System.nanoTime()
-        val existingIntType: Boolean = if (firstRecordBatch) {
-          // Check whether the recordbatch contain the Int data type.
-          schema.getFields.asScala.exists(_.getType.getTypeID == ArrowTypeID.Int)
-        } else false
 
-        if (customizedCompressCodecWhitelist.contains(customizedCompressCodec)) {
-          firstRecordBatch = false
-          splitterJniWrapper.setCompressType(nativeSplitter, customizedCompressCodec)
-        }
-        // Choose the compress type based on the compress size of the first record batch.
-        if (firstRecordBatch && conf.getBoolean("spark.shuffle.compress", true) &&
-          customizedCompressCodec != defaultCompressionCodec && existingIntType) {
-          // Compute the default compress size
-          splitterJniWrapper.setCompressType(nativeSplitter, defaultCompressionCodec)
-          val defaultCompressedSize = splitterJniWrapper.split(
-            nativeSplitter, cb.numRows, cArray.memoryAddress(), firstRecordBatch)
-
-          // Compute the custom compress size.
-          splitterJniWrapper.setCompressType(nativeSplitter, customizedCompressCodec)
-          val customizedCompressedSize = splitterJniWrapper.split(
-            nativeSplitter, cb.numRows, cArray.memoryAddress(), firstRecordBatch)
-
-          // Choose the compress algorithm based on the compress size.
-          if (customizedCompressedSize != -1 && defaultCompressedSize != -1) {
-            if (customizedCompressedSize > defaultCompressedSize) {
-              splitterJniWrapper.setCompressType(nativeSplitter, defaultCompressionCodec)
-            }
-          } else {
-            logError("Failed to compute the compress size in the first record batch")
-          }
-        }
-        firstRecordBatch = false
         dep.prepareTime.add(System.nanoTime() - startTimeForPrepare)
 
         splitterJniWrapper
-          .split(nativeSplitter, cb.numRows, cArray.memoryAddress(), firstRecordBatch)
+          .split(nativeSplitter, cb.numRows, cArray.memoryAddress())
         dep.splitTime.add(System.nanoTime() - startTime)
         dep.numInputRows.add(cb.numRows)
         writeMetrics.incRecordsWritten(1)

--- a/backends-velox/src/main/scala/org/apache/spark/shuffle/VeloxColumnarShuffleWriter.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/shuffle/VeloxColumnarShuffleWriter.scala
@@ -142,10 +142,11 @@ class VeloxColumnarShuffleWriter[K, V](
         // RecordBatch to ArrowArray without Schema, may optimize later
         val rb = ArrowConverterUtils.createArrowRecordBatch(cb)
         dep.dataSize.add(rb.getBuffersLayout.asScala.map(buf => buf.getSize).sum)
-        schema = if (firstRecordBatch) {
-          ArrowConverterUtils.getSchemaFromBytesBuf(dep.nativePartitioning.getSchema)
+
+        if (firstRecordBatch) {
+          schema = ArrowConverterUtils.getSchemaFromBytesBuf(dep.nativePartitioning.getSchema)
           firstRecordBatch = false
-        } else schema
+        }
         try {
           ArrowAbiUtil.exportFromArrowRecordBatch(allocator, rb, schema,
             null, cArray)

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -899,8 +899,7 @@ Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_split(
     jobject,
     jlong splitter_id,
     jint num_rows,
-    jlong c_array,
-    jboolean first_record_batch) {
+    jlong c_array) {
   JNI_METHOD_START
   auto splitter = shuffle_splitter_holder_.Lookup(splitter_id);
   if (!splitter) {
@@ -913,9 +912,6 @@ Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_split(
           reinterpret_cast<struct ArrowArray*>(c_array),
           splitter->input_schema()));
 
-  if (first_record_batch) {
-    return splitter->CompressedSize(*in);
-  }
   gluten::JniAssertOkOrThrow(
       splitter->Split(*in), "Native split: splitter split failed");
   return -1L;


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

