### PR TITLE
Extract rules that applied before AddTransformHintRule

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -167,6 +167,8 @@ case class FallbackMultiCodegens() extends Rule[SparkPlan] {
   }
 }
 
+// This rule will fall back the whole plan if it contains OneRowRelation scan.
+// This should only affect some light-weight cases in some basic UTs.
 case class FallbackOneRowRelation() extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     val hasOneRowRelation =

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -97,5 +97,6 @@ object VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFrameSetOperationsSuite]
   enableSuite[GlutenSubquerySuite]
     .include("SPARK-27279: Reuse Subquery", "Subquery reuse across the whole plan")
+    .include("SPARK-15832: Test embedded existential predicate sub-queries")
 
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSessionExtensionSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql
 
-import io.glutenproject.extension.{ColumnarOverrideRules, ColumnarQueryStagePrepRule, JoinSelectionOverrides}
-
+import io.glutenproject.extension.columnar.{FallbackMultiCodegens, FallbackOneRowRelation}
+import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.StaticSQLConf.SPARK_SESSION_EXTENSIONS
 
@@ -30,7 +30,9 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
-    assert(spark.sessionState.queryStagePrepRules.contains(ColumnarQueryStagePrepRule(spark)))
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackOneRowRelation()))
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens()))
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))
     assert(spark.sessionState.planner.strategies.contains(JoinSelectionOverrides))
 


### PR DESCRIPTION
When AQE is on, those rules which have the privilege to override transformable tag (tag a plan before AddTransformHintRule), need to be placed in QueryStagePrepRules but not ColumnarRules.