### PR TITLE
[CI] Disable shared maven cache in Velox CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup docker container
         run: |
-          EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID --detach" NON_INTERACTIVE=ON tools/gluten-te/cbash.sh sleep 14400
+          EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Install Gluten Velox-backend spark3.2 and Run Unit test
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \


### PR DESCRIPTION
We should disable the shared maven cache among the CI docker containers for Velox backend. Otherwise once a build is finished the other builds might be affected by the installed jar.