### PR TITLE
[OPPRO-286] Disable two optimization rules in UT to avoid static evaluation for literal input

### DIFF
--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -158,6 +158,23 @@ arrow::Status VeloxToRowConverter::Write() {
         }
         break;
       }
+      case arrow::BooleanType::type_id: {
+        auto vec = vecs_[col_idx];
+        bool mayHaveNulls = vec->mayHaveNulls();
+        for (int row_idx = 0; row_idx < num_rows_; row_idx++) {
+          if (mayHaveNulls && vec->isNullAt(row_idx)) {
+            SetNullAt(
+                buffer_address_, offsets_[row_idx], field_offset, col_idx);
+          } else {
+            // Will use Velox's conversion.
+            auto write_address =
+                (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
+            auto serialized = row::UnsafeRowSerializer::serialize<BooleanType>(
+                vec, write_address, row_idx);
+          }
+        }
+        break;
+      }
       case arrow::StringType::type_id: {
         auto vec = vecs_[col_idx];
         auto str_views = vec->asFlatVector<StringView>()->rawValues();

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxNotSupport.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxNotSupport.scala
@@ -26,7 +26,6 @@ object VeloxNotSupport extends NotSupport {
 
   override lazy val fullSupportSuiteList: Set[String] = Set(
     simpleClassName[LiteralExpressionSuite],
-    simpleClassName[NullExpressionsSuite],
     simpleClassName[IntervalExpressionsSuite],
     simpleClassName[DecimalExpressionSuite]
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

We found that for some literal input test case, like `_FUNC_(123)`, spark has an optimization in catalyst to statically evaluate the result and make the plan become `RES as _FUNC_(123)`, which will not actually get the original plan evaluated by gluten. So we are proposing some changes in unit test configuration to turn off such optimizations.   


## How was this patch tested?
UT.

