### PR TITLE
[CH-226] Fix a weird bug to handle expressions for ClickHouse Backend

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/utils/RangePartitionerBoundsGenerator.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/utils/RangePartitionerBoundsGenerator.scala
@@ -299,6 +299,11 @@ object RangePartitionerBoundsGenerator {
           enableRangePartitioning = false
           break
         }
+        // FIXME: there is a weird bug to handle expressions.
+        if (!ordering.child.isInstanceOf[Attribute]) {
+          enableRangePartitioning = false
+          break
+        }
       }
     }
     enableRangePartitioning


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Disable running range partitioning in backend when the partition keys contain expressions.

## How was this patch tested?

unit tests


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

