### PR TITLE
[OPPRO-314] Correctly fall back scan operator with unsupported filters

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/columnarbatch/ArrowColumnarBatches.java
+++ b/backends-velox/src/main/java/io/glutenproject/columnarbatch/ArrowColumnarBatches.java
@@ -63,7 +63,11 @@ public class ArrowColumnarBatches {
 
   public static ColumnarBatch load(BufferAllocator allocator, ColumnarBatch input) {
     if (!GlutenColumnarBatches.isIntermediateColumnarBatch(input)) {
-      throw new IllegalArgumentException("input is not intermediate Gluten columnar input");
+      throw new IllegalArgumentException("input is not intermediate Gluten columnar input. " +
+          "Please consider to use vanilla spark's row based input by setting one of the below configs: \n" +
+          "spark.sql.parquet.enableVectorizedReader=false\n" +
+          "spark.sql.inMemoryColumnarStorage.enableVectorizedReader=false\n" +
+          "spark.sql.orc.enableVectorizedReader=false\n");
     }
     if (input.numCols() == 0) {
       return input;

--- a/backends-velox/src/main/java/io/glutenproject/columnarbatch/ArrowColumnarBatches.java
+++ b/backends-velox/src/main/java/io/glutenproject/columnarbatch/ArrowColumnarBatches.java
@@ -64,7 +64,8 @@ public class ArrowColumnarBatches {
   public static ColumnarBatch load(BufferAllocator allocator, ColumnarBatch input) {
     if (!GlutenColumnarBatches.isIntermediateColumnarBatch(input)) {
       throw new IllegalArgumentException("input is not intermediate Gluten columnar input. " +
-          "Please consider to use vanilla spark's row based input by setting one of the below configs: \n" +
+          "Please consider to use vanilla spark's row based input by setting one of the below" +
+          " configs: \n" +
           "spark.sql.parquet.enableVectorizedReader=false\n" +
           "spark.sql.inMemoryColumnarStorage.enableVectorizedReader=false\n" +
           "spark.sql.orc.enableVectorizedReader=false\n");

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxFilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxFilterExecTransformer.scala
@@ -104,10 +104,9 @@ case class VeloxFilterExecTransformer(condition: Expression,
         batchScanTransformer.filterExprs()
       case fileScanTransformer: FileSourceScanExecTransformer =>
         fileScanTransformer.filterExprs()
-      // In ColumnarGuardRules, the child is still row-based. Need to get the original filters.
+      // For fallback scan, we need to keep original filter.
       case _ =>
         Seq.empty[Expression]
-//        FilterHandler.getScanFilters(child)
     }
     if (scanFilters.isEmpty) {
       condition

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxFilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxFilterExecTransformer.scala
@@ -106,7 +106,8 @@ case class VeloxFilterExecTransformer(condition: Expression,
         fileScanTransformer.filterExprs()
       // In ColumnarGuardRules, the child is still row-based. Need to get the original filters.
       case _ =>
-        FilterHandler.getScanFilters(child)
+        Seq.empty[Expression]
+//        FilterHandler.getScanFilters(child)
     }
     if (scanFilters.isEmpty) {
       condition

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -114,7 +114,7 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
             }
           case p =>
             return p.withNewChildren(
-              plan.children.map(replaceWithTransformerPlan(_, isSupportAdaptive)))
+              p.children.map(replaceWithTransformerPlan(_, isSupportAdaptive)))
         }
     }
     plan match {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -26,6 +26,10 @@ case class GlutenNumaBindingInfo(
 
 class GlutenConfig(conf: SQLConf) extends Logging {
 
+  // With this setting, row based input will be used in the fallback case of data source v1.
+  // TODO: remove this setting if vanilla spark's vectorized input is supported.
+  conf.setConfString("spark.sql.parquet.enableVectorizedReader", "false")
+
   val enableNativeEngine: Boolean =
     conf.getConfString("spark.gluten.sql.enable.native.engine", "true").toBoolean
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -26,10 +26,6 @@ case class GlutenNumaBindingInfo(
 
 class GlutenConfig(conf: SQLConf) extends Logging {
 
-  // With this setting, row based input will be used in the fallback case of data source v1.
-  // TODO: remove this setting if vanilla spark's vectorized input is supported.
-  conf.setConfString("spark.sql.parquet.enableVectorizedReader", "false")
-
   val enableNativeEngine: Boolean =
     conf.getConfString("spark.gluten.sql.enable.native.engine", "true").toBoolean
 


### PR DESCRIPTION
The code for handling filter push down should check whether scan is transformable, considering unsupported filter can be pushed down to scan.
Reproducible issue link: https://github.com/oap-project/gluten/issues/560.