### PR TITLE
[GLUTEN-663] Support spliting partition by files count strategy for ClickHouse Backend (experimental)

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -38,6 +38,13 @@ object CHBackendSettings extends BackendSettings {
   val GLUTEN_CLICKHOUSE_SEP_SCAN_RDD = "spark.gluten.sql.columnar.separate.scan.rdd.for.ch"
   val GLUTEN_CLICKHOUSE_SEP_SCAN_RDD_DEFAULT = "false"
 
+  // experimental: when the files count per partition exceeds this threshold,
+  // it will put the files into one partition.
+  val GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD =
+    GlutenConfig.GLUTEN_CONFIG_PREFIX + GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND +
+      ".files.per.partition.threshold"
+  val GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD_DEFAULT = "-1"
+
   override def supportFileFormatRead(): FileFormat => Boolean = {
     case _: ParquetFileFormat => true
     case _ => false

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
@@ -16,11 +16,12 @@
  */
 package io.glutenproject.backendsapi.clickhouse
 
+import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.{BackendsApiManager, ITransformerApi}
 import io.glutenproject.expression.{ExpressionConverter, ExpressionTransformer}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.SelectionNode
-import io.glutenproject.utils.InputPartitionsUtil
+import io.glutenproject.utils.CHInputPartitionsUtil
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.utils.RangePartitionerBoundsGenerator
@@ -63,6 +64,7 @@ class CHTransformerApi extends ITransformerApi with Logging {
             })
           .exists(_ == false))
       case RangePartitioning(orderings, _) =>
+        GlutenConfig.getSessionConf.enableColumnarSort &&
         RangePartitionerBoundsGenerator.supportedOrderings(orderings)
       case _ => true
     }
@@ -86,7 +88,7 @@ class CHTransformerApi extends ITransformerApi with Logging {
       relation.location.asInstanceOf[ClickHouseFileIndex].partsPartitions
     } else {
       // Generate FilePartition for Parquet
-      InputPartitionsUtil.genInputPartitionSeq(relation, selectedPartitions)
+      CHInputPartitionsUtil.genInputPartitionSeq(relation, selectedPartitions)
     }
   }
 }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHInputPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHInputPartitionsUtil.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils
+
+import io.glutenproject.backendsapi.clickhouse.CHBackendSettings
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.execution.PartitionedFileUtil
+import org.apache.spark.sql.execution.datasources.{FilePartition, HadoopFsRelation, PartitionDirectory, PartitionedFile}
+
+import scala.collection.mutable.ArrayBuffer
+
+object CHInputPartitionsUtil extends Logging {
+
+  def genInputPartitionSeq(
+      relation: HadoopFsRelation,
+      selectedPartitions: Array[PartitionDirectory]): Seq[InputPartition] = {
+    // TODO: Support bucketed reads
+    val maxSplitBytes =
+      FilePartition.maxSplitBytes(relation.sparkSession, selectedPartitions)
+
+    val splitFiles = selectedPartitions
+      .flatMap {
+        partition =>
+          partition.files.flatMap {
+            file =>
+              // getPath() is very expensive so we only want to call it once in this block:
+              val filePath = file.getPath
+              val isSplitable =
+                relation.fileFormat.isSplitable(relation.sparkSession, relation.options, filePath)
+              PartitionedFileUtil.splitFiles(
+                sparkSession = relation.sparkSession,
+                file = file,
+                filePath = filePath,
+                isSplitable = isSplitable,
+                maxSplitBytes = maxSplitBytes,
+                partitionValues = partition.values)
+          }
+      }
+      .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+
+    val totalCores = SparkResourcesUtil.getTotalCores(relation.sparkSession.sessionState.conf)
+    val fileCntPerPartition = math.ceil((splitFiles.size * 1.0) / totalCores).toInt
+    val fileCntThreshold = relation.sparkSession.sessionState.conf
+      .getConfString(
+        CHBackendSettings.GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD,
+        CHBackendSettings.GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD_DEFAULT
+      )
+      .toInt
+
+    if (fileCntThreshold > 0 && fileCntPerPartition > fileCntThreshold) {
+      getFilePartitionsByFileCnt(splitFiles, fileCntPerPartition)
+    } else {
+      FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
+    }
+  }
+
+  /** Generate `Seq[FilePartition]` according to the file count */
+  def getFilePartitionsByFileCnt(
+      partitionedFiles: Seq[PartitionedFile],
+      fileCntPerPartition: Int): Seq[FilePartition] = {
+    val partitions = new ArrayBuffer[FilePartition]
+    val currentFiles = new ArrayBuffer[PartitionedFile]
+    var currentFileCnt = 0L
+
+    /** Close the current partition and move to the next. */
+    def closePartition(): Unit = {
+      if (currentFiles.nonEmpty) {
+        // Copy to a new Array.
+        val newPartition = FilePartition(partitions.size, currentFiles.toArray)
+        partitions += newPartition
+      }
+      currentFiles.clear()
+      currentFileCnt = 0L
+    }
+
+    partitionedFiles.foreach {
+      file =>
+        if (currentFileCnt >= fileCntPerPartition) {
+          closePartition()
+        }
+        // Add the given file to the current partition.
+        currentFileCnt += 1L
+        currentFiles += file
+    }
+    closePartition()
+    partitions.toSeq
+  }
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/utils/MergeTreePartsPartitionsUtil.scala
@@ -16,20 +16,22 @@
  */
 package org.apache.spark.sql.execution.datasources.utils
 
+import io.glutenproject.backendsapi.clickhouse.CHBackendSettings
 import io.glutenproject.execution.GlutenMergeTreePartition
+import io.glutenproject.utils.SparkResourcesUtil
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.table.ClickHouseTableV2
 
 import scala.collection.mutable.ArrayBuffer
 
-object MergeTreePartsPartitionsUtil {
+object MergeTreePartsPartitionsUtil extends Logging {
 
   def getPartsPartitions(
       sparkSession: SparkSession,
       table: ClickHouseTableV2): Seq[InputPartition] = {
-    val maxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
     val partsFiles = table.listFiles()
 
     val partitions = new ArrayBuffer[InputPartition]
@@ -40,10 +42,12 @@ object MergeTreePartsPartitionsUtil {
       ("default", "file_format")
     }
     val engine = table.snapshot.metadata.configuration.get("engine").get
+    // TODO: remove `substring`
     val tablePath = table.deltaLog.dataPath.toString.substring(6)
     var currentMinPartsNum = -1L
     var currentMaxPartsNum = -1L
     var currentSize = 0L
+    var currentFileCnt = 0L
 
     /** Close the current partition and move to the next. */
     def closePartition(): Unit = {
@@ -61,21 +65,53 @@ object MergeTreePartsPartitionsUtil {
       currentMinPartsNum = -1L
       currentMaxPartsNum = -1L
       currentSize = 0
+      currentFileCnt = 0L
     }
 
-    val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
-    // Assign files to partitions using "Next Fit Decreasing"
-    partsFiles.foreach {
-      parts =>
-        if (currentSize + parts.bytesOnDisk > maxSplitBytes) {
-          closePartition()
-        }
-        // Add the given file to the current partition.
-        currentSize += parts.bytesOnDisk + openCostInBytes
-        if (currentMinPartsNum == -1L) {
-          currentMinPartsNum = parts.minBlockNumber
-        }
-        currentMaxPartsNum = parts.maxBlockNumber
+    val totalCores = SparkResourcesUtil.getTotalCores(sparkSession.sessionState.conf)
+    val fileCntPerPartition = math.ceil((partsFiles.size * 1.0) / totalCores).toInt
+    val fileCntThreshold = sparkSession.sessionState.conf
+      .getConfString(
+        CHBackendSettings.GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD,
+        CHBackendSettings.GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD_DEFAULT
+      )
+      .toInt
+
+    if (fileCntThreshold > 0 && fileCntPerPartition > fileCntThreshold) {
+      // generate `Seq[InputPartition]` by file count
+      // Assign files to partitions using "Next Fit Decreasing"
+      partsFiles.foreach {
+        parts =>
+          if (currentFileCnt >= fileCntPerPartition) {
+            closePartition()
+          }
+          // Add the given file to the current partition.
+          currentFileCnt += 1
+          if (currentMinPartsNum == -1L) {
+            currentMinPartsNum = parts.minBlockNumber
+          }
+          currentMaxPartsNum = parts.maxBlockNumber
+      }
+    } else {
+      // generate `Seq[InputPartition]` by file size
+      val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
+      val maxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
+      logInfo(
+        s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+          s"open cost is considered as scanning $openCostInBytes bytes.")
+      // Assign files to partitions using "Next Fit Decreasing"
+      partsFiles.foreach {
+        parts =>
+          if (currentSize + parts.bytesOnDisk > maxSplitBytes) {
+            closePartition()
+          }
+          // Add the given file to the current partition.
+          currentSize += parts.bytesOnDisk + openCostInBytes
+          if (currentMinPartsNum == -1L) {
+            currentMinPartsNum = parts.minBlockNumber
+          }
+          currentMaxPartsNum = parts.maxBlockNumber
+      }
     }
     closePartition()
     partitions

--- a/gluten-core/src/main/scala/io/glutenproject/utils/SparkResourcesUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/SparkResourcesUtil.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.internal.SQLConf
+
+object SparkResourcesUtil extends Logging {
+
+  /**
+   * Get the total cores of the Spark application
+   */
+  def getTotalCores(sqlConf: SQLConf): Int = {
+    sqlConf.getConfString("spark.master") match {
+      case local if local.startsWith("local") =>
+        sqlConf.getConfString("spark.default.parallelism", "1").toInt
+      case yarn if yarn.startsWith("yarn") =>
+        val instances = getYarnExecutorNum(sqlConf)
+        val cores = sqlConf.getConfString("spark.executor.cores").toInt
+        Math.max(instances * cores, sqlConf.getConfString("spark.default.parallelism", "1").toInt)
+      case standalone if standalone.startsWith("spark:") =>
+        Math.max(sqlConf.getConfString("spark.cores.max").toInt,
+          sqlConf.getConfString("spark.default.parallelism", "1").toInt)
+    }
+  }
+
+  /**
+   * Get the executor number for yarn
+   */
+  def getYarnExecutorNum(sqlConf: SQLConf): Int = {
+    if (sqlConf.getConfString("spark.dynamicAllocation.enabled", "false").toBoolean) {
+      val maxExecutors =
+        sqlConf.getConfString("spark.dynamicAllocation.maxExecutors",
+          sqlConf.getConfString("spark.default.parallelism")).toInt
+      maxExecutors
+    } else {
+      sqlConf.getConfString("spark.executor.instances").toInt
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support spliting partition by files count strategy for ClickHouse Backend (experimental): When the number of data files is several times the total number of cores, merge multiple files into one partition for processing to improve performance and reduce the amount of shuffle data. Note: make sure there is enough memory for processing multiple files in one partition.

Add a parameter spark.gluten.sql.columnar.backend.ch.files.per.partition.threshold to control the number of merged files, the default value is -1, means it will not take effect.

For example:
When set the parameter spark.gluten.sql.columnar.backend.ch.files.per.partition.threshold to 5, and there are 100 data files and 10 cores, theoretically 1 core can process 10 data files, which exceeds 5, it will merge 10 files into one partition to process.

Please refer to the details in #663 .

Close #663 .


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

