### PR TITLE
Refactor cpp module according to the team discussion

### DIFF
--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -49,13 +49,12 @@ ArrowExecBackend::~ArrowExecBackend() {
 #endif
 }
 
-std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterator(
-    gluten::memory::MemoryAllocator* allocator) {
+std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterator(gluten::MemoryAllocator* allocator) {
   return GetResultIterator(allocator, {});
 }
 
 std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterator(
-    gluten::memory::MemoryAllocator* allocator,
+    gluten::MemoryAllocator* allocator,
     std::vector<std::shared_ptr<gluten::GlutenResultIterator>> inputs) {
   GLUTEN_ASSIGN_OR_THROW(auto decls, arrow::engine::ConvertPlan(plan_));
   if (decls.size() != 1) {
@@ -364,7 +363,7 @@ std::shared_ptr<gluten::ColumnarBatch> ArrowExecResultIterator::Next() {
     std::unique_ptr<ArrowSchema> c_schema = std::make_unique<ArrowSchema>();
     std::unique_ptr<ArrowArray> c_array = std::make_unique<ArrowArray>();
     GLUTEN_THROW_NOT_OK(arrow::ExportRecordBatch(*batch, c_array.get(), c_schema.get()));
-    return std::make_shared<gluten::memory::GlutenArrowCStructColumnarBatch>(std::move(c_schema), std::move(c_array));
+    return std::make_shared<gluten::ArrowCStructColumnarBatch>(std::move(c_schema), std::move(c_array));
   }
   return nullptr;
 }

--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -303,7 +303,7 @@ void ArrowExecBackend::ReplaceSourceDecls(std::vector<arrow::compute::Declaratio
   }
 }
 
-std::shared_ptr<gluten::memory::GlutenColumnarBatch> ArrowExecResultIterator::Next() {
+std::shared_ptr<gluten::ColumnarBatch> ArrowExecResultIterator::Next() {
   GLUTEN_ASSIGN_OR_THROW(auto exec_batch, iter_.Next());
   if (exec_batch.has_value()) {
     cur_ = std::move(exec_batch.value());

--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -27,8 +27,7 @@
 
 #include "compute/exec_backend.h"
 
-namespace gazellecpp {
-namespace compute {
+namespace gluten {
 
 const arrow::FieldVector kAugmentedFields{
     field("__fragment_index", arrow::int32()),
@@ -50,8 +49,8 @@ ArrowExecBackend::~ArrowExecBackend() {
 #endif
 }
 
-std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterator(
-    gluten::memory::MemoryAllocator* allocator) {
+std::shared_ptr<gluten::GlutenResultIterator>
+ArrowExecBackend::GetResultIterator(gluten::memory::MemoryAllocator* allocator) {
   return GetResultIterator(allocator, {});
 }
 
@@ -81,7 +80,8 @@ std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterato
           },
           std::move(*inputs[i]->ToArrowArrayIterator()));
       GLUTEN_ASSIGN_OR_THROW(
-          auto gen, arrow::MakeBackgroundGenerator(std::move(batch_it), arrow::internal::GetCpuThreadPool()));
+          auto gen,
+          arrow::MakeBackgroundGenerator(std::move(batch_it), arrow::internal::GetCpuThreadPool()));
       source_decls.emplace_back("source", arrow::compute::SourceNodeOptions{schema, std::move(gen)});
     }
     ReplaceSourceDecls(std::move(source_decls));
@@ -112,8 +112,11 @@ std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterato
   // Add sink node. It's added after constructing plan from decls because sink
   // node doesn't have output schema.
   arrow::AsyncGenerator<arrow::util::optional<arrow::compute::ExecBatch>> sink_gen;
-  GLUTEN_THROW_NOT_OK(
-      arrow::compute::MakeExecNode("sink", exec_plan_.get(), {node}, arrow::compute::SinkNodeOptions{&sink_gen}));
+  GLUTEN_THROW_NOT_OK(arrow::compute::MakeExecNode(
+      "sink",
+      exec_plan_.get(),
+      {node},
+      arrow::compute::SinkNodeOptions{&sink_gen}));
 
   GLUTEN_THROW_NOT_OK(exec_plan_->Validate());
   GLUTEN_THROW_NOT_OK(exec_plan_->StartProducing());
@@ -147,8 +150,8 @@ void ArrowExecBackend::PushDownFilter() {
       if (input_decl.factory_name == "filter" && input_decl.inputs.size() == 1) {
         auto scan_decl = arrow::util::get<arrow::compute::Declaration>(input_decl.inputs[0]);
         if (scan_decl.factory_name == "scan") {
-          auto expression = arrow::internal::checked_pointer_cast<arrow::compute::FilterNodeOptions>(input_decl.options)
-                                ->filter_expression;
+          auto expression =
+              arrow::internal::checked_pointer_cast<arrow::compute::FilterNodeOptions>(input_decl.options)->filter_expression;
           auto scan_options = arrow::internal::checked_pointer_cast<arrow::dataset::ScanNodeOptions>(scan_decl.options);
           const auto& schema = scan_options->dataset->schema();
           FieldPathToName(&expression, schema);
@@ -370,7 +373,7 @@ std::shared_ptr<gluten::memory::GlutenColumnarBatch> ArrowExecResultIterator::Ne
   return nullptr;
 }
 
-void Initialize() {
+void GazelleInitialize() {
   static auto function_registry = arrow::compute::GetFunctionRegistry();
   static auto extension_registry = arrow::engine::default_extension_id_registry();
   if (function_registry && extension_registry) {
@@ -382,5 +385,4 @@ void Initialize() {
   }
 }
 
-} // namespace compute
 } // namespace gazellecpp

--- a/cpp/gazelle-cpp/compute/substrait_arrow.cc
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.cc
@@ -49,8 +49,8 @@ ArrowExecBackend::~ArrowExecBackend() {
 #endif
 }
 
-std::shared_ptr<gluten::GlutenResultIterator>
-ArrowExecBackend::GetResultIterator(gluten::memory::MemoryAllocator* allocator) {
+std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterator(
+    gluten::memory::MemoryAllocator* allocator) {
   return GetResultIterator(allocator, {});
 }
 
@@ -80,8 +80,7 @@ std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterato
           },
           std::move(*inputs[i]->ToArrowArrayIterator()));
       GLUTEN_ASSIGN_OR_THROW(
-          auto gen,
-          arrow::MakeBackgroundGenerator(std::move(batch_it), arrow::internal::GetCpuThreadPool()));
+          auto gen, arrow::MakeBackgroundGenerator(std::move(batch_it), arrow::internal::GetCpuThreadPool()));
       source_decls.emplace_back("source", arrow::compute::SourceNodeOptions{schema, std::move(gen)});
     }
     ReplaceSourceDecls(std::move(source_decls));
@@ -112,11 +111,8 @@ std::shared_ptr<gluten::GlutenResultIterator> ArrowExecBackend::GetResultIterato
   // Add sink node. It's added after constructing plan from decls because sink
   // node doesn't have output schema.
   arrow::AsyncGenerator<arrow::util::optional<arrow::compute::ExecBatch>> sink_gen;
-  GLUTEN_THROW_NOT_OK(arrow::compute::MakeExecNode(
-      "sink",
-      exec_plan_.get(),
-      {node},
-      arrow::compute::SinkNodeOptions{&sink_gen}));
+  GLUTEN_THROW_NOT_OK(
+      arrow::compute::MakeExecNode("sink", exec_plan_.get(), {node}, arrow::compute::SinkNodeOptions{&sink_gen}));
 
   GLUTEN_THROW_NOT_OK(exec_plan_->Validate());
   GLUTEN_THROW_NOT_OK(exec_plan_->StartProducing());
@@ -150,8 +146,8 @@ void ArrowExecBackend::PushDownFilter() {
       if (input_decl.factory_name == "filter" && input_decl.inputs.size() == 1) {
         auto scan_decl = arrow::util::get<arrow::compute::Declaration>(input_decl.inputs[0]);
         if (scan_decl.factory_name == "scan") {
-          auto expression =
-              arrow::internal::checked_pointer_cast<arrow::compute::FilterNodeOptions>(input_decl.options)->filter_expression;
+          auto expression = arrow::internal::checked_pointer_cast<arrow::compute::FilterNodeOptions>(input_decl.options)
+                                ->filter_expression;
           auto scan_options = arrow::internal::checked_pointer_cast<arrow::dataset::ScanNodeOptions>(scan_decl.options);
           const auto& schema = scan_options->dataset->schema();
           FieldPathToName(&expression, schema);
@@ -385,4 +381,4 @@ void GazelleInitialize() {
   }
 }
 
-} // namespace gazellecpp
+} // namespace gluten

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -31,10 +31,10 @@ class ArrowExecBackend : public Backend {
 
   ~ArrowExecBackend() override;
 
-  std::shared_ptr<gluten::GlutenResultIterator> GetResultIterator(gluten::memory::MemoryAllocator* allocator) override;
+  std::shared_ptr<gluten::GlutenResultIterator> GetResultIterator(gluten::MemoryAllocator* allocator) override;
 
   std::shared_ptr<gluten::GlutenResultIterator> GetResultIterator(
-      gluten::memory::MemoryAllocator* allocator,
+      gluten::MemoryAllocator* allocator,
       std::vector<std::shared_ptr<gluten::GlutenResultIterator>> inputs) override;
 
   std::shared_ptr<arrow::Schema> GetOutputSchema() override;
@@ -98,12 +98,10 @@ class ArrowExecBackend : public Backend {
 class ArrowExecResultIterator {
  public:
   ArrowExecResultIterator(
-      gluten::memory::MemoryAllocator* allocator,
+      gluten::MemoryAllocator* allocator,
       std::shared_ptr<arrow::Schema> schema,
       arrow::Iterator<nonstd::optional<arrow::compute::ExecBatch>> iter)
-      : memory_pool_(gluten::memory::AsWrappedArrowMemoryPool(allocator)),
-        schema_(std::move(schema)),
-        iter_(std::move(iter)) {}
+      : memory_pool_(gluten::AsWrappedArrowMemoryPool(allocator)), schema_(std::move(schema)), iter_(std::move(iter)) {}
 
   std::shared_ptr<gluten::ColumnarBatch> Next();
 

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -105,7 +105,7 @@ class ArrowExecResultIterator {
         schema_(std::move(schema)),
         iter_(std::move(iter)) {}
 
-  std::shared_ptr<gluten::memory::GlutenColumnarBatch> Next();
+  std::shared_ptr<gluten::ColumnarBatch> Next();
 
  private:
   std::shared_ptr<arrow::MemoryPool> memory_pool_;

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -26,7 +26,7 @@
 namespace gazellecpp {
 namespace compute {
 
-class ArrowExecBackend : public gluten::ExecBackend {
+class ArrowExecBackend : public Backend {
  public:
   ArrowExecBackend();
 

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -97,10 +97,13 @@ class ArrowExecBackend : public Backend {
 
 class ArrowExecResultIterator {
  public:
-  ArrowExecResultIterator(gluten::memory::MemoryAllocator* allocator, std::shared_ptr<arrow::Schema> schema,
+  ArrowExecResultIterator(
+      gluten::memory::MemoryAllocator* allocator,
+      std::shared_ptr<arrow::Schema> schema,
       arrow::Iterator<nonstd::optional<arrow::compute::ExecBatch>> iter)
-      : memory_pool_(gluten::memory::AsWrappedArrowMemoryPool(allocator)), 
-      schema_(std::move(schema)), iter_(std::move(iter)) {}
+      : memory_pool_(gluten::memory::AsWrappedArrowMemoryPool(allocator)),
+        schema_(std::move(schema)),
+        iter_(std::move(iter)) {}
 
   std::shared_ptr<gluten::memory::GlutenColumnarBatch> Next();
 

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -23,8 +23,7 @@
 
 #include <utility>
 
-namespace gazellecpp {
-namespace compute {
+namespace gluten {
 
 class ArrowExecBackend : public Backend {
  public:
@@ -88,20 +87,20 @@ class ArrowExecBackend : public Backend {
 
   // This method is used to get the input schema in InputRel.
   arrow::Status GetIterInputSchemaFromRel(const ::substrait::Rel& srel);
+
   void ReplaceSourceDecls(std::vector<arrow::compute::Declaration> source_decls);
+
   void PushDownFilter();
+
   static void FieldPathToName(arrow::compute::Expression* expression, const std::shared_ptr<arrow::Schema>& schema);
 };
 
 class ArrowExecResultIterator {
  public:
-  ArrowExecResultIterator(
-      gluten::memory::MemoryAllocator* allocator,
-      std::shared_ptr<arrow::Schema> schema,
+  ArrowExecResultIterator(gluten::memory::MemoryAllocator* allocator, std::shared_ptr<arrow::Schema> schema,
       arrow::Iterator<nonstd::optional<arrow::compute::ExecBatch>> iter)
-      : memory_pool_(gluten::memory::AsWrappedArrowMemoryPool(allocator)),
-        schema_(std::move(schema)),
-        iter_(std::move(iter)) {}
+      : memory_pool_(gluten::memory::AsWrappedArrowMemoryPool(allocator)), 
+      schema_(std::move(schema)), iter_(std::move(iter)) {}
 
   std::shared_ptr<gluten::memory::GlutenColumnarBatch> Next();
 
@@ -112,7 +111,6 @@ class ArrowExecResultIterator {
   arrow::compute::ExecBatch cur_;
 };
 
-void Initialize();
+void GazelleInitialize();
 
-} // namespace compute
-} // namespace gazellecpp
+} // namespace gluten

--- a/cpp/gazelle-cpp/compute/substrait_arrow.h
+++ b/cpp/gazelle-cpp/compute/substrait_arrow.h
@@ -26,7 +26,7 @@
 namespace gazellecpp {
 namespace compute {
 
-class ArrowExecBackend : public gluten::ExecBackendBase {
+class ArrowExecBackend : public gluten::ExecBackend {
  public:
   ArrowExecBackend();
 

--- a/cpp/gazelle-cpp/jni/jni_wrapper.cc
+++ b/cpp/gazelle-cpp/jni/jni_wrapper.cc
@@ -44,7 +44,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 JNIEXPORT void JNICALL
 Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv* env, jobject obj) {
   JNI_METHOD_START
-  GazelleInitialize();
+  gluten::GazelleInitialize();
   gluten::SetBackendFactory([] { return std::make_shared<gluten::ArrowExecBackend>(); });
   JNI_METHOD_END()
 }

--- a/cpp/gazelle-cpp/jni/jni_wrapper.cc
+++ b/cpp/gazelle-cpp/jni/jni_wrapper.cc
@@ -44,15 +44,14 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 JNIEXPORT void JNICALL
 Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv* env, jobject obj) {
   JNI_METHOD_START
-  gazellecpp::compute::Initialize();
-  gluten::SetBackendFactory([] { return std::make_shared<gazellecpp::compute::ArrowExecBackend>(); });
+  GazelleInitialize();
+  gluten::SetBackendFactory([] { return std::make_shared<gluten::ArrowExecBackend>(); });
   JNI_METHOD_END()
 }
 
-JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
-    JNIEnv* env,
-    jobject obj,
-    jbyteArray planArray) {
+JNIEXPORT jboolean JNICALL
+Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
+    JNIEnv* env, jobject obj, jbyteArray planArray) {
   JNI_METHOD_START
   auto data = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
   auto size = env->GetArrayLength(planArray);

--- a/cpp/gazelle-cpp/jni/jni_wrapper.cc
+++ b/cpp/gazelle-cpp/jni/jni_wrapper.cc
@@ -49,9 +49,10 @@ Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(
   JNI_METHOD_END()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
-    JNIEnv* env, jobject obj, jbyteArray planArray) {
+JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
+    JNIEnv* env,
+    jobject obj,
+    jbyteArray planArray) {
   JNI_METHOD_START
   auto data = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
   auto size = env->GetArrayLength(planArray);

--- a/cpp/gazelle-cpp/tests/test_substrait.cc
+++ b/cpp/gazelle-cpp/tests/test_substrait.cc
@@ -30,8 +30,8 @@
 class TestSubstrait : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
-    gazellecpp::compute::Initialize();
-    gluten::SetBackendFactory([] { return std::make_shared<gazellecpp::compute::ArrowExecBackend>(); });
+    GazelleInitialize();
+    gluten::SetBackendFactory([] { return std::make_shared<gluten::ArrowExecBackend>(); });
     // setenv("MEMKIND_HBW_NODES", "0", 1);
   }
 

--- a/cpp/src/benchmarks/compression_benchmark.cc
+++ b/cpp/src/benchmarks/compression_benchmark.cc
@@ -345,7 +345,7 @@ int main(int argc, char** argv) {
   std::cout << "threads = " << threads << std::endl;
   std::cout << "datafile = " << datafile << std::endl;
 
-  sparkcolumnarplugin::shuffle::BenchmarkCompression_IterateScan_Benchmark bck(datafile, split_buffer_size);
+  gluten::BenchmarkCompression_IterateScan_Benchmark bck(datafile, split_buffer_size);
 
   benchmark::RegisterBenchmark("BenchmarkCompression::IterateScan", bck)
       ->Iterations(iterations)

--- a/cpp/src/benchmarks/compression_benchmark.cc
+++ b/cpp/src/benchmarks/compression_benchmark.cc
@@ -231,15 +231,29 @@ class BenchmarkCompression {
     auto total_time = (end_time - start_time).count();
 
     state.counters["rowgroups"] = benchmark::Counter(
-        row_group_indices.size(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
-    state.counters["columns"] =
-        benchmark::Counter(column_indices.size(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
-    state.counters["batches"] =
-        benchmark::Counter(num_batches, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
-    state.counters["num_rows"] =
-        benchmark::Counter(num_rows, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
-    state.counters["batch_buffer_size"] =
-        benchmark::Counter(split_buffer_size, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
+        row_group_indices.size(),
+        benchmark::Counter::kAvgThreads,
+        benchmark::Counter::OneK::kIs1000);
+
+    state.counters["columns"] = benchmark::Counter(
+        column_indices.size(),
+        benchmark::Counter::kAvgThreads,
+        benchmark::Counter::OneK::kIs1000);
+
+    state.counters["batches"] = benchmark::Counter(
+        num_batches,
+        benchmark::Counter::kAvgThreads,
+        benchmark::Counter::OneK::kIs1000);
+
+    state.counters["num_rows"] = benchmark::Counter(
+        num_rows,
+        benchmark::Counter::kAvgThreads,
+        benchmark::Counter::OneK::kIs1000);
+
+    state.counters["batch_buffer_size"] = benchmark::Counter(
+        split_buffer_size,
+        benchmark::Counter::kAvgThreads,
+        benchmark::Counter::OneK::kIs1024);
 
     state.counters["parquet_parse"] =
         benchmark::Counter(elapse_read, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
@@ -306,8 +320,8 @@ class BenchmarkCompression_IterateScan_Benchmark : public BenchmarkCompression {
         }
         auto payload = std::make_shared<arrow::ipc::IpcPayload>();
 
-        TIME_NANO_OR_THROW(
-            compress_time, arrow::ipc::GetRecordBatchPayload(*record_batch, ipc_write_options, payload.get()));
+        TIME_NANO_OR_THROW(compress_time,
+            arrow::ipc::GetRecordBatchPayload(*record_batch, ipc_write_options, payload.get()));
         std::cout << "Compressed " << num_batches << " batches" << std::endl;
         TIME_NANO_OR_THROW(elapse_read, record_batch_reader->ReadNext(&record_batch));
       }

--- a/cpp/src/benchmarks/compression_benchmark.cc
+++ b/cpp/src/benchmarks/compression_benchmark.cc
@@ -49,11 +49,10 @@ void print_trace(void) {
 using arrow::RecordBatchReader;
 using arrow::Status;
 using gluten::GlutenException;
-using gluten::shuffle::SplitOptions;
-using gluten::shuffle::Splitter;
+using gluten::SplitOptions;
+using gluten::Splitter;
 
-namespace sparkcolumnarplugin {
-namespace shuffle {
+namespace gluten {
 
 #define ALIGNMENT 2 * 1024 * 1024
 
@@ -319,8 +318,7 @@ class BenchmarkCompression_IterateScan_Benchmark : public BenchmarkCompression {
   }
 };
 
-} // namespace shuffle
-} // namespace sparkcolumnarplugin
+} // namespace gluten
 
 int main(int argc, char** argv) {
   uint32_t iterations = 1;

--- a/cpp/src/benchmarks/compression_benchmark.cc
+++ b/cpp/src/benchmarks/compression_benchmark.cc
@@ -231,29 +231,19 @@ class BenchmarkCompression {
     auto total_time = (end_time - start_time).count();
 
     state.counters["rowgroups"] = benchmark::Counter(
-        row_group_indices.size(),
-        benchmark::Counter::kAvgThreads,
-        benchmark::Counter::OneK::kIs1000);
+        row_group_indices.size(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
 
-    state.counters["columns"] = benchmark::Counter(
-        column_indices.size(),
-        benchmark::Counter::kAvgThreads,
-        benchmark::Counter::OneK::kIs1000);
+    state.counters["columns"] =
+        benchmark::Counter(column_indices.size(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
 
-    state.counters["batches"] = benchmark::Counter(
-        num_batches,
-        benchmark::Counter::kAvgThreads,
-        benchmark::Counter::OneK::kIs1000);
+    state.counters["batches"] =
+        benchmark::Counter(num_batches, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
 
-    state.counters["num_rows"] = benchmark::Counter(
-        num_rows,
-        benchmark::Counter::kAvgThreads,
-        benchmark::Counter::OneK::kIs1000);
+    state.counters["num_rows"] =
+        benchmark::Counter(num_rows, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
 
-    state.counters["batch_buffer_size"] = benchmark::Counter(
-        split_buffer_size,
-        benchmark::Counter::kAvgThreads,
-        benchmark::Counter::OneK::kIs1024);
+    state.counters["batch_buffer_size"] =
+        benchmark::Counter(split_buffer_size, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
 
     state.counters["parquet_parse"] =
         benchmark::Counter(elapse_read, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
@@ -320,8 +310,8 @@ class BenchmarkCompression_IterateScan_Benchmark : public BenchmarkCompression {
         }
         auto payload = std::make_shared<arrow::ipc::IpcPayload>();
 
-        TIME_NANO_OR_THROW(compress_time,
-            arrow::ipc::GetRecordBatchPayload(*record_batch, ipc_write_options, payload.get()));
+        TIME_NANO_OR_THROW(
+            compress_time, arrow::ipc::GetRecordBatchPayload(*record_batch, ipc_write_options, payload.get()));
         std::cout << "Compressed " << num_batches << " batches" << std::endl;
         TIME_NANO_OR_THROW(elapse_read, record_batch_reader->ReadNext(&record_batch));
       }

--- a/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -479,7 +479,7 @@ int main(int argc, char** argv) {
 
   */
 
-  sparkcolumnarplugin::shuffle::BenchmarkShuffleSplit_IterateScan_Benchmark bck(datafile);
+  gluten::BenchmarkShuffleSplit_IterateScan_Benchmark bck(datafile);
 
   benchmark::RegisterBenchmark("BenchmarkShuffleSplit::IterateScan", bck)
       ->Iterations(iterations)

--- a/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -48,12 +48,12 @@ void print_trace(void) {
 
 using arrow::RecordBatchReader;
 using arrow::Status;
-using gluten::GlutenException;
-using gluten::shuffle::SplitOptions;
-using gluten::shuffle::Splitter;
 
-namespace sparkcolumnarplugin {
-namespace shuffle {
+using gluten::GlutenException;
+using gluten::SplitOptions;
+using gluten::Splitter;
+
+namespace gluten {
 
 #define ALIGNMENT 2 * 1024 * 1024
 
@@ -438,8 +438,7 @@ class BenchmarkShuffleSplit_IterateScan_Benchmark : public BenchmarkShuffleSplit
   }
 };
 
-} // namespace shuffle
-} // namespace sparkcolumnarplugin
+} // namespace gluten
 
 int main(int argc, char** argv) {
   uint32_t iterations = 1;

--- a/cpp/src/benchmarks/shuffle_split_benchmark.cc
+++ b/cpp/src/benchmarks/shuffle_split_benchmark.cc
@@ -295,6 +295,7 @@ class BenchmarkShuffleSplit {
     CPU_SET(cpuindex, &cs);
     return sched_setaffinity(0, sizeof(cs), &cs);
   }
+
   virtual void Do_Split(
       std::shared_ptr<Splitter>& splitter,
       int64_t& elapse_read,

--- a/cpp/src/compute/exec_backend.cc
+++ b/cpp/src/compute/exec_backend.cc
@@ -22,16 +22,17 @@
 
 namespace gluten {
 
-static std::function<std::shared_ptr<ExecBackendBase>()> backend_factory;
+static std::function<std::shared_ptr<ExecBackend>()> backend_factory;
 
-void SetBackendFactory(std::function<std::shared_ptr<ExecBackendBase>()> factory) {
+void SetBackendFactory(
+    std::function<std::shared_ptr<ExecBackend>()> factory) {
 #ifdef GLUTEN_PRINT_DEBUG
   std::cout << "Set backend factory." << std::endl;
 #endif
   backend_factory = std::move(factory);
 }
 
-std::shared_ptr<ExecBackendBase> CreateBackend() {
+std::shared_ptr<ExecBackend> CreateBackend() {
   if (backend_factory == nullptr) {
     throw std::runtime_error(
         "Execution backend not set. This may due to the backend library not loaded, or SetBackendFactory() is not called in nativeInitNative() JNI call.");

--- a/cpp/src/compute/exec_backend.h
+++ b/cpp/src/compute/exec_backend.h
@@ -35,8 +35,11 @@
 #endif
 
 namespace gluten {
+
 using ArrowArrayIterator = arrow::Iterator<std::shared_ptr<ArrowArray>>;
-using GlutenIterator = arrow::Iterator<std::shared_ptr<memory::GlutenColumnarBatch>>;
+using GlutenIterator =
+    arrow::Iterator<std::shared_ptr<memory::GlutenColumnarBatch>>;
+
 class GlutenResultIterator;
 
 template <typename T>

--- a/cpp/src/compute/exec_backend_test.cc
+++ b/cpp/src/compute/exec_backend_test.cc
@@ -24,8 +24,7 @@ namespace gluten {
 
 class DummyBackend : public Backend {
  public:
-  std::shared_ptr<GlutenResultIterator> GetResultIterator(
-      MemoryAllocator* allocator) override {
+  std::shared_ptr<GlutenResultIterator> GetResultIterator(MemoryAllocator* allocator) override {
     auto res_iter = std::make_shared<ResultIterator>();
     return std::make_shared<GlutenResultIterator>(std::move(res_iter));
   }
@@ -53,12 +52,12 @@ class DummyBackend : public Backend {
 
       RETURN_NOT_OK(builder->Append(1000));
       RETURN_NOT_OK(builder->Finish(&array));
-      std::vector<std::shared_ptr<arrow::Field>> ret_types = { arrow::field("res", arrow::float64())};
+      std::vector<std::shared_ptr<arrow::Field>> ret_types = {arrow::field("res", arrow::float64())};
       auto batch = arrow::RecordBatch::Make(arrow::schema(ret_types), 1, {array});
       std::unique_ptr<ArrowSchema> cSchema = std::make_unique<ArrowSchema>();
       std::unique_ptr<ArrowArray> cArray = std::make_unique<ArrowArray>();
-      GLUTEN_THROW_NOT_OK( arrow::ExportRecordBatch(*batch, cArray.get(), cSchema.get()));
-      return std::make_shared<ArrowCStructColumnarBatch>( std::move(cSchema), std::move(cArray));
+      GLUTEN_THROW_NOT_OK(arrow::ExportRecordBatch(*batch, cArray.get(), cSchema.get()));
+      return std::make_shared<ArrowCStructColumnarBatch>(std::move(cSchema), std::move(cArray));
     }
 
    private:

--- a/cpp/src/compute/exec_backend_test.cc
+++ b/cpp/src/compute/exec_backend_test.cc
@@ -21,7 +21,7 @@
 #include <gtest/gtest.h>
 namespace gluten {
 
-class DummyBackend : public ExecBackendBase {
+class DummyBackend : public ExecBackend {
  public:
   std::shared_ptr<GlutenResultIterator> GetResultIterator(gluten::memory::MemoryAllocator* allocator) override {
     auto res_iter = std::make_shared<ResultIterator>();

--- a/cpp/src/compute/protobuf_utils.h
+++ b/cpp/src/compute/protobuf_utils.h
@@ -34,6 +34,10 @@ bool ParseProtobuf(const uint8_t* buf, int bufLen, google::protobuf::Message* ms
 arrow::Result<std::shared_ptr<arrow::Buffer>> SubstraitFromJSON(
     arrow::util::string_view type_name,
     arrow::util::string_view json);
-arrow::Result<std::string> SubstraitToJSON(arrow::util::string_view type_name, const arrow::Buffer& buf);
+
+arrow::Result<std::string> SubstraitToJSON(
+    arrow::util::string_view type_name,
+    const arrow::Buffer& buf);
+
 // Write a Protobuf message into a specified file with JSON format.
 void MessageToJSONFile(const google::protobuf::Message& message, const std::string& file_path);

--- a/cpp/src/compute/protobuf_utils.h
+++ b/cpp/src/compute/protobuf_utils.h
@@ -35,9 +35,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> SubstraitFromJSON(
     arrow::util::string_view type_name,
     arrow::util::string_view json);
 
-arrow::Result<std::string> SubstraitToJSON(
-    arrow::util::string_view type_name,
-    const arrow::Buffer& buf);
+arrow::Result<std::string> SubstraitToJSON(arrow::util::string_view type_name, const arrow::Buffer& buf);
 
 // Write a Protobuf message into a specified file with JSON format.
 void MessageToJSONFile(const google::protobuf::Message& message, const std::string& file_path);

--- a/cpp/src/jni/concurrent_map.h
+++ b/cpp/src/jni/concurrent_map.h
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  */
 
-#ifndef JNI_ID_TO_MODULE_MAP_H
-#define JNI_ID_TO_MODULE_MAP_H
+#pragma once
 
 #include <memory>
 #include <mutex>
@@ -25,8 +24,7 @@
 
 #include "arrow/util/macros.h"
 
-namespace arrow {
-namespace jni {
+namespace gluten {
 
 /**
  * An utility class that map module id to module pointers.
@@ -75,11 +73,10 @@ class ConcurrentMap {
 
   int64_t module_id_;
   std::mutex mtx_;
+
   // map from module ids returned to Java and module pointers
   std::unordered_map<jlong, Holder> map_;
 };
 
-} // namespace jni
-} // namespace arrow
+} // namespace gluten
 
-#endif // JNI_ID_TO_MODULE_MAP_H

--- a/cpp/src/jni/concurrent_map.h
+++ b/cpp/src/jni/concurrent_map.h
@@ -79,4 +79,3 @@ class ConcurrentMap {
 };
 
 } // namespace gluten
-

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -64,7 +64,7 @@ std::shared_ptr<arrow::DataType> GetOffsetDataType(std::shared_ptr<arrow::DataTy
   switch (parent_type->id()) {
     case arrow::BinaryType::type_id:
       return std::make_shared<arrow::TypeTraits<arrow::BinaryType>::OffsetType>();
-    case arrow::LargeBinaryType::type_id:
+    case arrow::LargeBinaryType::type_id: 
       return std::make_shared<arrow::TypeTraits<arrow::LargeBinaryType>::OffsetType>();
     case arrow::ListType::type_id:
       return std::make_shared<arrow::TypeTraits<arrow::ListType>::OffsetType>();
@@ -95,8 +95,7 @@ arrow::Status AppendNodes(std::shared_ptr<arrow::Array> column, std::vector<std:
   return arrow::Status::OK();
 }
 
-arrow::Status AppendBuffers(
-    std::shared_ptr<arrow::Array> column,
+arrow::Status AppendBuffers(std::shared_ptr<arrow::Array> column,
     std::vector<std::shared_ptr<arrow::Buffer>>* buffers) {
   auto type = column->type();
   switch (type->id()) {
@@ -286,7 +285,7 @@ jbyteArray ToSchemaByteArray(JNIEnv* env, std::shared_ptr<arrow::Schema> schema)
   arrow::Status status;
   // std::shared_ptr<arrow::Buffer> buffer;
   arrow::Result<std::shared_ptr<arrow::Buffer>> maybe_buffer;
-  maybe_buffer = arrow::ipc::SerializeSchema(*schema.get(), gluten::memory::GetDefaultWrappedArrowMemoryPool().get());
+  maybe_buffer = arrow::ipc::SerializeSchema(*schema.get(), gluten::GetDefaultWrappedArrowMemoryPool().get());
   if (!status.ok()) {
     std::string error_message = "Unable to convert schema to byte array, err is " + status.message();
     throw gluten::GlutenException(error_message);
@@ -396,15 +395,19 @@ void CheckException(JNIEnv* env) {
     jthrowable t = env->ExceptionOccurred();
     env->ExceptionClear();
     jclass describer_class = env->FindClass("io/glutenproject/exception/JniExceptionDescriber");
-    jmethodID describe_method =
-        env->GetStaticMethodID(describer_class, "describe", "(Ljava/lang/Throwable;)Ljava/lang/String;");
-    std::string description =
-        JStringToCString(env, (jstring)env->CallStaticObjectMethod(describer_class, describe_method, t));
+    jmethodID describe_method = env->GetStaticMethodID(
+        describer_class,
+        "describe",
+        "(Ljava/lang/Throwable;)Ljava/lang/String;");
+    std::string description = JStringToCString(
+        env,
+        (jstring)env->CallStaticObjectMethod(
+            describer_class, describe_method, t));
     throw gluten::GlutenException("Error during calling Java code from native code: " + description);
   }
 }
 
-class SparkAllocationListener : public gluten::memory::AllocationListener {
+class SparkAllocationListener : public gluten::AllocationListener {
  public:
   SparkAllocationListener(
       JavaVM* vm,
@@ -426,8 +429,8 @@ class SparkAllocationListener : public gluten::memory::AllocationListener {
   ~SparkAllocationListener() override {
     JNIEnv* env;
     if (vm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
-      std::cerr << "SparkAllocationListener#~SparkAllocationListener(): "
-                << "JNIEnv was not attached to current thread" << std::endl;
+      std::cerr << "SparkAllocationListener#~SparkAllocationListener(): " 
+          << "JNIEnv was not attached to current thread" << std::endl;
       return;
     }
     env->DeleteGlobalRef(java_listener_);
@@ -484,3 +487,4 @@ class SparkAllocationListener : public gluten::memory::AllocationListener {
   int64_t max_bytes_reserved_ = 0L;
   std::mutex mutex_;
 };
+

--- a/cpp/src/jni/jni_common.h
+++ b/cpp/src/jni/jni_common.h
@@ -64,7 +64,7 @@ std::shared_ptr<arrow::DataType> GetOffsetDataType(std::shared_ptr<arrow::DataTy
   switch (parent_type->id()) {
     case arrow::BinaryType::type_id:
       return std::make_shared<arrow::TypeTraits<arrow::BinaryType>::OffsetType>();
-    case arrow::LargeBinaryType::type_id: 
+    case arrow::LargeBinaryType::type_id:
       return std::make_shared<arrow::TypeTraits<arrow::LargeBinaryType>::OffsetType>();
     case arrow::ListType::type_id:
       return std::make_shared<arrow::TypeTraits<arrow::ListType>::OffsetType>();
@@ -95,7 +95,8 @@ arrow::Status AppendNodes(std::shared_ptr<arrow::Array> column, std::vector<std:
   return arrow::Status::OK();
 }
 
-arrow::Status AppendBuffers(std::shared_ptr<arrow::Array> column,
+arrow::Status AppendBuffers(
+    std::shared_ptr<arrow::Array> column,
     std::vector<std::shared_ptr<arrow::Buffer>>* buffers) {
   auto type = column->type();
   switch (type->id()) {
@@ -395,14 +396,10 @@ void CheckException(JNIEnv* env) {
     jthrowable t = env->ExceptionOccurred();
     env->ExceptionClear();
     jclass describer_class = env->FindClass("io/glutenproject/exception/JniExceptionDescriber");
-    jmethodID describe_method = env->GetStaticMethodID(
-        describer_class,
-        "describe",
-        "(Ljava/lang/Throwable;)Ljava/lang/String;");
-    std::string description = JStringToCString(
-        env,
-        (jstring)env->CallStaticObjectMethod(
-            describer_class, describe_method, t));
+    jmethodID describe_method =
+        env->GetStaticMethodID(describer_class, "describe", "(Ljava/lang/Throwable;)Ljava/lang/String;");
+    std::string description =
+        JStringToCString(env, (jstring)env->CallStaticObjectMethod(describer_class, describe_method, t));
     throw gluten::GlutenException("Error during calling Java code from native code: " + description);
   }
 }
@@ -429,8 +426,8 @@ class SparkAllocationListener : public gluten::AllocationListener {
   ~SparkAllocationListener() override {
     JNIEnv* env;
     if (vm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION) != JNI_OK) {
-      std::cerr << "SparkAllocationListener#~SparkAllocationListener(): " 
-          << "JNIEnv was not attached to current thread" << std::endl;
+      std::cerr << "SparkAllocationListener#~SparkAllocationListener(): "
+                << "JNIEnv was not attached to current thread" << std::endl;
       return;
     }
     env->DeleteGlobalRef(java_listener_);
@@ -487,4 +484,3 @@ class SparkAllocationListener : public gluten::AllocationListener {
   int64_t max_bytes_reserved_ = 0L;
   std::mutex mutex_;
 };
-

--- a/cpp/src/jni/jni_errors.h
+++ b/cpp/src/jni/jni_errors.h
@@ -84,8 +84,8 @@ static struct JniErrorsGlobalState {
     std::lock_guard<std::mutex> lock_guard(mtx_);
     io_exception_class_ = CreateGlobalClassReference(env, "Ljava/io/IOException;");
     runtime_exception_class_ = CreateGlobalClassReference(env, "Ljava/lang/RuntimeException;");
-    unsupportedoperation_exception_class_ = CreateGlobalClassReference(env, 
-        "Ljava/lang/UnsupportedOperationException;");
+    unsupportedoperation_exception_class_ =
+        CreateGlobalClassReference(env, "Ljava/lang/UnsupportedOperationException;");
     illegal_access_exception_class_ = CreateGlobalClassReference(env, "Ljava/lang/IllegalAccessException;");
     illegal_argument_exception_class_ = CreateGlobalClassReference(env, "Ljava/lang/IllegalArgumentException;");
   }

--- a/cpp/src/jni/jni_errors.h
+++ b/cpp/src/jni/jni_errors.h
@@ -84,8 +84,8 @@ static struct JniErrorsGlobalState {
     std::lock_guard<std::mutex> lock_guard(mtx_);
     io_exception_class_ = CreateGlobalClassReference(env, "Ljava/io/IOException;");
     runtime_exception_class_ = CreateGlobalClassReference(env, "Ljava/lang/RuntimeException;");
-    unsupportedoperation_exception_class_ =
-        CreateGlobalClassReference(env, "Ljava/lang/UnsupportedOperationException;");
+    unsupportedoperation_exception_class_ = CreateGlobalClassReference(env, 
+        "Ljava/lang/UnsupportedOperationException;");
     illegal_access_exception_class_ = CreateGlobalClassReference(env, "Ljava/lang/IllegalAccessException;");
     illegal_argument_exception_class_ = CreateGlobalClassReference(env, "Ljava/lang/IllegalArgumentException;");
   }
@@ -93,9 +93,7 @@ static struct JniErrorsGlobalState {
   jclass RuntimeExceptionClass() {
     std::lock_guard<std::mutex> lock_guard(mtx_);
     if (runtime_exception_class_ == nullptr) {
-      throw gluten::GlutenException(
-          "Fatal: JniGlobalState::Initialize(...) was not called before using the "
-          "utility");
+      throw gluten::GlutenException("Fatal: JniGlobalState::Initialize(...) was not called before using the utility");
     }
     return runtime_exception_class_;
   }
@@ -103,9 +101,7 @@ static struct JniErrorsGlobalState {
   jclass IllegalAccessExceptionClass() {
     std::lock_guard<std::mutex> lock_guard(mtx_);
     if (illegal_access_exception_class_ == nullptr) {
-      throw gluten::GlutenException(
-          "Fatal: JniGlobalState::Initialize(...) was not called before using the "
-          "utility");
+      throw gluten::GlutenException("Fatal: JniGlobalState::Initialize(...) was not called before using the utility");
     }
     return illegal_access_exception_class_;
   }

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -43,7 +43,7 @@
 #include "utils/metrics.h"
 
 namespace types {
-  class ExpressionList;
+class ExpressionList;
 } // namespace types
 
 using namespace gluten;
@@ -112,7 +112,8 @@ class JavaInputStreamAdaptor : public arrow::io::InputStream {
     auto status = JavaInputStreamAdaptor::Close();
     if (!status.ok()) {
 #ifdef GLUTEN_PRINT_DEBUG
-    std::cout << __func__ << " call JavaInputStreamAdaptor::Close() failed, status:" << status.ToString() << std::endl;
+      std::cout << __func__ << " call JavaInputStreamAdaptor::Close() failed, status:" << status.ToString()
+                << std::endl;
 #endif
     }
   };
@@ -149,7 +150,8 @@ class JavaInputStreamAdaptor : public arrow::io::InputStream {
   }
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
-    GLUTEN_ASSIGN_OR_THROW(auto buffer, arrow::AllocateResizableBuffer(nbytes, GetDefaultWrappedArrowMemoryPool().get()))
+    GLUTEN_ASSIGN_OR_THROW(
+        auto buffer, arrow::AllocateResizableBuffer(nbytes, GetDefaultWrappedArrowMemoryPool().get()))
     GLUTEN_ASSIGN_OR_THROW(int64_t bytes_read, Read(nbytes, buffer->mutable_data()));
     GLUTEN_THROW_NOT_OK(buffer->Resize(bytes_read, false));
     buffer->ZeroPadding();
@@ -188,8 +190,8 @@ class JavaArrowArrayIterator {
     JNIEnv* env;
     AttachCurrentThreadAsDaemonOrThrow(vm_, &env);
 #ifdef GLUTEN_PRINT_DEBUG
-    std::cout << "PICKING ITERATOR REF "
-              << reinterpret_cast<long>(java_serialized_arrow_array_iterator_) << "..." << std::endl;
+    std::cout << "PICKING ITERATOR REF " << reinterpret_cast<long>(java_serialized_arrow_array_iterator_) << "..."
+              << std::endl;
 #endif
     if (!env->CallBooleanMethod(java_serialized_arrow_array_iterator_, serialized_arrow_array_iterator_hasNext)) {
       CheckException(env);
@@ -211,11 +213,15 @@ class JavaArrowArrayIterator {
 // See Java class
 // org/apache/arrow/dataset/jni/NativeSerializedRecordBatchIterator
 //
-std::shared_ptr<JavaArrowArrayIterator> MakeJavaArrowArrayIterator( JNIEnv* env, jobject java_serialized_arrow_array_iterator) {
+std::shared_ptr<JavaArrowArrayIterator> MakeJavaArrowArrayIterator(
+    JNIEnv* env,
+    jobject java_serialized_arrow_array_iterator) {
 #ifdef GLUTEN_PRINT_DEBUG
-  std::cout << "CREATING ITERATOR REF " << reinterpret_cast<long>(java_serialized_arrow_array_iterator) << "..." << std::endl;
+  std::cout << "CREATING ITERATOR REF " << reinterpret_cast<long>(java_serialized_arrow_array_iterator) << "..."
+            << std::endl;
 #endif
-  std::shared_ptr<JavaArrowArrayIterator> itr = std::make_shared<JavaArrowArrayIterator>(env, java_serialized_arrow_array_iterator);
+  std::shared_ptr<JavaArrowArrayIterator> itr =
+      std::make_shared<JavaArrowArrayIterator>(env, java_serialized_arrow_array_iterator);
   return itr;
 }
 
@@ -250,12 +256,14 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   }
   gluten::GetJniErrorsState()->Initialize(env);
 
-  serializable_obj_builder_class = CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/NativeSerializableObject;");
+  serializable_obj_builder_class =
+      CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/NativeSerializableObject;");
   serializable_obj_builder_constructor = GetMethodIDOrError(env, serializable_obj_builder_class, "<init>", "([J[I)V");
 
   byte_array_class = CreateGlobalClassReferenceOrError(env, "[B");
 
-  jni_byte_input_stream_class = CreateGlobalClassReferenceOrError( env, "Lio/glutenproject/vectorized/JniByteInputStream;");
+  jni_byte_input_stream_class =
+      CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/JniByteInputStream;");
   jni_byte_input_stream_read = GetMethodIDOrError(env, jni_byte_input_stream_class, "read", "(JJ)J");
   jni_byte_input_stream_tell = GetMethodIDOrError(env, jni_byte_input_stream_class, "tell", "()J");
   jni_byte_input_stream_close = GetMethodIDOrError(env, jni_byte_input_stream_class, "close", "()V");
@@ -265,18 +273,26 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   metrics_builder_class = CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/Metrics;");
 
-  metrics_builder_constructor = GetMethodIDOrError(env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J)V");
+  metrics_builder_constructor =
+      GetMethodIDOrError(env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J)V");
 
-  serialized_arrow_array_iterator_class = CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ArrowInIterator;");
+  serialized_arrow_array_iterator_class =
+      CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ArrowInIterator;");
 
-  serialized_arrow_array_iterator_hasNext = GetMethodIDOrError(env, serialized_arrow_array_iterator_class, "hasNext", "()Z");
+  serialized_arrow_array_iterator_hasNext =
+      GetMethodIDOrError(env, serialized_arrow_array_iterator_class, "hasNext", "()Z");
 
   serialized_arrow_array_iterator_next = GetMethodIDOrError(env, serialized_arrow_array_iterator_class, "next", "()J");
 
-  native_columnar_to_row_info_class = CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/NativeColumnarToRowInfo;");
-  native_columnar_to_row_info_constructor = GetMethodIDOrError(env, native_columnar_to_row_info_class, "<init>", "(J[I[IJ)V");
+  native_columnar_to_row_info_class =
+      CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/NativeColumnarToRowInfo;");
+  native_columnar_to_row_info_constructor =
+      GetMethodIDOrError(env, native_columnar_to_row_info_class, "<init>", "(J[I[IJ)V");
 
-  java_reservation_listener_class = CreateGlobalClassReference(env, "Lio/glutenproject/memory/alloc/" "ReservationListener;");
+  java_reservation_listener_class = CreateGlobalClassReference(
+      env,
+      "Lio/glutenproject/memory/alloc/"
+      "ReservationListener;");
 
   reserve_memory_method = GetMethodIDOrError(env, java_reservation_listener_class, "reserveOrThrow", "(J)V");
   unreserve_memory_method = GetMethodIDOrError(env, java_reservation_listener_class, "unreserve", "(J)J");
@@ -304,9 +320,10 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   env->DeleteGlobalRef(byte_array_class);
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetJavaTmpDir(
-    JNIEnv* env, jobject obj, jstring pathObj) {
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetJavaTmpDir(
+    JNIEnv* env,
+    jobject obj,
+    jstring pathObj) {
   JNI_METHOD_START
   jboolean ifCopy;
   auto path = env->GetStringUTFChars(pathObj, &ifCopy);
@@ -315,21 +332,26 @@ Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetJavaTmpD
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetBatchSize(
-    JNIEnv* env, jobject obj, jint batch_size) {
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetBatchSize(
+    JNIEnv* env,
+    jobject obj,
+    jint batch_size) {
   setenv("NATIVESQL_BATCH_SIZE", std::to_string(batch_size).c_str(), 1);
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetMetricsTime(
-    JNIEnv* env, jobject obj, jboolean is_enable) {
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeSetMetricsTime(
+    JNIEnv* env,
+    jobject obj,
+    jboolean is_enable) {
   setenv("NATIVESQL_METRICS_TIME", (is_enable ? "true" : "false"), 1);
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeCreateKernelWithIterator(
-    JNIEnv* env, jobject obj, jlong allocator_id, jbyteArray plan_arr, jobjectArray iter_arr) {
+JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeCreateKernelWithIterator(
+    JNIEnv* env,
+    jobject obj,
+    jlong allocator_id,
+    jbyteArray plan_arr,
+    jobjectArray iter_arr) {
   JNI_METHOD_START
   arrow::Status msg;
 
@@ -435,23 +457,11 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
     env->SetLongArrayRegion(peakMemoryBytes, 0, numMetrics, metrics->peakMemoryBytes);
     env->SetLongArrayRegion(numMemoryAllocations, 0, numMetrics, metrics->numMemoryAllocations);
 
-    env->SetLongArrayRegion(
-        numDynamicFiltersProduced,
-        0,
-        numMetrics,
-        metrics->numDynamicFiltersProduced);
+    env->SetLongArrayRegion(numDynamicFiltersProduced, 0, numMetrics, metrics->numDynamicFiltersProduced);
 
-    env->SetLongArrayRegion(
-        numDynamicFiltersAccepted,
-        0,
-        numMetrics,
-        metrics->numDynamicFiltersAccepted);
+    env->SetLongArrayRegion(numDynamicFiltersAccepted, 0, numMetrics, metrics->numDynamicFiltersAccepted);
 
-    env->SetLongArrayRegion(
-        numReplacedWithDynamicFilterRows,
-        0,
-        numMetrics,
-        metrics->numReplacedWithDynamicFilterRows);
+    env->SetLongArrayRegion(numReplacedWithDynamicFilterRows, 0, numMetrics, metrics->numReplacedWithDynamicFilterRows);
   }
 
   return env->NewObject(
@@ -490,9 +500,11 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeClose(JNIEnv* env, jobje
   JNI_METHOD_END()
 }
 
-JNIEXPORT jobject JNICALL
-Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeConvertColumnarToRow(
-    JNIEnv* env, jobject, jlong batch_handle, jlong allocator_id) {
+JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeConvertColumnarToRow(
+    JNIEnv* env,
+    jobject,
+    jlong batch_handle,
+    jlong allocator_id) {
   JNI_METHOD_START
   std::shared_ptr<ColumnarBatch> cb = gluten_columnarbatch_holder_.Lookup(batch_handle);
   int64_t num_rows = cb->GetNumRows();
@@ -502,14 +514,14 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeConvertColu
     gluten::JniThrow("Memory pool does not exist or has been closed");
   }
   auto backend = gluten::CreateBackend();
-  std::shared_ptr<ColumnarToRowConverter>
-      columnar_to_row_converter = gluten::JniGetOrThrow(backend->getColumnarConverter(allocator, cb));
+  std::shared_ptr<ColumnarToRowConverter> columnar_to_row_converter =
+      gluten::JniGetOrThrow(backend->getColumnarConverter(allocator, cb));
   gluten::JniAssertOkOrThrow(
       columnar_to_row_converter->Init(),
       "Native convert columnar to row: Init "
       "ColumnarToRowConverter failed");
-  gluten::JniAssertOkOrThrow(columnar_to_row_converter->Write(),
-      "Native convert columnar to row: ColumnarToRowConverter write failed");
+  gluten::JniAssertOkOrThrow(
+      columnar_to_row_converter->Write(), "Native convert columnar to row: ColumnarToRowConverter write failed");
 
   const auto& offsets = columnar_to_row_converter->GetOffsets();
   const auto& lengths = columnar_to_row_converter->GetLengths();
@@ -565,9 +577,12 @@ Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_getNumRows(JNIEnv* e
   JNI_METHOD_END(-1L)
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_exportToArrow(
-    JNIEnv* env, jobject, jlong handle, jlong c_schema, jlong c_array) {
+JNIEXPORT void JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_exportToArrow(
+    JNIEnv* env,
+    jobject,
+    jlong handle,
+    jlong c_schema,
+    jlong c_array) {
   JNI_METHOD_START
   std::shared_ptr<ColumnarBatch> batch = gluten_columnarbatch_holder_.Lookup(handle);
   std::shared_ptr<ArrowSchema> exported_schema = batch->exportArrowSchema();
@@ -577,9 +592,11 @@ Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_exportToArrow(
   JNI_METHOD_END()
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_createWithArrowArray(
-    JNIEnv* env, jobject, jlong c_schema, jlong c_array) {
+JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_createWithArrowArray(
+    JNIEnv* env,
+    jobject,
+    jlong c_schema,
+    jlong c_array) {
   JNI_METHOD_START
   std::unique_ptr<ArrowSchema> target_schema = std::make_unique<ArrowSchema>();
   std::unique_ptr<ArrowArray> target_array = std::make_unique<ArrowArray>();
@@ -587,8 +604,8 @@ Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_createWithArrowArray
   auto* arrow_array = reinterpret_cast<ArrowArray*>(c_array);
   ArrowArrayMove(arrow_array, target_array.get());
   ArrowSchemaMove(arrow_schema, target_schema.get());
-  std::shared_ptr<ColumnarBatch> batch = std::make_shared<ArrowCStructColumnarBatch>(
-          std::move(target_schema), std::move(target_array));
+  std::shared_ptr<ColumnarBatch> batch =
+      std::make_shared<ArrowCStructColumnarBatch>(std::move(target_schema), std::move(target_array));
   return gluten_columnarbatch_holder_.Insert(batch);
   JNI_METHOD_END(-1L)
 }
@@ -703,9 +720,12 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
   JNI_METHOD_END(-1L)
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_nativeSpill(
-    JNIEnv* env, jobject, jlong splitter_id, jlong size, jboolean callBySelf) {
+JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_nativeSpill(
+    JNIEnv* env,
+    jobject,
+    jlong splitter_id,
+    jlong size,
+    jboolean callBySelf) {
   JNI_METHOD_START
   auto splitter = shuffle_splitter_holder_.Lookup(splitter_id);
   if (!splitter) {
@@ -718,17 +738,20 @@ Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_nativeSpill(
   JNI_METHOD_END(-1L)
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_split(
-    JNIEnv* env, jobject, jlong splitter_id, jint num_rows, jlong c_array) {
+JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_split(
+    JNIEnv* env,
+    jobject,
+    jlong splitter_id,
+    jint num_rows,
+    jlong c_array) {
   JNI_METHOD_START
   auto splitter = shuffle_splitter_holder_.Lookup(splitter_id);
   if (!splitter) {
     std::string error_message = "Invalid splitter id " + std::to_string(splitter_id);
     gluten::JniThrow(error_message);
   }
-  std::shared_ptr<arrow::RecordBatch> in =
-      gluten::JniGetOrThrow(arrow::ImportRecordBatch(reinterpret_cast<struct ArrowArray*>(c_array), splitter->input_schema()));
+  std::shared_ptr<arrow::RecordBatch> in = gluten::JniGetOrThrow(
+      arrow::ImportRecordBatch(reinterpret_cast<struct ArrowArray*>(c_array), splitter->input_schema()));
 
   gluten::JniAssertOkOrThrow(splitter->Split(*in), "Native split: splitter split failed");
   return -1L;
@@ -779,17 +802,23 @@ Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_close(JNIEnv* env, jo
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_LowCopyNettyJniByteInputStream_memCopy(
-    JNIEnv* env, jobject, jlong srcAddress, jlong destAddress, jlong size) {
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_LowCopyNettyJniByteInputStream_memCopy(
+    JNIEnv* env,
+    jobject,
+    jlong srcAddress,
+    jlong destAddress,
+    jlong size) {
   JNI_METHOD_START
   std::memcpy(reinterpret_cast<void*>(destAddress), reinterpret_cast<void*>(srcAddress), size);
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_OnHeapJniByteInputStream_memCopyFromHeap(
-    JNIEnv* env, jobject, jbyteArray source, jlong destAddress, jint size) {
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_OnHeapJniByteInputStream_memCopyFromHeap(
+    JNIEnv* env,
+    jobject,
+    jbyteArray source,
+    jlong destAddress,
+    jint size) {
   JNI_METHOD_START
   jbyte* bytes = env->GetByteArrayElements(source, nullptr);
   std::memcpy(reinterpret_cast<void*>(destAddress), reinterpret_cast<const void*>(bytes), size);
@@ -803,7 +832,8 @@ Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_make(JNIEnv* env, jclas
   std::shared_ptr<arrow::io::InputStream> in = std::make_shared<JavaInputStreamAdaptor>(env, jni_in);
   ReaderOptions options = ReaderOptions::Defaults();
   options.ipc_read_options.use_threads = false;
-  std::shared_ptr<arrow::Schema> schema = gluten::JniGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(c_schema)));
+  std::shared_ptr<arrow::Schema> schema =
+      gluten::JniGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(c_schema)));
   auto reader = std::make_shared<Reader>(in, schema, options);
   return shuffle_reader_holder_.Insert(reader);
   JNI_METHOD_END(-1L)
@@ -837,20 +867,17 @@ Java_io_glutenproject_memory_alloc_NativeMemoryAllocator_getDefaultAllocator(JNI
   JNI_METHOD_END(-1L)
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_memory_alloc_NativeMemoryAllocator_createListenableAllocator(JNIEnv* env, jclass, jobject jlistener) {
+JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_alloc_NativeMemoryAllocator_createListenableAllocator(
+    JNIEnv* env,
+    jclass,
+    jobject jlistener) {
   JNI_METHOD_START
   JavaVM* vm;
   if (env->GetJavaVM(&vm) != JNI_OK) {
     gluten::JniThrow("Unable to get JavaVM instance");
   }
-  std::shared_ptr<AllocationListener> listener =
-      std::make_shared<SparkAllocationListener>(
-          vm,
-          jlistener,
-          reserve_memory_method,
-          unreserve_memory_method,
-          8L << 10 << 10);
+  std::shared_ptr<AllocationListener> listener = std::make_shared<SparkAllocationListener>(
+      vm, jlistener, reserve_memory_method, unreserve_memory_method, 8L << 10 << 10);
   auto allocator = new ListenableMemoryAllocator(DefaultMemoryAllocator().get(), listener);
   return reinterpret_cast<jlong>(allocator);
   JNI_METHOD_END(-1L)

--- a/cpp/src/jni/jni_wrapper.cc
+++ b/cpp/src/jni/jni_wrapper.cc
@@ -114,7 +114,14 @@ class JavaInputStreamAdaptor : public arrow::io::InputStream {
   }
 
   ~JavaInputStreamAdaptor() override {
-    GLUTEN_THROW_NOT_OK(JavaInputStreamAdaptor::Close());
+    auto status = JavaInputStreamAdaptor::Close();
+    if (!status.ok()) {
+#ifdef GLUTEN_PRINT_DEBUG
+    std::cout << __func__ << " call JavaInputStreamAdaptor::Close() failed, status:" 
+              << status.ToString()
+              << std::endl;
+#endif
+    }
   };
 
   // not thread safe

--- a/cpp/src/memory/allocator.cc
+++ b/cpp/src/memory/allocator.cc
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include <iostream>
 #include "allocator.h"
+#include <iostream>
 #include "hbw_allocator.h"
 
 namespace gluten {
@@ -70,7 +70,12 @@ bool ListenableMemoryAllocator::Reallocate(void* p, int64_t size, int64_t new_si
   return succeed;
 }
 
-bool ListenableMemoryAllocator::ReallocateAligned(void* p, uint16_t alignment, int64_t size, int64_t new_size, void** out) {
+bool ListenableMemoryAllocator::ReallocateAligned(
+    void* p,
+    uint16_t alignment,
+    int64_t size,
+    int64_t new_size,
+    void** out) {
   int64_t diff = new_size - size;
   listener_->AllocationChanged(diff);
   bool succeed = delegated_->ReallocateAligned(p, alignment, size, new_size, out);
@@ -146,7 +151,7 @@ int64_t StdMemoryAllocator::GetBytes() const {
   return bytes_;
 }
 
-arrow::Status WrappedArrowMemoryPool::Allocate(int64_t size, uint8_t** out) { 
+arrow::Status WrappedArrowMemoryPool::Allocate(int64_t size, uint8_t** out) {
   if (!allocator_->Allocate(size, reinterpret_cast<void**>(out))) {
     return arrow::Status::Invalid("WrappedMemoryPool: Error allocating " + std::to_string(size) + " bytes");
   }
@@ -160,7 +165,7 @@ arrow::Status WrappedArrowMemoryPool::Reallocate(int64_t old_size, int64_t new_s
   return arrow::Status::OK();
 }
 
-void WrappedArrowMemoryPool::Free(uint8_t* buffer, int64_t size) { 
+void WrappedArrowMemoryPool::Free(uint8_t* buffer, int64_t size) {
   allocator_->Free(buffer, size);
 }
 

--- a/cpp/src/memory/allocator.cc
+++ b/cpp/src/memory/allocator.cc
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-#include "allocator.h"
 #include <iostream>
+#include "allocator.h"
 #include "hbw_allocator.h"
 
-bool gluten::memory::ListenableMemoryAllocator::Allocate(int64_t size, void** out) {
+namespace gluten {
+
+bool ListenableMemoryAllocator::Allocate(int64_t size, void** out) {
   listener_->AllocationChanged(size);
   bool succeed = delegated_->Allocate(size, out);
   if (!succeed) {
@@ -31,7 +33,7 @@ bool gluten::memory::ListenableMemoryAllocator::Allocate(int64_t size, void** ou
   return succeed;
 }
 
-bool gluten::memory::ListenableMemoryAllocator::AllocateZeroFilled(int64_t nmemb, int64_t size, void** out) {
+bool ListenableMemoryAllocator::AllocateZeroFilled(int64_t nmemb, int64_t size, void** out) {
   listener_->AllocationChanged(size * nmemb);
   bool succeed = delegated_->AllocateZeroFilled(nmemb, size, out);
   if (!succeed) {
@@ -43,7 +45,7 @@ bool gluten::memory::ListenableMemoryAllocator::AllocateZeroFilled(int64_t nmemb
   return succeed;
 }
 
-bool gluten::memory::ListenableMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) {
+bool ListenableMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) {
   listener_->AllocationChanged(size);
   bool succeed = delegated_->AllocateAligned(alignment, size, out);
   if (!succeed) {
@@ -55,7 +57,7 @@ bool gluten::memory::ListenableMemoryAllocator::AllocateAligned(uint16_t alignme
   return succeed;
 }
 
-bool gluten::memory::ListenableMemoryAllocator::Reallocate(void* p, int64_t size, int64_t new_size, void** out) {
+bool ListenableMemoryAllocator::Reallocate(void* p, int64_t size, int64_t new_size, void** out) {
   int64_t diff = new_size - size;
   listener_->AllocationChanged(diff);
   bool succeed = delegated_->Reallocate(p, size, new_size, out);
@@ -68,12 +70,7 @@ bool gluten::memory::ListenableMemoryAllocator::Reallocate(void* p, int64_t size
   return succeed;
 }
 
-bool gluten::memory::ListenableMemoryAllocator::ReallocateAligned(
-    void* p,
-    uint16_t alignment,
-    int64_t size,
-    int64_t new_size,
-    void** out) {
+bool ListenableMemoryAllocator::ReallocateAligned(void* p, uint16_t alignment, int64_t size, int64_t new_size, void** out) {
   int64_t diff = new_size - size;
   listener_->AllocationChanged(diff);
   bool succeed = delegated_->ReallocateAligned(p, alignment, size, new_size, out);
@@ -86,7 +83,7 @@ bool gluten::memory::ListenableMemoryAllocator::ReallocateAligned(
   return succeed;
 }
 
-bool gluten::memory::ListenableMemoryAllocator::Free(void* p, int64_t size) {
+bool ListenableMemoryAllocator::Free(void* p, int64_t size) {
   listener_->AllocationChanged(-size);
   bool succeed = delegated_->Free(p, size);
   if (!succeed) {
@@ -98,40 +95,35 @@ bool gluten::memory::ListenableMemoryAllocator::Free(void* p, int64_t size) {
   return succeed;
 }
 
-int64_t gluten::memory::ListenableMemoryAllocator::GetBytes() {
+int64_t ListenableMemoryAllocator::GetBytes() const {
   return bytes_;
 }
 
-bool gluten::memory::StdMemoryAllocator::Allocate(int64_t size, void** out) {
+bool StdMemoryAllocator::Allocate(int64_t size, void** out) {
   *out = std::malloc(size);
   bytes_ += size;
   return true;
 }
 
-bool gluten::memory::StdMemoryAllocator::AllocateZeroFilled(int64_t nmemb, int64_t size, void** out) {
+bool StdMemoryAllocator::AllocateZeroFilled(int64_t nmemb, int64_t size, void** out) {
   *out = std::calloc(nmemb, size);
   bytes_ += size;
   return true;
 }
 
-bool gluten::memory::StdMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) {
+bool StdMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) {
   *out = aligned_alloc(alignment, size);
   bytes_ += size;
   return true;
 }
 
-bool gluten::memory::StdMemoryAllocator::Reallocate(void* p, int64_t size, int64_t new_size, void** out) {
+bool StdMemoryAllocator::Reallocate(void* p, int64_t size, int64_t new_size, void** out) {
   *out = std::realloc(p, new_size);
   bytes_ += (new_size - size);
   return true;
 }
 
-bool gluten::memory::StdMemoryAllocator::ReallocateAligned(
-    void* p,
-    uint16_t alignment,
-    int64_t size,
-    int64_t new_size,
-    void** out) {
+bool StdMemoryAllocator::ReallocateAligned(void* p, uint16_t alignment, int64_t size, int64_t new_size, void** out) {
   if (new_size <= 0) {
     return false;
   }
@@ -144,44 +136,44 @@ bool gluten::memory::StdMemoryAllocator::ReallocateAligned(
   return true;
 }
 
-bool gluten::memory::StdMemoryAllocator::Free(void* p, int64_t size) {
+bool StdMemoryAllocator::Free(void* p, int64_t size) {
   std::free(p);
   bytes_ -= size;
   return true;
 }
 
-int64_t gluten::memory::StdMemoryAllocator::GetBytes() {
+int64_t StdMemoryAllocator::GetBytes() const {
   return bytes_;
 }
 
-arrow::Status gluten::memory::WrappedArrowMemoryPool::Allocate(int64_t size, uint8_t** out) {
+arrow::Status WrappedArrowMemoryPool::Allocate(int64_t size, uint8_t** out) { 
   if (!allocator_->Allocate(size, reinterpret_cast<void**>(out))) {
     return arrow::Status::Invalid("WrappedMemoryPool: Error allocating " + std::to_string(size) + " bytes");
   }
   return arrow::Status::OK();
 }
 
-arrow::Status gluten::memory::WrappedArrowMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
+arrow::Status WrappedArrowMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
   if (!allocator_->Reallocate(*ptr, old_size, new_size, reinterpret_cast<void**>(ptr))) {
     return arrow::Status::Invalid("WrappedMemoryPool: Error reallocating " + std::to_string(new_size) + " bytes");
   }
   return arrow::Status::OK();
 }
 
-void gluten::memory::WrappedArrowMemoryPool::Free(uint8_t* buffer, int64_t size) {
+void WrappedArrowMemoryPool::Free(uint8_t* buffer, int64_t size) { 
   allocator_->Free(buffer, size);
 }
 
-int64_t gluten::memory::WrappedArrowMemoryPool::bytes_allocated() const {
+int64_t WrappedArrowMemoryPool::bytes_allocated() const {
   // fixme use self accountant
   return allocator_->GetBytes();
 }
 
-std::string gluten::memory::WrappedArrowMemoryPool::backend_name() const {
+std::string WrappedArrowMemoryPool::backend_name() const {
   return "gluten allocator";
 }
 
-std::shared_ptr<gluten::memory::MemoryAllocator> gluten::memory::DefaultMemoryAllocator() {
+std::shared_ptr<MemoryAllocator> DefaultMemoryAllocator() {
 #if defined(GLUTEN_ENABLE_HBM)
   static std::shared_ptr<MemoryAllocator> alloc = std::make_shared<HbwMemoryAllocator>();
 #else
@@ -189,3 +181,5 @@ std::shared_ptr<gluten::memory::MemoryAllocator> gluten::memory::DefaultMemoryAl
 #endif
   return alloc;
 }
+
+} // namespace gluten

--- a/cpp/src/memory/allocator.h
+++ b/cpp/src/memory/allocator.h
@@ -27,18 +27,21 @@
 #include "arrow/util/memory.h"
 
 namespace gluten {
-namespace memory {
 
 class MemoryAllocator {
  public:
   virtual ~MemoryAllocator() = default;
+
   virtual bool Allocate(int64_t size, void** out) = 0;
   virtual bool AllocateZeroFilled(int64_t nmemb, int64_t size, void** out) = 0;
   virtual bool AllocateAligned(uint16_t alignment, int64_t size, void** out) = 0;
+
   virtual bool Reallocate(void* p, int64_t size, int64_t new_size, void** out) = 0;
   virtual bool ReallocateAligned(void* p, uint16_t alignment, int64_t size, int64_t new_size, void** out) = 0;
+
   virtual bool Free(void* p, int64_t size) = 0;
-  virtual int64_t GetBytes() = 0;
+
+  virtual int64_t GetBytes() const = 0;
 };
 
 class AllocationListener {
@@ -70,7 +73,7 @@ class ListenableMemoryAllocator : public MemoryAllocator {
 
   bool Free(void* p, int64_t size) override;
 
-  int64_t GetBytes() override;
+  int64_t GetBytes() const override;
 
  private:
   MemoryAllocator* delegated_;
@@ -92,7 +95,7 @@ class StdMemoryAllocator : public MemoryAllocator {
 
   bool Free(void* p, int64_t size) override;
 
-  int64_t GetBytes() override;
+  int64_t GetBytes() const override;
 
  private:
   std::atomic_int64_t bytes_{0};
@@ -119,5 +122,4 @@ class WrappedArrowMemoryPool : public arrow::MemoryPool {
 
 std::shared_ptr<MemoryAllocator> DefaultMemoryAllocator();
 
-} // namespace memory
 } // namespace gluten

--- a/cpp/src/memory/arrow_memory_pool.cc
+++ b/cpp/src/memory/arrow_memory_pool.cc
@@ -18,16 +18,14 @@
 #include "arrow_memory_pool.h"
 
 namespace gluten {
-namespace memory {
 
-std::shared_ptr<arrow::MemoryPool> AsWrappedArrowMemoryPool(gluten::memory::MemoryAllocator* allocator) {
+std::shared_ptr<arrow::MemoryPool> AsWrappedArrowMemoryPool(MemoryAllocator* allocator) {
   return std::make_shared<WrappedArrowMemoryPool>(allocator);
 }
 
 std::shared_ptr<arrow::MemoryPool> GetDefaultWrappedArrowMemoryPool() {
-  static auto static_pool = AsWrappedArrowMemoryPool(gluten::memory::DefaultMemoryAllocator().get());
+  static auto static_pool = AsWrappedArrowMemoryPool(DefaultMemoryAllocator().get());
   return static_pool;
 }
 
-} // namespace memory
 } // namespace gluten

--- a/cpp/src/memory/arrow_memory_pool.h
+++ b/cpp/src/memory/arrow_memory_pool.h
@@ -20,11 +20,9 @@
 #include "allocator.h"
 
 namespace gluten {
-namespace memory {
 
 std::shared_ptr<arrow::MemoryPool> AsWrappedArrowMemoryPool(MemoryAllocator* allocator);
 
 std::shared_ptr<arrow::MemoryPool> GetDefaultWrappedArrowMemoryPool();
 
-} // namespace memory
 } // namespace gluten

--- a/cpp/src/memory/columnar_batch.h
+++ b/cpp/src/memory/columnar_batch.h
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <memory>
 
 #include "arrow/c/helpers.h"
@@ -22,26 +24,23 @@
 #include "releases/include/arrow/c/bridge.h"
 #include "utils/exception.h"
 
-#pragma once
-
 namespace gluten {
-namespace memory {
-class GlutenColumnarBatch {
- public:
-  GlutenColumnarBatch(int32_t numColumns, int32_t numRows)
-      : numColumns(numColumns), numRows(numRows), exportNanos_(0) {}
 
-  virtual ~GlutenColumnarBatch() = default;
+class ColumnarBatch {
+ public:
+  ColumnarBatch(int32_t numColumns, int32_t numRows) : numColumns_(numColumns), numRows_(numRows), exportNanos_(0) {}
+
+  virtual ~ColumnarBatch() = default;
 
   int32_t GetNumColumns() const {
-    return numColumns;
+    return numColumns_;
   }
 
   int32_t GetNumRows() const {
-    return numRows;
+    return numRows_;
   }
 
-  virtual std::string GetType() = 0;
+  virtual std::string GetType() const = 0;
 
   virtual std::shared_ptr<ArrowArray> exportArrowArray() = 0;
 
@@ -52,32 +51,30 @@ class GlutenColumnarBatch {
   };
 
  private:
-  int32_t numColumns;
-  int32_t numRows;
+  int32_t numColumns_;
+  int32_t numRows_;
 
  protected:
   int64_t exportNanos_;
 };
 
-class GlutenArrowColumnarBatch : public GlutenColumnarBatch {
+class ArrowColumnarBatch : public ColumnarBatch {
  public:
-  explicit GlutenArrowColumnarBatch(std::shared_ptr<arrow::RecordBatch> batch)
-      : GlutenColumnarBatch(batch->num_columns(), batch->num_rows()), batch_(std::move(batch)) {}
+  explicit ArrowColumnarBatch(std::shared_ptr<arrow::RecordBatch> batch)
+      : ColumnarBatch(batch->num_columns(), batch->num_rows()), batch_(std::move(batch)) {}
 
-  ~GlutenArrowColumnarBatch() override = default;
-
-  std::string GetType() override {
+  std::string GetType() const override {
     return "arrow";
   }
 
   std::shared_ptr<ArrowSchema> exportArrowSchema() override {
-    std::shared_ptr<ArrowSchema> c_schema = std::make_shared<ArrowSchema>();
+    auto c_schema = std::make_shared<ArrowSchema>();
     GLUTEN_THROW_NOT_OK(arrow::ExportSchema(*batch_->schema(), c_schema.get()));
     return c_schema;
   }
 
   std::shared_ptr<ArrowArray> exportArrowArray() override {
-    std::shared_ptr<ArrowArray> c_array = std::make_shared<ArrowArray>();
+    auto c_array = std::make_shared<ArrowArray>();
     GLUTEN_THROW_NOT_OK(arrow::ExportRecordBatch(*batch_, c_array.get()));
     return c_array;
   }
@@ -86,20 +83,20 @@ class GlutenArrowColumnarBatch : public GlutenColumnarBatch {
   std::shared_ptr<arrow::RecordBatch> batch_;
 };
 
-class GlutenArrowCStructColumnarBatch : public GlutenColumnarBatch {
+class ArrowCStructColumnarBatch : public ColumnarBatch {
  public:
-  GlutenArrowCStructColumnarBatch(std::unique_ptr<ArrowSchema> cSchema, std::unique_ptr<ArrowArray> cArray)
-      : GlutenColumnarBatch(cArray->n_children, cArray->length) {
+  ArrowCStructColumnarBatch(std::unique_ptr<ArrowSchema> cSchema, std::unique_ptr<ArrowArray> cArray)
+      : ColumnarBatch(cArray->n_children, cArray->length) {
     ArrowSchemaMove(cSchema.get(), cSchema_.get());
     ArrowArrayMove(cArray.get(), cArray_.get());
   }
 
-  ~GlutenArrowCStructColumnarBatch() override {
+  ~ArrowCStructColumnarBatch() override {
     ArrowSchemaRelease(cSchema_.get());
     ArrowArrayRelease(cArray_.get());
   }
 
-  std::string GetType() override {
+  std::string GetType() const override {
     return "arrow_array";
   }
 
@@ -116,5 +113,4 @@ class GlutenArrowCStructColumnarBatch : public GlutenColumnarBatch {
   std::shared_ptr<ArrowArray> cArray_ = std::make_shared<ArrowArray>();
 };
 
-} // namespace memory
 } // namespace gluten

--- a/cpp/src/memory/hbw_allocator.cc
+++ b/cpp/src/memory/hbw_allocator.cc
@@ -34,7 +34,7 @@ bool HbwMemoryAllocator::AllocateZeroFilled(int64_t nmemb, int64_t size, void** 
   return true;
 }
 
-bool HbwMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) { 
+bool HbwMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) {
   if (hbw_posix_memalign(out, alignment, size) != 0) {
     return false;
   }

--- a/cpp/src/memory/hbw_allocator.cc
+++ b/cpp/src/memory/hbw_allocator.cc
@@ -21,7 +21,6 @@
 #include "allocator.h"
 
 namespace gluten {
-namespace memory {
 
 bool HbwMemoryAllocator::Allocate(int64_t size, void** out) {
   *out = hbw_malloc(size);
@@ -35,7 +34,7 @@ bool HbwMemoryAllocator::AllocateZeroFilled(int64_t nmemb, int64_t size, void** 
   return true;
 }
 
-bool HbwMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) {
+bool HbwMemoryAllocator::AllocateAligned(uint16_t alignment, int64_t size, void** out) { 
   if (hbw_posix_memalign(out, alignment, size) != 0) {
     return false;
   }
@@ -70,9 +69,8 @@ bool HbwMemoryAllocator::Free(void* p, int64_t size) {
   return true;
 }
 
-int64_t HbwMemoryAllocator::GetBytes() {
+int64_t HbwMemoryAllocator::GetBytes() const {
   return bytes_;
 }
 
-} // namespace memory
 } // namespace gluten

--- a/cpp/src/memory/hbw_allocator.h
+++ b/cpp/src/memory/hbw_allocator.h
@@ -20,7 +20,6 @@
 #include "allocator.h"
 
 namespace gluten {
-namespace memory {
 
 class HbwMemoryAllocator : public MemoryAllocator {
  public:
@@ -36,11 +35,10 @@ class HbwMemoryAllocator : public MemoryAllocator {
 
   bool Free(void* p, int64_t size) override;
 
-  int64_t GetBytes() override;
+  int64_t GetBytes() const override;
 
  private:
   std::atomic_int64_t bytes_{0};
 };
 
-} // namespace memory
 } // namespace gluten

--- a/cpp/src/operators/c2r/arrow_columnar_to_row_converter.cc
+++ b/cpp/src/operators/c2r/arrow_columnar_to_row_converter.cc
@@ -23,7 +23,6 @@
 #include <iostream>
 
 namespace gluten {
-namespace columnartorow {
 
 uint32_t x_7[8] __attribute__((aligned(32))) = {0x7, 0x7, 0x7, 0x7, 0x7, 0x7, 0x7, 0x7};
 uint32_t x_8[8] __attribute__((aligned(32))) = {0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8};
@@ -375,5 +374,4 @@ arrow::Status ArrowColumnarToRowConverter::Write() {
   return arrow::Status::OK();
 }
 
-} // namespace columnartorow
 } // namespace gluten

--- a/cpp/src/operators/c2r/arrow_columnar_to_row_converter.h
+++ b/cpp/src/operators/c2r/arrow_columnar_to_row_converter.h
@@ -20,12 +20,11 @@
 #include "columnar_to_row_base.h"
 
 namespace gluten {
-namespace columnartorow {
 
-class ArrowColumnarToRowConverter : public ColumnarToRowConverterBase {
+class ArrowColumnarToRowConverter : public ColumnarToRowConverter {
  public:
   ArrowColumnarToRowConverter(std::shared_ptr<arrow::RecordBatch> rb, std::shared_ptr<arrow::MemoryPool> memory_pool)
-      : ColumnarToRowConverterBase(memory_pool), rb_(rb) {}
+      : ColumnarToRowConverter(memory_pool), rb_(rb) {}
 
   arrow::Status Init() override;
 
@@ -51,5 +50,4 @@ class ArrowColumnarToRowConverter : public ColumnarToRowConverterBase {
   std::shared_ptr<arrow::RecordBatch> rb_;
 };
 
-} // namespace columnartorow
 } // namespace gluten

--- a/cpp/src/operators/c2r/columnar_to_row_base.cc
+++ b/cpp/src/operators/c2r/columnar_to_row_base.cc
@@ -18,14 +18,15 @@
 #include "columnar_to_row_base.h"
 
 #include <arrow/util/decimal.h>
-namespace gluten {
-namespace columnartorow {
 
-int64_t ColumnarToRowConverterBase::CalculateBitSetWidthInBytes(int32_t numFields) {
+namespace gluten {
+
+int64_t ColumnarToRowConverter::CalculateBitSetWidthInBytes(
+    int32_t numFields) {
   return ((numFields + 63) >> 6) << 3;
 }
 
-int32_t ColumnarToRowConverterBase::RoundNumberOfBytesToNearestWord(int32_t numBytes) {
+int32_t ColumnarToRowConverter::RoundNumberOfBytesToNearestWord(int32_t numBytes) {
   int32_t remainder = numBytes & 0x07; // This is equivalent to `numBytes % 8`
 
   return numBytes + ((8 - remainder) & 0x7);
@@ -36,7 +37,8 @@ int32_t ColumnarToRowConverterBase::RoundNumberOfBytesToNearestWord(int32_t numB
   }*/
 }
 
-int64_t ColumnarToRowConverterBase::CalculatedFixeSizePerRow(std::shared_ptr<arrow::Schema> schema, int64_t num_cols) {
+int64_t ColumnarToRowConverter::CalculatedFixeSizePerRow(
+    std::shared_ptr<arrow::Schema> schema, int64_t num_cols) {
   std::vector<std::shared_ptr<arrow::Field>> fields = schema->fields();
   // Calculate the decimal col num when the precision >18
   int32_t count = 0;
@@ -55,11 +57,11 @@ int64_t ColumnarToRowConverterBase::CalculatedFixeSizePerRow(std::shared_ptr<arr
   return fixed_size + decimal_cols_size;
 }
 
-int64_t ColumnarToRowConverterBase::GetFieldOffset(int64_t nullBitsetWidthInBytes, int32_t index) {
+int64_t ColumnarToRowConverter::GetFieldOffset(int64_t nullBitsetWidthInBytes, int32_t index) {
   return nullBitsetWidthInBytes + 8L * index;
 }
 
-void ColumnarToRowConverterBase::BitSet(uint8_t* buffer_address, int32_t index) {
+void ColumnarToRowConverter::BitSet(uint8_t* buffer_address, int32_t index) { 
   int64_t mask = 1L << (index & 0x3f); // mod 64 and shift
   int64_t wordOffset = (index >> 6) * 8;
   int64_t word;
@@ -68,7 +70,7 @@ void ColumnarToRowConverterBase::BitSet(uint8_t* buffer_address, int32_t index) 
   *(int64_t*)(buffer_address + wordOffset) = value;
 }
 
-void ColumnarToRowConverterBase::SetNullAt(
+void ColumnarToRowConverter::SetNullAt(
     uint8_t* buffer_address,
     int64_t row_offset,
     int64_t field_offset,
@@ -76,11 +78,9 @@ void ColumnarToRowConverterBase::SetNullAt(
   BitSet(buffer_address + row_offset, col_index);
   // set the value to 0
   *(int64_t*)(buffer_address + row_offset + field_offset) = 0;
-
-  return;
 }
 
-int32_t ColumnarToRowConverterBase::FirstNonzeroLongNum(std::vector<int32_t> mag, int32_t length) {
+int32_t ColumnarToRowConverter::FirstNonzeroLongNum( std::vector<int32_t> mag, int32_t length) {
   int32_t fn = 0;
   int32_t i;
   for (i = length - 1; i >= 0 && mag[i] == 0; i--)
@@ -89,7 +89,7 @@ int32_t ColumnarToRowConverterBase::FirstNonzeroLongNum(std::vector<int32_t> mag
   return fn;
 }
 
-int32_t ColumnarToRowConverterBase::GetInt(int32_t n, int32_t sig, std::vector<int32_t> mag, int32_t length) {
+int32_t ColumnarToRowConverter::GetInt(int32_t n, int32_t sig, std::vector<int32_t> mag, int32_t length) {
   if (n < 0)
     return 0;
   if (n >= length)
@@ -99,7 +99,7 @@ int32_t ColumnarToRowConverterBase::GetInt(int32_t n, int32_t sig, std::vector<i
   return (sig >= 0 ? magInt : (n <= FirstNonzeroLongNum(mag, length) ? -magInt : ~magInt));
 }
 
-int32_t ColumnarToRowConverterBase::GetNumberOfLeadingZeros(uint32_t i) {
+int32_t ColumnarToRowConverter::GetNumberOfLeadingZeros(uint32_t i) {
   // HD, Figure 5-6
   if (i == 0)
     return 32;
@@ -124,11 +124,11 @@ int32_t ColumnarToRowConverterBase::GetNumberOfLeadingZeros(uint32_t i) {
   return n;
 }
 
-int32_t ColumnarToRowConverterBase::GetBitLengthForInt(uint32_t n) {
+int32_t ColumnarToRowConverter::GetBitLengthForInt(uint32_t n) {
   return 32 - GetNumberOfLeadingZeros(n);
 }
 
-int32_t ColumnarToRowConverterBase::GetBitCount(uint32_t i) {
+int32_t ColumnarToRowConverter::GetBitCount(uint32_t i) {
   // HD, Figure 5-2
   i = i - ((i >> 1) & 0x55555555);
   i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
@@ -138,7 +138,7 @@ int32_t ColumnarToRowConverterBase::GetBitCount(uint32_t i) {
   return i & 0x3f;
 }
 
-int32_t ColumnarToRowConverterBase::GetBitLength(int32_t sig, std::vector<int32_t> mag, int32_t len) {
+int32_t ColumnarToRowConverter::GetBitLength(int32_t sig, std::vector<int32_t> mag, int32_t len) {
   int32_t n = -1;
   if (len == 0) {
     n = 0;
@@ -159,7 +159,7 @@ int32_t ColumnarToRowConverterBase::GetBitLength(int32_t sig, std::vector<int32_
   return n;
 }
 
-std::vector<uint32_t> ColumnarToRowConverterBase::ConvertMagArray(int64_t new_high, uint64_t new_low, int32_t* size) {
+std::vector<uint32_t> ColumnarToRowConverter::ConvertMagArray(int64_t new_high, uint64_t new_low, int32_t* size) {
   std::vector<uint32_t> mag;
   int64_t orignal_low = new_low;
   int64_t orignal_high = new_high;
@@ -191,7 +191,7 @@ std::vector<uint32_t> ColumnarToRowConverterBase::ConvertMagArray(int64_t new_hi
 /*
  *  This method refer to the BigInterger#toByteArray() method in Java side.
  */
-std::array<uint8_t, 16> ColumnarToRowConverterBase::ToByteArray(arrow::Decimal128 value, int32_t* length) {
+std::array<uint8_t, 16> ColumnarToRowConverter::ToByteArray(arrow::Decimal128 value, int32_t* length) {
   int64_t high = value.high_bits();
   uint64_t low = value.low_bits();
   arrow::Decimal128 new_value;
@@ -237,5 +237,5 @@ std::array<uint8_t, 16> ColumnarToRowConverterBase::ToByteArray(arrow::Decimal12
   *length = byte_length;
   return out;
 }
-} // namespace columnartorow
+
 } // namespace gluten

--- a/cpp/src/operators/c2r/columnar_to_row_base.cc
+++ b/cpp/src/operators/c2r/columnar_to_row_base.cc
@@ -21,8 +21,7 @@
 
 namespace gluten {
 
-int64_t ColumnarToRowConverter::CalculateBitSetWidthInBytes(
-    int32_t numFields) {
+int64_t ColumnarToRowConverter::CalculateBitSetWidthInBytes(int32_t numFields) {
   return ((numFields + 63) >> 6) << 3;
 }
 
@@ -37,8 +36,7 @@ int32_t ColumnarToRowConverter::RoundNumberOfBytesToNearestWord(int32_t numBytes
   }*/
 }
 
-int64_t ColumnarToRowConverter::CalculatedFixeSizePerRow(
-    std::shared_ptr<arrow::Schema> schema, int64_t num_cols) {
+int64_t ColumnarToRowConverter::CalculatedFixeSizePerRow(std::shared_ptr<arrow::Schema> schema, int64_t num_cols) {
   std::vector<std::shared_ptr<arrow::Field>> fields = schema->fields();
   // Calculate the decimal col num when the precision >18
   int32_t count = 0;
@@ -61,7 +59,7 @@ int64_t ColumnarToRowConverter::GetFieldOffset(int64_t nullBitsetWidthInBytes, i
   return nullBitsetWidthInBytes + 8L * index;
 }
 
-void ColumnarToRowConverter::BitSet(uint8_t* buffer_address, int32_t index) { 
+void ColumnarToRowConverter::BitSet(uint8_t* buffer_address, int32_t index) {
   int64_t mask = 1L << (index & 0x3f); // mod 64 and shift
   int64_t wordOffset = (index >> 6) * 8;
   int64_t word;
@@ -80,7 +78,7 @@ void ColumnarToRowConverter::SetNullAt(
   *(int64_t*)(buffer_address + row_offset + field_offset) = 0;
 }
 
-int32_t ColumnarToRowConverter::FirstNonzeroLongNum( std::vector<int32_t> mag, int32_t length) {
+int32_t ColumnarToRowConverter::FirstNonzeroLongNum(std::vector<int32_t> mag, int32_t length) {
   int32_t fn = 0;
   int32_t i;
   for (i = length - 1; i >= 0 && mag[i] == 0; i--)

--- a/cpp/src/operators/c2r/columnar_to_row_base.h
+++ b/cpp/src/operators/c2r/columnar_to_row_base.h
@@ -28,13 +28,12 @@
 #include <boost/align.hpp>
 
 namespace gluten {
-namespace columnartorow {
 
-class ColumnarToRowConverterBase {
+class ColumnarToRowConverter {
  public:
-  ColumnarToRowConverterBase(std::shared_ptr<arrow::MemoryPool> arrow_pool) : arrow_pool_(arrow_pool) {}
+  ColumnarToRowConverter(std::shared_ptr<arrow::MemoryPool> arrow_pool) : arrow_pool_(arrow_pool) {}
 
-  virtual ~ColumnarToRowConverterBase() = default;
+  virtual ~ColumnarToRowConverter() = default;
 
   virtual arrow::Status Init() = 0;
   virtual arrow::Status Write() = 0;
@@ -42,10 +41,12 @@ class ColumnarToRowConverterBase {
   uint8_t* GetBufferAddress() {
     return buffer_address_;
   }
+
   const std::vector<int32_t>& GetOffsets() {
     return offsets_;
   }
-  const std::vector<int32_t, boost::alignment::aligned_allocator<int32_t, 32>>& GetLengths() {
+
+  const std::vector<int32_t, boost::alignment::aligned_allocator<int32_t, 32>>& GetLengths() const{
     return lengths_;
   }
 
@@ -91,5 +92,4 @@ class ColumnarToRowConverterBase {
   std::array<uint8_t, 16> ToByteArray(arrow::Decimal128 value, int32_t* length);
 };
 
-} // namespace columnartorow
 } // namespace gluten

--- a/cpp/src/operators/c2r/columnar_to_row_base.h
+++ b/cpp/src/operators/c2r/columnar_to_row_base.h
@@ -46,7 +46,7 @@ class ColumnarToRowConverter {
     return offsets_;
   }
 
-  const std::vector<int32_t, boost::alignment::aligned_allocator<int32_t, 32>>& GetLengths() const{
+  const std::vector<int32_t, boost::alignment::aligned_allocator<int32_t, 32>>& GetLengths() const {
     return lengths_;
   }
 

--- a/cpp/src/operators/shuffle/reader.cc
+++ b/cpp/src/operators/shuffle/reader.cc
@@ -27,12 +27,8 @@ ReaderOptions ReaderOptions::Defaults() {
   return {};
 }
 
-Reader::Reader(std::shared_ptr<arrow::io::InputStream> in,
-    std::shared_ptr<arrow::Schema> schema,
-    ReaderOptions options)
-    : in_(std::move(in)),
-      schema_(std::move(schema)),
-      options_(std::move(options)) {
+Reader::Reader(std::shared_ptr<arrow::io::InputStream> in, std::shared_ptr<arrow::Schema> schema, ReaderOptions options)
+    : in_(std::move(in)), schema_(std::move(schema)), options_(std::move(options)) {
   GLUTEN_ASSIGN_OR_THROW(first_message_, arrow::ipc::ReadMessage(in_.get()))
   if (first_message_->type() == arrow::ipc::MessageType::SCHEMA) {
     GLUTEN_ASSIGN_OR_THROW(schema_, arrow::ipc::ReadSchema(*first_message_, nullptr))
@@ -52,8 +48,8 @@ arrow::Result<std::shared_ptr<ColumnarBatch>> Reader::Next() {
   if (message_to_read == nullptr) {
     return nullptr;
   }
-  GLUTEN_ASSIGN_OR_THROW(arrow_batch,
-      arrow::ipc::ReadRecordBatch(*message_to_read, schema_, nullptr, options_.ipc_read_options))
+  GLUTEN_ASSIGN_OR_THROW(
+      arrow_batch, arrow::ipc::ReadRecordBatch(*message_to_read, schema_, nullptr, options_.ipc_read_options))
   std::shared_ptr<ColumnarBatch> gluten_batch = std::make_shared<ArrowColumnarBatch>(arrow_batch);
   return gluten_batch;
 }

--- a/cpp/src/operators/shuffle/reader.cc
+++ b/cpp/src/operators/shuffle/reader.cc
@@ -22,17 +22,17 @@
 #include <utility>
 
 namespace gluten {
-namespace shuffle {
 
 ReaderOptions ReaderOptions::Defaults() {
   return {};
 }
 
-Reader::Reader(
-    std::shared_ptr<arrow::io::InputStream> in,
+Reader::Reader(std::shared_ptr<arrow::io::InputStream> in,
     std::shared_ptr<arrow::Schema> schema,
-    gluten::shuffle::ReaderOptions options)
-    : in_(std::move(in)), schema_(std::move(schema)), options_(std::move(options)) {
+    ReaderOptions options)
+    : in_(std::move(in)),
+      schema_(std::move(schema)),
+      options_(std::move(options)) {
   GLUTEN_ASSIGN_OR_THROW(first_message_, arrow::ipc::ReadMessage(in_.get()))
   if (first_message_->type() == arrow::ipc::MessageType::SCHEMA) {
     GLUTEN_ASSIGN_OR_THROW(schema_, arrow::ipc::ReadSchema(*first_message_, nullptr))
@@ -40,7 +40,7 @@ Reader::Reader(
   }
 }
 
-arrow::Result<std::shared_ptr<gluten::memory::GlutenColumnarBatch>> Reader::Next() {
+arrow::Result<std::shared_ptr<ColumnarBatch>> Reader::Next() {
   std::shared_ptr<arrow::RecordBatch> arrow_batch;
   std::unique_ptr<arrow::ipc::Message> message_to_read;
   if (!first_message_consumed_) {
@@ -52,15 +52,14 @@ arrow::Result<std::shared_ptr<gluten::memory::GlutenColumnarBatch>> Reader::Next
   if (message_to_read == nullptr) {
     return nullptr;
   }
-  GLUTEN_ASSIGN_OR_THROW(
-      arrow_batch, arrow::ipc::ReadRecordBatch(*message_to_read, schema_, nullptr, options_.ipc_read_options))
-  std::shared_ptr<gluten::memory::GlutenColumnarBatch> gluten_batch =
-      std::make_shared<gluten::memory::GlutenArrowColumnarBatch>(arrow_batch);
+  GLUTEN_ASSIGN_OR_THROW(arrow_batch,
+      arrow::ipc::ReadRecordBatch(*message_to_read, schema_, nullptr, options_.ipc_read_options))
+  std::shared_ptr<ColumnarBatch> gluten_batch = std::make_shared<ArrowColumnarBatch>(arrow_batch);
   return gluten_batch;
 }
 
 arrow::Status Reader::Close() {
   return arrow::Status::OK();
 }
-} // namespace shuffle
+
 } // namespace gluten

--- a/cpp/src/operators/shuffle/reader.h
+++ b/cpp/src/operators/shuffle/reader.h
@@ -21,25 +21,22 @@
 #include "type.h"
 
 namespace gluten {
-namespace shuffle {
 
 class Reader {
  public:
-  Reader(
-      std::shared_ptr<arrow::io::InputStream> in,
+  Reader(std::shared_ptr<arrow::io::InputStream> in,
       std::shared_ptr<arrow::Schema> schema,
-      gluten::shuffle::ReaderOptions options);
+      ReaderOptions options);
 
-  arrow::Result<std::shared_ptr<gluten::memory::GlutenColumnarBatch>> Next();
+  arrow::Result<std::shared_ptr<ColumnarBatch>> Next();
   arrow::Status Close();
 
  private:
   std::shared_ptr<arrow::io::InputStream> in_;
-  gluten::shuffle::ReaderOptions options_;
+  ReaderOptions options_;
   std::shared_ptr<arrow::Schema> schema_;
   std::unique_ptr<arrow::ipc::Message> first_message_;
   bool first_message_consumed_ = false;
 };
 
-} // namespace shuffle
 } // namespace gluten

--- a/cpp/src/operators/shuffle/reader.h
+++ b/cpp/src/operators/shuffle/reader.h
@@ -24,9 +24,7 @@ namespace gluten {
 
 class Reader {
  public:
-  Reader(std::shared_ptr<arrow::io::InputStream> in,
-      std::shared_ptr<arrow::Schema> schema,
-      ReaderOptions options);
+  Reader(std::shared_ptr<arrow::io::InputStream> in, std::shared_ptr<arrow::Schema> schema, ReaderOptions options);
 
   arrow::Result<std::shared_ptr<ColumnarBatch>> Next();
   arrow::Status Close();

--- a/cpp/src/operators/shuffle/splitter.cc
+++ b/cpp/src/operators/shuffle/splitter.cc
@@ -1342,8 +1342,8 @@ arrow::Status HashSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch&
         "lea (%[num_partitions],%[pid],1),%[tmp]\n"
         "test %[pid],%[pid]\n"
         "cmovs %[tmp],%[pid]\n"
-        : [pid] "+r"(pid)
-        : [num_partitions] "r"(num_partitions_), [tmp] "r"(0));
+        : [ pid ] "+r"(pid)
+        : [ num_partitions ] "r"(num_partitions_), [ tmp ] "r"(0));
     partition_id_[i] = pid;
     partition_id_cnt_[pid]++;
   }

--- a/cpp/src/operators/shuffle/splitter.cc
+++ b/cpp/src/operators/shuffle/splitter.cc
@@ -36,7 +36,7 @@
 #include "utils/macros.h"
 
 namespace gluten {
-namespace shuffle {
+
 using arrow::internal::checked_cast;
 
 #ifndef SPLIT_BUFFER_SIZE
@@ -49,7 +49,8 @@ using arrow::internal::checked_cast;
 static const std::vector<arrow::Compression::type> supported_codec = {
     arrow::Compression::LZ4_FRAME,
     arrow::Compression::ZSTD,
-    arrow::Compression::GZIP};
+    arrow::Compression::GZIP
+};
 
 template <typename T>
 std::string __m128i_toString(const __m128i var) {
@@ -57,12 +58,11 @@ std::string __m128i_toString(const __m128i var) {
   T values[16 / sizeof(T)];
   std::memcpy(values, &var, sizeof(values)); // See discussion below
   if (sizeof(T) == 1) {
-    for (unsigned int i = 0; i < sizeof(__m128i); i++) { // C++11: Range for
-                                                         // also possible
+    for (unsigned int i = 0; i < sizeof(__m128i); i++) { // C++11: Range for also possible
       sstr << std::hex << (int)values[i] << " " << std::dec;
     }
   } else {
-    for (unsigned int i = 0; i < sizeof(__m128i) / sizeof(T); i++) { // C++11: Range for also possible
+    for (unsigned int i = 0; i < sizeof(__m128i) / sizeof(T); i++) {
       sstr << std::hex << values[i] << " " << std::dec;
     }
   }
@@ -75,8 +75,7 @@ SplitOptions SplitOptions::Defaults() {
 
 class Splitter::PartitionWriter {
  public:
-  explicit PartitionWriter(Splitter* splitter, int32_t partition_id)
-      : splitter_(splitter), partition_id_(partition_id) {}
+  PartitionWriter(Splitter* splitter, int32_t partition_id) : splitter_(splitter), partition_id_(partition_id) {}
 
   arrow::Status Spill() {
 #ifndef SKIPWRITE
@@ -130,8 +129,7 @@ class Splitter::PartitionWriter {
   }
 
   arrow::Status MergeSpilled() {
-    ARROW_ASSIGN_OR_RAISE(
-        auto spilled_file_is_, arrow::io::MemoryMappedFile::Open(spilled_file_, arrow::io::FileMode::READ));
+    ARROW_ASSIGN_OR_RAISE(auto spilled_file_is_, arrow::io::MemoryMappedFile::Open(spilled_file_, arrow::io::FileMode::READ));
     // copy spilled data blocks
     ARROW_ASSIGN_OR_RAISE(auto nbytes, spilled_file_is_->GetSize());
     ARROW_ASSIGN_OR_RAISE(auto buffer, spilled_file_is_->Read(nbytes));
@@ -156,7 +154,11 @@ class Splitter::PartitionWriter {
     int32_t metadata_length = 0; // unused
 #ifndef SKIPWRITE
     for (auto& payload : splitter_->partition_cached_recordbatch_[partition_id_]) {
-      RETURN_NOT_OK(arrow::ipc::WriteIpcPayload(*payload, splitter_->options_.ipc_write_options, os, &metadata_length));
+      RETURN_NOT_OK(arrow::ipc::WriteIpcPayload(
+          *payload,
+          splitter_->options_.ipc_write_options,
+          os,
+          &metadata_length));
       payload = nullptr;
     }
 #endif
@@ -268,16 +270,22 @@ arrow::Status Splitter::Init() {
   input_has_null_.resize(array_cnt, false);
   partition_binary_addrs_.resize(binary_array_idx.size());
 
-  std::for_each(partition_validity_addrs_.begin(), partition_validity_addrs_.end(), [this](std::vector<uint8_t*>& v) {
-    v.resize(num_partitions_, nullptr);
-  });
+  std::for_each(
+      partition_validity_addrs_.begin(),
+      partition_validity_addrs_.end(),
+      [this](std::vector<uint8_t*>& v) { v.resize(num_partitions_, nullptr); });
+
   std::for_each(
       partition_fixed_width_value_addrs_.begin(),
       partition_fixed_width_value_addrs_.end(),
       [this](std::vector<uint8_t*>& v) { v.resize(num_partitions_, nullptr); });
-  std::for_each(partition_buffers_.begin(), partition_buffers_.end(), [this](std::vector<arrow::BufferVector>& v) {
-    v.resize(num_partitions_);
-  });
+
+  std::for_each(
+      partition_buffers_.begin(),
+      partition_buffers_.end(),
+      [this](std::vector<arrow::BufferVector>& v) {
+        v.resize(num_partitions_);
+      });
 
   std::for_each(partition_binary_addrs_.begin(), partition_binary_addrs_.end(), [this](std::vector<BinaryBuff>& v) {
     v.resize(num_partitions_);
@@ -325,7 +333,8 @@ arrow::Status Splitter::AllocateBufferFromPool(std::shared_ptr<arrow::Buffer>& b
   } else if (combine_buffer_->capacity() - combine_buffer_->size() < size) {
     // memory pool is not enough
     ARROW_ASSIGN_OR_RAISE(
-        combine_buffer_, arrow::AllocateResizableBuffer(SPLIT_BUFFER_SIZE, options_.memory_pool.get()));
+        combine_buffer_,
+        arrow::AllocateResizableBuffer(SPLIT_BUFFER_SIZE, options_.memory_pool.get()));
     combine_buffer_->Resize(0, /*shrink_to_fit = */ false);
   }
   buffer = arrow::SliceMutableBuffer(combine_buffer_, combine_buffer_->size(), size);
@@ -347,9 +356,10 @@ int64_t Splitter::CompressedSize(const arrow::RecordBatch& rb) {
 }
 
 arrow::Status Splitter::SetCompressType(arrow::Compression::type compressed_type) {
-  if (std::any_of(supported_codec.begin(), supported_codec.end(), [&](const auto& codec) {
-        return codec == compressed_type;
-      })) {
+  if (std::any_of(
+          supported_codec.begin(),
+          supported_codec.end(),
+          [&](const auto& codec) { return codec == compressed_type; })) {
     ARROW_ASSIGN_OR_RAISE(options_.ipc_write_options.codec, arrow::util::Codec::Create(compressed_type));
   } else {
     options_.ipc_write_options.codec = nullptr;
@@ -371,8 +381,8 @@ arrow::Status Splitter::Stop() {
   std::shared_ptr<arrow::io::FileOutputStream> fout;
   ARROW_ASSIGN_OR_RAISE(fout, arrow::io::FileOutputStream::Open(options_.data_file, true));
   if (options_.buffered_write) {
-    ARROW_ASSIGN_OR_RAISE(
-        data_file_os_, arrow::io::BufferedOutputStream::Create(16384, options_.memory_pool.get(), fout));
+    ARROW_ASSIGN_OR_RAISE(data_file_os_,
+        arrow::io::BufferedOutputStream::Create(16384, options_.memory_pool.get(), fout));
   } else {
     data_file_os_ = fout;
   }
@@ -407,6 +417,7 @@ arrow::Status Splitter::Stop() {
 
   return arrow::Status::OK();
 }
+
 int64_t batch_nbytes(const arrow::RecordBatch& batch) {
   int64_t accumulated = 0L;
 
@@ -522,8 +533,8 @@ arrow::Status Splitter::CacheRecordBatch(int32_t partition_id, bool reset_buffer
             if (column_type_id_[i]->id() == arrow::BooleanType::type_id)
               buffers[1] = arrow::SliceBuffer(buffers[1], 0, arrow::bit_util::BytesForBits(num_rows));
             else
-              buffers[1] =
-                  arrow::SliceBuffer(buffers[1], 0, num_rows * (arrow::bit_width(column_type_id_[i]->id()) >> 3));
+              buffers[1] = arrow::SliceBuffer(buffers[1], 0,
+                  num_rows * (arrow::bit_width(column_type_id_[i]->id()) >> 3));
           }
 
           arrays[i] =
@@ -546,15 +557,17 @@ arrow::Status Splitter::CacheRecordBatch(int32_t partition_id, bool reset_buffer
 #ifndef SKIPCOMPRESS
     if (num_rows <= options_.batch_compress_threshold) {
       TIME_NANO_OR_RAISE(
-          total_compress_time_, arrow::ipc::GetRecordBatchPayload(*batch, tiny_bach_write_options_, payload.get()));
+          total_compress_time_,
+          arrow::ipc::GetRecordBatchPayload(*batch, tiny_bach_write_options_, payload.get()));
     } else {
       TIME_NANO_OR_RAISE(
-          total_compress_time_, arrow::ipc::GetRecordBatchPayload(*batch, options_.ipc_write_options, payload.get()));
+          total_compress_time_,
+          arrow::ipc::GetRecordBatchPayload(*batch, options_.ipc_write_options, payload.get()));
     }
 #else
     // for test reason
-    TIME_NANO_OR_RAISE(
-        total_compress_time_, arrow::ipc::GetRecordBatchPayload(*batch, tiny_bach_write_options_, payload.get()));
+    TIME_NANO_OR_RAISE(total_compress_time_,
+        arrow::ipc::GetRecordBatchPayload(*batch, tiny_bach_write_options_, payload.get()));
 #endif
 
     partition_cached_recordbatch_size_[partition_id] += payload->body_length;
@@ -589,8 +602,7 @@ arrow::Status Splitter::AllocatePartitionBuffers(int32_t partition_id, int32_t n
         std::shared_ptr<arrow::Buffer> offset_buffer;
         std::shared_ptr<arrow::Buffer> validity_buffer = nullptr;
         auto value_buf_size = binary_array_empirical_size_[binary_idx] * new_size + 1024;
-        ARROW_ASSIGN_OR_RAISE(
-            std::shared_ptr<arrow::Buffer> value_buffer,
+        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Buffer> value_buffer,
             arrow::AllocateResizableBuffer(value_buf_size, options_.memory_pool.get()));
         ARROW_RETURN_NOT_OK(AllocateBufferFromPool(offset_buffer, new_size * sizeof_binary_offset + 1));
         // set the first offset to 0
@@ -646,7 +658,7 @@ arrow::Status Splitter::AllocatePartitionBuffers(int32_t partition_id, int32_t n
         } else {
           partition_validity_addrs_[fixed_width_idx][partition_id] = nullptr;
         }
-        partition_buffers_[fixed_width_idx][partition_id] = {std::move(validity_buffer), std::move(value_buffer)};
+        partition_buffers_[fixed_width_idx][partition_id] = { std::move(validity_buffer), std::move(value_buffer) };
         fixed_width_idx++;
         break;
       }
@@ -1384,7 +1396,7 @@ arrow::Status FallbackRangeSplitter::Split(const arrow::RecordBatch& rb) {
   return arrow::Status::OK();
 }
 
-arrow::Status FallbackRangeSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch& rb) {
+arrow::Status FallbackRangeSplitter::ComputeAndCountPartitionId( const arrow::RecordBatch& rb) {
   if (rb.column(0)->type_id() != arrow::Type::INT32) {
     return arrow::Status::Invalid(
         "RecordBatch field 0 should be ", arrow::int32()->ToString(), ", actual is ", rb.column(0)->type()->ToString());
@@ -1406,5 +1418,4 @@ arrow::Status FallbackRangeSplitter::ComputeAndCountPartitionId(const arrow::Rec
   return arrow::Status::OK();
 }
 
-} // namespace shuffle
 } // namespace gluten

--- a/cpp/src/operators/shuffle/splitter.h
+++ b/cpp/src/operators/shuffle/splitter.h
@@ -32,13 +32,11 @@
 #include "substrait/algebra.pb.h"
 
 namespace gluten {
-namespace shuffle {
 
 class Splitter {
  protected:
   struct BinaryBuff {
-    BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c, uint64_t f)
-        : valueptr(v), offsetptr(o), value_capacity(c), value_offset(f) {}
+    BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c, uint64_t f) : valueptr(v), offsetptr(o), value_capacity(c), value_offset(f) {}
     BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c) : valueptr(v), offsetptr(o), value_capacity(c), value_offset(0) {}
     BinaryBuff() : valueptr(nullptr), offsetptr(nullptr), value_capacity(0), value_offset(0) {}
 
@@ -162,29 +160,21 @@ class Splitter {
   arrow::Status SplitBinaryArray(const arrow::RecordBatch& rb);
 
   template <typename T>
-  arrow::Status SplitBinaryType(
-      const uint8_t* src_addr,
-      const T* src_offset_addr,
-      std::vector<BinaryBuff>& dst_addrs,
-      const int binary_idx);
+  arrow::Status SplitBinaryType(const uint8_t* src_addr, const T* src_offset_addr,
+      std::vector<BinaryBuff>& dst_addrs, const int binary_idx);
 
   arrow::Status SplitListArray(const arrow::RecordBatch& rb);
 
   arrow::Status AllocateBufferFromPool(std::shared_ptr<arrow::Buffer>& buffer, uint32_t size);
 
-  template <
-      typename T,
+  template <typename T,
       typename ArrayType = typename arrow::TypeTraits<T>::ArrayType,
       typename BuilderType = typename arrow::TypeTraits<T>::BuilderType>
-  arrow::Status AppendBinary(
-      const std::shared_ptr<ArrayType>& src_arr,
-      const std::vector<std::shared_ptr<BuilderType>>& dst_builders,
-      int64_t num_rows);
+  arrow::Status AppendBinary(const std::shared_ptr<ArrayType>& src_arr,
+      const std::vector<std::shared_ptr<BuilderType>>& dst_builders, int64_t num_rows);
 
-  arrow::Status AppendList(
-      const std::shared_ptr<arrow::Array>& src_arr,
-      const std::vector<std::shared_ptr<arrow::ArrayBuilder>>& dst_builders,
-      int64_t num_rows);
+  arrow::Status AppendList(const std::shared_ptr<arrow::Array>& src_arr,
+      const std::vector<std::shared_ptr<arrow::ArrayBuilder>>& dst_builders, int64_t num_rows);
 
   // Cache the partition buffer/builder as compressed record batch. If reset
   // buffers, the partition buffer/builder will be set to nullptr. Two cases for
@@ -302,8 +292,8 @@ class Splitter {
 
 class RoundRobinSplitter : public Splitter {
  public:
-  static arrow::Result<std::shared_ptr<RoundRobinSplitter>>
-  Create(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+  static arrow::Result<std::shared_ptr<RoundRobinSplitter>> Create(
+      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
 
  private:
   RoundRobinSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options)
@@ -316,8 +306,9 @@ class RoundRobinSplitter : public Splitter {
 
 class HashSplitter : public Splitter {
  public:
-  static arrow::Result<std::shared_ptr<HashSplitter>>
-  Create(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+  static arrow::Result<std::shared_ptr<HashSplitter>> Create(
+      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+
   const std::shared_ptr<arrow::Schema>& input_schema() const override {
     return input_schema_;
   }
@@ -337,8 +328,8 @@ class HashSplitter : public Splitter {
 
 class FallbackRangeSplitter : public Splitter {
  public:
-  static arrow::Result<std::shared_ptr<FallbackRangeSplitter>>
-  Create(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+  static arrow::Result<std::shared_ptr<FallbackRangeSplitter>> Create(
+      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
 
   arrow::Status Split(const arrow::RecordBatch& rb) override;
 
@@ -357,5 +348,4 @@ class FallbackRangeSplitter : public Splitter {
   std::shared_ptr<arrow::Schema> input_schema_;
 };
 
-} // namespace shuffle
 } // namespace gluten

--- a/cpp/src/operators/shuffle/splitter.h
+++ b/cpp/src/operators/shuffle/splitter.h
@@ -36,7 +36,8 @@ namespace gluten {
 class Splitter {
  protected:
   struct BinaryBuff {
-    BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c, uint64_t f) : valueptr(v), offsetptr(o), value_capacity(c), value_offset(f) {}
+    BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c, uint64_t f)
+        : valueptr(v), offsetptr(o), value_capacity(c), value_offset(f) {}
     BinaryBuff(uint8_t* v, uint8_t* o, uint64_t c) : valueptr(v), offsetptr(o), value_capacity(c), value_offset(0) {}
     BinaryBuff() : valueptr(nullptr), offsetptr(nullptr), value_capacity(0), value_offset(0) {}
 
@@ -160,21 +161,29 @@ class Splitter {
   arrow::Status SplitBinaryArray(const arrow::RecordBatch& rb);
 
   template <typename T>
-  arrow::Status SplitBinaryType(const uint8_t* src_addr, const T* src_offset_addr,
-      std::vector<BinaryBuff>& dst_addrs, const int binary_idx);
+  arrow::Status SplitBinaryType(
+      const uint8_t* src_addr,
+      const T* src_offset_addr,
+      std::vector<BinaryBuff>& dst_addrs,
+      const int binary_idx);
 
   arrow::Status SplitListArray(const arrow::RecordBatch& rb);
 
   arrow::Status AllocateBufferFromPool(std::shared_ptr<arrow::Buffer>& buffer, uint32_t size);
 
-  template <typename T,
+  template <
+      typename T,
       typename ArrayType = typename arrow::TypeTraits<T>::ArrayType,
       typename BuilderType = typename arrow::TypeTraits<T>::BuilderType>
-  arrow::Status AppendBinary(const std::shared_ptr<ArrayType>& src_arr,
-      const std::vector<std::shared_ptr<BuilderType>>& dst_builders, int64_t num_rows);
+  arrow::Status AppendBinary(
+      const std::shared_ptr<ArrayType>& src_arr,
+      const std::vector<std::shared_ptr<BuilderType>>& dst_builders,
+      int64_t num_rows);
 
-  arrow::Status AppendList(const std::shared_ptr<arrow::Array>& src_arr,
-      const std::vector<std::shared_ptr<arrow::ArrayBuilder>>& dst_builders, int64_t num_rows);
+  arrow::Status AppendList(
+      const std::shared_ptr<arrow::Array>& src_arr,
+      const std::vector<std::shared_ptr<arrow::ArrayBuilder>>& dst_builders,
+      int64_t num_rows);
 
   // Cache the partition buffer/builder as compressed record batch. If reset
   // buffers, the partition buffer/builder will be set to nullptr. Two cases for
@@ -292,8 +301,8 @@ class Splitter {
 
 class RoundRobinSplitter : public Splitter {
  public:
-  static arrow::Result<std::shared_ptr<RoundRobinSplitter>> Create(
-      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+  static arrow::Result<std::shared_ptr<RoundRobinSplitter>>
+  Create(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
 
  private:
   RoundRobinSplitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options)
@@ -306,8 +315,8 @@ class RoundRobinSplitter : public Splitter {
 
 class HashSplitter : public Splitter {
  public:
-  static arrow::Result<std::shared_ptr<HashSplitter>> Create(
-      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+  static arrow::Result<std::shared_ptr<HashSplitter>>
+  Create(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
 
   const std::shared_ptr<arrow::Schema>& input_schema() const override {
     return input_schema_;
@@ -328,8 +337,8 @@ class HashSplitter : public Splitter {
 
 class FallbackRangeSplitter : public Splitter {
  public:
-  static arrow::Result<std::shared_ptr<FallbackRangeSplitter>> Create(
-      int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
+  static arrow::Result<std::shared_ptr<FallbackRangeSplitter>>
+  Create(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options);
 
   arrow::Status Split(const arrow::RecordBatch& rb) override;
 

--- a/cpp/src/operators/shuffle/type.h
+++ b/cpp/src/operators/shuffle/type.h
@@ -27,7 +27,6 @@
 #include "memory/arrow_memory_pool.h"
 
 namespace gluten {
-namespace shuffle {
 
 static constexpr int32_t kDefaultSplitterBufferSize = 4096;
 static constexpr int32_t kDefaultNumSubDirs = 64;
@@ -59,7 +58,7 @@ struct SplitOptions {
   int64_t thread_id = -1;
   int64_t task_attempt_id = -1;
 
-  std::shared_ptr<arrow::MemoryPool> memory_pool = gluten::memory::GetDefaultWrappedArrowMemoryPool();
+  std::shared_ptr<arrow::MemoryPool> memory_pool = GetDefaultWrappedArrowMemoryPool();
 
   arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
 
@@ -101,5 +100,5 @@ static const typeId all[] = {
 };
 
 } // namespace Type
-} // namespace shuffle
+
 } // namespace gluten

--- a/cpp/src/operators/shuffle/utils.h
+++ b/cpp/src/operators/shuffle/utils.h
@@ -32,7 +32,6 @@
 #include <thread>
 
 namespace gluten {
-namespace shuffle {
 
 #define EVAL_START(name, thread_id) \
   //  auto eval_start = std::chrono::duration_cast<std::chrono::nanoseconds>(    \
@@ -52,7 +51,8 @@ static std::string GenerateUUID() {
   return boost::uuids::to_string(generator());
 }
 
-static std::string GetSpilledShuffleFileDir(const std::string& configured_dir, int32_t sub_dir_id) {
+static std::string GetSpilledShuffleFileDir(
+    const std::string& configured_dir, int32_t sub_dir_id) {
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(2) << std::hex << sub_dir_id;
@@ -85,7 +85,7 @@ static arrow::Result<std::vector<std::string>> GetConfiguredLocalDirs() {
   }
 }
 
-static arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) {
+static arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) { 
   if (dir.length() == 0) {
     return arrow::Status::Invalid("Failed to create spilled file, got empty path.");
   }
@@ -161,5 +161,4 @@ static int64_t GetBufferSizes(const std::shared_ptr<arrow::Array>& array) {
       });
 }
 
-} // namespace shuffle
 } // namespace gluten

--- a/cpp/src/operators/shuffle/utils.h
+++ b/cpp/src/operators/shuffle/utils.h
@@ -51,8 +51,7 @@ static std::string GenerateUUID() {
   return boost::uuids::to_string(generator());
 }
 
-static std::string GetSpilledShuffleFileDir(
-    const std::string& configured_dir, int32_t sub_dir_id) {
+static std::string GetSpilledShuffleFileDir(const std::string& configured_dir, int32_t sub_dir_id) {
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(2) << std::hex << sub_dir_id;
@@ -85,7 +84,7 @@ static arrow::Result<std::vector<std::string>> GetConfiguredLocalDirs() {
   }
 }
 
-static arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) { 
+static arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) {
   if (dir.length() == 0) {
     return arrow::Status::Invalid("Failed to create spilled file, got empty path.");
   }

--- a/cpp/src/tests/hbw_allocator_test.cc
+++ b/cpp/src/tests/hbw_allocator_test.cc
@@ -35,11 +35,11 @@ class TestHbwAllocator : public ::testing::Test {
     buf = nullptr;
   }
 
-  std::shared_ptr<gluten::memory::MemoryAllocator> allocator = gluten::memory::DefaultMemoryAllocator();
+  std::shared_ptr<gluten::MemoryAllocator> allocator = gluten::DefaultMemoryAllocator();
 };
 
 TEST_F(TestHbwAllocator, TestHbwEnabled) {
-  auto ptr = std::dynamic_pointer_cast<gluten::memory::HbwMemoryAllocator>(allocator);
+  auto ptr = std::dynamic_pointer_cast<gluten::HbwMemoryAllocator>(allocator);
   ASSERT_NE(ptr, nullptr);
 }
 
@@ -64,3 +64,4 @@ TEST_F(TestHbwAllocator, Test) {
   allocator->ReallocateAligned(buf, 64, size, size << 1, &buf);
   CheckBytesAndFree(buf, size << 1);
 }
+

--- a/cpp/src/tests/hbw_allocator_test.cc
+++ b/cpp/src/tests/hbw_allocator_test.cc
@@ -64,4 +64,3 @@ TEST_F(TestHbwAllocator, Test) {
   allocator->ReallocateAligned(buf, 64, size, size << 1, &buf);
   CheckBytesAndFree(buf, size << 1);
 }
-

--- a/cpp/src/utils/metrics.h
+++ b/cpp/src/utils/metrics.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+namespace gluten {
+
 struct Metrics {
   int numMetrics = 0;
 
@@ -60,6 +62,11 @@ struct Metrics {
     numReplacedWithDynamicFilterRows = new long[numMetrics]();
   }
 
+  Metrics(const Metrics&) = delete;
+  Metrics(Metrics&&) = delete;
+  Metrics& operator=(const Metrics&) = delete;
+  Metrics& operator=(Metrics&&) = delete;
+
   ~Metrics() {
     delete[] inputRows;
     delete[] inputVectors;
@@ -75,3 +82,5 @@ struct Metrics {
     delete[] numMemoryAllocations;
   }
 };
+
+} // namespace gluten

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -166,6 +166,7 @@ set(VELOX_SRCS
     compute/DwrfDatasource.cc
     compute/bridge.cc
     memory/velox_memory_pool.cc
+    memory/velox_columnar_batch.cc
     )
 add_library(velox SHARED ${VELOX_SRCS})
 

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -69,8 +69,10 @@ arrow::Result<std::string> getGeneratedFilePath(const std::string& fileName) {
 }
 
 void InitVeloxBackend() {
-  gluten::SetBackendFactory([] { return std::make_shared<::velox::compute::VeloxPlanConverter>(confMap); });
-  auto veloxInitializer = std::make_shared<::velox::compute::VeloxInitializer>(confMap);
+  gluten::SetBackendFactory([] {
+    return std::make_shared<gluten::VeloxBackend>(confMap);
+  });
+  auto veloxInitializer = std::make_shared<gluten::VeloxInitializer>(confMap);
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string& filePath) {
@@ -85,8 +87,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string&
 }
 
 std::shared_ptr<facebook::velox::substrait::SplitInfo> getFileInfos(
-    const std::string& datasetPath,
-    const std::string& fileFormat) {
+    const std::string& datasetPath, const std::string& fileFormat) {
   auto scanInfo = std::make_shared<facebook::velox::substrait::SplitInfo>();
 
   // Set format to scan info.

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -69,9 +69,7 @@ arrow::Result<std::string> getGeneratedFilePath(const std::string& fileName) {
 }
 
 void InitVeloxBackend() {
-  gluten::SetBackendFactory([] {
-    return std::make_shared<gluten::VeloxBackend>(confMap);
-  });
+  gluten::SetBackendFactory([] { return std::make_shared<gluten::VeloxBackend>(confMap); });
   auto veloxInitializer = std::make_shared<gluten::VeloxInitializer>(confMap);
 }
 
@@ -87,7 +85,8 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string&
 }
 
 std::shared_ptr<facebook::velox::substrait::SplitInfo> getFileInfos(
-    const std::string& datasetPath, const std::string& fileFormat) {
+    const std::string& datasetPath,
+    const std::string& fileFormat) {
   auto scanInfo = std::make_shared<facebook::velox::substrait::SplitInfo>();
 
   // Set format to scan info.

--- a/cpp/velox/benchmarks/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/BenchmarkUtils.h
@@ -66,7 +66,7 @@ class BatchIteratorWrapper {
 
   virtual ~BatchIteratorWrapper() = default;
 
-  virtual arrow::Result<std::shared_ptr<gluten::memory::GlutenColumnarBatch>> Next() = 0;
+  virtual arrow::Result<std::shared_ptr<gluten::ColumnarBatch>> Next() = 0;
 
   void CreateReader() {
     ::parquet::ArrowReaderProperties properties = ::parquet::default_arrow_reader_properties();
@@ -100,11 +100,11 @@ class BatchVectorIterator : public BatchIteratorWrapper {
 #endif
   }
 
-  arrow::Result<std::shared_ptr<gluten::memory::GlutenColumnarBatch>> Next() override {
+  arrow::Result<std::shared_ptr<gluten::ColumnarBatch>> Next() override {
     if (iter_ == batches_.cend()) {
       return nullptr;
     }
-    return std::make_shared<gluten::memory::GlutenArrowColumnarBatch>(*iter_++);
+    return std::make_shared<gluten::ArrowColumnarBatch>(*iter_++);
   }
 
  private:
@@ -125,7 +125,7 @@ class BatchStreamIterator : public BatchIteratorWrapper {
     CreateReader();
   }
 
-  arrow::Result<std::shared_ptr<gluten::memory::GlutenColumnarBatch>> Next() override {
+  arrow::Result<std::shared_ptr<gluten::ColumnarBatch>> Next() override {
     auto startTime = std::chrono::steady_clock::now();
     GLUTEN_ASSIGN_OR_THROW(auto batch, recordBatchReader_->Next());
     if (batch == nullptr) {
@@ -133,7 +133,7 @@ class BatchStreamIterator : public BatchIteratorWrapper {
     }
     collectBatchTime_ +=
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - startTime).count();
-    return std::make_shared<gluten::memory::GlutenArrowColumnarBatch>(batch);
+    return std::make_shared<gluten::ArrowColumnarBatch>(batch);
   }
 };
 

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -64,7 +64,7 @@ auto BM_Generic = [](::benchmark::State& state,
         });
 
     backend->ParsePlan(plan->data(), plan->size());
-    auto resultIter = backend->GetResultIterator(gluten::memory::DefaultMemoryAllocator().get(), std::move(inputIters));
+    auto resultIter = backend->GetResultIterator(gluten::DefaultMemoryAllocator().get(), std::move(inputIters));
     auto outputSchema = backend->GetOutputSchema();
 
     while (resultIter->HasNext()) {
@@ -86,7 +86,7 @@ auto BM_Generic = [](::benchmark::State& state,
           return sum + iter->GetCollectBatchTime();
         });
 
-    auto* rawIter = static_cast<velox::compute::WholeStageResIter*>(resultIter->GetRaw());
+    auto* rawIter = static_cast<gluten::WholeStageResIter*>(resultIter->GetRaw());
     const auto& task = rawIter->task_;
     const auto& planNode = rawIter->planNode_;
     auto statsStr = ::facebook::velox::exec::printPlanWithStats(*planNode, task->taskStats(), true);

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -41,10 +41,10 @@ auto BM = [](::benchmark::State& state,
 
   for (auto _ : state) {
     state.PauseTiming();
-    auto backend = std::dynamic_pointer_cast<velox::compute::VeloxPlanConverter>(gluten::CreateBackend());
+    auto backend = std::dynamic_pointer_cast<gluten::VeloxBackend>(gluten::CreateBackend());
     state.ResumeTiming();
     backend->ParsePlan(plan->data(), plan->size());
-    auto resultIter = backend->GetResultIterator(gluten::memory::DefaultMemoryAllocator().get(), scanInfos);
+    auto resultIter = backend->GetResultIterator(gluten::DefaultMemoryAllocator().get(), scanInfos);
     auto outputSchema = backend->GetOutputSchema();
     while (resultIter->HasNext()) {
       auto array = resultIter->Next()->exportArrowArray();

--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -165,4 +165,3 @@ std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const RowType
   }
   return arrow::schema(fields);
 }
-

--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -165,3 +165,4 @@ std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const RowType
   }
   return arrow::schema(fields);
 }
+

--- a/cpp/velox/compute/ArrowTypeUtils.h
+++ b/cpp/velox/compute/ArrowTypeUtils.h
@@ -29,4 +29,3 @@ std::shared_ptr<arrow::DataType> toArrowType(const facebook::velox::TypePtr& typ
 const char* arrowTypeIdToFormatStr(arrow::Type::type typeId);
 
 std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const facebook::velox::RowType>& row_type);
-

--- a/cpp/velox/compute/ArrowTypeUtils.h
+++ b/cpp/velox/compute/ArrowTypeUtils.h
@@ -22,12 +22,11 @@
 
 #include "velox/type/Type.h"
 
-using namespace facebook::velox;
-
 std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& type_name);
 
-std::shared_ptr<arrow::DataType> toArrowType(const TypePtr& type);
+std::shared_ptr<arrow::DataType> toArrowType(const facebook::velox::TypePtr& type);
 
 const char* arrowTypeIdToFormatStr(arrow::Type::type typeId);
 
-std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const RowType>& row_type);
+std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const facebook::velox::RowType>& row_type);
+

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -55,7 +55,8 @@ void DwrfDatasource::Init(const std::unordered_map<std::string, std::string>& sp
   std::string file_name = file_path_.substr(last_pos + 1, (file_path_.length() - last_pos - 6));
   final_path_ = dir_path + "/" + file_name;
   std::string command = "touch " + final_path_;
-  system(command.c_str());
+  auto ret = system(command.c_str());
+  (void)(ret); // suppress warning
 
   ArrowSchema c_schema{};
   arrow::Status status = arrow::ExportSchema(*(schema_.get()), &c_schema);

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -99,8 +99,9 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
   reader_options.setFileFormat(format);
 
   if (strncmp(file_path_.c_str(), "file:", 5) == 0) {
-    std::unique_ptr<dwio::common::Reader> reader = dwio::common::getReaderFactory(reader_options.getFileFormat())
-          ->createReader(std::make_unique<dwio::common::FileInputStream>(file_path_.substr(5)), reader_options);
+    std::unique_ptr<dwio::common::Reader> reader =
+        dwio::common::getReaderFactory(reader_options.getFileFormat())
+            ->createReader(std::make_unique<dwio::common::FileInputStream>(file_path_.substr(5)), reader_options);
     return toArrowSchema(reader->rowType());
   }
 #ifdef VELOX_ENABLE_HDFS
@@ -113,7 +114,8 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
     std::regex hdfsPrefixExp("hdfs://(\\w+)/");
     std::string hdfsFilePath = regex_replace(file_path_.c_str(), hdfsPrefixExp, "/");
     HdfsReadFile readFile(hdfs, hdfsFilePath);
-    std::unique_ptr<dwio::common::Reader> reader = dwio::common::getReaderFactory(reader_options.getFileFormat())
+    std::unique_ptr<dwio::common::Reader> reader =
+        dwio::common::getReaderFactory(reader_options.getFileFormat())
             ->createReader(std::make_unique<dwio::common::ReadFileInputStream>(&readFile), reader_options);
     return toArrowSchema(reader->rowType());
   }
@@ -152,4 +154,4 @@ void DwrfDatasource::Write(const std::shared_ptr<arrow::RecordBatch>& rb) {
   writer_->write(row_vec);
 }
 
-} // namespace velox
+} // namespace gluten

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -34,10 +34,8 @@
 #include "velox/vector/arrow/c/Bridge.h"
 
 using namespace facebook::velox;
-using namespace facebook::velox::dwio::common;
 
-namespace velox {
-namespace compute {
+namespace gluten {
 
 void DwrfDatasource::Init(const std::unordered_map<std::string, std::string>& sparkConfs) {
   // Construct the file path and writer
@@ -65,38 +63,34 @@ void DwrfDatasource::Init(const std::unordered_map<std::string, std::string>& sp
   }
 
   type_ = importFromArrow(c_schema);
-  auto sink = std::make_unique<facebook::velox::dwio::common::FileSink>(final_path_);
-  auto config = std::make_shared<facebook::velox::dwrf::Config>();
+  auto sink = std::make_unique<dwio::common::FileSink>(final_path_);
+  auto config = std::make_shared<dwrf::Config>();
 
   for (auto iter = sparkConfs.begin(); iter != sparkConfs.end(); iter++) {
     auto key = iter->first;
     if (strcmp(key.c_str(), "hive.exec.orc.stripe.size") == 0) {
-      config->set(facebook::velox::dwrf::Config::STRIPE_SIZE, static_cast<uint64_t>(stoi(iter->second)));
+      config->set(dwrf::Config::STRIPE_SIZE, static_cast<uint64_t>(stoi(iter->second)));
     } else if (strcmp(key.c_str(), "hive.exec.orc.row.index.stride") == 0) {
-      config->set(facebook::velox::dwrf::Config::ROW_INDEX_STRIDE, static_cast<uint32_t>(stoi(iter->second)));
+      config->set(dwrf::Config::ROW_INDEX_STRIDE, static_cast<uint32_t>(stoi(iter->second)));
     } else if (strcmp(key.c_str(), "hive.exec.orc.compress") == 0) {
       // Currently velox only support ZLIB and ZSTD and the default is ZSTD.
       if (strcasecmp(iter->second.c_str(), "ZLIB") == 0) {
-        config->set(
-            facebook::velox::dwrf::Config::COMPRESSION,
-            facebook::velox::dwio::common::CompressionKind::CompressionKind_ZLIB);
+        config->set(dwrf::Config::COMPRESSION, dwio::common::CompressionKind::CompressionKind_ZLIB);
       } else {
-        config->set(
-            facebook::velox::dwrf::Config::COMPRESSION,
-            facebook::velox::dwio::common::CompressionKind::CompressionKind_ZSTD);
+        config->set(dwrf::Config::COMPRESSION, dwio::common::CompressionKind::CompressionKind_ZSTD);
       }
     }
   }
   const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max();
 
-  facebook::velox::dwrf::WriterOptions options;
+  dwrf::WriterOptions options;
   options.config = config;
   options.schema = type_;
   options.memoryBudget = writerMemoryCap;
   options.flushPolicyFactory = nullptr;
   options.layoutPlannerFactory = nullptr;
 
-  writer_ = std::make_unique<facebook::velox::dwrf::Writer>(options, std::move(sink), *pool_);
+  writer_ = std::make_unique<dwrf::Writer>(options, std::move(sink), *pool_);
 }
 
 std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
@@ -105,9 +99,8 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
   reader_options.setFileFormat(format);
 
   if (strncmp(file_path_.c_str(), "file:", 5) == 0) {
-    std::unique_ptr<dwio::common::Reader> reader =
-        dwio::common::getReaderFactory(reader_options.getFileFormat())
-            ->createReader(std::make_unique<dwio::common::FileInputStream>(file_path_.substr(5)), reader_options);
+    std::unique_ptr<dwio::common::Reader> reader = dwio::common::getReaderFactory(reader_options.getFileFormat())
+          ->createReader(std::make_unique<dwio::common::FileInputStream>(file_path_.substr(5)), reader_options);
     return toArrowSchema(reader->rowType());
   }
 #ifdef VELOX_ENABLE_HDFS
@@ -120,8 +113,7 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
     std::regex hdfsPrefixExp("hdfs://(\\w+)/");
     std::string hdfsFilePath = regex_replace(file_path_.c_str(), hdfsPrefixExp, "/");
     HdfsReadFile readFile(hdfs, hdfsFilePath);
-    std::unique_ptr<dwio::common::Reader> reader =
-        dwio::common::getReaderFactory(reader_options.getFileFormat())
+    std::unique_ptr<dwio::common::Reader> reader = dwio::common::getReaderFactory(reader_options.getFileFormat())
             ->createReader(std::make_unique<dwio::common::ReadFileInputStream>(&readFile), reader_options);
     return toArrowSchema(reader->rowType());
   }
@@ -160,5 +152,4 @@ void DwrfDatasource::Write(const std::shared_ptr<arrow::RecordBatch>& rb) {
   writer_->write(row_vec);
 }
 
-} // namespace compute
 } // namespace velox

--- a/cpp/velox/compute/DwrfDatasource.h
+++ b/cpp/velox/compute/DwrfDatasource.h
@@ -39,8 +39,11 @@ namespace gluten {
 
 class DwrfDatasource {
  public:
-  DwrfDatasource(const std::string& file_path, std::shared_ptr<arrow::Schema> schema, 
-      facebook::velox::memory::MemoryPool* pool) : file_path_(file_path), schema_(schema), pool_(pool) {}
+  DwrfDatasource(
+      const std::string& file_path,
+      std::shared_ptr<arrow::Schema> schema,
+      facebook::velox::memory::MemoryPool* pool)
+      : file_path_(file_path), schema_(schema), pool_(pool) {}
 
   void Init(const std::unordered_map<std::string, std::string>& sparkConfs);
   std::shared_ptr<arrow::Schema> InspectSchema();
@@ -59,4 +62,4 @@ class DwrfDatasource {
   facebook::velox::memory::MemoryPool* pool_;
 };
 
-} // namespace velox
+} // namespace gluten

--- a/cpp/velox/compute/DwrfDatasource.h
+++ b/cpp/velox/compute/DwrfDatasource.h
@@ -25,6 +25,7 @@
 
 #include "operators/c2r/arrow_columnar_to_row_converter.h"
 #include "operators/c2r/columnar_to_row_base.h"
+
 #include "velox/common/file/FileSystems.h"
 #ifdef VELOX_ENABLE_HDFS
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
@@ -34,15 +35,12 @@
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/vector/ComplexVector.h"
 
-using namespace facebook::velox;
-
-namespace velox {
-namespace compute {
+namespace gluten {
 
 class DwrfDatasource {
  public:
-  DwrfDatasource(const std::string& file_path, std::shared_ptr<arrow::Schema> schema, memory::MemoryPool* pool)
-      : file_path_(file_path), schema_(schema), pool_(pool) {}
+  DwrfDatasource(const std::string& file_path, std::shared_ptr<arrow::Schema> schema, 
+      facebook::velox::memory::MemoryPool* pool) : file_path_(file_path), schema_(schema), pool_(pool) {}
 
   void Init(const std::unordered_map<std::string, std::string>& sparkConfs);
   std::shared_ptr<arrow::Schema> InspectSchema();
@@ -55,11 +53,10 @@ class DwrfDatasource {
   int32_t count_ = 0;
   int64_t num_rbs_ = 0;
   std::shared_ptr<arrow::Schema> schema_;
-  std::vector<RowVectorPtr> row_vecs_;
+  std::vector<facebook::velox::RowVectorPtr> row_vecs_;
   std::shared_ptr<const facebook::velox::Type> type_;
   std::shared_ptr<facebook::velox::dwrf::Writer> writer_;
-  memory::MemoryPool* pool_;
+  facebook::velox::memory::MemoryPool* pool_;
 };
 
-} // namespace compute
 } // namespace velox

--- a/cpp/velox/compute/RegistrationAllFunctions.cc
+++ b/cpp/velox/compute/RegistrationAllFunctions.cc
@@ -23,7 +23,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::aggregate::prestosql;
 
-namespace velox::compute {
+namespace gluten {
 
 void registerCustomFunctions() {
   exec::registerVectorFunction(
@@ -40,4 +40,4 @@ void registerAllFunctions() {
   registerAllAggregateFunctions();
 }
 
-} // namespace velox::compute
+} // namespace gluten

--- a/cpp/velox/compute/RegistrationAllFunctions.h
+++ b/cpp/velox/compute/RegistrationAllFunctions.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-namespace velox::compute {
+namespace gluten {
 
 void registerAllFunctions();
 
-} // namespace velox::compute
+} // namespace gluten

--- a/cpp/velox/compute/RowConstructor.cc
+++ b/cpp/velox/compute/RowConstructor.cc
@@ -20,12 +20,11 @@
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-namespace velox::compute {
+namespace gluten {
 
-namespace {
 class RowConstructor : public exec::VectorFunction {
-  void apply(
-      const SelectivityVector& rows,
+
+  void apply(const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
       exec::EvalCtx& context,
@@ -59,5 +58,4 @@ class RowConstructor : public exec::VectorFunction {
   }
 };
 
-} // namespace
 } // namespace velox::compute

--- a/cpp/velox/compute/RowConstructor.cc
+++ b/cpp/velox/compute/RowConstructor.cc
@@ -23,8 +23,8 @@ using namespace facebook::velox::exec;
 namespace gluten {
 
 class RowConstructor : public exec::VectorFunction {
-
-  void apply(const SelectivityVector& rows,
+  void apply(
+      const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
       exec::EvalCtx& context,
@@ -58,4 +58,4 @@ class RowConstructor : public exec::VectorFunction {
   }
 };
 
-} // namespace velox::compute
+} // namespace gluten

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -72,8 +72,8 @@
 
 namespace gluten {
 
-std::shared_ptr<facebook::velox::core::QueryCtx> 
-createNewVeloxQueryCtx(facebook::velox::memory::MemoryPool* memoryPool);
+std::shared_ptr<facebook::velox::core::QueryCtx> createNewVeloxQueryCtx(
+    facebook::velox::memory::MemoryPool* memoryPool);
 
 class VeloxInitializer {
  public:
@@ -86,7 +86,8 @@ class VeloxInitializer {
 
 class WholeStageResIter {
  public:
-  WholeStageResIter(std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
+  WholeStageResIter(
+      std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
       std::shared_ptr<const facebook::velox::core::PlanNode> planNode,
       const std::unordered_map<std::string, std::string>& confMap)
       : pool_(pool), planNode_(planNode), confMap_(confMap) {
@@ -116,14 +117,16 @@ class WholeStageResIter {
 
  private:
   /// Get all the children plan node ids with postorder traversal.
-  void getOrderedNodeIds(const std::shared_ptr<const facebook::velox::core::PlanNode>&, 
+  void getOrderedNodeIds(
+      const std::shared_ptr<const facebook::velox::core::PlanNode>&,
       std::vector<facebook::velox::core::PlanNodeId>& nodeIds);
 
   /// Collect Velox metrics.
   void collectMetrics();
 
   /// Return the sum of one runtime metric.
-  int64_t sumOfRuntimeMetric(const std::unordered_map<std::string, facebook::velox::RuntimeMetric>& runtimeStats, 
+  int64_t sumOfRuntimeMetric(
+      const std::unordered_map<std::string, facebook::velox::RuntimeMetric>& runtimeStats,
       const std::string& metricId) const;
 
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
@@ -148,19 +151,23 @@ class VeloxBackend : public Backend {
 
   std::shared_ptr<GlutenResultIterator> GetResultIterator(MemoryAllocator* allocator) override;
 
-  std::shared_ptr<GlutenResultIterator> GetResultIterator(MemoryAllocator* allocator,
+  std::shared_ptr<GlutenResultIterator> GetResultIterator(
+      MemoryAllocator* allocator,
       std::vector<std::shared_ptr<GlutenResultIterator>> inputs) override;
 
   // Used by unit test and benchmark.
-  std::shared_ptr<GlutenResultIterator> GetResultIterator(MemoryAllocator* allocator,
+  std::shared_ptr<GlutenResultIterator> GetResultIterator(
+      MemoryAllocator* allocator,
       const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos);
 
-  arrow::Result<std::shared_ptr<ColumnarToRowConverter>>
-  getColumnarConverter(MemoryAllocator* allocator, std::shared_ptr<ColumnarBatch> cb) override;
+  arrow::Result<std::shared_ptr<ColumnarToRowConverter>> getColumnarConverter(
+      MemoryAllocator* allocator,
+      std::shared_ptr<ColumnarBatch> cb) override;
 
   /// Separate the scan ids and stream ids, and get the scan infos.
-  void getInfoAndIds(std::unordered_map<facebook::velox::core::PlanNodeId,
-      std::shared_ptr<facebook::velox::substrait::SplitInfo>> splitInfoMap,
+  void getInfoAndIds(
+      std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<facebook::velox::substrait::SplitInfo>>
+          splitInfoMap,
       std::unordered_set<facebook::velox::core::PlanNodeId> leafPlanNodeIds,
       std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos,
       std::vector<facebook::velox::core::PlanNodeId>& scanIds,
@@ -214,8 +221,9 @@ class VeloxBackend : public Backend {
   std::shared_ptr<facebook::velox::substrait::SubstraitParser> subParser_ =
       std::make_shared<facebook::velox::substrait::SubstraitParser>();
 
-  std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter> subVeloxPlanConverter_ = 
-      std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(GetDefaultWrappedVeloxMemoryPool().get());
+  std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter> subVeloxPlanConverter_ =
+      std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(
+          GetDefaultWrappedVeloxMemoryPool().get());
 
   // Cache for tests/benchmark purpose.
   std::shared_ptr<const facebook::velox::core::PlanNode> planNode_;

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -166,7 +166,7 @@ class WholeStageResIter {
 };
 
 // This class is used to convert the Substrait plan into Velox plan.
-class VeloxPlanConverter : public gluten::ExecBackendBase {
+class VeloxPlanConverter : public gluten::ExecBackend {
  public:
   VeloxPlanConverter(const std::unordered_map<std::string, std::string>& confMap) : confMap_(confMap) {}
 

--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -181,7 +181,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<DoubleType>( vec, write_address, row_idx);
+            auto serialized = row::UnsafeRowSerializer::serialize<DoubleType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -195,7 +195,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<BooleanType>( vec, write_address, row_idx);
+            auto serialized = row::UnsafeRowSerializer::serialize<BooleanType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -222,7 +222,8 @@ arrow::Status VeloxToRowConverter::Write() {
         break;
       }
       default:
-        return arrow::Status::Invalid("Type " + schema_->field(col_idx)->type()->name() + " is not supported in VeloxToRow conversion.");
+        return arrow::Status::Invalid(
+            "Type " + schema_->field(col_idx)->type()->name() + " is not supported in VeloxToRow conversion.");
     }
   }
   return arrow::Status::OK();

--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -28,8 +28,9 @@
 #include "velox/row/UnsafeRowSerializer.h"
 #include "velox/vector/arrow/c/Bridge.h"
 
-namespace velox {
-namespace compute {
+using namespace facebook::velox;
+
+namespace gluten {
 
 arrow::Status VeloxToRowConverter::Init() {
   num_rows_ = rv_->size();
@@ -180,7 +181,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<DoubleType>(vec, write_address, row_idx);
+            auto serialized = row::UnsafeRowSerializer::serialize<DoubleType>( vec, write_address, row_idx);
           }
         }
         break;
@@ -194,7 +195,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<BooleanType>(vec, write_address, row_idx);
+            auto serialized = row::UnsafeRowSerializer::serialize<BooleanType>( vec, write_address, row_idx);
           }
         }
         break;
@@ -221,12 +222,10 @@ arrow::Status VeloxToRowConverter::Write() {
         break;
       }
       default:
-        return arrow::Status::Invalid(
-            "Type " + schema_->field(col_idx)->type()->name() + " is not supported in VeloxToRow conversion.");
+        return arrow::Status::Invalid("Type " + schema_->field(col_idx)->type()->name() + " is not supported in VeloxToRow conversion.");
     }
   }
   return arrow::Status::OK();
 }
 
-} // namespace compute
-} // namespace velox
+} // namespace gluten

--- a/cpp/velox/compute/VeloxToRowConverter.h
+++ b/cpp/velox/compute/VeloxToRowConverter.h
@@ -25,18 +25,14 @@
 #include "operators/c2r/columnar_to_row_base.h"
 #include "velox/vector/ComplexVector.h"
 
-using namespace facebook::velox;
+namespace gluten {
 
-namespace velox {
-namespace compute {
-
-class VeloxToRowConverter : public gluten::columnartorow::ColumnarToRowConverterBase {
+class VeloxToRowConverter : public ColumnarToRowConverter {
  public:
-  VeloxToRowConverter(
-      RowVectorPtr rv,
+  VeloxToRowConverter(facebook::velox::RowVectorPtr rv,
       std::shared_ptr<arrow::MemoryPool> arrow_pool,
-      std::shared_ptr<memory::MemoryPool> velox_pool)
-      : ColumnarToRowConverterBase(arrow_pool), rv_(rv), velox_pool_(velox_pool) {}
+      std::shared_ptr<facebook::velox::memory::MemoryPool> velox_pool)
+      : ColumnarToRowConverter(arrow_pool), rv_(rv), velox_pool_(velox_pool) {}
 
   arrow::Status Init() override;
 
@@ -45,11 +41,10 @@ class VeloxToRowConverter : public gluten::columnartorow::ColumnarToRowConverter
  private:
   void ResumeVeloxVector();
 
-  RowVectorPtr rv_;
-  std::shared_ptr<memory::MemoryPool> velox_pool_;
-  std::vector<VectorPtr> vecs_;
+  facebook::velox::RowVectorPtr rv_;
+  std::shared_ptr<facebook::velox::memory::MemoryPool> velox_pool_;
+  std::vector<facebook::velox::VectorPtr> vecs_;
   std::shared_ptr<arrow::Schema> schema_;
 };
 
-} // namespace compute
-} // namespace velox
+} // namespace gluten

--- a/cpp/velox/compute/VeloxToRowConverter.h
+++ b/cpp/velox/compute/VeloxToRowConverter.h
@@ -29,7 +29,8 @@ namespace gluten {
 
 class VeloxToRowConverter : public ColumnarToRowConverter {
  public:
-  VeloxToRowConverter(facebook::velox::RowVectorPtr rv,
+  VeloxToRowConverter(
+      facebook::velox::RowVectorPtr rv,
       std::shared_ptr<arrow::MemoryPool> arrow_pool,
       std::shared_ptr<facebook::velox::memory::MemoryPool> velox_pool)
       : ColumnarToRowConverter(arrow_pool), rv_(rv), velox_pool_(velox_pool) {}

--- a/cpp/velox/compute/bridge.cc
+++ b/cpp/velox/compute/bridge.cc
@@ -134,7 +134,8 @@ class ExportedArrayStreamByArray {
 
 } // namespace
 
-arrow::Status ExportArrowArray(std::shared_ptr<arrow::Schema> schema,
+arrow::Status ExportArrowArray(
+    std::shared_ptr<arrow::Schema> schema,
     std::shared_ptr<gluten::ArrowArrayIterator> reader,
     struct ArrowArrayStream* out) {
   out->get_schema = ExportedArrayStreamByArray::StaticGetSchema;

--- a/cpp/velox/compute/bridge.h
+++ b/cpp/velox/compute/bridge.h
@@ -4,12 +4,12 @@
 #include "releases/include/arrow/c/bridge.h"
 
 namespace gluten {
+
 using ArrowArrayIterator = arrow::Iterator<std::shared_ptr<ArrowArray>>;
-}
-namespace arrow {
+
 ARROW_EXPORT
-Status ExportArrowArray(
-    std::shared_ptr<arrow::Schema> schema,
-    std::shared_ptr<gluten::ArrowArrayIterator> reader,
+arrow::Status ExportArrowArray(std::shared_ptr<arrow::Schema> schema, 
+    std::shared_ptr<ArrowArrayIterator> reader, 
     struct ArrowArrayStream* out);
-} // namespace arrow
+
+} // namespace gluten

--- a/cpp/velox/compute/bridge.h
+++ b/cpp/velox/compute/bridge.h
@@ -8,8 +8,9 @@ namespace gluten {
 using ArrowArrayIterator = arrow::Iterator<std::shared_ptr<ArrowArray>>;
 
 ARROW_EXPORT
-arrow::Status ExportArrowArray(std::shared_ptr<arrow::Schema> schema, 
-    std::shared_ptr<ArrowArrayIterator> reader, 
+arrow::Status ExportArrowArray(
+    std::shared_ptr<arrow::Schema> schema,
+    std::shared_ptr<ArrowArrayIterator> reader,
     struct ArrowArrayStream* out);
 
 } // namespace gluten

--- a/cpp/velox/jni/jni_wrapper.cc
+++ b/cpp/velox/jni/jni_wrapper.cc
@@ -50,7 +50,8 @@ void setUpConfMap(JNIEnv* env, jobject obj, jbyteArray planArray) {
       const auto& enhancement = extension.enhancement();
       ::substrait::Expression expression;
       if (!enhancement.UnpackTo(&expression)) {
-        std::string error_message = "Can't Unapck the Any object to Expression Literal when passing the spark conf to velox";
+        std::string error_message =
+            "Can't Unapck the Any object to Expression Literal when passing the spark conf to velox";
         gluten::JniThrow(error_message);
       }
       if (expression.has_literal()) {
@@ -89,19 +90,21 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION);
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv* env, jobject obj, jbyteArray planArray) {
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(
+    JNIEnv* env,
+    jobject obj,
+    jbyteArray planArray) {
   JNI_METHOD_START
   setUpConfMap(env, obj, planArray);
-  gluten::SetBackendFactory([] {
-    return std::make_shared<gluten::VeloxBackend>(sparkConfs_);
-  });
+  gluten::SetBackendFactory([] { return std::make_shared<gluten::VeloxBackend>(sparkConfs_); });
   static auto veloxInitializer = std::make_shared<gluten::VeloxInitializer>(sparkConfs_);
   JNI_METHOD_END()
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(JNIEnv* env, jobject obj, jbyteArray planArray) {
+JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
+    JNIEnv* env,
+    jobject obj,
+    jbyteArray planArray) {
   JNI_METHOD_START
   auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
   auto planSize = env->GetArrayLength(planArray);
@@ -115,23 +118,29 @@ Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
   // An execution context used for function validation.
   std::unique_ptr<core::ExecCtx> execCtx_ = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
 
-  auto planValidator = std::make_shared<facebook::velox::substrait::SubstraitToVeloxPlanValidator>(pool.get(), execCtx_.get());
+  auto planValidator =
+      std::make_shared<facebook::velox::substrait::SubstraitToVeloxPlanValidator>(pool.get(), execCtx_.get());
   return planValidator->validate(subPlan);
   JNI_METHOD_END(false)
 }
 
 JNIEXPORT jlong JNICALL
 Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWrapper_nativeInitDwrfDatasource(
-    JNIEnv* env, jobject obj, jstring file_path, jlong c_schema) {
+    JNIEnv* env,
+    jobject obj,
+    jstring file_path,
+    jlong c_schema) {
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool = gluten::GetDefaultWrappedVeloxMemoryPool();
   if (c_schema == -1) {
     // Only inspect the schema and not write
-    auto dwrfDatasource = std::make_shared<gluten::DwrfDatasource>(JStringToCString(env, file_path), nullptr, pool.get());
+    auto dwrfDatasource =
+        std::make_shared<gluten::DwrfDatasource>(JStringToCString(env, file_path), nullptr, pool.get());
     // dwrfDatasource->Init( );
     return CreateNativeRef(dwrfDatasource);
   } else {
     auto schema = gluten::JniGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(c_schema)));
-    auto dwrfDatasource = std::make_shared<gluten::DwrfDatasource>(JStringToCString(env, file_path), schema, pool.get());
+    auto dwrfDatasource =
+        std::make_shared<gluten::DwrfDatasource>(JStringToCString(env, file_path), schema, pool.get());
     dwrfDatasource->Init(sparkConfs_);
     return CreateNativeRef(dwrfDatasource);
   }
@@ -139,7 +148,9 @@ Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWra
 
 JNIEXPORT jbyteArray JNICALL
 Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWrapper_inspectSchema(
-    JNIEnv* env, jobject obj, jlong instanceId) {
+    JNIEnv* env,
+    jobject obj,
+    jlong instanceId) {
   JNI_METHOD_START
   auto dwrfDatasource = RetrieveNativeInstance<gluten::DwrfDatasource>(instanceId);
   auto schema = dwrfDatasource->InspectSchema();
@@ -147,9 +158,10 @@ Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWra
   JNI_METHOD_END(nullptr)
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWrapper_close(
-    JNIEnv* env, jobject obj, jlong instanceId) {
+JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWrapper_close(
+    JNIEnv* env,
+    jobject obj,
+    jlong instanceId) {
   JNI_METHOD_START
   auto dwrfDatasource = RetrieveNativeInstance<gluten::DwrfDatasource>(instanceId);
   dwrfDatasource->Close();
@@ -165,8 +177,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_vel
     jlong c_array) {
   JNI_METHOD_START
   std::shared_ptr<arrow::RecordBatch> rb = gluten::JniGetOrThrow(arrow::ImportRecordBatch(
-          reinterpret_cast<struct ArrowArray*>(c_array),
-          reinterpret_cast<struct ArrowSchema*>(c_schema)));
+      reinterpret_cast<struct ArrowArray*>(c_array), reinterpret_cast<struct ArrowSchema*>(c_schema)));
 
   auto dwrfDatasource = RetrieveNativeInstance<gluten::DwrfDatasource>(instanceId);
   dwrfDatasource->Write(rb);

--- a/cpp/velox/memory/velox_columnar_batch.cc
+++ b/cpp/velox/memory/velox_columnar_batch.cc
@@ -17,8 +17,8 @@ void VeloxColumnarBatch::EnsureFlattened() {
   }
 
   // Perform copy to flatten dictionary vectors.
-  RowVectorPtr copy = std::dynamic_pointer_cast<RowVector>(BaseVector::create(
-      rowVector_->type(), rowVector_->size(), rowVector_->pool()));
+  RowVectorPtr copy = std::dynamic_pointer_cast<RowVector>(
+      BaseVector::create(rowVector_->type(), rowVector_->size(), rowVector_->pool()));
   copy->copy(rowVector_.get(), 0, 0, rowVector_->size());
   flattened_ = copy;
   auto endTime = std::chrono::steady_clock::now();
@@ -49,4 +49,4 @@ RowVectorPtr VeloxColumnarBatch::getFlattenedRowVector() {
   return flattened_;
 }
 
-} // namespace velox
+} // namespace gluten

--- a/cpp/velox/memory/velox_columnar_batch.cc
+++ b/cpp/velox/memory/velox_columnar_batch.cc
@@ -1,0 +1,52 @@
+#include "velox_columnar_batch.h"
+
+namespace gluten {
+
+using facebook::velox::BaseVector;
+using facebook::velox::RowVector;
+using facebook::velox::RowVectorPtr;
+
+void VeloxColumnarBatch::EnsureFlattened() {
+  if (flattened_ != nullptr) {
+    return;
+  }
+  auto startTime = std::chrono::steady_clock::now();
+  // Make sure to load lazy vector if not loaded already.
+  for (auto& child : rowVector_->children()) {
+    child->loadedVector();
+  }
+
+  // Perform copy to flatten dictionary vectors.
+  RowVectorPtr copy = std::dynamic_pointer_cast<RowVector>(BaseVector::create(
+      rowVector_->type(), rowVector_->size(), rowVector_->pool()));
+  copy->copy(rowVector_.get(), 0, 0, rowVector_->size());
+  flattened_ = copy;
+  auto endTime = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
+  exportNanos_ += duration;
+}
+
+std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
+  auto out = std::make_shared<ArrowSchema>();
+  EnsureFlattened();
+  facebook::velox::exportToArrow(flattened_, *out);
+  return out;
+}
+
+std::shared_ptr<ArrowArray> VeloxColumnarBatch::exportArrowArray() {
+  auto out = std::make_shared<ArrowArray>();
+  EnsureFlattened();
+  facebook::velox::exportToArrow(flattened_, *out, GetDefaultWrappedVeloxMemoryPool().get());
+  return out;
+}
+
+RowVectorPtr VeloxColumnarBatch::getRowVector() const {
+  return rowVector_;
+}
+
+RowVectorPtr VeloxColumnarBatch::getFlattenedRowVector() {
+  EnsureFlattened();
+  return flattened_;
+}
+
+} // namespace velox

--- a/cpp/velox/memory/velox_columnar_batch.h
+++ b/cpp/velox/memory/velox_columnar_batch.h
@@ -26,8 +26,8 @@ namespace gluten {
 
 class VeloxColumnarBatch : public ColumnarBatch {
  public:
-  VeloxColumnarBatch(facebook::velox::RowVectorPtr rowVector) 
-    : ColumnarBatch(rowVector->childrenSize(), rowVector->size()), rowVector_(rowVector) {}
+  VeloxColumnarBatch(facebook::velox::RowVectorPtr rowVector)
+      : ColumnarBatch(rowVector->childrenSize(), rowVector->size()), rowVector_(rowVector) {}
 
   std::string GetType() const override {
     return "velox";

--- a/cpp/velox/memory/velox_columnar_batch.h
+++ b/cpp/velox/memory/velox_columnar_batch.h
@@ -15,25 +15,35 @@
  * limitations under the License.
  */
 
-#include "exec_backend.h"
+#pragma once
+
+#include "memory/columnar_batch.h"
+#include "memory/velox_memory_pool.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/arrow/c/Bridge.h"
 
 namespace gluten {
 
-static std::function<std::shared_ptr<Backend>()> backend_factory;
+class VeloxColumnarBatch : public ColumnarBatch {
+ public:
+  VeloxColumnarBatch(facebook::velox::RowVectorPtr rowVector) 
+    : ColumnarBatch(rowVector->childrenSize(), rowVector->size()), rowVector_(rowVector) {}
 
-void SetBackendFactory(std::function<std::shared_ptr<Backend>()> factory) {
-#ifdef GLUTEN_PRINT_DEBUG
-  std::cout << "Set backend factory." << std::endl;
-#endif
-  backend_factory = std::move(factory);
-}
-
-std::shared_ptr<Backend> CreateBackend() {
-  if (backend_factory == nullptr) {
-    throw std::runtime_error(
-        "Execution backend not set. This may due to the backend library not loaded, or SetBackendFactory() is not called in nativeInitNative() JNI call.");
+  std::string GetType() const override {
+    return "velox";
   }
-  return backend_factory();
-}
+
+  std::shared_ptr<ArrowSchema> exportArrowSchema() override;
+  std::shared_ptr<ArrowArray> exportArrowArray() override;
+
+  facebook::velox::RowVectorPtr getRowVector() const;
+  facebook::velox::RowVectorPtr getFlattenedRowVector();
+
+ private:
+  void EnsureFlattened();
+
+  facebook::velox::RowVectorPtr rowVector_ = nullptr;
+  facebook::velox::RowVectorPtr flattened_ = nullptr;
+};
 
 } // namespace gluten

--- a/cpp/velox/memory/velox_memory_pool.cc
+++ b/cpp/velox/memory/velox_memory_pool.cc
@@ -40,8 +40,9 @@ class VeloxMemoryAllocatorVariant {
   void* allocZeroFilled(int64_t numMembers, int64_t sizeEach) {
     void* out;
     if (!gluten_alloc_->AllocateZeroFilled(numMembers, sizeEach, &out)) {
-      VELOX_FAIL("VeloxMemoryAllocatorVariant: Failed to allocate (zero filled) " +
-          std::to_string(numMembers) + " members, " + std::to_string(sizeEach) + " bytes for each")
+      VELOX_FAIL(
+          "VeloxMemoryAllocatorVariant: Failed to allocate (zero filled) " + std::to_string(numMembers) + " members, " +
+          std::to_string(sizeEach) + " bytes for each")
     }
     return out;
   }
@@ -186,9 +187,8 @@ class WrappedVeloxMemoryPool : public facebook::velox::memory::MemoryPool {
   }
 
   void setSubtreeMemoryUsage(int64_t size) {
-    updateSubtreeMemoryUsage([size](facebook::velox::memory::MemoryUsage& subtreeUsage) {
-          subtreeUsage.setCurrentBytes(size);
-        });
+    updateSubtreeMemoryUsage(
+        [size](facebook::velox::memory::MemoryUsage& subtreeUsage) { subtreeUsage.setCurrentBytes(size); });
   }
 
   int64_t updateSubtreeMemoryUsage(int64_t size) {
@@ -354,10 +354,9 @@ std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(Me
       "wrapped", nullptr, std::make_shared<VeloxMemoryAllocatorVariant>(allocator));
 }
 
-std::shared_ptr<facebook::velox::memory::MemoryPool>
-GetDefaultWrappedVeloxMemoryPool() {
+std::shared_ptr<facebook::velox::memory::MemoryPool> GetDefaultWrappedVeloxMemoryPool() {
   static auto default_pool = std::make_shared<WrappedVeloxMemoryPool<VeloxMemoryAllocatorVariant>>(
-          "root", nullptr, VeloxMemoryAllocatorVariant::createDefaultAllocator());
+      "root", nullptr, VeloxMemoryAllocatorVariant::createDefaultAllocator());
   return default_pool;
 }
 

--- a/cpp/velox/memory/velox_memory_pool.h
+++ b/cpp/velox/memory/velox_memory_pool.h
@@ -21,15 +21,12 @@
 #include "velox/common/memory/Memory.h"
 
 namespace gluten {
-namespace memory {
 
 constexpr uint16_t kNoAlignment = facebook::velox::memory::kNoAlignment;
 constexpr int64_t kMaxMemory = facebook::velox::memory::kMaxMemory;
 
-std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(
-    gluten::memory::MemoryAllocator* allocator);
+std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(MemoryAllocator* allocator);
 
 std::shared_ptr<facebook::velox::memory::MemoryPool> GetDefaultWrappedVeloxMemoryPool();
 
-} // namespace memory
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. unify the namespace, and make all CPP types/functions under the namespace gluten, the multi-level namespace is unnecessary for gluten and brings difficulty.
2. remove the suffix `xxTypeBase` and rename some classes to consider clearness.
3. rename ExecBackendBase to Backend and VeloxPlanConverter to VeloxBackend, this change makes the public inheriting reflect the `VeloxBackend is a Backend` relation.
4. add const for read-only member functions.
5. add new files velox_columnar_batch.h/cc to define `VeloxColumnarBatch` separately.
6. format codes according to the new 120-column limit.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

