### PR TITLE
(bug#615) Fixing compilation error caused by bridge.h including

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -64,6 +64,8 @@ option(STATIC_ARROW "Build Arrow with Static Libraries" OFF)
 
 include(ConfigArrow)
 
+include_directories(build)
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 

--- a/cpp/src/memory/columnar_batch.h
+++ b/cpp/src/memory/columnar_batch.h
@@ -17,9 +17,9 @@
 
 #include <memory>
 
-#include "releases/include/arrow/c/bridge.h"
 #include "arrow/c/helpers.h"
 #include "arrow/record_batch.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "utils/exception.h"
 
 #pragma once

--- a/cpp/src/memory/columnar_batch.h
+++ b/cpp/src/memory/columnar_batch.h
@@ -17,7 +17,7 @@
 
 #include <memory>
 
-#include "arrow/c/bridge.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "arrow/c/helpers.h"
 #include "arrow/record_batch.h"
 #include "utils/exception.h"

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -28,10 +28,10 @@
 
 #include "ArrowTypeUtils.h"
 #include "releases/include/arrow/c/bridge.h"
-#include "velox/vector/arrow/c/Bridge.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 #include "velox/row/UnsafeRowSerializer.h"
+#include "velox/vector/arrow/c/Bridge.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -27,8 +27,8 @@
 #include <string>
 
 #include "ArrowTypeUtils.h"
-#include "arrow/c/Bridge.h"
-#include "arrow/c/bridge.h"
+#include "releases/include/arrow/c/bridge.h"
+#include "velox/vector/arrow/c/Bridge.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 #include "velox/row/UnsafeRowSerializer.h"

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -23,13 +23,13 @@
 
 #include "ArrowTypeUtils.h"
 #include "RegistrationAllFunctions.cc"
-#include "velox/vector/arrow/c/Bridge.h"
-#include "releases/include/arrow/c/bridge.h"
 #include "bridge.h"
 #include "compute/exec_backend.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/vector/arrow/c/Bridge.h"
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::connector;

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -14,10 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "VeloxPlanConverter.h"
 
-#include <arrow/c/bridge.h>
 #include <arrow/type_fwd.h>
 #include <arrow/util/iterator.h>
 
@@ -25,8 +23,8 @@
 
 #include "ArrowTypeUtils.h"
 #include "RegistrationAllFunctions.cc"
-#include "arrow/c/Bridge.h"
-#include "arrow/c/bridge.h"
+#include "velox/vector/arrow/c/Bridge.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "bridge.h"
 #include "compute/exec_backend.h"
 #include "velox/buffer/Buffer.h"

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -27,10 +27,10 @@
 
 #include "VeloxToRowConverter.h"
 #include "arrow/c/abi.h"
-#include "releases/include/arrow/c/bridge.h"
 #include "compute/exec_backend.h"
 #include "memory/columnar_batch.h"
 #include "memory/velox_memory_pool.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "substrait/algebra.pb.h"
 #include "substrait/capabilities.pb.h"
 #include "substrait/extensions/extensions.pb.h"

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -27,7 +27,7 @@
 
 #include "VeloxToRowConverter.h"
 #include "arrow/c/abi.h"
-#include "arrow/c/bridge.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "compute/exec_backend.h"
 #include "memory/columnar_batch.h"
 #include "memory/velox_memory_pool.h"

--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -22,11 +22,11 @@
 #include <arrow/type_traits.h>
 
 #include "ArrowTypeUtils.h"
-#include "velox/vector/arrow/c/Bridge.h"
-#include "releases/include/arrow/c/bridge.h"
 #include "arrow/c/helpers.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 #include "velox/row/UnsafeRowSerializer.h"
+#include "velox/vector/arrow/c/Bridge.h"
 
 namespace velox {
 namespace compute {

--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -22,8 +22,8 @@
 #include <arrow/type_traits.h>
 
 #include "ArrowTypeUtils.h"
-#include "arrow/c/Bridge.h"
-#include "arrow/c/bridge.h"
+#include "velox/vector/arrow/c/Bridge.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "arrow/c/helpers.h"
 #include "velox/row/UnsafeRowDynamicSerializer.h"
 #include "velox/row/UnsafeRowSerializer.h"

--- a/cpp/velox/compute/bridge.h
+++ b/cpp/velox/compute/bridge.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "arrow/c/bridge.h"
+#include "releases/include/arrow/c/bridge.h"
 #include "arrow/util/iterator.h"
 
 namespace gluten {

--- a/cpp/velox/compute/bridge.h
+++ b/cpp/velox/compute/bridge.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "releases/include/arrow/c/bridge.h"
 #include "arrow/util/iterator.h"
+#include "releases/include/arrow/c/bridge.h"
 
 namespace gluten {
 using ArrowArrayIterator = arrow::Iterator<std::shared_ptr<ArrowArray>>;

--- a/cpp/velox/jni/jni_wrapper.cc
+++ b/cpp/velox/jni/jni_wrapper.cc
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include "releases/include/arrow/c/bridge.h"
 #include <folly/system/ThreadName.h>
 #include <jni.h>
+#include "releases/include/arrow/c/bridge.h"
 
 #include <jni/jni_common.h>
 #include "compute/DwrfDatasource.h"

--- a/cpp/velox/jni/jni_wrapper.cc
+++ b/cpp/velox/jni/jni_wrapper.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <arrow/c/bridge.h>
+#include "releases/include/arrow/c/bridge.h"
 #include <folly/system/ThreadName.h>
 #include <jni.h>
 


### PR DESCRIPTION
there are three `bridge.h` files ignored case sensitivity and may cause compile problem.
so, I fixed this problem by specifying file location

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

