### PR TITLE
Remove "sudo" from Velox.md

### DIFF
--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -7,7 +7,7 @@ Velox uses the script setup-ubuntu.sh to install all dependency libraries, but A
 
 ```shell script
 apt-get update
-apt-get install -y software-properties-common maven build-essential cmake libssl-dev libre2-dev libcurl4-openssl-dev clang lldb lld libz-dev git ninja-build uuid-dev sudo openjdk-8-jdk default-jdk
+apt-get install -y software-properties-common maven build-essential cmake libssl-dev libre2-dev libcurl4-openssl-dev clang lldb lld libz-dev git ninja-build uuid-dev openjdk-8-jdk default-jdk
 ```
 
 Also, we need to set up the JAVA_HOME env. Currently, java 8 is required and the support for java 11/17 is not ready.
@@ -21,7 +21,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 ```shell script
 
 ## install gcc and libraries to build arrow
-apt-get update && apt-get install -y sudo locales wget tar tzdata git ccache cmake ninja-build build-essential llvm-11-dev clang-11 libiberty-dev libdwarf-dev libre2-dev libz-dev libssl-dev libboost-all-dev libcurl4-openssl-dev openjdk-8-jdk maven
+apt-get update && apt-get install -y locales wget tar tzdata git ccache cmake ninja-build build-essential llvm-11-dev clang-11 libiberty-dev libdwarf-dev libre2-dev libz-dev libssl-dev libboost-all-dev libcurl4-openssl-dev openjdk-8-jdk maven
 
 ## make sure jdk8 is used
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
"sudo" should not be used in the sample commands.

Users should elevate privileges knowingly rather than through copy-paste

This also fixes a typo in one of the commands (misplaced sudo)
