### PR TITLE
Use Maven public repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -714,18 +714,4 @@
       </plugin>
     </plugins>
   </reporting>
-  <repositories>
-    <repository>
-      <id>Kyligence</id>
-      <name>Kyligence Repository</name>
-      <url>https://repository.kyligence.io/repository/maven-public/
-      </url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>


### PR DESCRIPTION

## What changes were proposed in this pull request?

This patch allows to use the maven repo instead of Kyligence repo - as it's very slow outside of PRC network

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

pass GHA

