### PR TITLE
[CPP Refactor] delete redundant Interfaces and avoid special processing

### DIFF
--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -43,11 +43,9 @@ class Backend : public std::enable_shared_from_this<Backend> {
  public:
   virtual ~Backend() = default;
 
-  virtual std::shared_ptr<ResultIterator> GetResultIterator(MemoryAllocator* allocator) = 0;
-
   virtual std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<ResultIterator>> inputs) = 0;
+      std::vector<std::shared_ptr<ResultIterator>> inputs = {}) = 0;
 
   /// Parse and cache the plan.
   /// Return true if parsed successfully.

--- a/cpp/core/compute/BackendTest.cc
+++ b/cpp/core/compute/BackendTest.cc
@@ -24,15 +24,11 @@ namespace gluten {
 
 class DummyBackend : public Backend {
  public:
-  std::shared_ptr<ResultIterator> GetResultIterator(MemoryAllocator* allocator) override {
-    auto res_iter = std::make_unique<DummyResultIterator>();
-    return std::make_shared<ResultIterator>(std::move(res_iter));
-  }
-
   std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<ResultIterator>> inputs) {
-    return GetResultIterator(allocator);
+      std::vector<std::shared_ptr<ResultIterator>> inputs = {}) override {
+    auto res_iter = std::make_unique<DummyResultIterator>();
+    return std::make_shared<ResultIterator>(std::move(res_iter));
   }
 
  private:

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -167,7 +167,7 @@ class JavaInputStreamAdaptor : public arrow::io::InputStream {
 
 class JavaArrowArrayIterator {
  public:
-  explicit JavaArrowArrayIterator(JNIEnv* env, jobject java_serialized_arrow_array_iterator) {
+  JavaArrowArrayIterator(JNIEnv* env, jobject java_serialized_arrow_array_iterator) {
     // IMPORTANT: DO NOT USE LOCAL REF IN DIFFERENT THREAD
     if (env->GetJavaVM(&vm_) != JNI_OK) {
       std::string error_message = "Unable to get JavaVM instance";
@@ -177,8 +177,10 @@ class JavaArrowArrayIterator {
   }
 
   // singleton, avoid stack instantiation
-  JavaArrowArrayIterator(const JavaArrowArrayIterator& itr) = delete;
-  JavaArrowArrayIterator(JavaArrowArrayIterator&& itr) = delete;
+  JavaArrowArrayIterator(const JavaArrowArrayIterator&) = delete;
+  JavaArrowArrayIterator(JavaArrowArrayIterator&&) = delete;
+  JavaArrowArrayIterator& operator=(const JavaArrowArrayIterator&) = delete;
+  JavaArrowArrayIterator& operator=(JavaArrowArrayIterator&&) = delete;
 
   virtual ~JavaArrowArrayIterator() {
     JNIEnv* env;
@@ -369,21 +371,14 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniW
   // Handle the Java iters
   jsize iters_len = env->GetArrayLength(iter_arr);
   std::vector<std::shared_ptr<ResultIterator>> input_iters;
-  if (iters_len > 0) {
-    for (int idx = 0; idx < iters_len; idx++) {
-      jobject iter = env->GetObjectArrayElement(iter_arr, idx);
-      auto array_iter = MakeJavaArrowArrayIterator(env, iter);
-      auto result_iter = std::make_shared<ResultIterator>(std::move(array_iter));
-      input_iters.push_back(std::move(result_iter));
-    }
+  for (int idx = 0; idx < iters_len; idx++) {
+    jobject iter = env->GetObjectArrayElement(iter_arr, idx);
+    auto array_iter = MakeJavaArrowArrayIterator(env, iter);
+    auto result_iter = std::make_shared<ResultIterator>(std::move(array_iter));
+    input_iters.push_back(std::move(result_iter));
   }
 
-  std::shared_ptr<ResultIterator> res_iter;
-  if (input_iters.empty()) {
-    res_iter = backend->GetResultIterator(allocator);
-  } else {
-    res_iter = backend->GetResultIterator(allocator, input_iters);
-  }
+  std::shared_ptr<ResultIterator> res_iter = backend->GetResultIterator(allocator, input_iters);
   return result_iterator_holder_.Insert(std::move(res_iter));
   JNI_METHOD_END(-1)
 }
@@ -455,11 +450,8 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
     env->SetLongArrayRegion(wallNanos, 0, numMetrics, metrics->wallNanos);
     env->SetLongArrayRegion(peakMemoryBytes, 0, numMetrics, metrics->peakMemoryBytes);
     env->SetLongArrayRegion(numMemoryAllocations, 0, numMetrics, metrics->numMemoryAllocations);
-
     env->SetLongArrayRegion(numDynamicFiltersProduced, 0, numMetrics, metrics->numDynamicFiltersProduced);
-
     env->SetLongArrayRegion(numDynamicFiltersAccepted, 0, numMetrics, metrics->numDynamicFiltersAccepted);
-
     env->SetLongArrayRegion(numReplacedWithDynamicFilterRows, 0, numMetrics, metrics->numReplacedWithDynamicFilterRows);
   }
 

--- a/cpp/gazelle-cpp/compute/SubstraitArrow.cc
+++ b/cpp/gazelle-cpp/compute/SubstraitArrow.cc
@@ -47,10 +47,6 @@ ArrowBackend::~ArrowBackend() {
 #endif
 }
 
-std::shared_ptr<gluten::ResultIterator> ArrowBackend::GetResultIterator(gluten::MemoryAllocator* allocator) {
-  return GetResultIterator(allocator, {});
-}
-
 std::shared_ptr<gluten::ResultIterator> ArrowBackend::GetResultIterator(
     gluten::MemoryAllocator* allocator,
     std::vector<std::shared_ptr<gluten::ResultIterator>> inputs) {

--- a/cpp/gazelle-cpp/compute/SubstraitArrow.h
+++ b/cpp/gazelle-cpp/compute/SubstraitArrow.h
@@ -31,11 +31,9 @@ class ArrowBackend : public Backend {
 
   ~ArrowBackend() override;
 
-  std::shared_ptr<gluten::ResultIterator> GetResultIterator(gluten::MemoryAllocator* allocator) override;
-
   std::shared_ptr<gluten::ResultIterator> GetResultIterator(
       gluten::MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<gluten::ResultIterator>> inputs) override;
+      std::vector<std::shared_ptr<gluten::ResultIterator>> inputs = {}) override;
 
   std::shared_ptr<arrow::Schema> GetOutputSchema() override;
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -339,11 +339,6 @@ void VeloxBackend::getInfoAndIds(
   }
 }
 
-std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(MemoryAllocator* allocator) {
-  std::vector<std::shared_ptr<ResultIterator>> inputs = {};
-  return GetResultIterator(allocator, inputs);
-}
-
 std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
     MemoryAllocator* allocator,
     std::vector<std::shared_ptr<ResultIterator>> inputs) {

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -149,11 +149,9 @@ class VeloxBackend : public Backend {
  public:
   VeloxBackend(const std::unordered_map<std::string, std::string>& confMap) : confMap_(confMap) {}
 
-  std::shared_ptr<ResultIterator> GetResultIterator(MemoryAllocator* allocator) override;
-
   std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<ResultIterator>> inputs) override;
+      std::vector<std::shared_ptr<ResultIterator>> inputs = {}) override;
 
   // Used by unit test and benchmark.
   std::shared_ptr<ResultIterator> GetResultIterator(


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Only one `GetResultIterator()` interface is enough, delete the redundant interfaces.
2. Avoid unnecessary checks, use the normal handle if possible.
3. If defining the `copy constructors`, you may also need to define the `assignment operator`, according to the `3/5/0 rules`.
4. The `explicit` keyword is used to avoid implicit converting for a single parameter, not for parameters.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

