### PR TITLE
[OPPRO-279] Implement runtime native bloom filter

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -50,6 +50,7 @@ object CHExpressionUtil {
   )
 
   final val CH_AGGREGATE_FUNC_BLACKLIST: Map[String, Set[String]] = Map(
-    STDDEV_SAMP -> Set(EMPTY_TYPE)
+    STDDEV_SAMP -> Set(EMPTY_TYPE),
+    COLLECT_LIST -> Set(EMPTY_TYPE)
   )
 }

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -797,9 +797,11 @@ Splitter::row_offset_type Splitter::CalculateSplitBatchSize(const arrow::RecordB
       size_per_row += arrow::bit_width(column_type_id_[col_idx]->id()) >> 3;
   }
 
-  int64_t prealloc_row_cnt = options_.offheap_per_task > 0 && size_per_row > 0
-      ? options_.offheap_per_task / size_per_row / num_partitions_ >> 2
-      : options_.buffer_size;
+  int64_t prealloc_row_cnt = num_partitions_ == 1
+      ? num_rows
+      : (options_.offheap_per_task > 0 && size_per_row > 0
+             ? options_.offheap_per_task / size_per_row / num_partitions_ >> 2
+             : options_.buffer_size);
   prealloc_row_cnt = std::min(prealloc_row_cnt, (int64_t)options_.buffer_size);
 
   return (row_offset_type)prealloc_row_cnt;

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -66,6 +66,7 @@ endfunction()
 
 macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(functions::sparksql::lib "${VELOX_COMPONENTS_PATH}/functions/sparksql/libvelox_functions_spark.a")
+  add_velox_dependency(functions::sparksql::agg "${VELOX_COMPONENTS_PATH}/functions/sparksql/aggregates/libvelox_functions_spark_aggregates.a")
   add_velox_dependency(functions::prestosql::agg "${VELOX_COMPONENTS_PATH}/functions/prestosql/aggregates/libvelox_aggregates.a")
 
   add_velox_dependency(functions::prestosql::window "${VELOX_COMPONENTS_PATH}/functions/prestosql/window/libvelox_window.a")

--- a/cpp/velox/compute/RegistrationAllFunctions.cc
+++ b/cpp/velox/compute/RegistrationAllFunctions.cc
@@ -20,6 +20,7 @@
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 #include "velox/functions/sparksql/Register.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -40,6 +41,7 @@ void registerAllFunctions() {
   functions::sparksql::registerFunctions("");
   registerCustomFunctions();
   registerAllAggregateFunctions();
+  functions::sparksql::aggregates::registerAggregateFunctions("");
   window::prestosql::registerAllWindowFunctions();
 }
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,6 +32,7 @@ You can add these configuration into spark-defaults.conf to enable or disable th
 | spark.gluten.sql.columnar.shuffle.customizedCompression.codec | Set up the codec to be used for Columnar Shuffle, default is lz4| lz4 |
 | spark.gluten.sql.columnar.numaBinding | Set up NUMABinding, default is false| true |
 | spark.gluten.sql.columnar.coreRange | Set up the core range for NUMABinding, only works when numaBinding set to true. <br /> The setting is based on the number of cores in your system. Use 72 cores as an example. | 0-17,36-53 &#124;18-35,54-71 |
+| spark.gluten.sql.native.bloomFilter | Enable of Disable native runtime bloomfilter | true |
 
 Below is an example for spark-default.conf, if you are using conda to install OAP project.
 

--- a/docs/VeloxNotSupport.md
+++ b/docs/VeloxNotSupport.md
@@ -1,0 +1,28 @@
+This document discribes some corner cases which will throw exception or has different apperance, cannot successfully fallback to vanilla.
+
+# Runtime BloomFilter
+
+Because velox BloomFilter implemention is different with spark, so if the query fallbacks might_contain to velox but offload bloom_filter_agg to velox, it will throw exception.
+
+## example
+
+```sql
+SELECT might_contain(null, null) both_null,
+       might_contain(null, 1L) null_bf,
+       might_contain((SELECT bloom_filter_agg(cast(id as long)) from range(1, 10000)),
+            null) null_value
+```
+
+Will throw exception
+
+```
+Unexpected Bloom filter version number (512)
+java.io.IOException: Unexpected Bloom filter version number (512)
+ at org.apache.spark.util.sketch.BloomFilterImpl.readFrom0(BloomFilterImpl.java:256)
+ at org.apache.spark.util.sketch.BloomFilterImpl.readFrom(BloomFilterImpl.java:265)
+ at org.apache.spark.util.sketch.BloomFilter.readFrom(BloomFilter.java:178)
+```
+
+## Solution
+
+Set the gluten config `spark.gluten.sql.native.bloomFilter=false`, it will fallback to vanilla bloom filter, you can also disable runtime filter by setting spark config `spark.sql.optimizer.runtime.bloomFilter.enabled=false`

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.execution.aggregate._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.sketch.BloomFilter
 
 import java.util
 import scala.collection.mutable.ListBuffer
@@ -820,8 +821,25 @@ abstract class HashAggregateExecBaseTransformer(
             case other =>
               throw new UnsupportedOperationException(s"not currently supported: $other.")
           }
-        case other =>
-          throw new UnsupportedOperationException(s"not currently supported: $other.")
+        case bloom if bloom.getClass.getSimpleName.equals("BloomFilterAggregate") =>
+        // for spark33
+          mode match {
+            case Partial =>
+              val bloom = aggregateFunc.asInstanceOf[TypedImperativeAggregate[BloomFilter]]
+              val aggBufferAttr = bloom.inputAggBufferAttributes
+              for (index <- aggBufferAttr.indices) {
+                val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+                aggregateAttr += attr
+              }
+              res_index += aggBufferAttr.size
+            case Final =>
+              aggregateAttr += aggregateAttributeList(res_index)
+              res_index += 1
+            case other =>
+              throw new UnsupportedOperationException(s"not currently supported: $other.")
+          }
+      case other =>
+        throw new UnsupportedOperationException(s"not currently supported: $other.")
       }
     }
     aggregateAttr.toList

--- a/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
@@ -28,20 +28,21 @@ object AggregateFunctionsBuilder {
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
 
     val substraitAggFuncName =
-      ExpressionMappings.aggregate_functions_map.get(aggregateFunc.getClass)
+      ExpressionMappings.aggregate_functions_map.getOrElse(aggregateFunc.getClass,
+        ExpressionMappings.getAggSigOther(aggregateFunc.prettyName))
     // Check whether Gluten supports this aggregate function
     if (substraitAggFuncName.isEmpty) {
       throw new UnsupportedOperationException(s"not currently supported: $aggregateFunc.")
     }
     // Check whether each backend supports this aggregate function
     if (!BackendsApiManager.getValidatorApiInstance.doAggregateFunctionValidate(
-      substraitAggFuncName.get, aggregateFunc )) {
+      substraitAggFuncName, aggregateFunc )) {
       throw new UnsupportedOperationException(s"not currently supported: $aggregateFunc.")
     }
     ExpressionBuilder.newScalarFunction(
       functionMap,
       ConverterUtils.makeFuncName(
-        substraitAggFuncName.get,
+        substraitAggFuncName,
         aggregateFunc.children.map(child => child.dataType),
         FunctionConfig.REQ))
   }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -31,22 +31,23 @@ object ExpressionConverter extends Logging {
   def replaceWithExpressionTransformer(expr: Expression,
       attributeSeq: Seq[Attribute]): ExpressionTransformer = {
     // Check whether Gluten supports this expression
-    val substraitExprName = ExpressionMappings.scalar_functions_map.get(expr.getClass)
+    val substraitExprName = ExpressionMappings.scalar_functions_map.getOrElse(expr.getClass,
+      ExpressionMappings.getScalarSigOther(expr.prettyName))
     if (substraitExprName.isEmpty) {
       throw new UnsupportedOperationException(s"Not supported: $expr.")
     }
     // Check whether each backend supports this expression
-    if (!BackendsApiManager.getValidatorApiInstance.doExprValidate(substraitExprName.get, expr)) {
+    if (!BackendsApiManager.getValidatorApiInstance.doExprValidate(substraitExprName, expr)) {
       throw new UnsupportedOperationException(s"Not supported: $expr.")
     }
     expr match {
       case c: CreateArray =>
         val children = c.children.map(child =>
           replaceWithExpressionTransformer(child, attributeSeq))
-        new CreateArrayTransformer(substraitExprName.get, children, true, c)
+        new CreateArrayTransformer(substraitExprName, children, true, c)
       case g: GetArrayItem =>
         new GetArrayItemTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(g.left, attributeSeq),
           replaceWithExpressionTransformer(g.right, attributeSeq),
           g.failOnError,
@@ -54,20 +55,20 @@ object ExpressionConverter extends Logging {
       case c: CreateMap =>
         val children = c.children.map(child =>
           replaceWithExpressionTransformer(child, attributeSeq))
-        new CreateMapTransformer(substraitExprName.get, children, c.useStringTypeWhenEmpty, c)
+        new CreateMapTransformer(substraitExprName, children, c.useStringTypeWhenEmpty, c)
       case g: GetMapValue =>
         new GetMapValueTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(g.child, attributeSeq),
           replaceWithExpressionTransformer(g.key, attributeSeq),
           g.failOnError,
           g)
       case e: Explode =>
-        new ExplodeTransformer(substraitExprName.get,
+        new ExplodeTransformer(substraitExprName,
           replaceWithExpressionTransformer(e.child, attributeSeq), e)
       case a: Alias =>
         BackendsApiManager.getSparkPlanExecApiInstance.genAliasTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(a.child, attributeSeq),
           a)
       case a: AttributeReference =>
@@ -89,7 +90,7 @@ object ExpressionConverter extends Logging {
       case l: Literal =>
         new LiteralTransformer(l)
       case f: FromUnixTime =>
-        new FromUnixTimeTransformer(substraitExprName.get,
+        new FromUnixTimeTransformer(substraitExprName,
           replaceWithExpressionTransformer(
             f.sec,
             attributeSeq),
@@ -98,7 +99,7 @@ object ExpressionConverter extends Logging {
             attributeSeq),
           f.timeZoneId, f)
       case d: DateDiff =>
-        new DateDiffTransformer(substraitExprName.get,
+        new DateDiffTransformer(substraitExprName,
           replaceWithExpressionTransformer(
             d.endDate,
             attributeSeq),
@@ -107,21 +108,21 @@ object ExpressionConverter extends Logging {
             attributeSeq),
           d)
       case t: ToUnixTimestamp =>
-        new ToUnixTimestampTransformer(substraitExprName.get,
+        new ToUnixTimestampTransformer(substraitExprName,
           replaceWithExpressionTransformer(t.timeExp, attributeSeq),
           replaceWithExpressionTransformer(t.format, attributeSeq),
           t.timeZoneId,
           t.failOnError,
           t)
       case u: UnixTimestamp =>
-        new UnixTimestampTransformer(substraitExprName.get,
+        new UnixTimestampTransformer(substraitExprName,
           replaceWithExpressionTransformer(u.timeExp, attributeSeq),
           replaceWithExpressionTransformer(u.format, attributeSeq),
           u.timeZoneId,
           u.failOnError,
           u)
       case r: RegExpReplace =>
-        new RegExpReplaceTransformer(substraitExprName.get,
+        new RegExpReplaceTransformer(substraitExprName,
           replaceWithExpressionTransformer(r.subject, attributeSeq),
           replaceWithExpressionTransformer(r.regexp, attributeSeq),
           replaceWithExpressionTransformer(r.rep, attributeSeq),
@@ -204,7 +205,7 @@ object ExpressionConverter extends Logging {
           throw new UnsupportedOperationException(s"not supported yet.")
         }
         new String2TrimExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(t.srcStr, attributeSeq),
           t)
       case l: StringTrimLeft =>
@@ -212,7 +213,7 @@ object ExpressionConverter extends Logging {
           throw new UnsupportedOperationException(s"not supported yet.")
         }
         new String2TrimExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(l.srcStr, attributeSeq),
           l)
       case r: StringTrimRight =>
@@ -220,12 +221,12 @@ object ExpressionConverter extends Logging {
           throw new UnsupportedOperationException(s"not supported yet.")
         }
         new String2TrimExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(r.srcStr, attributeSeq),
           r)
       case m: HashExpression[_] =>
         new HashExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           m.children.map { expr =>
             replaceWithExpressionTransformer(
               expr,
@@ -234,13 +235,13 @@ object ExpressionConverter extends Logging {
           m)
       case complex: ComplexTypeMergingExpression =>
         ComplexTypeMergingExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           complex.children.map(replaceWithExpressionTransformer(_, attributeSeq)),
           complex)
       // Extract date
       case g: GetDateField =>
         new ExtractDateTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(
             g.child,
             attributeSeq),
@@ -248,7 +249,7 @@ object ExpressionConverter extends Logging {
       case getStructField: GetStructField =>
         // Different backends may have different result
         val transformer = BackendsApiManager.getSparkPlanExecApiInstance.
-          genGetStructFieldTransformer(substraitExprName.get,
+          genGetStructFieldTransformer(substraitExprName,
             replaceWithExpressionTransformer(getStructField.child, attributeSeq),
             getStructField.ordinal,
             getStructField)
@@ -257,17 +258,17 @@ object ExpressionConverter extends Logging {
         }
         transformer
       case l: LeafExpression =>
-        LeafExpressionTransformer(substraitExprName.get, l)
+        LeafExpressionTransformer(substraitExprName, l)
       case u: UnaryExpression =>
         UnaryExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(
             u.child,
             attributeSeq),
           u)
       case b: BinaryExpression =>
         BinaryExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(
             b.left,
             attributeSeq),
@@ -277,7 +278,7 @@ object ExpressionConverter extends Logging {
           b)
       case t: TernaryExpression =>
         TernaryExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(
             t.first,
             attributeSeq),
@@ -290,7 +291,7 @@ object ExpressionConverter extends Logging {
           t)
       case q: QuaternaryExpression =>
         QuaternaryExpressionTransformer(
-          substraitExprName.get,
+          substraitExprName,
           replaceWithExpressionTransformer(
             q.first,
             attributeSeq),

--- a/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenValidatorApi.scala
+++ b/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenValidatorApi.scala
@@ -39,11 +39,12 @@ abstract class GlutenValidatorApi extends IValidatorApi {
                   expr: Expression): Boolean = {
     // To handle cast(struct as string) AS col_name expression
     val key = if (substraitExprName.toLowerCase().equals(ExpressionMappings.ALIAS)) {
-      ExpressionMappings.scalar_functions_map.get(expr.asInstanceOf[Alias].child.getClass)
-    } else Some(substraitExprName)
+      ExpressionMappings.scalar_functions_map.getOrElse(expr.asInstanceOf[Alias].child.getClass,
+        ExpressionMappings.getScalarSigOther(expr.asInstanceOf[Alias].child.prettyName))
+    } else substraitExprName
     if (key.isEmpty) return false
     if (blacklist.isEmpty) return true
-    val value = blacklist.get(key.get)
+    val value = blacklist.get(key)
     if (value.isEmpty) {
       return true
     }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenBloomFilterAggregateQuerySuite.scala
@@ -15,15 +15,9 @@
  * limitations under the License.
  */
 
-package io.glutenproject.utils.velox
+package org.apache.spark.sql
 
-import io.glutenproject.utils.BackendTestSettings
+class GlutenBloomFilterAggregateQuerySuite extends BloomFilterAggregateQuerySuite
+  with GlutenSQLTestsTrait {
 
-import org.apache.spark.sql.{GlutenBloomFilterAggregateQuerySuite, GlutenStringFunctionsSuite}
-
-class VeloxTestSettings extends BackendTestSettings {
-  enableSuite[GlutenStringFunctionsSuite]
-  enableSuite[GlutenBloomFilterAggregateQuerySuite]
-    // fallback might_contain, the input argument binary is not same with vanilla spark
-    .exclude("Test NULL inputs for might_contain")
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -176,6 +176,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   val enableColumnarGenerate: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.generate", "true").toBoolean
 
+  val enableNativeBloomFilter: Boolean =
+    conf.getConfString("spark.gluten.sql.native.bloomFilter", "true").toBoolean
+
   val numaBindingInfo: GlutenNumaBindingInfo = {
     val enableNumaBinding: Boolean =
       conf.getConfString("spark.gluten.sql.columnar.numaBinding", "false").toBoolean

--- a/tools/gluten-it/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
+++ b/tools/gluten-it/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
@@ -15,6 +15,8 @@ object Constants {
     .set("spark.sql.parquet.enableVectorizedReader", "true")
     .set("spark.plugins", "io.glutenproject.GlutenPlugin")
     .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+    .set("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")
+    .set("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "0")
 
   val GAZELLE_CPP_BACKEND_CONF: SparkConf = new SparkConf()
     .set("spark.gluten.sql.columnar.backend.lib", "gazelle_cpp")

--- a/tools/gluten-it/src/main/scala/io/glutenproject/integration/tpc/TpcRunner.scala
+++ b/tools/gluten-it/src/main/scala/io/glutenproject/integration/tpc/TpcRunner.scala
@@ -36,6 +36,11 @@ class TpcRunner(val queryResourceFolder: String, val dataPath: String) {
     println(s"Executing SQL query from resource path $path...")
     val sql = TpcRunner.resourceToString(path)
     val prev = System.nanoTime()
+    if (caseId.equals("q8")) {
+      // because q8 fallback might_contain and offload bloomfilter
+      print("set bloomFilter false\n")
+      spark.conf.set("spark.gluten.sql.native.bloomFilter", "false")
+    }
     val df = spark.sql(sql)
     if (explain) {
       df.explain(extended = true)


### PR DESCRIPTION
1. Implement might_contain and bloom_filter_agg, TPCDS performance gain 14% improvement(bloom ON/OFF)
2. Fix splitter prealloc_row_count is inaccurate, caused OOM
3. Fallback CH backend collect_list
4. Add config spark.gluten.sql.native.bloomFilter to let user fix might_contain fallback to vanila spark but bloom_filter_agg offload to gluten
