### PR TITLE
[OPPRO-242] Remove the workaround for anti join

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -157,7 +157,7 @@ class CHSparkPlanExecApi extends ISparkPlanExecApi with AdaptiveSparkPlanHelper 
                                           right: SparkPlan,
                                           isNullAwareAntiJoin: Boolean = false)
   : BroadcastHashJoinExecTransformer = CHBroadcastHashJoinExecTransformer(
-    leftKeys, rightKeys, joinType, buildSide, condition, left, right)
+    leftKeys, rightKeys, joinType, buildSide, condition, left, right, isNullAwareAntiJoin)
 
   /**
    * Generate Alias transformer.

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
@@ -44,9 +44,9 @@ case class CHBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
                                               condition: Option[Expression],
                                               left: SparkPlan,
                                               right: SparkPlan,
-                                              isNullAwareAntiJoin: Boolean = false)
+                                              isNullAwareAntiJoin: Boolean)
   extends BroadcastHashJoinExecTransformer(
-    leftKeys, rightKeys, joinType, buildSide, condition, left, right) {
+    leftKeys, rightKeys, joinType, buildSide, condition, left, right, isNullAwareAntiJoin) {
 
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan, newRight: SparkPlan): CHBroadcastHashJoinExecTransformer =

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -140,7 +140,7 @@ class VeloxSparkPlanExecApi extends ISparkPlanExecApi {
     right: SparkPlan,
     isNullAwareAntiJoin: Boolean = false)
   : BroadcastHashJoinExecTransformer = VeloxBroadcastHashJoinExecTransformer(
-    leftKeys, rightKeys, joinType, buildSide, condition, left, right)
+    leftKeys, rightKeys, joinType, buildSide, condition, left, right, isNullAwareAntiJoin)
 
   /**
    * Generate Alias transformer.

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
@@ -17,198 +17,13 @@
 
 package io.glutenproject.execution
 
-import io.glutenproject.execution.HashJoinLikeExecTransformer.{makeAndExpression, makeEqualToExpression, makeIsNullExpression}
-import io.glutenproject.expression._
-import io.glutenproject.substrait.SubstraitContext
-import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
-import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.substrait.proto.JoinRel
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.{FilterExec, SparkPlan}
-import org.apache.spark.sql.types.{BooleanType, DataType}
-import java.util
 
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
-
-import scala.collection.JavaConverters._
-
-trait VeloxHashJoinLikeExecTransformer extends HashJoinLikeExecTransformer {
-
-  // Direct output order of substrait join operation
-  override protected val substraitJoinType: JoinRel.JoinType = joinType match {
-    case Inner =>
-      JoinRel.JoinType.JOIN_TYPE_INNER
-    case FullOuter =>
-      JoinRel.JoinType.JOIN_TYPE_OUTER
-    case LeftOuter | RightOuter =>
-      // The right side is required to be used for building hash table in Substrait plan.
-      // Therefore, for RightOuter Join, the left and right relations are exchanged and the
-      // join type is reverted.
-      JoinRel.JoinType.JOIN_TYPE_LEFT
-    case LeftSemi =>
-      JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI
-    case LeftAnti =>
-      if (!antiJoinWorkaroundNeeded) {
-        JoinRel.JoinType.JOIN_TYPE_ANTI
-      } else {
-        // Use Left to replace Anti as a workaround.
-        JoinRel.JoinType.JOIN_TYPE_LEFT
-      }
-    case _ =>
-      // TODO: Support cross join with Cross Rel
-      // TODO: Support existence join
-      JoinRel.JoinType.UNRECOGNIZED
-  }
-
-  /**
-   * Use a workaround for Anti join with 'not exists' semantics.
-   * Firstly, add an aggregation rel over build rel to make the build keys distinct.
-   * Secondly, add a project rel over the aggregation rel to append a column of true constant.
-   * Then, this project rel is returned and will be used as the input rel for join build side.
-   * @param buildInfo: the original build keys, build rel and build outputs.
-   * @param context: Substrait context.
-   * @param operatorId: operator id of this join.
-   * @return original build keys, new build rel and build outputs.
-   */
-  private def createSpecialRelForAntiBuild(
-      buildInfo: (Seq[(ExpressionNode, DataType)], RelNode, Seq[Attribute]),
-      context: SubstraitContext,
-      operatorId: java.lang.Long,
-      validation: Boolean): (Seq[(ExpressionNode, DataType)], RelNode, Seq[Attribute]) = {
-    // Create an Aggregation Rel over build Rel.
-    val groupingNodes = new util.ArrayList[ExpressionNode]()
-    var colIdx = 0
-    buildInfo._3.foreach(_ => {
-      groupingNodes.add(ExpressionBuilder.makeSelection(colIdx))
-      colIdx += 1
-    })
-    val aggNode = RelBuilder.makeAggregateRel(
-      buildInfo._2,
-      groupingNodes,
-      new util.ArrayList[AggregateFunctionNode](),
-      context,
-      operatorId)
-    // Create a Project Rel over Aggregation Rel.
-    val expressionNodes = groupingNodes
-    // Append a new column of true constant.
-    expressionNodes.add(ExpressionBuilder.makeBooleanLiteral(true))
-    val projectNode = RelBuilder.makeProjectRel(
-      aggNode,
-      expressionNodes,
-      createExtensionNode(buildInfo._3, validation),
-      context,
-      operatorId)
-    (
-      buildInfo._1,
-      projectNode,
-      buildInfo._3 :+ AttributeReference(s"constant_true", BooleanType)()
-    )
-  }
-
-  override def createJoinRel(inputStreamedRelNode: RelNode,
-                             inputBuildRelNode: RelNode,
-                             inputStreamedOutput: Seq[Attribute],
-                             inputBuildOutput: Seq[Attribute],
-                             substraitContext: SubstraitContext,
-                             operatorId: java.lang.Long,
-                             validation: Boolean = false): RelNode = {
-    // Create pre-projection for build/streamed plan. Append projected keys to each side.
-    val (streamedKeys, streamedRelNode, streamedOutput) = createPreProjectionIfNeeded(
-      streamedKeyExprs,
-      inputStreamedRelNode,
-      inputStreamedOutput,
-      inputStreamedOutput,
-      substraitContext,
-      operatorId,
-      validation)
-
-    val (buildKeys, buildRelNode, buildOutput) = {
-      val (keys, relNode, output) = createPreProjectionIfNeeded(
-        buildKeyExprs,
-        inputBuildRelNode,
-        inputBuildOutput,
-        streamedOutput ++ inputBuildOutput,
-        substraitContext,
-        operatorId,
-        validation)
-      if (!antiJoinWorkaroundNeeded) {
-        (keys, relNode, output)
-      } else {
-        // Use a workaround for Anti join.
-        createSpecialRelForAntiBuild(
-          (keys, relNode, output), substraitContext, operatorId, validation)
-      }
-    }
-
-    // Combine join keys to make a single expression.
-    val joinExpressionNode = (streamedKeys zip buildKeys).map {
-      case ((leftKey, leftType), (rightKey, rightType)) =>
-        makeEqualToExpression(
-          leftKey, leftType, rightKey, rightType, substraitContext.registeredFunction)
-    }.reduce((l, r) => makeAndExpression(l, r, substraitContext.registeredFunction))
-
-    // Create post-join filter, which will be computed in hash join.
-    val postJoinFilter = condition.map {
-      expr =>
-        ExpressionConverter
-          .replaceWithExpressionTransformer(expr, streamedOutput ++ buildOutput)
-          .asInstanceOf[ExpressionTransformer]
-          .doTransform(substraitContext.registeredFunction)
-    }
-
-    // Create JoinRel.
-    val joinRel = {
-      val joinNode = RelBuilder.makeJoinRel(
-        streamedRelNode,
-        buildRelNode,
-        substraitJoinType,
-        joinExpressionNode,
-        postJoinFilter.orNull,
-        createJoinExtensionNode(streamedOutput ++ buildOutput, validation),
-        substraitContext,
-        operatorId)
-      if (!antiJoinWorkaroundNeeded) {
-        joinNode
-      } else {
-        // Use an isNulll filter to select the rows needed by Anti join from Left join outputs.
-        val isNullFilter = makeIsNullExpression(
-          ExpressionBuilder.makeSelection(streamedOutput.size + buildOutput.size - 1),
-          substraitContext.registeredFunction)
-        RelBuilder.makeFilterRel(
-          joinNode,
-          isNullFilter,
-          createJoinExtensionNode(streamedOutput ++ buildOutput, validation),
-          substraitContext,
-          operatorId)
-      }
-    }
-
-    // Result projection will drop the appended keys, and exchange columns order if BuildLeft.
-    val resultProjection = if (exchangeTable) {
-      val (leftOutput, rightOutput) =
-        getResultProjectionOutput(inputBuildOutput, inputStreamedOutput)
-      // Exchange the order of build and streamed.
-      leftOutput.indices.map(idx =>
-        ExpressionBuilder.makeSelection(idx + streamedOutput.size)) ++
-        rightOutput.indices
-          .map(ExpressionBuilder.makeSelection(_))
-    } else {
-      val (leftOutput, rightOutput) =
-        getResultProjectionOutput(inputStreamedOutput, inputBuildOutput)
-      leftOutput.indices.map(ExpressionBuilder.makeSelection(_)) ++
-        rightOutput.indices.map(idx => ExpressionBuilder.makeSelection(idx + streamedOutput.size))
-    }
-
-    RelBuilder.makeProjectRel(
-      joinRel,
-      new java.util.ArrayList[ExpressionNode](resultProjection.asJava),
-      createExtensionNode(streamedOutput ++ buildOutput, validation),
-      substraitContext,
-      operatorId)
-  }
-}
 
 case class VeloxShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
                                                 rightKeys: Seq[Expression],
@@ -224,7 +39,7 @@ case class VeloxShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
     buildSide,
     condition,
     left,
-    right) with VeloxHashJoinLikeExecTransformer {
+    right) {
 
   // Used to specify the preferred build side in backend's real execution.
   object PreferredBuildSide extends Serializable {
@@ -335,27 +150,12 @@ case class VeloxShuffledHashJoinExecTransformer(leftKeys: Seq[Expression],
         JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI
       }
     }
-    case LeftAnti => if (!antiJoinWorkaroundNeeded) {
+    case LeftAnti =>
       JoinRel.JoinType.JOIN_TYPE_ANTI
-    } else {
-      // Use Left to replace Anti as a workaround.
-      JoinRel.JoinType.JOIN_TYPE_LEFT
-    }
     case _ =>
       // TODO: Support cross join with Cross Rel
       // TODO: Support existence join
       JoinRel.JoinType.UNRECOGNIZED
-  }
-
-  /**
-   * Returns whether a workaround for Anti join is needed. True for 'not exists' semantics.
-   * For SHJ, always returns true for Anti join.
-   */
-  override def antiJoinWorkaroundNeeded: Boolean = {
-    joinType match {
-      case LeftAnti => true
-      case _ => false
-    }
   }
 
   override protected def withNewChildrenInternal(
@@ -378,26 +178,7 @@ case class VeloxBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
     buildSide,
     condition,
     left,
-    right) with VeloxHashJoinLikeExecTransformer {
-
-  /**
-   * Returns whether a workaround for Anti join is needed. True for 'not exists' semantics.
-   * For BHJ, only when isNullAwareAntiJoin is disabled, true is returned.
-   */
-  override def antiJoinWorkaroundNeeded: Boolean = {
-    joinType match {
-      case LeftAnti =>
-        if (isNullAwareAntiJoin) {
-          false
-        } else {
-          // Velox's Anti semantics are matched with the case when isNullAwareAntiJoin is enabled.
-          // So a workaround is needed if isNullAwareAntiJoin is disabled.
-          true
-        }
-      case _ =>
-        false
-    }
-  }
+    right) {
 
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan, newRight: SparkPlan): VeloxBroadcastHashJoinExecTransformer =

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashJoinExecTransformer.scala
@@ -170,7 +170,7 @@ case class VeloxBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
                                                  condition: Option[Expression],
                                                  left: SparkPlan,
                                                  right: SparkPlan,
-                                                 isNullAwareAntiJoin: Boolean = false)
+                                                 isNullAwareAntiJoin: Boolean)
   extends BroadcastHashJoinExecTransformer(
     leftKeys,
     rightKeys,
@@ -178,7 +178,8 @@ case class VeloxBroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
     buildSide,
     condition,
     left,
-    right) {
+    right,
+    isNullAwareAntiJoin) {
 
   override protected def withNewChildrenInternal(
       newLeft: SparkPlan, newRight: SparkPlan): VeloxBroadcastHashJoinExecTransformer =

--- a/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/jvm/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -1057,7 +1057,7 @@ abstract class BroadcastHashJoinExecTransformer(leftKeys: Seq[Expression],
                                                 condition: Option[Expression],
                                                 left: SparkPlan,
                                                 right: SparkPlan,
-                                                isNullAwareAntiJoin: Boolean = false)
+                                                isNullAwareAntiJoin: Boolean)
   extends HashJoinLikeExecTransformer {
 
   override def joinBuildSide: BuildSide = buildSide

--- a/tools/build_velox.sh
+++ b/tools/build_velox.sh
@@ -9,8 +9,8 @@ COMPILE_VELOX=OFF
 ENABLE_EP_CACHE=OFF
 VELOX_HOME=/root/velox
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/rui-mo/velox.git
+VELOX_BRANCH=anti_join
 
 for arg in "$@"
 do

--- a/tools/build_velox.sh
+++ b/tools/build_velox.sh
@@ -9,8 +9,8 @@ COMPILE_VELOX=OFF
 ENABLE_EP_CACHE=OFF
 VELOX_HOME=/root/velox
 
-VELOX_REPO=https://github.com/rui-mo/velox.git
-VELOX_BRANCH=anti_join
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 for arg in "$@"
 do


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed the workaround for anti join because Velox upstream already supported regular anti join.
Related to https://github.com/oap-project/gluten/pull/375.

## How was this patch tested?

verified on Jenkins

