### PR TITLE
[GLUTEN-666] Remove the unused parameter 'spark.gluten.sql.columnar.loadnative'

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHInitializerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHInitializerApi.scala
@@ -35,11 +35,7 @@ class CHInitializerApi extends IInitializerApi {
     }
     // Path based load. Ignore all other loadees.
     JniLibLoader.loadFromPath(libPath, true)
-    // SQLConf is not initialed here, so it's not possible to use 'GlutenConfig.getConf' to
-    // get conf.
-    if (conf.getBoolean(GlutenConfig.GLUTEN_LOAD_NATIVE, defaultValue = true)) {
-      val initKernel = new CHNativeExpressionEvaluator()
-      initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
-    }
+    val initKernel = new CHNativeExpressionEvaluator()
+    initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
   }
 }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/RunTPCHTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/RunTPCHTest.scala
@@ -92,7 +92,6 @@ object RunTPCHTest {
       .config("spark.databricks.delta.stalenessLimit", 3600 * 1000)
       .config("spark.gluten.sql.columnar.columnartorow", columnarColumnToRow)
       .config("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
-      .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .config(GlutenConfig.GLUTEN_LIB_PATH, libPath)
       .config("spark.gluten.sql.columnar.iterator", "true")
       .config("spark.gluten.sql.columnar.hashagg.enablefinal", "true")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseSyntheticDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseSyntheticDataSuite.scala
@@ -71,7 +71,6 @@ class GlutenClickHouseSyntheticDataSuite extends WholeStageTransformerSuite with
       .set("spark.databricks.delta.stalenessLimit", "3600000")
       .set("spark.gluten.sql.columnar.columnartorow", "true")
       .set("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .set(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -97,7 +97,6 @@ abstract class GlutenClickHouseTPCDSAbstractSuite extends WholeStageTransformerS
       .set("spark.databricks.delta.stalenessLimit", "3600000")
       .set("spark.gluten.sql.columnar.columnartorow", "true")
       .set("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .set(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
@@ -511,7 +511,6 @@ abstract class GlutenClickHouseTPCHAbstractSuite extends WholeStageTransformerSu
       .set("spark.databricks.delta.stalenessLimit", "3600000")
       .set("spark.gluten.sql.columnar.columnartorow", "true")
       .set("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .set(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHAggAndShuffleBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHAggAndShuffleBenchmark.scala
@@ -80,7 +80,6 @@ object CHAggAndShuffleBenchmark extends SqlBasedBenchmark {
       .set("spark.databricks.delta.properties.defaults.checkpointInterval", "5")
       .set("spark.databricks.delta.stalenessLimit", "3600000")
       .set("spark.gluten.sql.columnar.columnartorow", "true")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
       .set("spark.gluten.sql.columnar.separate.scan.rdd.for.ch", "false")
       .set("spark.sql.adaptive.enabled", "false")

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
@@ -84,7 +84,6 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark {
       .set("spark.databricks.delta.properties.defaults.checkpointInterval", "5")
       .set("spark.databricks.delta.stalenessLimit", "3600000")
       .set("spark.gluten.sql.columnar.columnartorow", "true")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .setIfMissing(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
       .set("spark.gluten.sql.enable.native.validation", "false")
       .set("spark.gluten.sql.columnar.separate.scan.rdd.for.ch", "true")

--- a/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleInitializerApi.scala
+++ b/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleInitializerApi.scala
@@ -43,11 +43,7 @@ class GazelleInitializerApi extends IInitializerApi {
     val baseLibName = conf.get(GlutenConfig.GLUTEN_LIB_NAME, "spark_columnar_jni")
     loader.mapAndLoad(baseLibName, true)
     loader.mapAndLoad(GlutenConfig.GLUTEN_GAZELLE_BACKEND, false)
-    // SQLConf is not initialed here, so it's not possible to use 'GlutenConfig.getConf' to
-    // get conf.
-    if (conf.getBoolean(GlutenConfig.GLUTEN_LOAD_NATIVE, defaultValue = true)) {
-      val initKernel = new VeloxNativeExpressionEvaluator()
-      initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
-    }
+    val initKernel = new VeloxNativeExpressionEvaluator()
+    initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
   }
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
@@ -40,11 +40,7 @@ class VeloxInitializerApi extends IInitializerApi {
     val baseLibName = conf.get(GlutenConfig.GLUTEN_LIB_NAME, "spark_columnar_jni")
     loader.mapAndLoad(baseLibName, true)
     loader.mapAndLoad(GlutenConfig.GLUTEN_VELOX_BACKEND, true)
-    // SQLConf is not initialed here, so it's not possible to use 'GlutenConfig.getConf' to
-    // get conf.
-    if (conf.getBoolean(GlutenConfig.GLUTEN_LOAD_NATIVE, defaultValue = true)) {
-      val initKernel = new VeloxNativeExpressionEvaluator()
-      initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
-    }
+    val initKernel = new VeloxNativeExpressionEvaluator()
+    initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
   }
 }

--- a/docs/ClickHouse.md
+++ b/docs/ClickHouse.md
@@ -174,7 +174,6 @@ cd spark-3.2.2-bin-hadoop2.7
   --conf spark.memory.offHeap.size=6442450944 \
   --conf spark.plugins=io.glutenproject.GlutenPlugin \
   --conf spark.gluten.sql.columnar.columnartorow=true \
-  --conf spark.gluten.sql.columnar.loadnative=true \
   --conf spark.gluten.sql.columnar.libpath=/path_to_clickhouse_library/libch.so \
   --conf spark.gluten.sql.columnar.iterator=true \
   --conf spark.gluten.sql.columnar.loadarrow=false \
@@ -296,7 +295,6 @@ cd spark-3.2.2-bin-hadoop2.7
   --conf spark.memory.offHeap.size=6442450944 \
   --conf spark.plugins=io.glutenproject.GlutenPlugin \
   --conf spark.gluten.sql.columnar.columnartorow=true \
-  --conf spark.gluten.sql.columnar.loadnative=true \
   --conf spark.gluten.sql.columnar.libpath=/path_to_clickhouse_library/libch.so \
   --conf spark.gluten.sql.columnar.iterator=true \
   --conf spark.gluten.sql.columnar.loadarrow=false \
@@ -435,7 +433,6 @@ cd spark-3.2.2-bin-hadoop2.7
   --conf spark.sql.sources.ignoreDataLocality=true \
   --conf spark.plugins=io.glutenproject.GlutenPlugin \
   --conf spark.gluten.sql.columnar.columnartorow=true \
-  --conf spark.gluten.sql.columnar.loadnative=true \
   --conf spark.gluten.sql.columnar.libpath=/path_to_clickhouse_library/libch.so \
   --conf spark.gluten.sql.columnar.iterator=true \
   --conf spark.gluten.sql.columnar.loadarrow=false \

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -24,8 +24,7 @@ import io.glutenproject.memory.alloc.{NativeMemoryAllocatorManager, Spiller}
 import io.glutenproject.row.BaseRowIterator
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.vectorized.{GeneralInIterator, GeneralOutIterator, NativeExpressionEvaluator}
-
+import io.glutenproject.vectorized.{GeneralOutIterator, NativeExpressionEvaluator}
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.rdd.RDD
@@ -72,7 +71,7 @@ trait IIteratorApi {
    *
    * @return
    */
-  def genFirstStageIterator(inputPartition: BaseGlutenPartition, loadNative: Boolean,
+  def genFirstStageIterator(inputPartition: BaseGlutenPartition,
                             outputAttributes: Seq[Attribute], context: TaskContext,
                             pipelineTime: SQLMetric,
                             updateOutputMetrics: (Long, Long) => Unit,

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
@@ -88,7 +88,6 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
       .set("spark.memory.offHeap.size", "1024MB")
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .set("spark.sql.warehouse.dir", warehouse)
 
     if (BackendsApiManager.getBackendName.equalsIgnoreCase(

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
@@ -108,7 +108,6 @@ trait GlutenTestsTrait extends SparkFunSuite with ExpressionEvalHelper with Glut
         .config("spark.memory.offHeap.size", "1024MB")
         .config("spark.plugins", "io.glutenproject.GlutenPlugin")
         .config("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
-        .config(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
         .config("spark.sql.warehouse.dir", warehouse)
         // Avoid static evaluation for literal input by spark catalyst.
         .config("spark.sql.optimizer.excludedRules", ConstantFolding.ruleName + ","  +

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
@@ -71,7 +71,6 @@ object ParquetReadBenchmark extends SqlBasedBenchmark {
       .setIfMissing("spark.memory.offHeap.size", offheapSize)
       .setIfMissing("spark.sql.columnVector.offheap.enabled", "true")
       .set("spark.gluten.sql.columnar.columnartorow", "true")
-      .set(GlutenConfig.GLUTEN_LOAD_NATIVE, "true")
       .set("spark.sql.adaptive.enabled", "false")
       .setIfMissing("spark.driver.memory", memorySize)
       .setIfMissing("spark.executor.memory", memorySize)

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -140,13 +140,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   val enableColumnarIterator: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.iterator", "true").toBoolean
 
-  // This config is used for deciding whether to load the native library.
-  // When false, only Java code will be executed for a quick test.
-  //
-  // FIXME remove / rename this option to emphasize on "debug" rather than "native"
-  val loadNative: Boolean =
-    conf.getConfString(GlutenConfig.GLUTEN_LOAD_NATIVE, "true").toBoolean
-
   // This config is used for specifying the name of the native library.
   val nativeLibName: String =
     conf.getConfString(GlutenConfig.GLUTEN_LIB_NAME, "spark_columnar_jni")
@@ -225,7 +218,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
 object GlutenConfig {
 
-  val GLUTEN_LOAD_NATIVE = "spark.gluten.sql.columnar.loadnative"
   val GLUTEN_LIB_NAME = "spark.gluten.sql.columnar.libname"
   val GLUTEN_LIB_PATH = "spark.gluten.sql.columnar.libpath"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the unused parameter 'spark.gluten.sql.columnar.loadnative'.

Close #666 .

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

