### PR TITLE
[OPPRO-328] Handle cast failure differently according to the config for ANSI

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxHashAggregateExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 
 package io.glutenproject.execution
-import java.util.ArrayList
 
 import scala.collection.JavaConverters._
 import com.google.protobuf.Any
@@ -32,6 +31,7 @@ import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DoubleType, LongType}
 
 case class VeloxHashAggregateExecTransformer(
@@ -107,7 +107,7 @@ case class VeloxHashAggregateExecTransformer(
           // Select count from Velox struct with count casted from LongType into DoubleType.
           expressionNodes.add(ExpressionBuilder
             .makeCast(ConverterUtils.getTypeNode(DoubleType, nullable = true),
-              ExpressionBuilder.makeSelection(colIdx, 0)))
+              ExpressionBuilder.makeSelection(colIdx, 0), SQLConf.get.ansiEnabled))
           // Select avg from Velox Struct.
           expressionNodes.add(ExpressionBuilder.makeSelection(colIdx, 1))
           // Select m2 from Velox Struct.
@@ -308,7 +308,8 @@ case class VeloxHashAggregateExecTransformer(
                       attr.copy(attr.name, LongType, attr.nullable, attr.metadata)(
                         attr.exprId, attr.qualifier)
                     ExpressionBuilder.makeCast(
-                      ConverterUtils.getTypeNode(LongType, attr.nullable), aggNode)
+                      ConverterUtils.getTypeNode(LongType, attr.nullable), aggNode,
+                      SQLConf.get.ansiEnabled)
                   } else {
                     newInputAttributes = newInputAttributes :+ attr
                     aggNode

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -14,8 +14,8 @@ BUILD_FOLLY=ON
 VELOX_BUILD_TYPE=release
 VELOX_HOME=/root/velox
 
-VELOX_REPO=https://github.com/PHILO-HE/velox.git
-VELOX_BRANCH=cast-nullOnFailure-oap
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 for arg in "$@"
 do

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -14,8 +14,8 @@ BUILD_FOLLY=ON
 VELOX_BUILD_TYPE=release
 VELOX_HOME=/root/velox
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=cast-nullOnFailure-oap
 
 for arg in "$@"
 do

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/CastNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/CastNode.java
@@ -26,9 +26,12 @@ public class CastNode implements ExpressionNode, Serializable {
   private final TypeNode typeNode;
   private final ExpressionNode expressionNode;
 
-  CastNode(TypeNode typeNode, ExpressionNode expressionNode) {
+  public final boolean ansiEnabled;
+
+  CastNode(TypeNode typeNode, ExpressionNode expressionNode, boolean ansiEnabled) {
     this.typeNode = typeNode;
     this.expressionNode = expressionNode;
+    this.ansiEnabled = ansiEnabled;
   }
 
   @Override
@@ -36,7 +39,13 @@ public class CastNode implements ExpressionNode, Serializable {
     Expression.Cast.Builder castBuilder = Expression.Cast.newBuilder();
     castBuilder.setType(typeNode.toProtobuf());
     castBuilder.setInput(expressionNode.toProtobuf());
-
+    if (ansiEnabled) {
+      // Throw exception on failure.
+      castBuilder.setFailureBehaviorValue(2);
+    } else {
+      // Return null on failure.
+      castBuilder.setFailureBehaviorValue(1);
+    }
     Expression.Builder builder = Expression.newBuilder();
     builder.setCast(castBuilder.build());
     return builder.build();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -235,7 +235,8 @@ public class ExpressionBuilder {
     return new AggregateFunctionNode(functionId, expressionNodes, phase, outputTypeNode);
   }
 
-  public static CastNode makeCast(TypeNode typeNode, ExpressionNode expressionNode, boolean ansiEnabled) {
+  public static CastNode makeCast(TypeNode typeNode, ExpressionNode expressionNode,
+                                  boolean ansiEnabled) {
     return new CastNode(typeNode, expressionNode, ansiEnabled);
   }
 

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -235,8 +235,8 @@ public class ExpressionBuilder {
     return new AggregateFunctionNode(functionId, expressionNodes, phase, outputTypeNode);
   }
 
-  public static CastNode makeCast(TypeNode typeNode, ExpressionNode expressionNode) {
-    return new CastNode(typeNode, expressionNode);
+  public static CastNode makeCast(TypeNode typeNode, ExpressionNode expressionNode, boolean ansiEnabled) {
+    return new CastNode(typeNode, expressionNode, ansiEnabled);
   }
 
   public static StringMapNode makeStringMap(Map<String, String> values) {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/UnaryOperatorTransformer.scala
@@ -21,10 +21,10 @@ import com.google.common.collect.Lists
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class IsNotNullTransformer(child: Expression, original: Expression)
@@ -590,7 +590,8 @@ class CastTransformer(child: Expression,
     }
 
     val typeNode = ConverterUtils.getTypeNode(dataType, original.nullable)
-    ExpressionBuilder.makeCast(typeNode, childNode.asInstanceOf[ExpressionNode])
+    ExpressionBuilder.makeCast(typeNode, childNode.asInstanceOf[ExpressionNode],
+      SQLConf.get.ansiEnabled)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Vanilla spark's behavior on cast failure can be different, depending on the config for ANSI (`spark.sql.ansi.enabled`). If ANSI is enabled, the expected behavior is just throwing a runtime exception. And if it is disabled, the expected behavior becomes returning a null result. Substrait already has a called `FailureBehaviorValue` flag for handling cast failure, which is helpful to us in doing this impl.

