### PR TITLE
share the place holder vector instance

### DIFF
--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/GlutenColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/GlutenColumnarBatches.java
@@ -37,7 +37,7 @@ public final class GlutenColumnarBatches {
     columnVectors[0] = iv;
     long numPlaceholders = numColumns - 1;
     for (int i = 0; i < numPlaceholders; i++) {
-      final GlutenPlaceholderVector pv = new GlutenPlaceholderVector();
+      final GlutenPlaceholderVector pv = GlutenPlaceholderVector.INSTANCE;
       columnVectors[i + 1] = pv;
     }
     return new ColumnarBatch(columnVectors, numRows);

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/GlutenPlaceholderVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/GlutenPlaceholderVector.java
@@ -25,8 +25,9 @@ import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class GlutenPlaceholderVector extends ColumnVector {
+  public static final GlutenPlaceholderVector INSTANCE = new GlutenPlaceholderVector();
 
-  protected GlutenPlaceholderVector() {
+  private GlutenPlaceholderVector() {
     super(DataTypes.NullType);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `GlutenPlaceholderVector` is not actually used and this pr is meant to avoid create it during each offload


## How was this patch tested?

existing tests
