### PR TITLE
[OPPRO-320] Get spark short version for loading corresponding spark shim

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShimLoader.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShimLoader.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.sql.shims
 
-import org.apache.spark.SPARK_VERSION
+import org.apache.spark.SPARK_VERSION_SHORT
 import org.apache.spark.internal.Logging
 
 import java.util.ServiceLoader
@@ -36,7 +36,7 @@ object SparkShimLoader extends Logging {
   }
 
   def getSparkVersion: String = {
-    SPARK_VERSION
+    SPARK_VERSION_SHORT
   }
 
   def setSparkShimProviderClass(providerClass: String): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In spark, short version stands for `major_version`-`minor_version`-`patch_version`. For a spark release, there is no difference between `SPARK_VERSION` & `SPARK_VERSION_SHORT`. But according to some customers' feedback, they are using their internally maintained spark. For example, their `SPARK_VERSION` can be 3.2.2.xxx. By using `SPARK_VERSION_SHORT`, gluten can load the expected spark-3.2.2 shim by ignoring the last part.

Ref.: https://github.com/oap-project/gazelle_plugin/pull/824

