### PR TITLE
[OPPRO-360] Fix nested struct and map to-arrow type conversion

### DIFF
--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -19,141 +19,143 @@
 
 using namespace facebook::velox;
 
-std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& type_name) {
-  if (type_name == "BOOLEAN") {
+std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& typeName) {
+  if (typeName == "BOOLEAN") {
     return arrow::boolean();
   }
-  if (type_name == "TINYINT") {
+  if (typeName == "TINYINT") {
     return arrow::int8();
   }
-  if (type_name == "SMALLINT") {
+  if (typeName == "SMALLINT") {
     return arrow::int16();
   }
-  if (type_name == "INTEGER") {
+  if (typeName == "INTEGER") {
     return arrow::int32();
   }
-  if (type_name == "BIGINT") {
+  if (typeName == "BIGINT") {
     return arrow::int64();
   }
-  if (type_name == "REAL") {
+  if (typeName == "REAL") {
     return arrow::float32();
   }
-  if (type_name == "DOUBLE") {
+  if (typeName == "DOUBLE") {
     return arrow::float64();
   }
-  if (type_name == "VARCHAR") {
+  if (typeName == "VARCHAR") {
     return arrow::utf8();
   }
-  if (type_name == "VARBINARY") {
+  if (typeName == "VARBINARY") {
     return arrow::utf8();
   }
-  if (type_name == "DATE") {
+  if (typeName == "DATE") {
     return arrow::date32();
   }
   // The type name of Array type is like ARRAY<type>.
-  std::string arrayType = "ARRAY";
-  if (type_name.substr(0, arrayType.length()) == arrayType) {
-    std::size_t start = type_name.find_first_of('<');
-    std::size_t end = type_name.find_last_of('>');
+  const std::string arrayType = "ARRAY";
+  if (typeName.substr(0, arrayType.length()) == arrayType) {
+    std::size_t start = typeName.find_first_of('<');
+    std::size_t end = typeName.find_last_of('>');
     if (start == std::string::npos || end == std::string::npos) {
-      throw std::runtime_error("Invalid array type: " + type_name);
+      throw std::runtime_error("Invalid array type: " + typeName);
     }
     // Extract the inner type of array type.
-    auto innerType = type_name.substr(start + 1, end - start - 1);
+    auto innerType = typeName.substr(start + 1, end - start - 1);
     return arrow::list(toArrowTypeFromName(innerType));
   }
 
   // The type name of MAP type is like MAP<type, type>.
-  std::string mapType = "MAP";
-  if (type_name.substr(0, mapType.length()) == mapType) {
-    std::size_t start = type_name.find_first_of('<');
-    std::size_t end = type_name.find_last_of('>');
+  const std::string mapType = "MAP";
+  if (typeName.substr(0, mapType.length()) == mapType) {
+    std::size_t start = typeName.find_first_of('<');
+    std::size_t end = typeName.find_last_of('>');
     if (start == std::string::npos || end == std::string::npos) {
-      throw std::runtime_error("Invalid map type: " + type_name);
+      throw std::runtime_error("Invalid map type: " + typeName);
     }
 
     // Extract the types of map type.
-    auto inner_type = type_name.substr(start + 1, end - start - 1);
-    std::size_t token_pos = inner_type.find_first_of(',');
-    if (token_pos == std::string::npos) {
-      throw std::runtime_error("Invalid map type: " + type_name);
+    auto innerType = typeName.substr(start + 1, end - start - 1);
+    std::size_t tokenPos = innerType.find_first_of(',');
+    if (tokenPos == std::string::npos) {
+      throw std::runtime_error("Invalid map type: " + typeName);
     }
 
-    auto split = inner_type.substr(0, token_pos);
-    // Count '<', '>' in split.
-    auto num_left = std::count_if(split.begin(), split.end(), [](const auto& c) { return c == '<'; });
-    auto num_right = std::count_if(split.begin(), split.end(), [](const auto& c) { return c == '>'; });
-    if (num_left > num_right) {
-      size_t i = token_pos + 1;
-      for (; num_left > num_right && i < inner_type.length(); ++i) {
-        if (inner_type[i] == '<') {
-          ++num_left;
-        } else if (inner_type[i] == '>') {
-          ++num_right;
+    auto part = innerType.substr(0, tokenPos);
+    // Count '<', '>' in part.
+    auto numLeft = std::count_if(part.begin(), part.end(), [](const auto& c) { return c == '<'; });
+    auto numRight = std::count_if(part.begin(), part.end(), [](const auto& c) { return c == '>'; });
+    if (numLeft > numRight) {
+      // Has unclosed '<'.
+      std::size_t i = tokenPos + 1;
+      for (; numLeft > numRight && i < innerType.length(); ++i) {
+        if (innerType[i] == '<') {
+          ++numLeft;
+        } else if (innerType[i] == '>') {
+          ++numRight;
         }
       }
       // Next character must be ','.
-      if (num_left != num_right || i >= inner_type.length() || inner_type[i] != ',') {
-        throw std::runtime_error("Invalid map type: " + type_name);
+      if (numLeft != numRight || i >= innerType.length() || innerType[i] != ',') {
+        throw std::runtime_error("Invalid map type: " + typeName);
       }
-      token_pos = i;
+      tokenPos = i;
+      part = innerType.substr(0, tokenPos);
     }
 
-    auto key_type = toArrowTypeFromName(inner_type.substr(0, token_pos));
-    auto value_type = toArrowTypeFromName(inner_type.substr(token_pos + 1, inner_type.length() - 1));
+    auto keyType = toArrowTypeFromName(part);
+    auto valueType = toArrowTypeFromName(innerType.substr(tokenPos + 1));
 
-    return arrow::map(key_type, value_type);
+    return arrow::map(keyType, valueType);
   }
 
   // The type name of ROW type is like ROW<type, type>.
   const std::string structType = "ROW";
-  if (type_name.substr(0, structType.length()) == structType) {
-    std::size_t start = type_name.find_first_of('<');
-    std::size_t end = type_name.find_last_of('>');
+  if (typeName.substr(0, structType.length()) == structType) {
+    std::size_t start = typeName.find_first_of('<');
+    std::size_t end = typeName.find_last_of('>');
     if (start == std::string::npos || end == std::string::npos) {
-      throw std::runtime_error("Invalid struct type: " + type_name);
+      throw std::runtime_error("Invalid struct type: " + typeName);
     }
 
     // Extract the types of struct type.
-    auto inner_type = type_name.substr(start + 1, end - start - 1);
+    auto innerType = typeName.substr(start + 1, end - start - 1);
     std::vector<std::shared_ptr<arrow::Field>> fields;
-    std::size_t token_pos = inner_type.find_first_of(',');
-    size_t split_start = 0;
-    auto col_pos = 0;
-    while (token_pos != std::string::npos && token_pos < inner_type.length()) {
-      auto split = inner_type.substr(split_start, token_pos - split_start);
-      // Count '<', '>' in split.
-      auto num_left = std::count_if(split.begin(), split.end(), [](const auto& c) { return c == '<'; });
-      auto num_right = std::count_if(split.begin(), split.end(), [](const auto& c) { return c == '>'; });
-      if (num_left > num_right) {
+    std::size_t tokenPos = innerType.find_first_of(',');
+    std::size_t splitStart = 0;
+    auto column = 0;
+    while (tokenPos != std::string::npos && tokenPos < innerType.length()) {
+      auto part = innerType.substr(splitStart, tokenPos - splitStart);
+      // Count '<', '>' in part.
+      auto numLeft = std::count_if(part.begin(), part.end(), [](const auto& c) { return c == '<'; });
+      auto numRight = std::count_if(part.begin(), part.end(), [](const auto& c) { return c == '>'; });
+      if (numLeft > numRight) {
         // Has unclosed '<'.
-        size_t i = token_pos + 1;
-        for (; num_left > num_right && i < inner_type.length(); ++i) {
-          if (inner_type[i] == '<') {
-            ++num_left;
-          } else if (inner_type[i] == '>') {
-            ++num_right;
+        std::size_t i = tokenPos + 1;
+        for (; numLeft > numRight && i < innerType.length(); ++i) {
+          if (innerType[i] == '<') {
+            ++numLeft;
+          } else if (innerType[i] == '>') {
+            ++numRight;
           }
         }
         // If not reach to end of string, next character must be ','.
-        if (num_left != num_right || i < inner_type.length() && inner_type[i] != ',') {
-          throw std::runtime_error("Invalid struct type: " + type_name);
+        if (numLeft != numRight || i < innerType.length() && innerType[i] != ',') {
+          throw std::runtime_error("Invalid struct type: " + typeName);
         }
-        token_pos = i;
-        split = inner_type.substr(split_start, token_pos - split_start);
+        tokenPos = i;
+        part = innerType.substr(splitStart, tokenPos - splitStart);
       }
-      fields.push_back(arrow::field("col_" + std::to_string(col_pos++), toArrowTypeFromName(split)));
-      split_start = token_pos + 1;
-      token_pos = inner_type.find(',', split_start);
+      fields.push_back(arrow::field("col_" + std::to_string(column++), toArrowTypeFromName(part)));
+      splitStart = tokenPos + 1;
+      tokenPos = innerType.find(',', splitStart);
     }
-    if (split_start < inner_type.length()) {
-      auto finalName = inner_type.substr(split_start);
-      fields.push_back(arrow::field("col_" + std::to_string(col_pos), toArrowTypeFromName(finalName)));
+    if (splitStart < innerType.length()) {
+      auto finalName = innerType.substr(splitStart);
+      fields.push_back(arrow::field("col_" + std::to_string(column), toArrowTypeFromName(finalName)));
     }
     return arrow::struct_(fields);
   }
 
-  throw std::runtime_error("Type name is not supported: " + type_name + ".");
+  throw std::runtime_error("Type name is not supported: " + typeName + ".");
 }
 
 std::shared_ptr<arrow::DataType> toArrowType(const TypePtr& type) {
@@ -195,12 +197,12 @@ const char* arrowTypeIdToFormatStr(arrow::Type::type typeId) {
   }
 }
 
-std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const RowType>& row_type) {
+std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const RowType>& rowType) {
   std::vector<std::shared_ptr<arrow::Field>> fields;
-  auto size = row_type->size();
+  auto size = rowType->size();
   fields.reserve(size);
   for (auto i = 0; i < size; ++i) {
-    fields.push_back(arrow::field(row_type->nameOf(i), toArrowType(row_type->childAt(i))));
+    fields.push_back(arrow::field(rowType->nameOf(i), toArrowType(rowType->childAt(i))));
   }
   return arrow::schema(fields);
 }

--- a/cpp/velox/compute/ArrowTypeUtils.h
+++ b/cpp/velox/compute/ArrowTypeUtils.h
@@ -22,10 +22,10 @@
 
 #include "velox/type/Type.h"
 
-std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& type_name);
+std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& typeName);
 
 std::shared_ptr<arrow::DataType> toArrowType(const facebook::velox::TypePtr& type);
 
 const char* arrowTypeIdToFormatStr(arrow::Type::type typeId);
 
-std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const facebook::velox::RowType>& row_type);
+std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const facebook::velox::RowType>& rowType);

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -18,8 +18,9 @@
 package io.glutenproject.utils.velox
 
 import io.glutenproject.utils.BackendTestSettings
-import org.apache.spark.sql.catalyst.expressions._
+
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions._
 
 object VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFrameAggregateSuite]
@@ -91,5 +92,10 @@ object VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenComplexTypeSuite]
   enableSuite[GlutenDateFunctionsSuite]
   enableSuite[GlutenDataFrameFunctionsSuite]
+  enableSuite[GlutenDataFrameTungstenSuite]
+    .exclude(
+      "primitive data type accesses in persist data",
+      "access cache multiple times",
+      "access only some column of the all of columns")
 
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameTungstenSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameTungstenSuite.scala
@@ -17,11 +17,19 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.types._
+
 class GlutenDataFrameTungstenSuite extends DataFrameTungstenSuite with GlutenSQLTestsTrait {
 
-  override def testNameBlackList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL,
-    "access cache multiple times",
-    "access only some column of the all of columns"
-  )
+  test("Map type with struct type as key") {
+    val kv = Map(Row(1, 2L) -> Seq("v"))
+    val data = sparkContext.parallelize(Seq(Row(1, kv)))
+    val schema = new StructType()
+      .add("a", IntegerType)
+      .add(
+        "b",
+        MapType(new StructType().add("k1", IntegerType).add("k2", LongType), ArrayType(StringType)))
+    val df = spark.createDataFrame(data, schema)
+    assert(df.select("b").first() === Row(kv))
+  }
 }


### PR DESCRIPTION
Enable below test cases can reproduce:
```
enableSuite[GlutenDataFrameTungstenSuite]
    .include("test nested struct type")
enableSuite[GlutenDataFrameSuite]
    .includeByPrefix("SPARK-37855")
```