### PR TITLE
Write benchmark output to parquet file

### DIFF
--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -27,9 +27,13 @@
 #include <sstream>
 #include <thread>
 
+#include "arrow/io/file.h"
+#include "arrow/table.h"
+#include "arrow/util/type_fwd.h"
 #include "compute/VeloxBackend.h"
 
 DEFINE_bool(print_result, true, "Print result for execution");
+DEFINE_string(write_file, "", "Write the output to parquet file, file absolute path");
 DEFINE_int32(cpu, -1, "Run benchmark on specific CPU");
 DEFINE_int32(threads, 0, "The number of threads to run this benchmark");
 DEFINE_int32(iterations, 0, "The number of iterations to run this benchmark");
@@ -71,6 +75,41 @@ arrow::Result<std::string> getGeneratedFilePath(const std::string& fileName) {
 void InitVeloxBackend() {
   gluten::SetBackendFactory([] { return std::make_shared<gluten::VeloxBackend>(confMap); });
   auto veloxInitializer = std::make_shared<gluten::VeloxInitializer>(confMap);
+}
+
+arrow::Status ArrowWriter::initWriter(std::string path_to_file, arrow::Schema& schema) {
+  // #include "parquet/arrow/writer.h"
+  // #include "arrow/util/type_fwd.h"
+  using parquet::ArrowWriterProperties;
+  using parquet::WriterProperties;
+  // Choose compression
+  std::shared_ptr<WriterProperties> props =
+      WriterProperties::Builder().compression(arrow::Compression::SNAPPY)->build();
+
+  // Opt to store Arrow schema for easier reads back into Arrow
+  std::shared_ptr<ArrowWriterProperties> arrow_props = ArrowWriterProperties::Builder().store_schema()->build();
+
+  // Create a writer
+  std::shared_ptr<arrow::io::FileOutputStream> outfile;
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(path_to_file));
+  ARROW_RETURN_NOT_OK(
+      parquet::arrow::FileWriter::Open(schema, arrow::default_memory_pool(), outfile, props, arrow_props, &writer_));
+  return arrow::Status::OK();
+}
+
+arrow::Status ArrowWriter::WriteInBatches(std::shared_ptr<arrow::RecordBatch> batch) {
+  // Write each batch as a row_group
+  ARROW_ASSIGN_OR_RAISE(auto table, arrow::Table::FromRecordBatches(batch->schema(), {batch}));
+  ARROW_RETURN_NOT_OK(writer_->WriteTable(*table.get(), batch->num_rows()));
+  return arrow::Status::OK();
+}
+
+arrow::Status ArrowWriter::closeWriter() {
+  // Write file footer and close
+  if (writer_ != nullptr) {
+    ARROW_RETURN_NOT_OK(writer_->Close());
+  }
+  return arrow::Status::OK();
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string& filePath) {

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -77,9 +77,7 @@ void InitVeloxBackend() {
   auto veloxInitializer = std::make_shared<gluten::VeloxInitializer>(confMap);
 }
 
-arrow::Status ArrowWriter::initWriter(std::string path_to_file, arrow::Schema& schema) {
-  // #include "parquet/arrow/writer.h"
-  // #include "arrow/util/type_fwd.h"
+arrow::Status ArrowWriter::initWriter(std::string& path_to_file, arrow::Schema& schema) {
   using parquet::ArrowWriterProperties;
   using parquet::WriterProperties;
   // Choose compression

--- a/cpp/velox/benchmarks/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/BenchmarkUtils.h
@@ -145,7 +145,7 @@ class BatchStreamIterator : public BatchIteratorWrapper {
 
 class ArrowWriter {
  public:
-  arrow::Status initWriter(std::string path_to_file, arrow::Schema& schema);
+  arrow::Status initWriter(std::string& path_to_file, arrow::Schema& schema);
 
   arrow::Status WriteInBatches(std::shared_ptr<arrow::RecordBatch> batch);
 
@@ -155,8 +155,7 @@ class ArrowWriter {
   std::unique_ptr<parquet::arrow::FileWriter> writer_;
 };
 
-std::shared_ptr<gluten::ResultIterator>
-getInputFromBatchVector(const std::string& path);
+std::shared_ptr<gluten::ResultIterator> getInputFromBatchVector(const std::string& path);
 
 std::shared_ptr<gluten::ResultIterator> getInputFromBatchStream(const std::string& path);
 

--- a/cpp/velox/benchmarks/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/BenchmarkUtils.h
@@ -23,6 +23,7 @@
 #include <parquet/arrow/reader.h>
 #include <velox/common/memory/Memory.h>
 #include <velox/substrait/SubstraitToVeloxPlan.h>
+#include "parquet/arrow/writer.h"
 
 #include <thread>
 #include <utility>
@@ -32,6 +33,7 @@
 #include "velox/common/memory/Memory.h"
 
 DECLARE_bool(print_result);
+DECLARE_string(write_file);
 DECLARE_int32(cpu);
 DECLARE_int32(threads);
 DECLARE_int32(iterations);
@@ -141,7 +143,20 @@ class BatchStreamIterator : public BatchIteratorWrapper {
   }
 };
 
-std::shared_ptr<gluten::ResultIterator> getInputFromBatchVector(const std::string& path);
+class ArrowWriter {
+ public:
+  arrow::Status initWriter(std::string path_to_file, arrow::Schema& schema);
+
+  arrow::Status WriteInBatches(std::shared_ptr<arrow::RecordBatch> batch);
+
+  arrow::Status closeWriter();
+
+ private:
+  std::unique_ptr<parquet::arrow::FileWriter> writer_;
+};
+
+std::shared_ptr<gluten::ResultIterator>
+getInputFromBatchVector(const std::string& path);
 
 std::shared_ptr<gluten::ResultIterator> getInputFromBatchStream(const std::string& path);
 

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -194,11 +194,5 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
   protected def vanillaSparkConfs(): Seq[(String, String)] = {
     List(("spark.gluten.sql.enable.native.engine", "false"))
   }
-
-  override def logForFailedTest(): Unit = {
-    logError("Test failed so abort")
-    // FIXME the code swallows exceptions. See https://github.com/oap-project/gluten/issues/676
-    System.exit(1)
-  }
 }
 

--- a/gluten-ut/pom.xml
+++ b/gluten-ut/pom.xml
@@ -338,6 +338,7 @@
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
                 <configuration>
+                    <testFailureIgnore>false</testFailureIgnore>
                     <junitxml>.</junitxml>
                 </configuration>
                 <executions>

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
@@ -71,12 +71,6 @@ trait GlutenSQLTestsTrait extends QueryTest with SharedSparkSession with GlutenT
     }
   }
 
-  override def logForFailedTest(): Unit = {
-    logError("Test failed so abort")
-    // FIXME the code swallows exceptions. See https://github.com/oap-project/gluten/issues/676
-    System.exit(1)
-  }
-
   override def sparkConf: SparkConf = {
     // Native SQL configs
     val conf = super.sparkConf

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,7 @@
           <artifactId>scalatest-maven-plugin</artifactId>
           <version>${scalatest-maven-plugin.version}</version>
           <configuration>
+            <testFailureIgnore>false</testFailureIgnore>
             <junitxml>.</junitxml>
           </configuration>
           <executions>


### PR DESCRIPTION
This generated parquet file maynot distinguished by velox sometimes, but can read by spark.
So we can read and write by vanilla spark, the converted file can read by gluten/velox
```
val tableDF = spark.read.format("parquet").load("/mnt/DP_disk2/tpcds/data/result_table.parquet")
tableDF.createOrReplaceTempView("tmp_table_4")
tableDF.write.format("parquet").save("/mnt/DP_disk2/tpcds/data/result_table_convert")
```
After velox fix this problem, we can use it directly.
usage:
./generic_benchmark  --threads 1 --print-result=false --write-file=/mnt/DP_disk2/tpcds/data/result_table_2.parquet --iterations 1