### PR TITLE
[OPPRO-347] Enable caching for Velox data connector

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -31,6 +31,7 @@
 #ifdef VELOX_ENABLE_S3
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 #endif
+#include "velox/common/memory/MmapAllocator.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
@@ -53,14 +54,14 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   // TODO(yuan): move to seperate func initcache()
   auto key = conf.find(kVeloxCacheEnabled);
   if (key != conf.end() && boost::algorithm::to_lower_copy(conf[kVeloxCacheEnabled]) == "true") {
-    uint64_t cacheSize = stol(kVeloxCacheSizeDefault);
-    int32_t cacheShards = stoi(kVeloxCacheShardsDefault);
+    uint64_t cacheSize = std::stol(kVeloxCacheSizeDefault);
+    int32_t cacheShards = std::stoi(kVeloxCacheShardsDefault);
     std::string cachePathPrefix = kVeloxCachePathDefault;
     for (auto& [k, v] : conf) {
       if (k == kVeloxCacheSize)
-        cacheSize = stol(v);
+        cacheSize = std::stol(v);
       if (k == kVeloxCacheShards)
-        cacheShards = stoi(v);
+        cacheShards = std::stoi(v);
       if (k == kVeloxCachePath)
         cachePathPrefix = v;
     }
@@ -69,7 +70,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
     auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
 
-    memory::MmapAllocatorOptions options;
+    memory::MmapAllocator::Options options;
     uint64_t memoryBytes = 20L << 30;
     options.capacity = memoryBytes;
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -55,7 +55,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   if (key != conf.end() && conf[kVeloxCacheEnabled] == "true") {
     uint64_t cacheSize = stol(conf[kVeloxCacheSize]);
     int32_t cacheShards = stoi(conf[kVeloxCacheShards]);
-    std::string cachePath = conf[kVeloxCachePath] + "/cache.";
+    std::string cachePath = conf[kVeloxCachePath] + "/cache." + genUuid();
     cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
     auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -76,7 +76,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
     mappedMemory_ = std::make_shared<cache::AsyncDataCache>(allocator, memoryBytes, std::move(ssd));
 
     // register as default instance, will be used in parquet reader
-    memory::MappedMemory::setDefaultInstance(mappedMemory_.get());
+    memory::MemoryAllocator::setDefaultInstance(mappedMemory_.get());
     VELOX_CHECK_NOT_NULL(dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
     LOG(INFO) << "STARTUP: Using AsyncDataCache";
   }

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -83,7 +83,10 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
     // register as default instance, will be used in parquet reader
     memory::MemoryAllocator::setDefaultInstance(mappedMemory_.get());
     VELOX_CHECK_NOT_NULL(dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
-    LOG(INFO) << "STARTUP: Using AsyncDataCache";
+    LOG(INFO) << "STARTUP: Using AsyncDataCache"
+              << ", cache size: " << cacheSize
+              << ", cache shards: " << cacheShards
+              << ", IO threads: " << ioTHreads;
   }
 
   std::unordered_map<std::string, std::string> configurationValues;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -56,7 +56,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   if (key != conf.end() && boost::algorithm::to_lower_copy(conf[kVeloxCacheEnabled]) == "true") {
     uint64_t cacheSize = std::stol(kVeloxCacheSizeDefault);
     int32_t cacheShards = std::stoi(kVeloxCacheShardsDefault);
-    int32_t ioTHreads = std::stoi(kVeloxIOThreadsDefault);
+    int32_t ioTHreads = std::stoi(kVeloxCacheIOThreadsDefault);
     std::string cachePathPrefix = kVeloxCachePathDefault;
     for (auto& [k, v] : conf) {
       if (k == kVeloxCacheSize)
@@ -65,7 +65,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
         cacheShards = std::stoi(v);
       if (k == kVeloxCachePath)
         cachePathPrefix = v;
-      if (k == kVeloxIOThreads)
+      if (k == kVeloxCacheIOThreads)
         ioTHreads = std::stoi(v);
     }
     std::string cachePath = cachePathPrefix + "/cache." + genUuid();
@@ -84,9 +84,8 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
     memory::MemoryAllocator::setDefaultInstance(mappedMemory_.get());
     VELOX_CHECK_NOT_NULL(dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
     LOG(INFO) << "STARTUP: Using AsyncDataCache"
-              << ", cache size: " << cacheSize
-              << ", cache shards: " << cacheShards
-              << ", IO threads: " << ioTHreads;
+              << ", cache size: " << cacheSize << ", cache shards: " << cacheShards << ", IO threads: " << ioTHreads
+              << ", cache path: " << cachePath;
   }
 
   std::unordered_map<std::string, std::string> configurationValues;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -53,10 +53,11 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   // TODO(yuan): move to seperate func initcache()
   auto key = conf.find(kVeloxCacheEnabled);
   if (key != conf.end() && conf[kVeloxCacheEnabled] == "true") {
-    uint64_t cacheSize = 1 << 30;
-    constexpr int32_t cacheShards = 4;
+    uint64_t cacheSize = stol(conf[kVeloxCacheSize]);
+    int32_t cacheShards = stoi(conf[kVeloxCacheShards]);
+    std::string cachePath = conf[kVeloxCachePath] + "/cache.";
     cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
-    auto ssd = std::make_unique<cache::SsdCache>("/tmp/cache.", cacheSize, cacheShards, cacheExecutor_.get());
+    auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
 
     memory::MmapAllocatorOptions options;
     uint64_t memoryBytes = 20L << 30;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -56,6 +56,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   if (key != conf.end() && boost::algorithm::to_lower_copy(conf[kVeloxCacheEnabled]) == "true") {
     uint64_t cacheSize = std::stol(kVeloxCacheSizeDefault);
     int32_t cacheShards = std::stoi(kVeloxCacheShardsDefault);
+    int32_t ioTHreads = std::stoi(kVeloxIOThreadsDefault);
     std::string cachePathPrefix = kVeloxCachePathDefault;
     for (auto& [k, v] : conf) {
       if (k == kVeloxCacheSize)
@@ -64,10 +65,12 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
         cacheShards = std::stoi(v);
       if (k == kVeloxCachePath)
         cachePathPrefix = v;
+      if (k == kVeloxIOThreads)
+        ioTHreads = std::stoi(v);
     }
     std::string cachePath = cachePathPrefix + "/cache." + genUuid();
     cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
-    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
+    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioTHreads);
     auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
 
     memory::MmapAllocator::Options options;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -52,7 +52,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
 
   // TODO(yuan): move to seperate func initcache()
   auto key = conf.find(kVeloxCacheEnabled);
-  if (key != conf.end() && conf[kVeloxCacheEnabled] == "true") {
+  if (key != conf.end() && boost::algorithm::to_lower_copy(conf[kVeloxCacheEnabled]) == "true") {
     uint64_t cacheSize = stol(kVeloxCacheSizeDefault);
     int32_t cacheShards = stoi(kVeloxCacheShardsDefault);
     std::string cachePathPrefix = kVeloxCachePathDefault;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -66,6 +66,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
     }
     std::string cachePath = cachePathPrefix + "/cache." + genUuid();
     cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
+    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
     auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
 
     memory::MmapAllocatorOptions options;
@@ -141,7 +142,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
 
   auto properties = std::make_shared<const core::MemConfig>(configurationValues);
   auto hiveConnector = getConnectorFactory(connector::hive::HiveConnectorFactory::kHiveConnectorName)
-                           ->newConnector(kHiveConnectorId, properties);
+                           ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
 
   registerConnector(hiveConnector);
   facebook::velox::parquet::registerParquetReaderFactory(ParquetReaderType::NATIVE);

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -50,23 +50,26 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   // Setup and register.
   filesystems::registerLocalFileSystem();
 
-  // TODO(yuan): move to seperate func
-  // TODO(yuan): make these configurable
-  constexpr int32_t kNumSsdShards = 4;
-  uint64_t cacheSize = 1 << 30;
-  cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(kNumSsdShards);
-  auto ssd = std::make_unique<cache::SsdCache>("/tmp/cache.", cacheSize, kNumSsdShards, cacheExecutor_.get());
+  // TODO(yuan): move to seperate func initcache()
+  auto key = conf.find(kVeloxCacheEnabled);
+  if (key != conf.end() && conf[kVeloxCacheEnabled] == "true") {
+    uint64_t cacheSize = 1 << 30;
+    constexpr int32_t cacheShards = 4;
+    cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
+    auto ssd = std::make_unique<cache::SsdCache>("/tmp/cache.", cacheSize, cacheShards, cacheExecutor_.get());
 
-  memory::MmapAllocatorOptions options;
-  uint64_t memoryBytes = 20L << 30;
-  options.capacity = memoryBytes;
-  options.useMmapArena = true;
+    memory::MmapAllocatorOptions options;
+    uint64_t memoryBytes = 20L << 30;
+    options.capacity = memoryBytes;
 
-  auto allocator = std::make_shared<memory::MmapAllocator>(options);
-  mappedMemory_ = std::make_shared<cache::AsyncDataCache>(allocator, memoryBytes, std::move(ssd));
+    auto allocator = std::make_shared<memory::MmapAllocator>(options);
+    mappedMemory_ = std::make_shared<cache::AsyncDataCache>(allocator, memoryBytes, std::move(ssd));
 
-  // register as default instance, used in parquet reader
-  memory::MappedMemory::setDefaultInstance(mappedMemory_.get());
+    // register as default instance, will be used in parquet reader
+    memory::MappedMemory::setDefaultInstance(mappedMemory_.get());
+    VELOX_CHECK_NOT_NULL(dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
+    LOG(INFO) << "STARTUP: Using AsyncDataCache";
+  }
 
   std::unordered_map<std::string, std::string> configurationValues;
 
@@ -127,8 +130,6 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
 #endif
 
   auto properties = std::make_shared<const core::MemConfig>(configurationValues);
-  VELOX_CHECK_NOT_NULL(dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
-  LOG(INFO) << "STARTUP: Using AsyncDataCache";
   auto hiveConnector = getConnectorFactory(connector::hive::HiveConnectorFactory::kHiveConnectorName)
                            ->newConnector(kHiveConnectorId, properties);
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -53,9 +53,18 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   // TODO(yuan): move to seperate func initcache()
   auto key = conf.find(kVeloxCacheEnabled);
   if (key != conf.end() && conf[kVeloxCacheEnabled] == "true") {
-    uint64_t cacheSize = stol(conf[kVeloxCacheSize]);
-    int32_t cacheShards = stoi(conf[kVeloxCacheShards]);
-    std::string cachePath = conf[kVeloxCachePath] + "/cache." + genUuid();
+    uint64_t cacheSize = stol(kVeloxCacheSizeDefault);
+    int32_t cacheShards = stoi(kVeloxCacheShardsDefault);
+    std::string cachePathPrefix = kVeloxCachePathDefault;
+    for (auto& [k, v] : conf) {
+      if (k == kVeloxCacheSize)
+        cacheSize = stol(v);
+      if (k == kVeloxCacheShards)
+        cacheShards = stoi(v);
+      if (k == kVeloxCachePath)
+        cachePathPrefix = v;
+    }
+    std::string cachePath = cachePathPrefix + "/cache." + genUuid();
     cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
     auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -70,7 +70,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
       if (k == kVeloxCacheIOThreads)
         ioTHreads = std::stoi(v);
     }
-    std::string cachePath = cachePathPrefix + "/cache." + genUuid();
+    std::string cachePath = cachePathPrefix + "/cache." + genUuid() + ".";
     cacheExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(cacheShards);
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioTHreads);
     auto ssd = std::make_unique<cache::SsdCache>(cachePath, cacheSize, cacheShards, cacheExecutor_.get());
@@ -95,8 +95,8 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
     memory::MemoryAllocator::setDefaultInstance(mappedMemory_.get());
     VELOX_CHECK_NOT_NULL(dynamic_cast<cache::AsyncDataCache*>(mappedMemory_.get()));
     LOG(INFO) << "STARTUP: Using AsyncDataCache"
-              << ", cache size: " << cacheSize << ", cache shards: " << cacheShards << ", IO threads: " << ioTHreads
-              << ", cache path: " << cachePath;
+              << ", cache prefix: " << cachePath << ", cache size: " << cacheSize << ", cache shards: " << cacheShards
+              << ", cache IO threads: " << ioTHreads;
   }
 
   std::unordered_map<std::string, std::string> configurationValues;

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -45,6 +45,13 @@ class VeloxInitializer {
   std::shared_ptr<facebook::velox::memory::MemoryAllocator> mappedMemory_;
   std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  const std::string kVeloxCacheEnabled = "spark.gluten.sql.columnar.backend.velox.cacheEnabled";
+  const std::string kVeloxCachePath = "spark.gluten.sql.columnar.backend.velox.cachePath";
+  const std::string kVeloxCachePathDefault = "/tmp/";
+  const std::string kVeloxCacheSize = "spark.gluten.sql.columnar.backend.velox.cacheSize";
+  const std::string kVeloxCacheSizeDefault = "1073741824";
+  const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
+  const std::string kVeloxCacheShardsDefault = "1";
 };
 
 // This class is used to convert the Substrait plan into Velox plan.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -52,8 +52,8 @@ class VeloxInitializer {
   const std::string kVeloxCacheSizeDefault = "1073741824";
   const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
   const std::string kVeloxCacheShardsDefault = "1";
-  const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.ioTHreads";
-  const std::string kVeloxIOThreadsDefault = "1";
+  const std::string kVeloxCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.ioTHreads";
+  const std::string kVeloxCacheIOThreadsDefault = "1";
 };
 
 // This class is used to convert the Substrait plan into Velox plan.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -41,7 +41,7 @@ class VeloxInitializer {
     return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
   }
   // Instance of AsyncDataCache used for all large allocations.
-  std::shared_ptr<facebook::velox::memory::MappedMemory> mappedMemory_;
+  std::shared_ptr<facebook::velox::memory::MemoryAllocator> mappedMemory_;
   std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
 };
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <folly/executors/IOThreadPoolExecutor.h>
+
 #include "VeloxColumnarToRowConverter.h"
 #include "WholeStageResultIterator.h"
 #include "compute/Backend.h"
@@ -31,6 +36,10 @@ class VeloxInitializer {
   void Init(std::unordered_map<std::string, std::string> conf);
 
   void InitCache();
+
+  std::string genUuid() {
+    return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+  }
   // Instance of AsyncDataCache used for all large allocations.
   std::shared_ptr<facebook::velox::memory::MappedMemory> mappedMemory_;
   std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -28,8 +28,12 @@ class VeloxInitializer {
   VeloxInitializer(std::unordered_map<std::string, std::string> conf) {
     Init(conf);
   }
-
   void Init(std::unordered_map<std::string, std::string> conf);
+
+  void InitCache();
+  // Instance of AsyncDataCache used for all large allocations.
+  std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
 };
 
 // This class is used to convert the Substrait plan into Velox plan.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -43,6 +43,7 @@ class VeloxInitializer {
   // Instance of AsyncDataCache used for all large allocations.
   std::shared_ptr<facebook::velox::memory::MemoryAllocator> mappedMemory_;
   std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
 };
 
 // This class is used to convert the Substrait plan into Velox plan.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -25,14 +25,14 @@ namespace gluten {
 
 class VeloxInitializer {
  public:
-  VeloxInitializer(std::unordered_map<std::string, std::string> conf) {
+  VeloxInitializer(const std::unordered_map<std::string, std::string>& conf) {
     Init(conf);
   }
   void Init(std::unordered_map<std::string, std::string> conf);
 
   void InitCache();
   // Instance of AsyncDataCache used for all large allocations.
-  std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  std::shared_ptr<facebook::velox::memory::MappedMemory> mappedMemory_;
   std::unique_ptr<folly::IOThreadPoolExecutor> cacheExecutor_;
 };
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -52,6 +52,8 @@ class VeloxInitializer {
   const std::string kVeloxCacheSizeDefault = "1073741824";
   const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
   const std::string kVeloxCacheShardsDefault = "1";
+  const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.ioTHreads";
+  const std::string kVeloxIOThreadsDefault = "1";
 };
 
 // This class is used to convert the Substrait plan into Velox plan.

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -18,8 +18,11 @@ const std::string kFlushRowCount = "flushRowCount";
 const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
 const std::string kVeloxCacheEnabled = "spark.gluten.sql.columnar.backend.velox.cacheEnabled";
 const std::string kVeloxCachePath = "spark.gluten.sql.columnar.backend.velox.cachePath";
+const std::string kVeloxCachePathDefault = "/tmp/";
 const std::string kVeloxCacheSize = "spark.gluten.sql.columnar.backend.velox.cacheSize";
+const std::string kVeloxCacheSizeDefault = "1073741824";
 const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
+const std::string kVeloxCacheShardsDefault = "1";
 std::atomic<int32_t> taskSerial;
 } // namespace
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -16,13 +16,6 @@ const std::string kDynamicFiltersAccepted = "dynamicFiltersAccepted";
 const std::string kReplacedWithDynamicFilterRows = "replacedWithDynamicFilterRows";
 const std::string kFlushRowCount = "flushRowCount";
 const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
-const std::string kVeloxCacheEnabled = "spark.gluten.sql.columnar.backend.velox.cacheEnabled";
-const std::string kVeloxCachePath = "spark.gluten.sql.columnar.backend.velox.cachePath";
-const std::string kVeloxCachePathDefault = "/tmp/";
-const std::string kVeloxCacheSize = "spark.gluten.sql.columnar.backend.velox.cacheSize";
-const std::string kVeloxCacheSizeDefault = "1073741824";
-const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
-const std::string kVeloxCacheShardsDefault = "1";
 std::atomic<int32_t> taskSerial;
 } // namespace
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -16,6 +16,10 @@ const std::string kDynamicFiltersAccepted = "dynamicFiltersAccepted";
 const std::string kReplacedWithDynamicFilterRows = "replacedWithDynamicFilterRows";
 const std::string kFlushRowCount = "flushRowCount";
 const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
+const std::string kVeloxCacheEnabled = "spark.gluten.sql.columnar.backend.velox.cacheEnabled";
+const std::string kVeloxCachePath = "spark.gluten.sql.columnar.backend.velox.cachePath";
+const std::string kVeloxCacheSize = "spark.gluten.sql.columnar.backend.velox.cacheSize";
+const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
 std::atomic<int32_t> taskSerial;
 } // namespace
 

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -6,6 +6,12 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h"
 #include "velox/substrait/SubstraitToVeloxPlan.h"
+#ifdef VELOX_ENABLE_HDFS
+#include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
+#endif
+#ifdef VELOX_ENABLE_S3
+#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#endif
 
 namespace gluten {
 

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -218,14 +218,15 @@ If you are using instance credentials you do not have to set the access key or s
 Note if testing with local S3-like service(Minio/Ceph), users may need to use different values for these configurations. E.g., on Minio setup, the "spark.hadoop.fs.s3a.path.style.access" need to set to "true".
 
 ## 2.6 Local Cache support
-Velox supports local cache when reading data from HDFS/S3. The feature is very useful if the remote storage is slow, e.g., reading from a public S3 repo. With this feature, Velox can asynchronously cache the data when reading from remote storage, and the future reading requests on already cached blocks will be serviced from local cache. To enable the local caching feature, below configurations are required:
+Velox supports local cache when reading data from HDFS/S3. The feature is very useful if remote storage is slow, e.g., reading from a public S3 bucket. With this feature, Velox can asynchronously cache the data on local disk when reading from remote storage, and the future reading requests on already cached blocks will be serviced from local cache files. To enable the local caching feature, below configurations are required:
 ```
 spark.gluten.sql.columnar.backend.velox.cacheEnabled // enable or disable velox cache, default off
 spark.gluten.sql.columnar.backend.velox.cachePath  // the folder to store the cache files, default to /tmp
 spark.gluten.sql.columnar.backend.velox.cacheSize  // the total size of the cache, default to 128MB
 spark.gluten.sql.columnar.backend.velox.cacheShards // the shards of the cache, default to 1
 ```
-It's recommened to mount SSDs to the cache path to get the best performance of local caching.
+It's recommened to mount SSDs to the cache path to get the best performance of local caching. 
+On the start up of Saprk contenxt, the cache files will be allocated under "spark.gluten.sql.columnar.backend.velox.cachePath", with UUID based suffix, e.g. "/tmp/cache.13e8ab65-3af4-46ac-8d28-ff99b2a9ec9b0". Currently Gluten is not able to reuse the cache from last run, and the old cache files are left there after Spark context shutdown.
 
 # 3 Coverage
 

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -215,7 +215,17 @@ spark.hadoop.fs.s3a.use.instance.credentials true
 ```
 If you are using instance credentials you do not have to set the access key or secret key.
 
-Note if testing with local S3-like service(Minio/Ceph), users may need to use different configurations for these configurations. E.g., on Minio setup, the "spark.hadoop.fs.s3a.path.style.access" need to set to "true".
+Note if testing with local S3-like service(Minio/Ceph), users may need to use different values for these configurations. E.g., on Minio setup, the "spark.hadoop.fs.s3a.path.style.access" need to set to "true".
+
+## 2.6 Local Cache support
+Velox supports local cache when reading data from HDFS/S3. The feature is very useful if the remote storage is slow, e.g., reading from a public S3 repo. With this feature, Velox can asynchronously cache the data when reading from remote storage, and the future reading requests on already cached blocks will be serviced from local cache. To enable the local caching feature, below configurations are required:
+```
+spark.gluten.sql.columnar.backend.velox.cacheEnabled // enable or disable velox cache, default off
+spark.gluten.sql.columnar.backend.velox.cachePath  // the folder to store the cache files, default to /tmp
+spark.gluten.sql.columnar.backend.velox.cacheSize  // the total size of the cache, default to 128MB
+spark.gluten.sql.columnar.backend.velox.cacheShards // the shards of the cache, default to 1
+```
+It's recommened to mount SSDs to the cache path to get the best performance of local caching.
 
 # 3 Coverage
 

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -224,7 +224,7 @@ spark.gluten.sql.columnar.backend.velox.cacheEnabled // enable or disable velox 
 spark.gluten.sql.columnar.backend.velox.cachePath  // the folder to store the cache files, default to /tmp
 spark.gluten.sql.columnar.backend.velox.cacheSize  // the total size of the cache, default to 128MB
 spark.gluten.sql.columnar.backend.velox.cacheShards // the shards of the cache, default to 1
-spark.gluten.sql.columnar.backend.velox.ioThreads // the IO threads for cache promoting, default to 1
+spark.gluten.sql.columnar.backend.velox.cacheIOThreads // the IO threads for cache promoting, default to 1
 ```
 It's recommened to mount SSDs to the cache path to get the best performance of local caching. 
 On the start up of Saprk contenxt, the cache files will be allocated under "spark.gluten.sql.columnar.backend.velox.cachePath", with UUID based suffix, e.g. "/tmp/cache.13e8ab65-3af4-46ac-8d28-ff99b2a9ec9b0". Currently Gluten is not able to reuse the cache from last run, and the old cache files are left there after Spark context shutdown.

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -224,6 +224,7 @@ spark.gluten.sql.columnar.backend.velox.cacheEnabled // enable or disable velox 
 spark.gluten.sql.columnar.backend.velox.cachePath  // the folder to store the cache files, default to /tmp
 spark.gluten.sql.columnar.backend.velox.cacheSize  // the total size of the cache, default to 128MB
 spark.gluten.sql.columnar.backend.velox.cacheShards // the shards of the cache, default to 1
+spark.gluten.sql.columnar.backend.velox.ioThreads // the IO threads for cache promoting, default to 1
 ```
 It's recommened to mount SSDs to the cache path to get the best performance of local caching. 
 On the start up of Saprk contenxt, the cache files will be allocated under "spark.gluten.sql.columnar.backend.velox.cachePath", with UUID based suffix, e.g. "/tmp/cache.13e8ab65-3af4-46ac-8d28-ff99b2a9ec9b0". Currently Gluten is not able to reuse the cache from last run, and the old cache files are left there after Spark context shutdown.

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -213,7 +213,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   // The IO threads for cache promoting
   val veloxIOThreads: Integer =
-    conf.getConfString("spark.gluten.sql.columnar.backend.velox.ioThreads", "1").toInt
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheIOThreads", "1").toInt
 
   val transformPlanLogLevel: String =
     conf.getConfString("spark.gluten.sql.transform.logLevel", "DEBUG")

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -205,7 +205,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   // The total cache size
   val veloxCacheSize: Long =
-    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheSize", "134217728").toLong
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheSize", "1073741824").toLong
 
   // The cache shards
   val veloxCacheShards: Integer =

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -194,6 +194,23 @@ class GlutenConfig(conf: SQLConf) extends Logging {
     }
   }
 
+  // velox caching options
+  // enable Velox cache, default off
+  val enableVeloxCache: Boolean =
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheEnabled", "false").toBoolean
+
+  // The folder to store the cache files, better on SSD
+  val veloxCachePath: String =
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cachePath", "/tmp")
+
+  // The total cache size
+  val veloxCacheSize: Integer =
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheSize", "134217728").toInt
+
+  // The cache shards
+  val veloxCacheShards: Integer =
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheShards", "1").toInt
+
   val transformPlanLogLevel: String =
     conf.getConfString("spark.gluten.sql.transform.logLevel", "DEBUG")
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -211,6 +211,10 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   val veloxCacheShards: Integer =
     conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheShards", "1").toInt
 
+  // The IO threads for cache promoting
+  val veloxIOThreads: Integer =
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.ioThreads", "1").toInt
+
   val transformPlanLogLevel: String =
     conf.getConfString("spark.gluten.sql.transform.logLevel", "DEBUG")
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -204,8 +204,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
     conf.getConfString("spark.gluten.sql.columnar.backend.velox.cachePath", "/tmp")
 
   // The total cache size
-  val veloxCacheSize: Integer =
-    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheSize", "134217728").toInt
+  val veloxCacheSize: Long =
+    conf.getConfString("spark.gluten.sql.columnar.backend.velox.cacheSize", "134217728").toLong
 
   // The cache shards
   val veloxCacheShards: Integer =


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch enables the caching feature for Velox. Cache file(s) will be generated on Spark context initialization, based on the configurations, velox will asynchronously caching the contents when reading from hdfs/s3.  The feature should be helpful if reading from slow/remote storage. 

Below configurations are added:
```
    spark.gluten.sql.columnar.backend.velox.cacheEnabled // enable or disable velox cache, default off
    spark.gluten.sql.columnar.backend.velox.cachePath  // the folder to store the cache files, default to /tmp
    spark.gluten.sql.columnar.backend.velox.cacheSize  // the total size of the cache, default to 1GB
    spark.gluten.sql.columnar.backend.velox.cacheShards // the shards of the cache, default to 1
    spark.gluten.sql.columnar.backend.velox.cacheIOThreads // the threads for cache promoting, default to 1

```
Note the current patch does not reuse the cache from last run - a new cache file will be generated for each new spark-context.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## How was this patch tested?

manually test
