### PR TITLE
[Gluten-466] Fix maven build issue with default spark version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <spark32bundle.version>3.2</spark32bundle.version>
     <spark33bundle.version>3.3</spark33bundle.version>
     <maven.compiler.plugin>3.8.0</maven.compiler.plugin>
+    <sparkbundle.version>${spark32bundle.version}</sparkbundle.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix maven build issue with default spark version
#466 


## How was this patch tested?
mvn clean package -Pbackends-velox -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip -Dbuild_cpp=ON -Dbuild_velox=ON -Dbuild_velox_from_source=ON -Dbuild_arrow=ON


@zhztheplayer  @jinchengchenghh   Gluten-it compilation issue and q69 accuracy issue have been resolved. 
