### PR TITLE
[GLUTEN-507] Fix 'WrappedArray$ofRef; local class incompatible: stream classdesc' error

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -122,6 +122,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2BenchmarkTest.scala
@@ -45,14 +45,14 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
 
   def main(args: Array[String]): Unit = {
 
-    // val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
-    //   "cmake-build-release/utils/local-engine/libch.so"
-    val libPath = "/usr/local/clickhouse/lib/libch.so"
+    val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
+      "cmake-build-release/utils/local-engine/libch.so"
+    // val libPath = "/usr/local/clickhouse/lib/libch.so"
     val thrdCnt = 8
     val shufflePartitions = 8
-    val shuffleManager = "sort"
-    // val shuffleManager = "org.apache.spark.shuffle.sort.ColumnarShuffleManager"
-    val ioCompressionCodec = "SNAPPY"
+    // val shuffleManager = "sort"
+    val shuffleManager = "org.apache.spark.shuffle.sort.ColumnarShuffleManager"
+    val ioCompressionCodec = "LZ4"
     val columnarColumnToRow = "true"
     val useV2 = "false"
     val separateScanRDD = "false"
@@ -213,6 +213,8 @@ object DSV2BenchmarkTest extends AdaptiveSparkPlanHelper {
         .config("spark.ui.retainedJobs", "2500")
         .config("spark.ui.retainedStages", "5000")
         .config(GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED, "true")
+        .config("spark.extraListeners", "io.glutenproject.softaffinity.scheduler.SoftAffinityListener")
+        .config("spark.gluten.sql.columnar.backend.ch.runtime_conf.logger.level", "error")
 
       if (!warehouse.isEmpty) {
         sessionBuilderTmp1

--- a/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/benchmarks/DSV2TPCDSBenchmarkTest.scala
@@ -31,9 +31,9 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
 
   def main(args: Array[String]): Unit = {
 
-    // val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
-    //   "cmake-build-release/utils/local-engine/libch.so"
-    val libPath = "/usr/local/clickhouse/lib/libch.so"
+    val libPath = "/home/myubuntu/Works/c_cpp_projects/Kyligence-ClickHouse-1/" +
+      "cmake-build-release/utils/local-engine/libch.so"
+    // val libPath = "/usr/local/clickhouse/lib/libch.so"
     val thrdCnt = 8
     val shufflePartitions = 8
     val shuffleManager = "sort"
@@ -198,6 +198,9 @@ object DSV2TPCDSBenchmarkTest extends AdaptiveSparkPlanHelper {
         .config("spark.sql.codegen.comments", "true")
         .config("spark.ui.retainedJobs", "2500")
         .config("spark.ui.retainedStages", "5000")
+        .config(GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED, "true")
+        .config("spark.extraListeners", "io.glutenproject.softaffinity.scheduler.SoftAffinityListener")
+        .config("spark.gluten.sql.columnar.backend.ch.runtime_conf.logger.level", "error")
 
       if (!warehouse.isEmpty) {
         sessionBuilderTmp1

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -117,6 +117,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/gluten-ut/pom.xml
+++ b/gluten-ut/pom.xml
@@ -93,6 +93,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -138,6 +138,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <spark33.version>3.3.0</spark33.version>
     <delta2.version>2.0.0</delta2.version>
     <delta1.version>1.2.1</delta1.version>
-    <scala.version>2.12.10</scala.version>
+    <scala.version>2.12.15</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spark.version>3.2.2</spark.version>
     <delta.version>${delta1.version}</delta.version>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -29,7 +29,7 @@
   <packaging>pom</packaging>
  
   <properties>
-    <scala.version>2.12.10</scala.version>
+    <scala.version>2.12.15</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scala.plugin.version>4.3.0</scala.plugin.version>
     <scalatest-maven-plugin.version>3.2.2</scalatest-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Gluten jar includes scala jars, and the version of the scala jars is different with the one of the Spark, which will lead to error 'WrappedArray$ofRef; local class incompatible: stream classdesc'.

Close #507 .


## How was this patch tested?

Exist UTs.


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

