### PR TITLE
[GLUTEN-665] Log substrait plan in json format when generating GlutenPartition

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -25,6 +25,7 @@ import io.glutenproject.row.BaseRowIterator
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.{ExtensionTableBuilder, LocalFilesBuilder}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+import io.glutenproject.utils.{LogLevelUtil, SubstraitPlanPrinterUtil}
 import io.glutenproject.vectorized._
 
 import org.apache.spark.{InterruptibleIterator, SparkConf, SparkContext, TaskContext}
@@ -42,7 +43,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
-class CHIteratorApi extends IIteratorApi with Logging {
+class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
 
   /**
    * Generate native row partition.
@@ -86,7 +87,11 @@ class CHIteratorApi extends IIteratorApi with Logging {
     wsCxt.substraitContext.setLocalFilesNodes(localFilesNodesWithLocations.map(_._1))
     val substraitPlan = wsCxt.root.toProtobuf
     if (index < 3) {
-      logDebug(s"The substrait plan for partition $index:\n${substraitPlan.toString}")
+      logOnLevel(
+        GlutenConfig.getSessionConf.substraitPlanLogLevel,
+        s"The substrait plan for partition $index:\n${SubstraitPlanPrinterUtil
+            .substraitPlanToJson(substraitPlan)}"
+      )
     }
     GlutenPartition(index, substraitPlan, localFilesNodesWithLocations.head._2)
   }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/RunTPCHTest.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/RunTPCHTest.scala
@@ -122,7 +122,7 @@ object RunTPCHTest {
     }
 
     for (sql <- bucketSQL) {
-      spark.sql(sql).show(10, truncate = false)
+      spark.sql(sql)
     }
   }
 
@@ -131,7 +131,6 @@ object RunTPCHTest {
       .sql(s"""
               |use default;
               |""".stripMargin)
-      .show(1000, truncate = false)
     try {
       val tookTimeArr = ArrayBuffer[Long]()
       for (i <- 1 to executedCnt) {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -70,7 +70,7 @@ abstract class GlutenClickHouseTPCDSAbstractSuite extends WholeStageTransformerS
       GenTPCDSTableScripts.genTPCDSParquetTables("tpcdsdb", resourcePath, "", "")
 
     for (sql <- parquetTables) {
-      spark.sql(sql).show(10, false)
+      spark.sql(sql)
     }
     spark.sql("use tpcdsdb;")
     val result = spark

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -70,7 +70,6 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
               file.delete()
             }
             salted_df.get.write.parquet(currentSaltedTablePath)
-//          salted_df.get.show(100)
           })
     }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxFunctionsValidateSuite.scala
@@ -226,17 +226,11 @@ class VeloxFunctionsValidateSuite extends WholeStageTransformerSuite {
     val df = runQueryAndCompare("SELECT shiftleft(int_field1, 1) from datatab limit 1") {
       checkOperatorMatch[ProjectExecTransformer]
     }
-    df.show()
-    df.explain(false)
-    df.printSchema()
   }
 
   test("Test shiftright function") {
     val df = runQueryAndCompare("SELECT shiftright(int_field1, 1) from datatab limit 1") {
       checkOperatorMatch[ProjectExecTransformer]
     }
-    df.show()
-    df.explain(false)
-    df.printSchema()
   }
 }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
@@ -50,8 +50,7 @@ public class ExtensionTableNode implements Serializable {
     ReadRel.ExtensionTable.Builder extensionTableBuilder = ReadRel.ExtensionTable.newBuilder();
     StringValue extensionTable =  StringValue.newBuilder()
             .setValue(extensionTableStr.toString()).build();
-    extensionTableBuilder.setDetail(Any.newBuilder()
-            .setValue(extensionTable.toByteString()));
+    extensionTableBuilder.setDetail(Any.pack(extensionTable));
     return extensionTableBuilder.build();
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -43,19 +43,11 @@ import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.extension.columnar.RemoveTransformHintRule
 import io.glutenproject.extension.columnar.TransformHint
 import io.glutenproject.extension.columnar.StoreExpandGroupExpression
+import io.glutenproject.utils.LogLevelUtil
 
 // This rule will conduct the conversion from Spark plan to the plan transformer.
 case class TransformPreOverrides() extends Rule[SparkPlan] {
   val columnarConf: GlutenConfig = GlutenConfig.getSessionConf
-  @transient private val logOnLevel: ( => String) => Unit =
-    columnarConf.transformPlanLogLevel match {
-      case "TRACE" => logTrace(_)
-      case "DEBUG" => logDebug(_)
-      case "INFO" => logInfo(_)
-      case "WARN" => logWarning(_)
-      case "ERROR" => logError(_)
-      case _ => logDebug(_)
-    }
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   private def getProjectWithHash(exprs: Seq[Expression], child: SparkPlan)
@@ -331,10 +323,8 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
     if (checkOneRowRelation) {
       plan
     } else {
-      logOnLevel(s"${ruleName} before plan ${plan.toString()}")
       val newPlan = replaceWithTransformerPlan(plan)
       planChangeLogger.logRule(ruleName, plan, newPlan)
-      logOnLevel(s"${ruleName} after plan ${newPlan.toString()}")
       newPlan
     }
   }
@@ -344,15 +334,6 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
 // into columnar implementations.
 case class TransformPostOverrides() extends Rule[SparkPlan] {
   val columnarConf = GlutenConfig.getSessionConf
-  @transient private val logOnLevel: ( => String) => Unit =
-    columnarConf.transformPlanLogLevel match {
-      case "TRACE" => logTrace(_)
-      case "DEBUG" => logDebug(_)
-      case "INFO" => logInfo(_)
-      case "WARN" => logWarning(_)
-      case "ERROR" => logError(_)
-      case _ => logDebug(_)
-    }
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   def replaceWithTransformerPlan(plan: SparkPlan): SparkPlan = plan match {
@@ -415,25 +396,16 @@ case class TransformPostOverrides() extends Rule[SparkPlan] {
 
   // apply for the physical not final plan
   def apply(plan: SparkPlan): SparkPlan = {
-    logOnLevel(s"${ruleName} before plan ${plan.toString()}")
     val newPlan = replaceWithTransformerPlan(plan)
     planChangeLogger.logRule(ruleName, plan, newPlan)
-    logOnLevel(s"${ruleName} after plan ${newPlan.toString()}")
     newPlan
   }
 }
 
-case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule with Logging {
+case class ColumnarOverrideRules(session: SparkSession)
+  extends ColumnarRule with Logging with LogLevelUtil {
 
-  @transient private lazy val logOnLevel: ( => String) => Unit =
-  GlutenConfig.getSessionConf.transformPlanLogLevel match {
-    case "TRACE" => logTrace(_)
-    case "DEBUG" => logDebug(_)
-    case "INFO" => logInfo(_)
-    case "WARN" => logWarning(_)
-    case "ERROR" => logError(_)
-    case _ => logDebug(_)
-  }
+  lazy val transformPlanLogLevel = GlutenConfig.getSessionConf.transformPlanLogLevel
   @transient private lazy val planChangeLogger = new PlanChangeLogger[SparkPlan]()
   // Do not create rules in class initialization as we should access SQLConf
   // while creating the rules. At this time SQLConf may not be there yet.
@@ -458,13 +430,18 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
     if (supportedGluten) {
       var overridden: SparkPlan = plan
       val startTime = System.nanoTime()
-      logOnLevel(s"preColumnarTransitions preOverriden plan ${plan.toString}")
+      logOnLevel(
+        transformPlanLogLevel,
+        s"preColumnarTransitions preOverriden plan:\n${plan.toString}")
       preOverrides.foreach { r =>
         overridden = r(session)(overridden)
         planChangeLogger.logRule(r(session).ruleName, plan, overridden)
       }
-      logOnLevel(s"preColumnarTransitions afterOverriden plan ${overridden.toString}")
-      logInfo(
+      logOnLevel(
+        transformPlanLogLevel,
+        s"preColumnarTransitions afterOverriden plan:\n${overridden.toString}")
+      logOnLevel(
+        transformPlanLogLevel,
         s"preTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
       overridden
     } else {
@@ -477,7 +454,9 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
       nativeEngineEnabled,
       plan)
 
-    logOnLevel(s"postColumnarTransitions preOverriden plan ${plan.toString}")
+    logOnLevel(
+      transformPlanLogLevel,
+      s"postColumnarTransitions preOverriden plan:\n${plan.toString}")
     if (supportedGluten) {
       var overridden: SparkPlan = plan
       val startTime = System.nanoTime()
@@ -485,8 +464,11 @@ case class ColumnarOverrideRules(session: SparkSession) extends ColumnarRule wit
         overridden = r(session)(overridden)
         planChangeLogger.logRule(r(session).ruleName, plan, overridden)
       }
-      logOnLevel(s"postColumnarTransitions afterOverriden plan ${overridden.toString}")
-      logInfo(
+      logOnLevel(
+        transformPlanLogLevel,
+        s"postColumnarTransitions afterOverriden plan:\n${overridden.toString}")
+      logOnLevel(
+        transformPlanLogLevel,
         s"postTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
       overridden
     } else {

--- a/gluten-core/src/main/scala/io/glutenproject/utils/LogLevelUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/LogLevelUtil.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils
+
+import org.apache.spark.internal.Logging
+
+trait LogLevelUtil { self: Logging =>
+
+  protected def logOnLevel(level: String, msg: => String): Unit =
+    level match {
+      case "TRACE" => logTrace(msg)
+      case "DEBUG" => logDebug(msg)
+      case "INFO" => logInfo(msg)
+      case "WARN" => logWarning(msg)
+      case "ERROR" => logError(msg)
+      case _ => logDebug(msg)
+    }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/utils/SubstraitPlanPrinterUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/SubstraitPlanPrinterUtil.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils
+
+import com.google.protobuf.WrappersProto
+import com.google.protobuf.util.JsonFormat
+import io.substrait.proto.Plan
+
+object SubstraitPlanPrinterUtil {
+
+  /**
+   * Transform Substrait Plan to json format.
+   */
+  def substraitPlanToJson(substraintPlan: Plan): String = {
+    val defaultRegistry = WrappersProto.getDescriptor.getMessageTypes
+    val registry = com.google.protobuf.TypeRegistry
+      .newBuilder()
+      .add(substraintPlan.getDescriptorForType())
+      .add(defaultRegistry)
+      .build()
+    JsonFormat.printer.usingTypeRegistry(registry).print(substraintPlan)
+  }
+}

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -158,7 +158,6 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
     var expected: Seq[Row] = null;
     withSQLConf(vanillaSparkConfs(): _*) {
       val df = spark.sql(sqlStr)
-      df.show(false)
       expected = df.collect()
     }
     val df = spark.sql(sqlStr)

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -221,6 +221,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   val transformPlanLogLevel: String =
     conf.getConfString("spark.gluten.sql.transform.logLevel", "DEBUG")
 
+  val substraitPlanLogLevel: String =
+    conf.getConfString("spark.gluten.sql.substrait.plan.logLevel", "DEBUG")
 }
 
 object GlutenConfig {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log substrait plan in json format when generating GlutenPartition

Close #665 .

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

