### PR TITLE
Add docker script for Ubuntu22.04

### DIFF
--- a/docs/developers/docker_ubuntu22.04.md
+++ b/docs/developers/docker_ubuntu22.04.md
@@ -1,0 +1,48 @@
+Here is a docker script we verified to build Gluten+Velox backend on Ubuntu22.04:
+
+Run on host as root user:
+```
+docker pull ubuntu:22.04
+docker run -itd --name gluten ubuntu:22.04 /bin/bash
+docker attach gluten
+```
+
+Run in docker:
+```
+apt-get update
+
+#install gcc and libraries to build arrow
+apt install software-properties-common
+apt install maven build-essential cmake libssl-dev libre2-dev libcurl4-openssl-dev clang lldb lld libz-dev git ninja-build uuid-dev
+
+#velox script needs sudo to install dependency libraries
+apt install sudo
+
+#make sure jdk8 is used. New version of jdk is not supported
+apt install -y openjdk-8-jdk
+apt install -y default-jdk
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+export PATH=$JAVA_HOME/bin:$PATH
+
+#manually install tzdata to avoid the interactive timezone config
+ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+dpkg --configure -a
+
+#setup proxy on necessary
+export http_proxy=xxxx
+export https_proxy=xxxx
+
+#clone gluten
+git clone https://github.com/oap-project/gluten.git
+cd gluten/
+
+#config maven proxy
+#mkdir ~/.m2/
+#apt install vim
+#vim ~/.m2/settings.xml
+
+# the script download velox & arrow and compile all dependency library automatically
+mvn clean package -Pbackends-velox -Pspark-3.2 -Dbuild_velox_from_source=ON -Dbuild_arrow=ON
+
+```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the script to compile gluten + velox in the docker of ubuntu22.04

## How was this patch tested?

Verified to work

