### PR TITLE
[OPPRO-354] Fallback to vanilla spark when exist multi joins

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.window.WindowExec
-import io.glutenproject.extension.columnar.{AddTransformHintRule, FallbackMultiMultiCodegens, RemoveTransformHintRule, StoreExpandGroupExpression, TransformHint, TransformHints}
+import io.glutenproject.extension.columnar.{AddTransformHintRule, FallbackMultiCodegens, RemoveTransformHintRule, StoreExpandGroupExpression, TransformHint, TransformHints}
 import io.glutenproject.utils.LogLevelUtil
 
 // This rule will conduct the conversion from Spark plan to the plan transformer.
@@ -414,7 +414,7 @@ case class ColumnarOverrideRules(session: SparkSession)
 
   def preOverrides: List[SparkSession => Rule[SparkPlan]] =
     List((_: SparkSession) => StoreExpandGroupExpression(),
-      (_: SparkSession) => FallbackMultiMultiCodegens(),
+      (_: SparkSession) => FallbackMultiCodegens(),
       (_: SparkSession) => AddTransformHintRule(),
       (_: SparkSession) => TransformPreOverrides(),
       (_: SparkSession) => RemoveTransformHintRule()) :::

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -22,7 +22,6 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.sql.shims.SparkShimLoader
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, Murmur3Hash}
@@ -38,11 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.window.WindowExec
-import io.glutenproject.extension.columnar.AddTransformHintRule
-import io.glutenproject.extension.columnar.TransformHints
-import io.glutenproject.extension.columnar.RemoveTransformHintRule
-import io.glutenproject.extension.columnar.TransformHint
-import io.glutenproject.extension.columnar.StoreExpandGroupExpression
+import io.glutenproject.extension.columnar.{AddTransformHintRule, FallbackMultiMultiCodegens, RemoveTransformHintRule, StoreExpandGroupExpression, TransformHint, TransformHints}
 import io.glutenproject.utils.LogLevelUtil
 
 // This rule will conduct the conversion from Spark plan to the plan transformer.
@@ -419,6 +414,7 @@ case class ColumnarOverrideRules(session: SparkSession)
 
   def preOverrides: List[SparkSession => Rule[SparkPlan]] =
     List((_: SparkSession) => StoreExpandGroupExpression(),
+      (_: SparkSession) => FallbackMultiMultiCodegens(),
       (_: SparkSession) => AddTransformHintRule(),
       (_: SparkSession) => TransformPreOverrides(),
       (_: SparkSession) => RemoveTransformHintRule()) :::

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension
 
 import io.glutenproject.{GlutenConfig, GlutenSparkExtensionsInjector}
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.extension.columnar.{FallbackMultiMultiCodegens, StoreExpandGroupExpression, TransformHint, TransformHints}
+import io.glutenproject.extension.columnar.{FallbackMultiCodegens, StoreExpandGroupExpression, TransformHint, TransformHints}
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
@@ -39,7 +39,7 @@ case class ColumnarQueryStagePrepRule(session: SparkSession) extends Rule[SparkP
   override def apply(plan: SparkPlan): SparkPlan = {
     val columnarConf: GlutenConfig = GlutenConfig.getSessionConf
     // TODO move this rule before ColumnarQueryStagePrepRule
-    val newPlan = FallbackMultiMultiCodegens().apply(plan)
+    val newPlan = FallbackMultiCodegens().apply(plan)
     newPlan.transformDown {
       case bhj: BroadcastHashJoinExec =>
         if (TransformHints.isAlreadyTagged(bhj) &&

--- a/gluten-core/src/main/scala/io/glutenproject/extension/StrategyOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/StrategyOverrides.scala
@@ -19,16 +19,17 @@ package io.glutenproject.extension
 
 import io.glutenproject.{GlutenConfig, GlutenSparkExtensionsInjector}
 import io.glutenproject.backendsapi.BackendsApiManager
-
+import io.glutenproject.extension.columnar.{TransformHint, TransformHints}
+import io.glutenproject.extension.columnar.TransformHints.TAG
 import org.apache.spark.sql.{SparkSessionExtensions, Strategy}
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, JoinSelectionHelper}
 import org.apache.spark.sql.catalyst.plans._
-import org.apache.spark.sql.catalyst.plans.logical.{JoinHint, LogicalPlan, SHUFFLE_MERGE}
-import org.apache.spark.sql.execution.{joins, JoinSelectionShim, SparkPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint, LogicalPlan, Project, SHUFFLE_MERGE}
+import org.apache.spark.sql.execution.{joins, CodegenSupport, JoinSelectionShim, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{BroadcastQueryStageExec, LogicalQueryStage}
-import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHashJoinExec}
 
 object StrategyOverrides extends GlutenSparkExtensionsInjector {
   override def inject(extensions: SparkSessionExtensions): Unit = {
@@ -41,6 +42,11 @@ object JoinSelectionOverrides extends Strategy with JoinSelectionHelper with SQL
   private def isBroadcastStage(plan: LogicalPlan): Boolean = plan match {
     case LogicalQueryStage(_, _: BroadcastQueryStageExec) => true
     case _ => false
+  }
+
+  private def ignoreForceShuffleJoin(plan: LogicalPlan): Boolean = {
+    plan.getTagValue(TAG).isDefined &&
+      plan.getTagValue(TAG) == TransformHint.TRANSFORM_UNSUPPORTED
   }
 
   def extractEqualJoinKeyCondition(
@@ -80,7 +86,7 @@ object JoinSelectionOverrides extends Strategy with JoinSelectionHelper with SQL
             planLater(right)))
       }
 
-      if (forceShuffledHashJoin) {
+      if (forceShuffledHashJoin && ignoreForceShuffleJoin(left) && ignoreForceShuffleJoin(right)) {
         // Force use of ShuffledHashJoin in preference to SortMergeJoin. With no respect to
         // conf setting "spark.sql.join.preferSortMergeJoin".
         val (leftBuildable, rightBuildable) = if (
@@ -142,7 +148,33 @@ object JoinSelectionOverrides extends Strategy with JoinSelectionHelper with SQL
     BackendsApiManager.getSettings.supportHashBuildJoinTypeOnRight(joinType)
   }
 
+  def existsMultiJoins(plan: LogicalPlan, count: Int = 0): Boolean = {
+    plan match {
+      case plan: Join =>
+        if ((count + 1) >= GlutenConfig.getSessionConf.logicalJoinOptimizationThrottle) return true
+        plan.children.map(existsMultiJoins(_, count + 1)).exists(_ == true)
+      case plan: Project =>
+        if ((count + 1) >= GlutenConfig.getSessionConf.logicalJoinOptimizationThrottle) return true
+        plan.children.map(existsMultiJoins(_, count + 1)).exists(_ == true)
+      case other => false
+    }
+  }
+
+  def tagNotTransformable(plan: LogicalPlan): LogicalPlan = {
+    plan.setTagValue(TAG, TransformHint.TRANSFORM_UNSUPPORTED)
+    plan
+  }
+
+  def tagNotTransformableRecursive(plan: LogicalPlan): LogicalPlan = {
+    tagNotTransformable(plan.withNewChildren(plan.children.map(tagNotTransformableRecursive)))
+  }
+
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
+    // Ignore forceShuffledHashJoin if exist multi continuous joins
+    if (GlutenConfig.getSessionConf.enableLogicalJoinOptimize &&
+      existsMultiJoins(plan)) {
+      tagNotTransformableRecursive(plan)
+    }
     plan match {
       // If the build side of BHJ is already decided by AQE, we need to keep the build side.
       case JoinSelectionShim.ExtractEquiJoinKeysShim(
@@ -155,7 +187,7 @@ object JoinSelectionOverrides extends Strategy with JoinSelectionHelper with SQL
           left,
           right,
           hint,
-          GlutenConfig.getConf.forceShuffledHashJoin)
+          GlutenConfig.getSessionConf.forceShuffledHashJoin)
       case _ => Nil
     }
   }

--- a/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenSparkPlanExecApi.scala
+++ b/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenSparkPlanExecApi.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{GlutenBuildSideRelation, SparkPlan}
+import org.apache.spark.sql.execution.{GlutenBuildSideRelation, GlutenColumnarToRowExec, SparkPlan}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.BuildSideRelation
 import org.apache.spark.sql.execution.metric.SQLMetric

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
@@ -15,24 +15,24 @@
  * limitations under the License.
  */
 
-package io.glutenproject.execution
-
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
+package org.apache.spark.sql.execution
 
 import io.glutenproject.columnarbatch.{ArrowColumnarBatches, GlutenColumnarBatches, GlutenIndicatorVector}
+import io.glutenproject.execution.GlutenColumnarToRowExecBase
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper}
-import org.slf4j.LoggerFactory
-
+import org.apache.spark.TaskContext
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection, UnsafeRow}
-import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types._
-import org.apache.spark.TaskContext
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.NANOSECONDS
 
 case class GlutenColumnarToRowExec(child: SparkPlan)
   extends GlutenColumnarToRowExecBase(child = child) {
@@ -62,6 +62,10 @@ case class GlutenColumnarToRowExec(child: SparkPlan)
             s"GlutenColumnarToRowExecBase.")
       }
     }
+  }
+
+  override def doExecuteBroadcast[T](): Broadcast[T] = {
+    child.doExecuteBroadcast()
   }
 
   override def doExecuteInternal(): RDD[InternalRow] = {
@@ -162,4 +166,3 @@ case class GlutenColumnarToRowExec(child: SparkPlan)
   protected def withNewChildInternal(newChild: SparkPlan): GlutenColumnarToRowExec =
     copy(child = newChild)
 }
-

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -151,7 +151,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   // fallback to row operators if there are several continous joins
   val physicalJoinOptimizationThrottle: Integer =
     conf.getConfString("spark.gluten.sql.columnar.physicalJoinOptimizationLevel", "12").toInt
-  // spark.gluten.sql.enable.
+
   val enablePhysicalJoinOptimize: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false").toBoolean
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -149,8 +149,17 @@ class GlutenConfig(conf: SQLConf) extends Logging {
     conf.getConfString(GlutenConfig.GLUTEN_LIB_PATH, "")
 
   // fallback to row operators if there are several continous joins
-  val joinOptimizationThrottle: Integer =
-    conf.getConfString("spark.gluten.sql.columnar.joinOptimizationLevel", "12").toInt
+  val physicalJoinOptimizationThrottle: Integer =
+    conf.getConfString("spark.gluten.sql.columnar.physicalJoinOptimizationLevel", "12").toInt
+  // spark.gluten.sql.enable.
+  val enablePhysicalJoinOptimize: Boolean =
+    conf.getConfString("spark.gluten.sql.columnar.physicalJoinOptimizeEnable", "false").toBoolean
+
+  val logicalJoinOptimizationThrottle: Integer =
+    conf.getConfString("spark.gluten.sql.columnar.logicalJoinOptimizationLevel", "12").toInt
+
+  val enableLogicalJoinOptimize: Boolean =
+    conf.getConfString("spark.gluten.sql.columnar.logicalJoinOptimizeEnable", "false").toBoolean
 
   val batchSize: Int =
     conf.getConfString(GlutenConfig.SPARK_BATCH_SIZE, "32768").toInt


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fallback TPC-DS Q72 to vanilla spark when smj optimization not available.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

