### PR TITLE
[OPPRO-361] Add flush row count and set max memory

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -272,7 +272,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   metrics_builder_class = CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/Metrics;");
 
   metrics_builder_constructor =
-      GetMethodIDOrError(env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J)V");
+      GetMethodIDOrError(env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J)V");
 
   serialized_arrow_array_iterator_class =
       CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ArrowInIterator;");
@@ -441,6 +441,7 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
   auto numDynamicFiltersProduced = env->NewLongArray(numMetrics);
   auto numDynamicFiltersAccepted = env->NewLongArray(numMetrics);
   auto numReplacedWithDynamicFilterRows = env->NewLongArray(numMetrics);
+  auto flushRowCount = env->NewLongArray(numMetrics);
 
   if (metrics) {
     env->SetLongArrayRegion(inputRows, 0, numMetrics, metrics->inputRows);
@@ -455,12 +456,10 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
     env->SetLongArrayRegion(wallNanos, 0, numMetrics, metrics->wallNanos);
     env->SetLongArrayRegion(peakMemoryBytes, 0, numMetrics, metrics->peakMemoryBytes);
     env->SetLongArrayRegion(numMemoryAllocations, 0, numMetrics, metrics->numMemoryAllocations);
-
     env->SetLongArrayRegion(numDynamicFiltersProduced, 0, numMetrics, metrics->numDynamicFiltersProduced);
-
     env->SetLongArrayRegion(numDynamicFiltersAccepted, 0, numMetrics, metrics->numDynamicFiltersAccepted);
-
     env->SetLongArrayRegion(numReplacedWithDynamicFilterRows, 0, numMetrics, metrics->numReplacedWithDynamicFilterRows);
+    env->SetLongArrayRegion(flushRowCount, 0, numMetrics, metrics->flushRowCount);
   }
 
   return env->NewObject(
@@ -481,7 +480,8 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
       numMemoryAllocations,
       numDynamicFiltersProduced,
       numDynamicFiltersAccepted,
-      numReplacedWithDynamicFilterRows);
+      numReplacedWithDynamicFilterRows,
+      flushRowCount);
   JNI_METHOD_END(nullptr)
 }
 

--- a/cpp/core/utils/metrics.h
+++ b/cpp/core/utils/metrics.h
@@ -43,6 +43,7 @@ struct Metrics {
   long* numDynamicFiltersProduced;
   long* numDynamicFiltersAccepted;
   long* numReplacedWithDynamicFilterRows;
+  long* flushRowCount;
 
   Metrics(int size) : numMetrics(size) {
     inputRows = new long[numMetrics]();
@@ -60,6 +61,7 @@ struct Metrics {
     numDynamicFiltersProduced = new long[numMetrics]();
     numDynamicFiltersAccepted = new long[numMetrics]();
     numReplacedWithDynamicFilterRows = new long[numMetrics]();
+    flushRowCount = new long[numMetrics]();
   }
 
   Metrics(const Metrics&) = delete;
@@ -80,6 +82,10 @@ struct Metrics {
     delete[] wallNanos;
     delete[] peakMemoryBytes;
     delete[] numMemoryAllocations;
+    delete[] numDynamicFiltersProduced;
+    delete[] numDynamicFiltersAccepted;
+    delete[] numReplacedWithDynamicFilterRows;
+    delete[] flushRowCount;
   }
 };
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -44,9 +44,11 @@ namespace gluten {
 namespace {
 const std::string kHiveConnectorId = "test-hive";
 const std::string kSparkBatchSizeKey = "spark.sql.execution.arrow.maxRecordsPerBatch";
+const std::string kSparkOffHeapSizeKey = "spark.memory.offHeap.size";
 const std::string kDynamicFiltersProduced = "dynamicFiltersProduced";
 const std::string kDynamicFiltersAccepted = "dynamicFiltersAccepted";
 const std::string kReplacedWithDynamicFilterRows = "replacedWithDynamicFilterRows";
+const std::string kFlushRowCount = "flushRowCount";
 const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
 std::atomic<int32_t> taskSerial;
 } // namespace
@@ -456,7 +458,7 @@ void WholeStageResIter::getOrderedNodeIds(
   for (const auto& sourceNode : sourceNodes) {
     // Filter over Project are mapped into FilterProject operator in Velox.
     // Metrics are all applied on Project node, and the metrics for Filter node
-    // does not exist.
+    // do not exist.
     if (isProjectNode && std::dynamic_pointer_cast<const core::FilterNode>(sourceNode)) {
       omittedNodeIds_.insert(sourceNode->id());
     }
@@ -518,23 +520,37 @@ void WholeStageResIter::collectMetrics() {
       metrics_->peakMemoryBytes[metricsIdx] = entry.second->peakMemoryBytes;
       metrics_->numMemoryAllocations[metricsIdx] = entry.second->numMemoryAllocations;
       metrics_->numDynamicFiltersProduced[metricsIdx] =
-          sumOfRuntimeMetric(entry.second->customStats, kDynamicFiltersProduced);
+          runtimeMetric("sum", entry.second->customStats, kDynamicFiltersProduced);
       metrics_->numDynamicFiltersAccepted[metricsIdx] =
-          sumOfRuntimeMetric(entry.second->customStats, kDynamicFiltersAccepted);
+          runtimeMetric("sum", entry.second->customStats, kDynamicFiltersAccepted);
       metrics_->numReplacedWithDynamicFilterRows[metricsIdx] =
-          sumOfRuntimeMetric(entry.second->customStats, kReplacedWithDynamicFilterRows);
+          runtimeMetric("sum", entry.second->customStats, kReplacedWithDynamicFilterRows);
+      metrics_->flushRowCount[metricsIdx] = runtimeMetric("sum", entry.second->customStats, kFlushRowCount);
       metricsIdx += 1;
     }
   }
 }
 
-int64_t WholeStageResIter::sumOfRuntimeMetric(
+int64_t WholeStageResIter::runtimeMetric(
+    const std::string& metricType,
     const std::unordered_map<std::string, RuntimeMetric>& runtimeStats,
     const std::string& metricId) const {
   if (runtimeStats.size() == 0 || runtimeStats.find(metricId) == runtimeStats.end()) {
     return 0;
   }
-  return runtimeStats.at(metricId).sum;
+  if (metricType == "sum") {
+    return runtimeStats.at(metricId).sum;
+  }
+  if (metricType == "count") {
+    return runtimeStats.at(metricId).count;
+  }
+  if (metricType == "min") {
+    return runtimeStats.at(metricId).min;
+  }
+  if (metricType == "max") {
+    return runtimeStats.at(metricId).max;
+  }
+  return 0;
 }
 
 void WholeStageResIter::setConfToQueryContext(const std::shared_ptr<core::QueryCtx>& queryCtx) {
@@ -543,6 +559,17 @@ void WholeStageResIter::setConfToQueryContext(const std::shared_ptr<core::QueryC
   auto got = confMap_.find(kSparkBatchSizeKey);
   if (got != confMap_.end()) {
     configs[core::QueryConfig::kPreferredOutputBatchSize] = got->second;
+  }
+  // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.
+  got = confMap_.find(kSparkOffHeapSizeKey);
+  if (got != confMap_.end()) {
+    try {
+      // Set the max memory of partial aggregation as 3/4 of offheap size.
+      auto maxMemory = (long)(0.75 * std::stol(got->second));
+      configs[core::QueryConfig::kMaxPartialAggregationMemory] = std::to_string(maxMemory);
+    } catch (const std::invalid_argument) {
+      throw std::runtime_error("Invalid offheap size.");
+    }
   }
   // To align with Spark's behavior, set casting to int to be truncating.
   configs[core::QueryConfig::kCastIntByTruncate] = std::to_string(true);

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -124,8 +124,9 @@ class WholeStageResIter {
   /// Collect Velox metrics.
   void collectMetrics();
 
-  /// Return the sum of one runtime metric.
-  int64_t sumOfRuntimeMetric(
+  /// Return a certain type of runtime metric. Supported metric types are: sum, count, min, max.
+  int64_t runtimeMetric(
+      const std::string& metricType,
       const std::unordered_map<std::string, facebook::velox::RuntimeMetric>& runtimeStats,
       const std::string& metricId) const;
 

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/Metrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/Metrics.java
@@ -33,18 +33,30 @@ public class Metrics {
   public long[] numDynamicFiltersProduced;
   public long[] numDynamicFiltersAccepted;
   public long[] numReplacedWithDynamicFilterRows;
+  public long[] flushRowCount;
   public SingleMetric singleMetric = new SingleMetric();
 
   /**
    * Create an instance for native metrics.
    */
   public Metrics(
-      long[] inputRows, long[] inputVectors, long[] inputBytes, long[] rawInputRows,
-      long[] rawInputBytes, long[] outputRows, long[] outputVectors, long[] outputBytes,
-      long[] count, long[] wallNanos, long veloxToArrow, long[] peakMemoryBytes,
+      long[] inputRows,
+      long[] inputVectors,
+      long[] inputBytes,
+      long[] rawInputRows,
+      long[] rawInputBytes,
+      long[] outputRows,
+      long[] outputVectors,
+      long[] outputBytes,
+      long[] count,
+      long[] wallNanos,
+      long veloxToArrow,
+      long[] peakMemoryBytes,
       long[] numMemoryAllocations,
-      long[] numDynamicFiltersProduced, long[] numDynamicFiltersAccepted,
-      long[] numReplacedWithDynamicFilterRows) {
+      long[] numDynamicFiltersProduced,
+      long[] numDynamicFiltersAccepted,
+      long[] numReplacedWithDynamicFilterRows,
+      long[] flushRowCount) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -61,6 +73,7 @@ public class Metrics {
     this.numDynamicFiltersProduced = numDynamicFiltersProduced;
     this.numDynamicFiltersAccepted = numDynamicFiltersAccepted;
     this.numReplacedWithDynamicFilterRows = numReplacedWithDynamicFilterRows;
+    this.flushRowCount = flushRowCount;
   }
 
   public OperatorMetrics getOperatorMetrics(int index) {
@@ -83,7 +96,8 @@ public class Metrics {
         numMemoryAllocations[index],
         numDynamicFiltersProduced[index],
         numDynamicFiltersAccepted[index],
-        numReplacedWithDynamicFilterRows[index]);
+        numReplacedWithDynamicFilterRows[index],
+        flushRowCount[index]);
   }
 
   public SingleMetric getSingleMetrics() {

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
@@ -28,22 +28,35 @@ public class OperatorMetrics {
   public long outputBytes;
   public long count;
   public long wallNanos;
-
   public long peakMemoryBytes;
   public long numMemoryAllocations;
   public long numDynamicFiltersProduced;
   public long numDynamicFiltersAccepted;
   public long numReplacedWithDynamicFilterRows;
+  public long flushRowCount;
+  public long partialAggregationPctSum;
+  public long partialAggregationPctCount;
 
   /**
    * Create an instance for operator metrics.
    */
   public OperatorMetrics(
-      long inputRows, long inputVectors, long inputBytes, long rawInputRows,
-      long rawInputBytes, long outputRows, long outputVectors, long outputBytes,
-      long count, long wallNanos, long peakMemoryBytes, long numMemoryAllocations,
-      long numDynamicFiltersProduced, long numDynamicFiltersAccepted,
-      long numReplacedWithDynamicFilterRows) {
+      long inputRows,
+      long inputVectors,
+      long inputBytes,
+      long rawInputRows,
+      long rawInputBytes,
+      long outputRows,
+      long outputVectors,
+      long outputBytes,
+      long count,
+      long wallNanos,
+      long peakMemoryBytes,
+      long numMemoryAllocations,
+      long numDynamicFiltersProduced,
+      long numDynamicFiltersAccepted,
+      long numReplacedWithDynamicFilterRows,
+      long flushRowCount) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -59,5 +72,6 @@ public class OperatorMetrics {
     this.numDynamicFiltersProduced = numDynamicFiltersProduced;
     this.numDynamicFiltersAccepted = numDynamicFiltersAccepted;
     this.numReplacedWithDynamicFilterRows = numReplacedWithDynamicFilterRows;
+    this.flushRowCount = flushRowCount;
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -125,6 +125,8 @@ abstract class HashAggregateExecBaseTransformer(
       sparkContext, "aggregation peak memory bytes"),
     "aggNumMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of aggregation memory allocations"),
+    "flushRowCount" -> SQLMetrics.createMetric(
+      sparkContext, "number of aggregation flushed rows"),
 
     "extractionInputRows" -> SQLMetrics.createMetric(
       sparkContext, "number of extraction input rows"),
@@ -219,6 +221,7 @@ abstract class HashAggregateExecBaseTransformer(
   val aggWallNanos: SQLMetric = longMetric("aggWallNanos")
   val aggPeakMemoryBytes: SQLMetric = longMetric("aggPeakMemoryBytes")
   val aggNumMemoryAllocations: SQLMetric = longMetric("aggNumMemoryAllocations")
+  val flushRowCount: SQLMetric = longMetric("flushRowCount")
 
   val extractionInputRows: SQLMetric = longMetric("extractionInputRows")
   val extractionInputVectors: SQLMetric = longMetric("extractionInputVectors")
@@ -346,6 +349,7 @@ abstract class HashAggregateExecBaseTransformer(
     aggWallNanos += aggMetrics.wallNanos
     aggPeakMemoryBytes += aggMetrics.peakMemoryBytes
     aggNumMemoryAllocations += aggMetrics.numMemoryAllocations
+    flushRowCount += aggMetrics.flushRowCount
     idx += 1
 
     if (aggParams.preProjectionNeeded) {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -411,6 +411,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
     var numDynamicFiltersProduced: Long = 0
     var numDynamicFiltersAccepted: Long = 0
     var numReplacedWithDynamicFilterRows: Long = 0
+    var flushRowCount: Long = 0
 
     val metricsIterator = operatorMetrics.iterator()
     while (metricsIterator.hasNext) {
@@ -422,6 +423,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       numDynamicFiltersProduced += metrics.numDynamicFiltersProduced
       numDynamicFiltersAccepted += metrics.numDynamicFiltersAccepted
       numReplacedWithDynamicFilterRows += metrics.numReplacedWithDynamicFilterRows
+      flushRowCount += metrics.flushRowCount
     }
 
     new OperatorMetrics(
@@ -439,7 +441,8 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       numMemoryAllocations,
       numDynamicFiltersProduced,
       numDynamicFiltersAccepted,
-      numReplacedWithDynamicFilterRows
+      numReplacedWithDynamicFilterRows,
+      flushRowCount
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To avoid flushing rows in Velox partial aggregation, this PR set the max memory usage according to offheap size. Metric `flushRowCount` to illustrate flushed rows was also added to Spark UI.


## How was this patch tested?

Verified on Jenkins.

