### PR TITLE
[WIP] Fix empty columnar batch in C2R/R2C.

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/GlutenRowToColumnarExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GlutenRowToColumnarExec.scala
@@ -51,23 +51,8 @@ abstract class GlutenRowToColumnarExec(child: SparkPlan) extends UnaryExecNode {
     "processTime" -> SQLMetrics.createTimingMetric(sparkContext, "totaltime_rowtoarrowcolumnar")
   )
 
-
   // fix schema is empty when converting unsafe row to columnar batch
-  override def output: Seq[Attribute] = getOutput(child)
-
-  def getOutput(child: SparkPlan): Seq[Attribute] = {
-    var output = child.output
-    if (output.isEmpty) {
-      child.children.foreach(plan => {
-        if (plan.output.nonEmpty) {
-          output = plan.output
-        } else {
-          output = getOutput(plan)
-        }
-      })
-    }
-    output
-  }
+  override def output: Seq[Attribute] = child.output
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GlutenRowToColumnarExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GlutenRowToColumnarExec.scala
@@ -51,7 +51,23 @@ abstract class GlutenRowToColumnarExec(child: SparkPlan) extends UnaryExecNode {
     "processTime" -> SQLMetrics.createTimingMetric(sparkContext, "totaltime_rowtoarrowcolumnar")
   )
 
-  override def output: Seq[Attribute] = child.output
+
+  // fix schema is empty when converting unsafe row to columnar batch
+  override def output: Seq[Attribute] = getOutput(child)
+
+  def getOutput(child: SparkPlan): Seq[Attribute] = {
+    var output = child.output
+    if (output.isEmpty) {
+      child.children.foreach(plan => {
+        if (plan.output.nonEmpty) {
+          output = plan.output
+        } else {
+          output = getOutput(plan)
+        }
+      })
+    }
+    output
+  }
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 

--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenColumnarToRowExec.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenColumnarToRowExec.scala
@@ -43,7 +43,12 @@ case class GlutenColumnarToRowExec(child: SparkPlan)
   override def supportCodegen: Boolean = false
 
   override def buildCheck(): Unit = {
+    // todo: ArrowInIterator -> ArrowOutIterator caused empty ColumnarBatch
     val schema = child.schema
+    if (schema.isEmpty) {
+      throw new UnsupportedOperationException(s"${child.toString()} has no field schema," +
+        s" so fall back to Vanilla Spark.")
+    }
     for (field <- schema.fields) {
       field.dataType match {
         case d: BooleanType =>

--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenRowToArrowColumnarExec.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenRowToArrowColumnarExec.scala
@@ -296,7 +296,23 @@ case class GlutenRowToArrowColumnarExec(child: SparkPlan)
     }
   }
 
-  override def output: Seq[Attribute] = child.output
+  override def output: Seq[Attribute] = getOutput(child)
+
+  def getOutput(child: SparkPlan): Seq[Attribute] = {
+    var output = child.output
+    if (output.nonEmpty) {
+      output
+    } else {
+      child.children.foreach(plan => {
+        if (plan.output.nonEmpty) {
+          output = plan.output
+        } else {
+          output = getOutput(plan)
+        }
+      })
+    }
+    output
+  }
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -67,6 +67,9 @@ object VeloxTestSettings extends BackendTestSettings {
       "cast from map II",
       "cast from struct II"
     )
+  enableSuite[GlutenDataFrameSuite]
+    .excludeByPrefix("SPARK-2")
+    .excludeByPrefix("SPARK-3")
 
   enableSuite[GlutenLiteralExpressionSuite]
   enableSuite[GlutenIntervalExpressionsSuite]

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -20,6 +20,12 @@ package org.apache.spark.sql
 class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
 
   override def testNameBlackList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
+    "repartitionByRange",
+    "coalesce",
+    "describe", // coredump
+    "NaN is greater than all other non-NaN numeric values",
+    "distributeBy and localSort",
+    "reuse exchange",
+    "SPARK-16664: persist with more than 200 columns",
   )
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

java.lang.RuntimeException: Error during calling Java code from native code: java.lang.UnsupportedOperationException: batch is not intermediate Gluten batch
	at io.glutenproject.columnarbatch.GlutenColumnarBatches.getNativeHandle(GlutenColumnarBatches.java:48)
	at io.glutenproject.vectorized.ArrowInIterator.next(ArrowInIterator.java:37)
	at io.glutenproject.vectorized.ArrowOutIterator.nativeHasNext(Native Method)
	at io.glutenproject.vectorized.ArrowOutIterator.hasNextInternal(ArrowOutIterator.java:47)
	at io.glutenproject.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:36)
	at io.glutenproject.backendsapi.glutendata.GlutenIteratorApi$$anon$3.hasNext(GlutenIteratorApi.scala:314)
	at io.glutenproject.vectorized.CloseableColumnBatchIterator.hasNext(CloseableColumnBatchIterator.scala:41)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at org.apache.spark.shuffle.GlutenColumnarShuffleWriter.internalWrite(GlutenColumnarShuffleWriter.scala:95)
	at org.apache.spark.shuffle.GlutenColumnarShuffleWriter.write(GlutenColumnarShuffleWriter.scala:206)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	at io.glutenproject.vectorized.ArrowOutIterator.nativeHasNext(Native Method)
	at io.glutenproject.vectorized.ArrowOutIterator.hasNextInternal(ArrowOutIterator.java:47)
	at io.glutenproject.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:36)
	at io.glutenproject.backendsapi.glutendata.GlutenIteratorApi$$anon$3.hasNext(GlutenIteratorApi.scala:314)
	at io.glutenproject.vectorized.CloseableColumnBatchIterator.hasNext(CloseableColumnBatchIterator.scala:41)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at org.apache.spark.shuffle.GlutenColumnarShuffleWriter.internalWrite(GlutenColumnarShuffleWriter.scala:95)
	at org.apache.spark.shuffle.GlutenColumnarShuffleWriter.write(GlutenColumnarShuffleWriter.scala:206)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

