### PR TITLE
Avoid referencing to Spark plan instance during task serialization

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -158,7 +158,7 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
       context: TaskContext,
       pipelineTime: SQLMetric,
       updateOutputMetrics: (Long, Long) => Unit,
-      updateNativeMetrics: GeneralOutIterator => Unit,
+      updateNativeMetrics: Metrics => Unit,
       inputIterators: Seq[Iterator[ColumnarBatch]] = Seq()): Iterator[ColumnarBatch] = {
     val beforeBuild = System.nanoTime()
     val transKernel = new CHNativeExpressionEvaluator()
@@ -202,7 +202,7 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
       rootNode: PlanNode,
       pipelineTime: SQLMetric,
       updateOutputMetrics: (Long, Long) => Unit,
-      updateNativeMetrics: GeneralOutIterator => Unit,
+      updateNativeMetrics: Metrics => Unit,
       buildRelationBatchHolder: Seq[ColumnarBatch],
       dependentKernels: Seq[NativeExpressionEvaluator],
       dependentKernelIterators: Seq[GeneralOutIterator]): Iterator[ColumnarBatch] = {

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -18,13 +18,12 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.GlutenNumaBindingInfo
-import io.glutenproject.execution.{BaseGlutenPartition, WholestageTransformContext}
+import io.glutenproject.execution.{BaseGlutenPartition, MetricsUpdater, WholestageTransformContext}
 import io.glutenproject.memory.TaskMemoryMetrics
 import io.glutenproject.memory.alloc.{NativeMemoryAllocatorManager, Spiller}
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.vectorized.{GeneralOutIterator, NativeExpressionEvaluator}
-
+import io.glutenproject.vectorized.{GeneralOutIterator, Metrics, NativeExpressionEvaluator}
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.rdd.RDD
@@ -75,7 +74,7 @@ trait IIteratorApi {
                             outputAttributes: Seq[Attribute], context: TaskContext,
                             pipelineTime: SQLMetric,
                             updateOutputMetrics: (Long, Long) => Unit,
-                            updateNativeMetrics: GeneralOutIterator => Unit,
+                            updateNativeMetrics: Metrics => Unit,
                             inputIterators: Seq[Iterator[ColumnarBatch]] = Seq())
   : Iterator[ColumnarBatch]
 
@@ -93,7 +92,7 @@ trait IIteratorApi {
                             rootNode: PlanNode,
                             pipelineTime: SQLMetric,
                             updateOutputMetrics: (Long, Long) => Unit,
-                            updateNativeMetrics: GeneralOutIterator => Unit,
+                            updateNativeMetrics: Metrics => Unit,
                             buildRelationBatchHolder: Seq[ColumnarBatch],
                             dependentKernels: Seq[NativeExpressionEvaluator],
                             dependentKernelIterators: Seq[GeneralOutIterator])

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -43,8 +43,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import java.util
 import scala.collection.JavaConverters._
 
-abstract class FilterExecBaseTransformer(condition: Expression,
-                                         child: SparkPlan) extends UnaryExecNode
+abstract class FilterExecBaseTransformer(val cond: Expression,
+                                         val input: SparkPlan) extends UnaryExecNode
   with TransformSupport
   with PredicateHelper
   with AliasAwareOutputPartitioning
@@ -104,7 +104,7 @@ abstract class FilterExecBaseTransformer(condition: Expression,
 
   val sparkConf: SparkConf = sparkContext.getConf
   // Split out all the IsNotNulls from condition.
-  private val (notNullPreds, otherPreds) = splitConjunctivePredicates(condition).partition {
+  private val (notNullPreds, otherPreds) = splitConjunctivePredicates(cond).partition {
     case IsNotNull(a) => isNullIntolerant(a) && a.references.subsetOf(child.outputSet)
     case _ => false
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -65,18 +65,42 @@ abstract class FilterExecBaseTransformer(condition: Expression,
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  val inputRows: SQLMetric = longMetric("inputRows")
-  val inputVectors: SQLMetric = longMetric("inputVectors")
-  val inputBytes: SQLMetric = longMetric("inputBytes")
-  val rawInputRows: SQLMetric = longMetric("rawInputRows")
-  val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
-  val outputRows: SQLMetric = longMetric("outputRows")
-  val outputVectors: SQLMetric = longMetric("outputVectors")
-  val outputBytes: SQLMetric = longMetric("outputBytes")
-  val count: SQLMetric = longMetric("count")
-  val wallNanos: SQLMetric = longMetric("wallNanos")
-  val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
-  val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+  object MetricsUpdaterImpl extends MetricsUpdater {
+    val inputRows: SQLMetric = longMetric("inputRows")
+    val inputVectors: SQLMetric = longMetric("inputVectors")
+    val inputBytes: SQLMetric = longMetric("inputBytes")
+    val rawInputRows: SQLMetric = longMetric("rawInputRows")
+    val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
+    val outputRows: SQLMetric = longMetric("outputRows")
+    val outputVectors: SQLMetric = longMetric("outputVectors")
+    val outputBytes: SQLMetric = longMetric("outputBytes")
+    val count: SQLMetric = longMetric("count")
+    val wallNanos: SQLMetric = longMetric("wallNanos")
+    val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
+    val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+
+    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
+      outputVectors += outNumBatches
+      outputRows += outNumRows
+    }
+
+    override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
+      if (operatorMetrics != null) {
+        inputRows += operatorMetrics.inputRows
+        inputVectors += operatorMetrics.inputVectors
+        inputBytes += operatorMetrics.inputBytes
+        rawInputRows += operatorMetrics.rawInputRows
+        rawInputBytes += operatorMetrics.rawInputBytes
+        outputRows += operatorMetrics.outputRows
+        outputVectors += operatorMetrics.outputVectors
+        outputBytes += operatorMetrics.outputBytes
+        count += operatorMetrics.count
+        wallNanos += operatorMetrics.wallNanos
+        peakMemoryBytes += operatorMetrics.peakMemoryBytes
+        numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      }
+    }
+  }
 
   val sparkConf: SparkConf = sparkContext.getConf
   // Split out all the IsNotNulls from condition.
@@ -117,27 +141,7 @@ abstract class FilterExecBaseTransformer(condition: Expression,
       this
   }
 
-  override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-    outputVectors += outNumBatches
-    outputRows += outNumRows
-  }
-
-  override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
-    if (operatorMetrics != null) {
-      inputRows += operatorMetrics.inputRows
-      inputVectors += operatorMetrics.inputVectors
-      inputBytes += operatorMetrics.inputBytes
-      rawInputRows += operatorMetrics.rawInputRows
-      rawInputBytes += operatorMetrics.rawInputBytes
-      outputRows += operatorMetrics.outputRows
-      outputVectors += operatorMetrics.outputVectors
-      outputBytes += operatorMetrics.outputBytes
-      count += operatorMetrics.count
-      wallNanos += operatorMetrics.wallNanos
-      peakMemoryBytes += operatorMetrics.peakMemoryBytes
-      numMemoryAllocations += operatorMetrics.numMemoryAllocations
-    }
-  }
+  override def metricsUpdater(): MetricsUpdater = MetricsUpdaterImpl
 
   override def getChild: SparkPlan = child
 
@@ -296,19 +300,37 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  val inputRows: SQLMetric = longMetric("inputRows")
-  val inputVectors: SQLMetric = longMetric("inputVectors")
-  val inputBytes: SQLMetric = longMetric("inputBytes")
-  val rawInputRows: SQLMetric = longMetric("rawInputRows")
-  val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
-  val outputRows: SQLMetric = longMetric("outputRows")
-  val outputVectors: SQLMetric = longMetric("outputVectors")
-  val outputBytes: SQLMetric = longMetric("outputBytes")
-  val count: SQLMetric = longMetric("count")
-  val wallNanos: SQLMetric = longMetric("wallNanos")
-  val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
-  val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+  object MetricsUpdaterImpl extends MetricsUpdater {
+    val inputRows: SQLMetric = longMetric("inputRows")
+    val inputVectors: SQLMetric = longMetric("inputVectors")
+    val inputBytes: SQLMetric = longMetric("inputBytes")
+    val rawInputRows: SQLMetric = longMetric("rawInputRows")
+    val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
+    val outputRows: SQLMetric = longMetric("outputRows")
+    val outputVectors: SQLMetric = longMetric("outputVectors")
+    val outputBytes: SQLMetric = longMetric("outputBytes")
+    val count: SQLMetric = longMetric("count")
+    val wallNanos: SQLMetric = longMetric("wallNanos")
+    val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
+    val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
 
+    override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
+      if (operatorMetrics != null) {
+        inputRows += operatorMetrics.inputRows
+        inputVectors += operatorMetrics.inputVectors
+        inputBytes += operatorMetrics.inputBytes
+        rawInputRows += operatorMetrics.rawInputRows
+        rawInputBytes += operatorMetrics.rawInputBytes
+        outputRows += operatorMetrics.outputRows
+        outputVectors += operatorMetrics.outputVectors
+        outputBytes += operatorMetrics.outputBytes
+        count += operatorMetrics.count
+        wallNanos += operatorMetrics.wallNanos
+        peakMemoryBytes += operatorMetrics.peakMemoryBytes
+        numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      }
+    }
+  }
   val sparkConf: SparkConf = sparkContext.getConf
 
   override def supportsColumnar: Boolean = GlutenConfig.getConf.enableColumnarIterator
@@ -360,22 +382,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
       this
   }
 
-  override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
-    if (operatorMetrics != null) {
-      inputRows += operatorMetrics.inputRows
-      inputVectors += operatorMetrics.inputVectors
-      inputBytes += operatorMetrics.inputBytes
-      rawInputRows += operatorMetrics.rawInputRows
-      rawInputBytes += operatorMetrics.rawInputBytes
-      outputRows += operatorMetrics.outputRows
-      outputVectors += operatorMetrics.outputVectors
-      outputBytes += operatorMetrics.outputBytes
-      count += operatorMetrics.count
-      wallNanos += operatorMetrics.wallNanos
-      peakMemoryBytes += operatorMetrics.peakMemoryBytes
-      numMemoryAllocations += operatorMetrics.numMemoryAllocations
-    }
-  }
+  override def metricsUpdater(): MetricsUpdater = MetricsUpdaterImpl
 
   override def getChild: SparkPlan = child
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -71,6 +71,8 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
 
   override protected def withNewChildInternal(newChild: SparkPlan): CoalesceExecTransformer =
     copy(child = newChild)
+
+  override def metricsUpdater(): MetricsUpdater = NoopMetricsUpdater
 }
 
 object CoalesceExecTransformer {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -61,37 +61,41 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  val inputRows: SQLMetric = longMetric("inputRows")
-  val inputVectors: SQLMetric = longMetric("inputVectors")
-  val inputBytes: SQLMetric = longMetric("inputBytes")
-  val rawInputRows: SQLMetric = longMetric("rawInputRows")
-  val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
-  val outputRows: SQLMetric = longMetric("outputRows")
-  val outputVectors: SQLMetric = longMetric("outputVectors")
-  val outputBytes: SQLMetric = longMetric("outputBytes")
-  val cpuCount: SQLMetric = longMetric("count")
-  val wallNanos: SQLMetric = longMetric("wallNanos")
-  val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
-  val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+  object MetricsUpdaterImpl extends MetricsUpdater {
+    val inputRows: SQLMetric = longMetric("inputRows")
+    val inputVectors: SQLMetric = longMetric("inputVectors")
+    val inputBytes: SQLMetric = longMetric("inputBytes")
+    val rawInputRows: SQLMetric = longMetric("rawInputRows")
+    val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
+    val outputRows: SQLMetric = longMetric("outputRows")
+    val outputVectors: SQLMetric = longMetric("outputVectors")
+    val outputBytes: SQLMetric = longMetric("outputBytes")
+    val cpuCount: SQLMetric = longMetric("count")
+    val wallNanos: SQLMetric = longMetric("wallNanos")
+    val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
+    val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+
+    override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
+      if (operatorMetrics != null) {
+        inputRows += operatorMetrics.inputRows
+        inputVectors += operatorMetrics.inputVectors
+        inputBytes += operatorMetrics.inputBytes
+        rawInputRows += operatorMetrics.rawInputRows
+        rawInputBytes += operatorMetrics.rawInputBytes
+        outputRows += operatorMetrics.outputRows
+        outputVectors += operatorMetrics.outputVectors
+        outputBytes += operatorMetrics.outputBytes
+        cpuCount += operatorMetrics.count
+        wallNanos += operatorMetrics.wallNanos
+        peakMemoryBytes += operatorMetrics.peakMemoryBytes
+        numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      }
+    }
+  }
 
   val originalInputAttributes: Seq[Attribute] = child.output
 
-  override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
-    if (operatorMetrics != null) {
-      inputRows += operatorMetrics.inputRows
-      inputVectors += operatorMetrics.inputVectors
-      inputBytes += operatorMetrics.inputBytes
-      rawInputRows += operatorMetrics.rawInputRows
-      rawInputBytes += operatorMetrics.rawInputBytes
-      outputRows += operatorMetrics.outputRows
-      outputVectors += operatorMetrics.outputVectors
-      outputBytes += operatorMetrics.outputBytes
-      cpuCount += operatorMetrics.count
-      wallNanos += operatorMetrics.wallNanos
-      peakMemoryBytes += operatorMetrics.peakMemoryBytes
-      numMemoryAllocations += operatorMetrics.numMemoryAllocations
-    }
-  }
+  override def metricsUpdater(): MetricsUpdater = MetricsUpdaterImpl
 
   // The GroupExpressions can output data with arbitrary partitioning, so set it
   // as UNKNOWN partitioning

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -187,5 +187,5 @@ case class GenerateExecTransformer(
     }
   }
 
-
+  override def metricsUpdater(): MetricsUpdater = NoopMetricsUpdater
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
@@ -20,7 +20,7 @@ package io.glutenproject.execution
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.substrait.plan.PlanBuilder
-import io.glutenproject.vectorized.GeneralOutIterator
+import io.glutenproject.vectorized.Metrics
 import io.substrait.proto.Plan
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
@@ -101,7 +101,7 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
                                   var rdds: Seq[RDD[ColumnarBatch]],
                                   pipelineTime: SQLMetric,
                                   updateOutputMetrics: (Long, Long) => Unit,
-                                  updateNativeMetrics: GeneralOutIterator => Unit)
+                                  updateNativeMetrics: Metrics => Unit)
   extends RDD[ColumnarBatch](sc, rdds.map(x => new OneToOneDependency(x))) {
   val numaBindingInfo = GlutenConfig.getConf.numaBindingInfo
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -22,12 +22,12 @@ import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
-import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.vectorized.OperatorMetrics
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -42,6 +42,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import java.util
 import scala.collection.mutable.ListBuffer
 import scala.util.control.Breaks.{break, breakable}
+
+trait HashAggregateMetricsUpdater extends MetricsUpdater {
+  def updateAggregationMetrics(aggregationMetrics: java.util.ArrayList[OperatorMetrics],
+                               aggParams: AggregationParams): Unit
+}
 
 /**
  * Columnar Based HashAggregateExec.
@@ -182,77 +187,172 @@ abstract class HashAggregateExecBaseTransformer(
     "finalOutputVectors" -> SQLMetrics.createMetric(
       sparkContext, "number of final output vectors"))
 
-  val inputRows: SQLMetric = longMetric("inputRows")
-  val inputVectors: SQLMetric = longMetric("inputVectors")
-  val inputBytes: SQLMetric = longMetric("inputBytes")
-  val rawInputRows: SQLMetric = longMetric("rawInputRows")
-  val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
-  val outputRows: SQLMetric = longMetric("outputRows")
-  val outputVectors: SQLMetric = longMetric("outputVectors")
-  val outputBytes: SQLMetric = longMetric("outputBytes")
-  val count: SQLMetric = longMetric("count")
-  val wallNanos: SQLMetric = longMetric("wallNanos")
-  val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
-  val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+  object MetricsUpdaterImpl extends HashAggregateMetricsUpdater {
+    val inputRows: SQLMetric = longMetric("inputRows")
+    val inputVectors: SQLMetric = longMetric("inputVectors")
+    val inputBytes: SQLMetric = longMetric("inputBytes")
+    val rawInputRows: SQLMetric = longMetric("rawInputRows")
+    val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
+    val outputRows: SQLMetric = longMetric("outputRows")
+    val outputVectors: SQLMetric = longMetric("outputVectors")
+    val outputBytes: SQLMetric = longMetric("outputBytes")
+    val count: SQLMetric = longMetric("count")
+    val wallNanos: SQLMetric = longMetric("wallNanos")
+    val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
+    val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
 
-  val preProjectionInputRows: SQLMetric = longMetric("preProjectionInputRows")
-  val preProjectionInputVectors: SQLMetric = longMetric("preProjectionInputVectors")
-  val preProjectionInputBytes: SQLMetric = longMetric("preProjectionInputBytes")
-  val preProjectionRawInputRows: SQLMetric = longMetric("preProjectionRawInputRows")
-  val preProjectionRawInputBytes: SQLMetric = longMetric("preProjectionRawInputBytes")
-  val preProjectionOutputRows: SQLMetric = longMetric("preProjectionOutputRows")
-  val preProjectionOutputVectors: SQLMetric = longMetric("preProjectionOutputVectors")
-  val preProjectionOutputBytes: SQLMetric = longMetric("preProjectionOutputBytes")
-  val preProjectionCount: SQLMetric = longMetric("preProjectionCount")
-  val preProjectionWallNanos: SQLMetric = longMetric("preProjectionWallNanos")
-  val preProjectionPeakMemoryBytes: SQLMetric = longMetric("preProjectionPeakMemoryBytes")
-  val preProjectionNumMemoryAllocations: SQLMetric =
-    longMetric("preProjectionNumMemoryAllocations")
+    val preProjectionInputRows: SQLMetric = longMetric("preProjectionInputRows")
+    val preProjectionInputVectors: SQLMetric = longMetric("preProjectionInputVectors")
+    val preProjectionInputBytes: SQLMetric = longMetric("preProjectionInputBytes")
+    val preProjectionRawInputRows: SQLMetric = longMetric("preProjectionRawInputRows")
+    val preProjectionRawInputBytes: SQLMetric = longMetric("preProjectionRawInputBytes")
+    val preProjectionOutputRows: SQLMetric = longMetric("preProjectionOutputRows")
+    val preProjectionOutputVectors: SQLMetric = longMetric("preProjectionOutputVectors")
+    val preProjectionOutputBytes: SQLMetric = longMetric("preProjectionOutputBytes")
+    val preProjectionCount: SQLMetric = longMetric("preProjectionCount")
+    val preProjectionWallNanos: SQLMetric = longMetric("preProjectionWallNanos")
+    val preProjectionPeakMemoryBytes: SQLMetric = longMetric("preProjectionPeakMemoryBytes")
+    val preProjectionNumMemoryAllocations: SQLMetric =
+      longMetric("preProjectionNumMemoryAllocations")
 
-  val aggInputRows: SQLMetric = longMetric("aggInputRows")
-  val aggInputVectors: SQLMetric = longMetric("aggInputVectors")
-  val aggInputBytes: SQLMetric = longMetric("aggInputBytes")
-  val aggRawInputRows: SQLMetric = longMetric("aggRawInputRows")
-  val aggRawInputBytes: SQLMetric = longMetric("aggRawInputBytes")
-  val aggOutputRows: SQLMetric = longMetric("aggOutputRows")
-  val aggOutputVectors: SQLMetric = longMetric("aggOutputVectors")
-  val aggOutputBytes: SQLMetric = longMetric("aggOutputBytes")
-  val aggCount: SQLMetric = longMetric("aggCount")
-  val aggWallNanos: SQLMetric = longMetric("aggWallNanos")
-  val aggPeakMemoryBytes: SQLMetric = longMetric("aggPeakMemoryBytes")
-  val aggNumMemoryAllocations: SQLMetric = longMetric("aggNumMemoryAllocations")
-  val flushRowCount: SQLMetric = longMetric("flushRowCount")
+    val aggInputRows: SQLMetric = longMetric("aggInputRows")
+    val aggInputVectors: SQLMetric = longMetric("aggInputVectors")
+    val aggInputBytes: SQLMetric = longMetric("aggInputBytes")
+    val aggRawInputRows: SQLMetric = longMetric("aggRawInputRows")
+    val aggRawInputBytes: SQLMetric = longMetric("aggRawInputBytes")
+    val aggOutputRows: SQLMetric = longMetric("aggOutputRows")
+    val aggOutputVectors: SQLMetric = longMetric("aggOutputVectors")
+    val aggOutputBytes: SQLMetric = longMetric("aggOutputBytes")
+    val aggCount: SQLMetric = longMetric("aggCount")
+    val aggWallNanos: SQLMetric = longMetric("aggWallNanos")
+    val aggPeakMemoryBytes: SQLMetric = longMetric("aggPeakMemoryBytes")
+    val aggNumMemoryAllocations: SQLMetric = longMetric("aggNumMemoryAllocations")
+    val flushRowCount: SQLMetric = longMetric("flushRowCount")
 
-  val extractionInputRows: SQLMetric = longMetric("extractionInputRows")
-  val extractionInputVectors: SQLMetric = longMetric("extractionInputVectors")
-  val extractionInputBytes: SQLMetric = longMetric("extractionInputBytes")
-  val extractionRawInputRows: SQLMetric = longMetric("extractionRawInputRows")
-  val extractionRawInputBytes: SQLMetric = longMetric("extractionRawInputBytes")
-  val extractionOutputRows: SQLMetric = longMetric("extractionOutputRows")
-  val extractionOutputVectors: SQLMetric = longMetric("extractionOutputVectors")
-  val extractionOutputBytes: SQLMetric = longMetric("extractionOutputBytes")
-  val extractionCount: SQLMetric = longMetric("extractionCount")
-  val extractionWallNanos: SQLMetric = longMetric("extractionWallNanos")
-  val extractionPeakMemoryBytes: SQLMetric = longMetric("extractionPeakMemoryBytes")
-  val extractionNumMemoryAllocations: SQLMetric =
-    longMetric("extractionNumMemoryAllocations")
+    val extractionInputRows: SQLMetric = longMetric("extractionInputRows")
+    val extractionInputVectors: SQLMetric = longMetric("extractionInputVectors")
+    val extractionInputBytes: SQLMetric = longMetric("extractionInputBytes")
+    val extractionRawInputRows: SQLMetric = longMetric("extractionRawInputRows")
+    val extractionRawInputBytes: SQLMetric = longMetric("extractionRawInputBytes")
+    val extractionOutputRows: SQLMetric = longMetric("extractionOutputRows")
+    val extractionOutputVectors: SQLMetric = longMetric("extractionOutputVectors")
+    val extractionOutputBytes: SQLMetric = longMetric("extractionOutputBytes")
+    val extractionCount: SQLMetric = longMetric("extractionCount")
+    val extractionWallNanos: SQLMetric = longMetric("extractionWallNanos")
+    val extractionPeakMemoryBytes: SQLMetric = longMetric("extractionPeakMemoryBytes")
+    val extractionNumMemoryAllocations: SQLMetric =
+      longMetric("extractionNumMemoryAllocations")
 
-  val postProjectionInputRows: SQLMetric = longMetric("postProjectionInputRows")
-  val postProjectionInputVectors: SQLMetric = longMetric("postProjectionInputVectors")
-  val postProjectionInputBytes: SQLMetric = longMetric("postProjectionInputBytes")
-  val postProjectionRawInputRows: SQLMetric = longMetric("postProjectionRawInputRows")
-  val postProjectionRawInputBytes: SQLMetric = longMetric("postProjectionRawInputBytes")
-  val postProjectionOutputRows: SQLMetric = longMetric("postProjectionOutputRows")
-  val postProjectionOutputVectors: SQLMetric = longMetric("postProjectionOutputVectors")
-  val postProjectionOutputBytes: SQLMetric = longMetric("postProjectionOutputBytes")
-  val postProjectionCount: SQLMetric = longMetric("postProjectionCount")
-  val postProjectionWallNanos: SQLMetric = longMetric("postProjectionWallNanos")
-  val postProjectionPeakMemoryBytes: SQLMetric = longMetric("postProjectionPeakMemoryBytes")
-  val postProjectionNumMemoryAllocations: SQLMetric =
-    longMetric("postProjectionNumMemoryAllocations")
+    val postProjectionInputRows: SQLMetric = longMetric("postProjectionInputRows")
+    val postProjectionInputVectors: SQLMetric = longMetric("postProjectionInputVectors")
+    val postProjectionInputBytes: SQLMetric = longMetric("postProjectionInputBytes")
+    val postProjectionRawInputRows: SQLMetric = longMetric("postProjectionRawInputRows")
+    val postProjectionRawInputBytes: SQLMetric = longMetric("postProjectionRawInputBytes")
+    val postProjectionOutputRows: SQLMetric = longMetric("postProjectionOutputRows")
+    val postProjectionOutputVectors: SQLMetric = longMetric("postProjectionOutputVectors")
+    val postProjectionOutputBytes: SQLMetric = longMetric("postProjectionOutputBytes")
+    val postProjectionCount: SQLMetric = longMetric("postProjectionCount")
+    val postProjectionWallNanos: SQLMetric = longMetric("postProjectionWallNanos")
+    val postProjectionPeakMemoryBytes: SQLMetric = longMetric("postProjectionPeakMemoryBytes")
+    val postProjectionNumMemoryAllocations: SQLMetric =
+      longMetric("postProjectionNumMemoryAllocations")
 
-  val finalOutputRows: SQLMetric = longMetric("finalOutputRows")
-  val finalOutputVectors: SQLMetric = longMetric("finalOutputVectors")
+    val finalOutputRows: SQLMetric = longMetric("finalOutputRows")
+    val finalOutputVectors: SQLMetric = longMetric("finalOutputVectors")
+
+    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
+      finalOutputVectors += outNumBatches
+      finalOutputRows += outNumRows
+    }
+
+    override def updateAggregationMetrics(aggregationMetrics: java.util.ArrayList[OperatorMetrics],
+                                 aggParams: AggregationParams): Unit = {
+      var idx = 0
+      if (aggParams.postProjectionNeeded) {
+        val metrics = aggregationMetrics.get(idx)
+        postProjectionInputRows += metrics.inputRows
+        postProjectionInputVectors += metrics.inputVectors
+        postProjectionInputBytes += metrics.inputBytes
+        postProjectionRawInputRows += metrics.rawInputRows
+        postProjectionRawInputBytes += metrics.rawInputBytes
+        postProjectionOutputRows += metrics.outputRows
+        postProjectionOutputVectors += metrics.outputVectors
+        postProjectionOutputBytes += metrics.outputBytes
+        postProjectionCount += metrics.count
+        postProjectionWallNanos += metrics.wallNanos
+        postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
+        postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      if (aggParams.extractionNeeded) {
+        val metrics = aggregationMetrics.get(idx)
+        extractionInputRows += metrics.inputRows
+        extractionInputVectors += metrics.inputVectors
+        extractionInputBytes += metrics.inputBytes
+        extractionRawInputRows += metrics.rawInputRows
+        extractionRawInputBytes += metrics.rawInputBytes
+        extractionOutputRows += metrics.outputRows
+        extractionOutputVectors += metrics.outputVectors
+        extractionOutputBytes += metrics.outputBytes
+        extractionCount += metrics.count
+        extractionWallNanos += metrics.wallNanos
+        extractionPeakMemoryBytes += metrics.peakMemoryBytes
+        extractionNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      val aggMetrics = aggregationMetrics.get(idx)
+      aggInputRows += aggMetrics.inputRows
+      aggInputVectors += aggMetrics.inputVectors
+      aggInputBytes += aggMetrics.inputBytes
+      aggRawInputRows += aggMetrics.rawInputRows
+      aggRawInputBytes += aggMetrics.rawInputBytes
+      aggOutputRows += aggMetrics.outputRows
+      aggOutputVectors += aggMetrics.outputVectors
+      aggOutputBytes += aggMetrics.outputBytes
+      aggCount += aggMetrics.count
+      aggWallNanos += aggMetrics.wallNanos
+      aggPeakMemoryBytes += aggMetrics.peakMemoryBytes
+      aggNumMemoryAllocations += aggMetrics.numMemoryAllocations
+      flushRowCount += aggMetrics.flushRowCount
+      idx += 1
+
+      if (aggParams.preProjectionNeeded) {
+        val metrics = aggregationMetrics.get(idx)
+        preProjectionInputRows += metrics.inputRows
+        preProjectionInputVectors += metrics.inputVectors
+        preProjectionInputBytes += metrics.inputBytes
+        preProjectionRawInputRows += metrics.rawInputRows
+        preProjectionRawInputBytes += metrics.rawInputBytes
+        preProjectionOutputRows += metrics.outputRows
+        preProjectionOutputVectors += metrics.outputVectors
+        preProjectionOutputBytes += metrics.outputBytes
+        preProjectionCount += metrics.count
+        preProjectionWallNanos += metrics.wallNanos
+        preProjectionPeakMemoryBytes += metrics.peakMemoryBytes
+        preProjectionNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      if (aggParams.isReadRel) {
+        val metrics = aggregationMetrics.get(idx)
+        inputRows += metrics.inputRows
+        inputVectors += metrics.inputVectors
+        inputBytes += metrics.inputBytes
+        rawInputRows += metrics.rawInputRows
+        rawInputBytes += metrics.rawInputBytes
+        outputRows += metrics.outputRows
+        outputVectors += metrics.outputVectors
+        outputBytes += metrics.outputBytes
+        count += metrics.count
+        wallNanos += metrics.wallNanos
+        peakMemoryBytes += metrics.peakMemoryBytes
+        numMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+    }
+  }
 
   val sparkConf = sparkContext.getConf
   val resAttributes: Seq[Attribute] = resultExpressions.map(_.toAttribute)
@@ -294,98 +394,7 @@ abstract class HashAggregateExecBaseTransformer(
       this
   }
 
-  override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-    finalOutputVectors += outNumBatches
-    finalOutputRows += outNumRows
-  }
-
-  def updateAggregationMetrics(aggregationMetrics: java.util.ArrayList[OperatorMetrics],
-                               aggParams: AggregationParams): Unit = {
-    var idx = 0
-    if (aggParams.postProjectionNeeded) {
-      val metrics = aggregationMetrics.get(idx)
-      postProjectionInputRows += metrics.inputRows
-      postProjectionInputVectors += metrics.inputVectors
-      postProjectionInputBytes += metrics.inputBytes
-      postProjectionRawInputRows += metrics.rawInputRows
-      postProjectionRawInputBytes += metrics.rawInputBytes
-      postProjectionOutputRows += metrics.outputRows
-      postProjectionOutputVectors += metrics.outputVectors
-      postProjectionOutputBytes += metrics.outputBytes
-      postProjectionCount += metrics.count
-      postProjectionWallNanos += metrics.wallNanos
-      postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
-      postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    if (aggParams.extractionNeeded) {
-      val metrics = aggregationMetrics.get(idx)
-      extractionInputRows += metrics.inputRows
-      extractionInputVectors += metrics.inputVectors
-      extractionInputBytes += metrics.inputBytes
-      extractionRawInputRows += metrics.rawInputRows
-      extractionRawInputBytes += metrics.rawInputBytes
-      extractionOutputRows += metrics.outputRows
-      extractionOutputVectors += metrics.outputVectors
-      extractionOutputBytes += metrics.outputBytes
-      extractionCount += metrics.count
-      extractionWallNanos += metrics.wallNanos
-      extractionPeakMemoryBytes += metrics.peakMemoryBytes
-      extractionNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    val aggMetrics = aggregationMetrics.get(idx)
-    aggInputRows += aggMetrics.inputRows
-    aggInputVectors += aggMetrics.inputVectors
-    aggInputBytes += aggMetrics.inputBytes
-    aggRawInputRows += aggMetrics.rawInputRows
-    aggRawInputBytes += aggMetrics.rawInputBytes
-    aggOutputRows += aggMetrics.outputRows
-    aggOutputVectors += aggMetrics.outputVectors
-    aggOutputBytes += aggMetrics.outputBytes
-    aggCount += aggMetrics.count
-    aggWallNanos += aggMetrics.wallNanos
-    aggPeakMemoryBytes += aggMetrics.peakMemoryBytes
-    aggNumMemoryAllocations += aggMetrics.numMemoryAllocations
-    flushRowCount += aggMetrics.flushRowCount
-    idx += 1
-
-    if (aggParams.preProjectionNeeded) {
-      val metrics = aggregationMetrics.get(idx)
-      preProjectionInputRows += metrics.inputRows
-      preProjectionInputVectors += metrics.inputVectors
-      preProjectionInputBytes += metrics.inputBytes
-      preProjectionRawInputRows += metrics.rawInputRows
-      preProjectionRawInputBytes += metrics.rawInputBytes
-      preProjectionOutputRows += metrics.outputRows
-      preProjectionOutputVectors += metrics.outputVectors
-      preProjectionOutputBytes += metrics.outputBytes
-      preProjectionCount += metrics.count
-      preProjectionWallNanos += metrics.wallNanos
-      preProjectionPeakMemoryBytes += metrics.peakMemoryBytes
-      preProjectionNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    if (aggParams.isReadRel) {
-      val metrics = aggregationMetrics.get(idx)
-      inputRows += metrics.inputRows
-      inputVectors += metrics.inputVectors
-      inputBytes += metrics.inputBytes
-      rawInputRows += metrics.rawInputRows
-      rawInputBytes += metrics.rawInputBytes
-      outputRows += metrics.outputRows
-      outputVectors += metrics.outputVectors
-      outputBytes += metrics.outputBytes
-      count += metrics.count
-      wallNanos += metrics.wallNanos
-      peakMemoryBytes += metrics.peakMemoryBytes
-      numMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-  }
+  override def metricsUpdater(): HashAggregateMetricsUpdater = MetricsUpdaterImpl
 
   override def getChild: SparkPlan = child
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -23,12 +23,11 @@ import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
 import io.glutenproject.sql.shims.SparkShimLoader
-import io.glutenproject.substrait.{JoinParams, SubstraitContext}
-import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
-import io.glutenproject.substrait.extensions.{AdvancedExtensionNode, ExtensionBuilder}
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+import io.glutenproject.substrait.{JoinParams, SubstraitContext}
 import io.glutenproject.vectorized.Metrics.SingleMetric
 import io.glutenproject.vectorized.OperatorMetrics
 import io.substrait.proto.JoinRel
@@ -96,6 +95,12 @@ trait ColumnarShuffledJoin extends BaseJoinExec {
           s"${getClass.getSimpleName} not take $x as the JoinType")
     }
   }
+}
+
+trait HashJoinMetricsUpdater extends MetricsUpdater {
+  def updateJoinMetrics(joinMetrics: java.util.ArrayList[OperatorMetrics],
+                        singleMetrics: SingleMetric,
+                        joinParams: JoinParams): Unit
 }
 
 /**
@@ -344,114 +349,250 @@ trait HashJoinLikeExecTransformer
     "finalOutputVectors" -> SQLMetrics.createMetric(
       sparkContext, "number of final output vectors"))
 
-  val streamInputRows: SQLMetric = longMetric("streamInputRows")
-  val streamInputVectors: SQLMetric = longMetric("streamInputVectors")
-  val streamInputBytes: SQLMetric = longMetric("streamInputBytes")
-  val streamRawInputRows: SQLMetric = longMetric("streamRawInputRows")
-  val streamRawInputBytes: SQLMetric = longMetric("streamRawInputBytes")
-  val streamOutputRows: SQLMetric = longMetric("streamOutputRows")
-  val streamOutputVectors: SQLMetric = longMetric("streamOutputVectors")
-  val streamOutputBytes: SQLMetric = longMetric("streamOutputBytes")
-  val streamCount: SQLMetric = longMetric("streamCount")
-  val streamWallNanos: SQLMetric = longMetric("streamWallNanos")
-  val streamVeloxToArrow: SQLMetric = longMetric("streamVeloxToArrow")
-  val streamPeakMemoryBytes: SQLMetric = longMetric("streamPeakMemoryBytes")
-  val streamNumMemoryAllocations: SQLMetric = longMetric("streamNumMemoryAllocations")
+  object MetricsUpdaterImpl extends HashJoinMetricsUpdater {
+    val streamInputRows: SQLMetric = longMetric("streamInputRows")
+    val streamInputVectors: SQLMetric = longMetric("streamInputVectors")
+    val streamInputBytes: SQLMetric = longMetric("streamInputBytes")
+    val streamRawInputRows: SQLMetric = longMetric("streamRawInputRows")
+    val streamRawInputBytes: SQLMetric = longMetric("streamRawInputBytes")
+    val streamOutputRows: SQLMetric = longMetric("streamOutputRows")
+    val streamOutputVectors: SQLMetric = longMetric("streamOutputVectors")
+    val streamOutputBytes: SQLMetric = longMetric("streamOutputBytes")
+    val streamCount: SQLMetric = longMetric("streamCount")
+    val streamWallNanos: SQLMetric = longMetric("streamWallNanos")
+    val streamVeloxToArrow: SQLMetric = longMetric("streamVeloxToArrow")
+    val streamPeakMemoryBytes: SQLMetric = longMetric("streamPeakMemoryBytes")
+    val streamNumMemoryAllocations: SQLMetric = longMetric("streamNumMemoryAllocations")
 
-  val streamPreProjectionInputRows: SQLMetric = longMetric("streamPreProjectionInputRows")
-  val streamPreProjectionInputVectors: SQLMetric = longMetric("streamPreProjectionInputVectors")
-  val streamPreProjectionInputBytes: SQLMetric = longMetric("streamPreProjectionInputBytes")
-  val streamPreProjectionRawInputRows: SQLMetric = longMetric("streamPreProjectionRawInputRows")
-  val streamPreProjectionRawInputBytes: SQLMetric = longMetric("streamPreProjectionRawInputBytes")
-  val streamPreProjectionOutputRows: SQLMetric = longMetric("streamPreProjectionOutputRows")
-  val streamPreProjectionOutputVectors: SQLMetric = longMetric("streamPreProjectionOutputVectors")
-  val streamPreProjectionOutputBytes: SQLMetric = longMetric("streamPreProjectionOutputBytes")
-  val streamPreProjectionCount: SQLMetric = longMetric("streamPreProjectionCount")
-  val streamPreProjectionWallNanos: SQLMetric = longMetric("streamPreProjectionWallNanos")
-  val streamPreProjectionPeakMemoryBytes: SQLMetric =
-    longMetric("streamPreProjectionPeakMemoryBytes")
-  val streamPreProjectionNumMemoryAllocations: SQLMetric =
-    longMetric("streamPreProjectionNumMemoryAllocations")
+    val streamPreProjectionInputRows: SQLMetric = longMetric("streamPreProjectionInputRows")
+    val streamPreProjectionInputVectors: SQLMetric = longMetric("streamPreProjectionInputVectors")
+    val streamPreProjectionInputBytes: SQLMetric = longMetric("streamPreProjectionInputBytes")
+    val streamPreProjectionRawInputRows: SQLMetric = longMetric("streamPreProjectionRawInputRows")
+    val streamPreProjectionRawInputBytes: SQLMetric = longMetric("streamPreProjectionRawInputBytes")
+    val streamPreProjectionOutputRows: SQLMetric = longMetric("streamPreProjectionOutputRows")
+    val streamPreProjectionOutputVectors: SQLMetric = longMetric("streamPreProjectionOutputVectors")
+    val streamPreProjectionOutputBytes: SQLMetric = longMetric("streamPreProjectionOutputBytes")
+    val streamPreProjectionCount: SQLMetric = longMetric("streamPreProjectionCount")
+    val streamPreProjectionWallNanos: SQLMetric = longMetric("streamPreProjectionWallNanos")
+    val streamPreProjectionPeakMemoryBytes: SQLMetric =
+      longMetric("streamPreProjectionPeakMemoryBytes")
+    val streamPreProjectionNumMemoryAllocations: SQLMetric =
+      longMetric("streamPreProjectionNumMemoryAllocations")
 
-  val buildInputRows: SQLMetric = longMetric("buildInputRows")
-  val buildInputVectors: SQLMetric = longMetric("buildInputVectors")
-  val buildInputBytes: SQLMetric = longMetric("buildInputBytes")
-  val buildRawInputRows: SQLMetric = longMetric("buildRawInputRows")
-  val buildRawInputBytes: SQLMetric = longMetric("buildRawInputBytes")
-  val buildOutputRows: SQLMetric = longMetric("buildOutputRows")
-  val buildOutputVectors: SQLMetric = longMetric("buildOutputVectors")
-  val buildOutputBytes: SQLMetric = longMetric("buildOutputBytes")
-  val buildCount: SQLMetric = longMetric("buildCount")
-  val buildWallNanos: SQLMetric = longMetric("buildWallNanos")
-  val buildPeakMemoryBytes: SQLMetric = longMetric("buildPeakMemoryBytes")
-  val buildNumMemoryAllocations: SQLMetric = longMetric("buildNumMemoryAllocations")
+    val buildInputRows: SQLMetric = longMetric("buildInputRows")
+    val buildInputVectors: SQLMetric = longMetric("buildInputVectors")
+    val buildInputBytes: SQLMetric = longMetric("buildInputBytes")
+    val buildRawInputRows: SQLMetric = longMetric("buildRawInputRows")
+    val buildRawInputBytes: SQLMetric = longMetric("buildRawInputBytes")
+    val buildOutputRows: SQLMetric = longMetric("buildOutputRows")
+    val buildOutputVectors: SQLMetric = longMetric("buildOutputVectors")
+    val buildOutputBytes: SQLMetric = longMetric("buildOutputBytes")
+    val buildCount: SQLMetric = longMetric("buildCount")
+    val buildWallNanos: SQLMetric = longMetric("buildWallNanos")
+    val buildPeakMemoryBytes: SQLMetric = longMetric("buildPeakMemoryBytes")
+    val buildNumMemoryAllocations: SQLMetric = longMetric("buildNumMemoryAllocations")
 
-  val buildPreProjectionInputRows: SQLMetric = longMetric("buildPreProjectionInputRows")
-  val buildPreProjectionInputVectors: SQLMetric = longMetric("buildPreProjectionInputVectors")
-  val buildPreProjectionInputBytes: SQLMetric = longMetric("buildPreProjectionInputBytes")
-  val buildPreProjectionRawInputRows: SQLMetric = longMetric("buildPreProjectionRawInputRows")
-  val buildPreProjectionRawInputBytes: SQLMetric = longMetric("buildPreProjectionRawInputBytes")
-  val buildPreProjectionOutputRows: SQLMetric = longMetric("buildPreProjectionOutputRows")
-  val buildPreProjectionOutputVectors: SQLMetric = longMetric("buildPreProjectionOutputVectors")
-  val buildPreProjectionOutputBytes: SQLMetric = longMetric("buildPreProjectionOutputBytes")
-  val buildPreProjectionCount: SQLMetric = longMetric("buildPreProjectionCount")
-  val buildPreProjectionWallNanos: SQLMetric = longMetric("buildPreProjectionWallNanos")
-  val buildPreProjectionPeakMemoryBytes: SQLMetric =
-    longMetric("buildPreProjectionPeakMemoryBytes")
-  val buildPreProjectionNumMemoryAllocations: SQLMetric =
-    longMetric("buildPreProjectionNumMemoryAllocations")
+    val buildPreProjectionInputRows: SQLMetric = longMetric("buildPreProjectionInputRows")
+    val buildPreProjectionInputVectors: SQLMetric = longMetric("buildPreProjectionInputVectors")
+    val buildPreProjectionInputBytes: SQLMetric = longMetric("buildPreProjectionInputBytes")
+    val buildPreProjectionRawInputRows: SQLMetric = longMetric("buildPreProjectionRawInputRows")
+    val buildPreProjectionRawInputBytes: SQLMetric = longMetric("buildPreProjectionRawInputBytes")
+    val buildPreProjectionOutputRows: SQLMetric = longMetric("buildPreProjectionOutputRows")
+    val buildPreProjectionOutputVectors: SQLMetric = longMetric("buildPreProjectionOutputVectors")
+    val buildPreProjectionOutputBytes: SQLMetric = longMetric("buildPreProjectionOutputBytes")
+    val buildPreProjectionCount: SQLMetric = longMetric("buildPreProjectionCount")
+    val buildPreProjectionWallNanos: SQLMetric = longMetric("buildPreProjectionWallNanos")
+    val buildPreProjectionPeakMemoryBytes: SQLMetric =
+      longMetric("buildPreProjectionPeakMemoryBytes")
+    val buildPreProjectionNumMemoryAllocations: SQLMetric =
+      longMetric("buildPreProjectionNumMemoryAllocations")
 
-  val hashBuildInputRows: SQLMetric = longMetric("hashBuildInputRows")
-  val hashBuildInputVectors: SQLMetric = longMetric("hashBuildInputVectors")
-  val hashBuildInputBytes: SQLMetric = longMetric("hashBuildInputBytes")
-  val hashBuildRawInputRows: SQLMetric = longMetric("hashBuildRawInputRows")
-  val hashBuildRawInputBytes: SQLMetric = longMetric("hashBuildRawInputBytes")
-  val hashBuildOutputRows: SQLMetric = longMetric("hashBuildOutputRows")
-  val hashBuildOutputVectors: SQLMetric = longMetric("hashBuildOutputVectors")
-  val hashBuildOutputBytes: SQLMetric = longMetric("hashBuildOutputBytes")
-  val hashBuildCount: SQLMetric = longMetric("hashBuildCount")
-  val hashBuildWallNanos: SQLMetric = longMetric("hashBuildWallNanos")
-  val hashBuildPeakMemoryBytes: SQLMetric = longMetric("hashBuildPeakMemoryBytes")
-  val hashBuildNumMemoryAllocations: SQLMetric = longMetric("hashBuildNumMemoryAllocations")
+    val hashBuildInputRows: SQLMetric = longMetric("hashBuildInputRows")
+    val hashBuildInputVectors: SQLMetric = longMetric("hashBuildInputVectors")
+    val hashBuildInputBytes: SQLMetric = longMetric("hashBuildInputBytes")
+    val hashBuildRawInputRows: SQLMetric = longMetric("hashBuildRawInputRows")
+    val hashBuildRawInputBytes: SQLMetric = longMetric("hashBuildRawInputBytes")
+    val hashBuildOutputRows: SQLMetric = longMetric("hashBuildOutputRows")
+    val hashBuildOutputVectors: SQLMetric = longMetric("hashBuildOutputVectors")
+    val hashBuildOutputBytes: SQLMetric = longMetric("hashBuildOutputBytes")
+    val hashBuildCount: SQLMetric = longMetric("hashBuildCount")
+    val hashBuildWallNanos: SQLMetric = longMetric("hashBuildWallNanos")
+    val hashBuildPeakMemoryBytes: SQLMetric = longMetric("hashBuildPeakMemoryBytes")
+    val hashBuildNumMemoryAllocations: SQLMetric = longMetric("hashBuildNumMemoryAllocations")
 
-  val hashProbeInputRows: SQLMetric = longMetric("hashProbeInputRows")
-  val hashProbeInputVectors: SQLMetric = longMetric("hashProbeInputVectors")
-  val hashProbeInputBytes: SQLMetric = longMetric("hashProbeInputBytes")
-  val hashProbeRawInputRows: SQLMetric = longMetric("hashProbeRawInputRows")
-  val hashProbeRawInputBytes: SQLMetric = longMetric("hashProbeRawInputBytes")
-  val hashProbeOutputRows: SQLMetric = longMetric("hashProbeOutputRows")
-  val hashProbeOutputVectors: SQLMetric = longMetric("hashProbeOutputVectors")
-  val hashProbeOutputBytes: SQLMetric = longMetric("hashProbeOutputBytes")
-  val hashProbeCount: SQLMetric = longMetric("hashProbeCount")
-  val hashProbeWallNanos: SQLMetric = longMetric("hashProbeWallNanos")
-  val hashProbePeakMemoryBytes: SQLMetric = longMetric("hashProbePeakMemoryBytes")
-  val hashProbeNumMemoryAllocations: SQLMetric = longMetric("hashProbeNumMemoryAllocations")
+    val hashProbeInputRows: SQLMetric = longMetric("hashProbeInputRows")
+    val hashProbeInputVectors: SQLMetric = longMetric("hashProbeInputVectors")
+    val hashProbeInputBytes: SQLMetric = longMetric("hashProbeInputBytes")
+    val hashProbeRawInputRows: SQLMetric = longMetric("hashProbeRawInputRows")
+    val hashProbeRawInputBytes: SQLMetric = longMetric("hashProbeRawInputBytes")
+    val hashProbeOutputRows: SQLMetric = longMetric("hashProbeOutputRows")
+    val hashProbeOutputVectors: SQLMetric = longMetric("hashProbeOutputVectors")
+    val hashProbeOutputBytes: SQLMetric = longMetric("hashProbeOutputBytes")
+    val hashProbeCount: SQLMetric = longMetric("hashProbeCount")
+    val hashProbeWallNanos: SQLMetric = longMetric("hashProbeWallNanos")
+    val hashProbePeakMemoryBytes: SQLMetric = longMetric("hashProbePeakMemoryBytes")
+    val hashProbeNumMemoryAllocations: SQLMetric = longMetric("hashProbeNumMemoryAllocations")
 
-  // The number of rows which were passed through without any processing
-  // after filter was pushed down.
-  val hashProbeReplacedWithDynamicFilterRows: SQLMetric =
+    // The number of rows which were passed through without any processing
+    // after filter was pushed down.
+    val hashProbeReplacedWithDynamicFilterRows: SQLMetric =
     longMetric("hashProbeReplacedWithDynamicFilterRows")
 
-  // The number of dynamic filters this join generated for push down.
-  val hashProbeDynamicFiltersProduced: SQLMetric =
-    longMetric("hashProbeDynamicFiltersProduced")
+    // The number of dynamic filters this join generated for push down.
+    val hashProbeDynamicFiltersProduced: SQLMetric =
+      longMetric("hashProbeDynamicFiltersProduced")
 
-  val postProjectionInputRows: SQLMetric = longMetric("postProjectionInputRows")
-  val postProjectionInputVectors: SQLMetric = longMetric("postProjectionInputVectors")
-  val postProjectionInputBytes: SQLMetric = longMetric("postProjectionInputBytes")
-  val postProjectionRawInputRows: SQLMetric = longMetric("postProjectionRawInputRows")
-  val postProjectionRawInputBytes: SQLMetric = longMetric("postProjectionRawInputBytes")
-  val postProjectionOutputRows: SQLMetric = longMetric("postProjectionOutputRows")
-  val postProjectionOutputVectors: SQLMetric = longMetric("postProjectionOutputVectors")
-  val postProjectionOutputBytes: SQLMetric = longMetric("postProjectionOutputBytes")
-  val postProjectionCount: SQLMetric = longMetric("postProjectionCount")
-  val postProjectionWallNanos: SQLMetric = longMetric("postProjectionWallNanos")
-  val postProjectionPeakMemoryBytes: SQLMetric = longMetric("postProjectionPeakMemoryBytes")
-  val postProjectionNumMemoryAllocations: SQLMetric =
-    longMetric("postProjectionNumMemoryAllocations")
+    val postProjectionInputRows: SQLMetric = longMetric("postProjectionInputRows")
+    val postProjectionInputVectors: SQLMetric = longMetric("postProjectionInputVectors")
+    val postProjectionInputBytes: SQLMetric = longMetric("postProjectionInputBytes")
+    val postProjectionRawInputRows: SQLMetric = longMetric("postProjectionRawInputRows")
+    val postProjectionRawInputBytes: SQLMetric = longMetric("postProjectionRawInputBytes")
+    val postProjectionOutputRows: SQLMetric = longMetric("postProjectionOutputRows")
+    val postProjectionOutputVectors: SQLMetric = longMetric("postProjectionOutputVectors")
+    val postProjectionOutputBytes: SQLMetric = longMetric("postProjectionOutputBytes")
+    val postProjectionCount: SQLMetric = longMetric("postProjectionCount")
+    val postProjectionWallNanos: SQLMetric = longMetric("postProjectionWallNanos")
+    val postProjectionPeakMemoryBytes: SQLMetric = longMetric("postProjectionPeakMemoryBytes")
+    val postProjectionNumMemoryAllocations: SQLMetric =
+      longMetric("postProjectionNumMemoryAllocations")
 
-  val finalOutputRows: SQLMetric = longMetric("finalOutputRows")
-  val finalOutputVectors: SQLMetric = longMetric("finalOutputVectors")
+    val finalOutputRows: SQLMetric = longMetric("finalOutputRows")
+    val finalOutputVectors: SQLMetric = longMetric("finalOutputVectors")
+
+    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
+      finalOutputVectors += outNumBatches
+      finalOutputRows += outNumRows
+    }
+
+    override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
+      throw new UnsupportedOperationException(s"updateNativeMetrics is not supported for join.")
+    }
+
+    override def updateJoinMetrics(joinMetrics: java.util.ArrayList[OperatorMetrics],
+                          singleMetrics: SingleMetric,
+                          joinParams: JoinParams): Unit = {
+      var idx = 0
+      if (joinParams.postProjectionNeeded) {
+        val metrics = joinMetrics.get(idx)
+        postProjectionInputRows += metrics.inputRows
+        postProjectionInputVectors += metrics.inputVectors
+        postProjectionInputBytes += metrics.inputBytes
+        postProjectionRawInputRows += metrics.rawInputRows
+        postProjectionRawInputBytes += metrics.rawInputBytes
+        postProjectionOutputRows += metrics.outputRows
+        postProjectionOutputVectors += metrics.outputVectors
+        postProjectionOutputBytes += metrics.outputBytes
+        postProjectionCount += metrics.count
+        postProjectionWallNanos += metrics.wallNanos
+        postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
+        postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      // HashProbe
+      val hashProbeMetrics = joinMetrics.get(idx)
+      hashProbeInputRows += hashProbeMetrics.inputRows
+      hashProbeInputVectors += hashProbeMetrics.inputVectors
+      hashProbeInputBytes += hashProbeMetrics.inputBytes
+      hashProbeRawInputRows += hashProbeMetrics.rawInputRows
+      hashProbeRawInputBytes += hashProbeMetrics.rawInputBytes
+      hashProbeOutputRows += hashProbeMetrics.outputRows
+      hashProbeOutputVectors += hashProbeMetrics.outputVectors
+      hashProbeOutputBytes += hashProbeMetrics.outputBytes
+      hashProbeCount += hashProbeMetrics.count
+      hashProbeWallNanos += hashProbeMetrics.wallNanos
+      hashProbePeakMemoryBytes += hashProbeMetrics.peakMemoryBytes
+      hashProbeNumMemoryAllocations += hashProbeMetrics.numMemoryAllocations
+      hashProbeReplacedWithDynamicFilterRows += hashProbeMetrics.numReplacedWithDynamicFilterRows
+      hashProbeDynamicFiltersProduced += hashProbeMetrics.numDynamicFiltersProduced
+      idx += 1
+
+      // HashBuild
+      val hashBuildMetrics = joinMetrics.get(idx)
+      hashBuildInputRows += hashBuildMetrics.inputRows
+      hashBuildInputVectors += hashBuildMetrics.inputVectors
+      hashBuildInputBytes += hashBuildMetrics.inputBytes
+      hashBuildRawInputRows += hashBuildMetrics.rawInputRows
+      hashBuildRawInputBytes += hashBuildMetrics.rawInputBytes
+      hashBuildOutputRows += hashBuildMetrics.outputRows
+      hashBuildOutputVectors += hashBuildMetrics.outputVectors
+      hashBuildOutputBytes += hashBuildMetrics.outputBytes
+      hashBuildCount += hashBuildMetrics.count
+      hashBuildWallNanos += hashBuildMetrics.wallNanos
+      hashBuildPeakMemoryBytes += hashBuildMetrics.peakMemoryBytes
+      hashBuildNumMemoryAllocations += hashBuildMetrics.numMemoryAllocations
+      idx += 1
+
+      if (joinParams.buildPreProjectionNeeded) {
+        val metrics = joinMetrics.get(idx)
+        buildPreProjectionInputRows += metrics.inputRows
+        buildPreProjectionInputVectors += metrics.inputVectors
+        buildPreProjectionInputBytes += metrics.inputBytes
+        buildPreProjectionRawInputRows += metrics.rawInputRows
+        buildPreProjectionRawInputBytes += metrics.rawInputBytes
+        buildPreProjectionOutputRows += metrics.outputRows
+        buildPreProjectionOutputVectors += metrics.outputVectors
+        buildPreProjectionOutputBytes += metrics.outputBytes
+        buildPreProjectionCount += metrics.count
+        buildPreProjectionWallNanos += metrics.wallNanos
+        buildPreProjectionPeakMemoryBytes += metrics.peakMemoryBytes
+        buildPreProjectionNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      if (joinParams.isBuildReadRel) {
+        val metrics = joinMetrics.get(idx)
+        buildInputRows += metrics.inputRows
+        buildInputVectors += metrics.inputVectors
+        buildInputBytes += metrics.inputBytes
+        buildRawInputRows += metrics.rawInputRows
+        buildRawInputBytes += metrics.rawInputBytes
+        buildOutputRows += metrics.outputRows
+        buildOutputVectors += metrics.outputVectors
+        buildOutputBytes += metrics.outputBytes
+        buildCount += metrics.count
+        buildWallNanos += metrics.wallNanos
+        buildPeakMemoryBytes += metrics.peakMemoryBytes
+        buildNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      if (joinParams.streamPreProjectionNeeded) {
+        val metrics = joinMetrics.get(idx)
+        streamPreProjectionInputRows += metrics.inputRows
+        streamPreProjectionInputVectors += metrics.inputVectors
+        streamPreProjectionInputBytes += metrics.inputBytes
+        streamPreProjectionRawInputRows += metrics.rawInputRows
+        streamPreProjectionRawInputBytes += metrics.rawInputBytes
+        streamPreProjectionOutputRows += metrics.outputRows
+        streamPreProjectionOutputVectors += metrics.outputVectors
+        streamPreProjectionOutputBytes += metrics.outputBytes
+        streamPreProjectionCount += metrics.count
+        streamPreProjectionWallNanos += metrics.wallNanos
+        streamPreProjectionPeakMemoryBytes += metrics.peakMemoryBytes
+        streamPreProjectionNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+
+      if (joinParams.isStreamedReadRel) {
+        val metrics = joinMetrics.get(idx)
+        streamInputRows += metrics.inputRows
+        streamInputVectors += metrics.inputVectors
+        streamInputBytes += metrics.inputBytes
+        streamRawInputRows += metrics.rawInputRows
+        streamRawInputBytes += metrics.rawInputBytes
+        streamOutputRows += metrics.outputRows
+        streamOutputVectors += metrics.outputVectors
+        streamOutputBytes += metrics.outputBytes
+        streamCount += metrics.count
+        streamWallNanos += metrics.wallNanos
+        streamVeloxToArrow += singleMetrics.veloxToArrow
+        streamPeakMemoryBytes += metrics.peakMemoryBytes
+        streamNumMemoryAllocations += metrics.numMemoryAllocations
+        idx += 1
+      }
+    }
+  }
   def isSkewJoin: Boolean = false
 
   // Whether the left and right side should be exchanged.
@@ -499,139 +640,7 @@ trait HashJoinLikeExecTransformer
       JoinRel.JoinType.UNRECOGNIZED
   }
 
-  override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-    finalOutputVectors += outNumBatches
-    finalOutputRows += outNumRows
-  }
-
-  override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
-    throw new UnsupportedOperationException(s"updateNativeMetrics is not supported for join.")
-  }
-
-  def updateJoinMetrics(joinMetrics: java.util.ArrayList[OperatorMetrics],
-                        singleMetrics: SingleMetric,
-                        joinParams: JoinParams): Unit = {
-    var idx = 0
-    if (joinParams.postProjectionNeeded) {
-      val metrics = joinMetrics.get(idx)
-      postProjectionInputRows += metrics.inputRows
-      postProjectionInputVectors += metrics.inputVectors
-      postProjectionInputBytes += metrics.inputBytes
-      postProjectionRawInputRows += metrics.rawInputRows
-      postProjectionRawInputBytes += metrics.rawInputBytes
-      postProjectionOutputRows += metrics.outputRows
-      postProjectionOutputVectors += metrics.outputVectors
-      postProjectionOutputBytes += metrics.outputBytes
-      postProjectionCount += metrics.count
-      postProjectionWallNanos += metrics.wallNanos
-      postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
-      postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    // HashProbe
-    val hashProbeMetrics = joinMetrics.get(idx)
-    hashProbeInputRows += hashProbeMetrics.inputRows
-    hashProbeInputVectors += hashProbeMetrics.inputVectors
-    hashProbeInputBytes += hashProbeMetrics.inputBytes
-    hashProbeRawInputRows += hashProbeMetrics.rawInputRows
-    hashProbeRawInputBytes += hashProbeMetrics.rawInputBytes
-    hashProbeOutputRows += hashProbeMetrics.outputRows
-    hashProbeOutputVectors += hashProbeMetrics.outputVectors
-    hashProbeOutputBytes += hashProbeMetrics.outputBytes
-    hashProbeCount += hashProbeMetrics.count
-    hashProbeWallNanos += hashProbeMetrics.wallNanos
-    hashProbePeakMemoryBytes += hashProbeMetrics.peakMemoryBytes
-    hashProbeNumMemoryAllocations += hashProbeMetrics.numMemoryAllocations
-    hashProbeReplacedWithDynamicFilterRows += hashProbeMetrics.numReplacedWithDynamicFilterRows
-    hashProbeDynamicFiltersProduced += hashProbeMetrics.numDynamicFiltersProduced
-    idx += 1
-
-    // HashBuild
-    val hashBuildMetrics = joinMetrics.get(idx)
-    hashBuildInputRows += hashBuildMetrics.inputRows
-    hashBuildInputVectors += hashBuildMetrics.inputVectors
-    hashBuildInputBytes += hashBuildMetrics.inputBytes
-    hashBuildRawInputRows += hashBuildMetrics.rawInputRows
-    hashBuildRawInputBytes += hashBuildMetrics.rawInputBytes
-    hashBuildOutputRows += hashBuildMetrics.outputRows
-    hashBuildOutputVectors += hashBuildMetrics.outputVectors
-    hashBuildOutputBytes += hashBuildMetrics.outputBytes
-    hashBuildCount += hashBuildMetrics.count
-    hashBuildWallNanos += hashBuildMetrics.wallNanos
-    hashBuildPeakMemoryBytes += hashBuildMetrics.peakMemoryBytes
-    hashBuildNumMemoryAllocations += hashBuildMetrics.numMemoryAllocations
-    idx += 1
-
-    if (joinParams.buildPreProjectionNeeded) {
-      val metrics = joinMetrics.get(idx)
-      buildPreProjectionInputRows += metrics.inputRows
-      buildPreProjectionInputVectors += metrics.inputVectors
-      buildPreProjectionInputBytes += metrics.inputBytes
-      buildPreProjectionRawInputRows += metrics.rawInputRows
-      buildPreProjectionRawInputBytes += metrics.rawInputBytes
-      buildPreProjectionOutputRows += metrics.outputRows
-      buildPreProjectionOutputVectors += metrics.outputVectors
-      buildPreProjectionOutputBytes += metrics.outputBytes
-      buildPreProjectionCount += metrics.count
-      buildPreProjectionWallNanos += metrics.wallNanos
-      buildPreProjectionPeakMemoryBytes += metrics.peakMemoryBytes
-      buildPreProjectionNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    if (joinParams.isBuildReadRel) {
-      val metrics = joinMetrics.get(idx)
-      buildInputRows += metrics.inputRows
-      buildInputVectors += metrics.inputVectors
-      buildInputBytes += metrics.inputBytes
-      buildRawInputRows += metrics.rawInputRows
-      buildRawInputBytes += metrics.rawInputBytes
-      buildOutputRows += metrics.outputRows
-      buildOutputVectors += metrics.outputVectors
-      buildOutputBytes += metrics.outputBytes
-      buildCount += metrics.count
-      buildWallNanos += metrics.wallNanos
-      buildPeakMemoryBytes += metrics.peakMemoryBytes
-      buildNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    if (joinParams.streamPreProjectionNeeded) {
-      val metrics = joinMetrics.get(idx)
-      streamPreProjectionInputRows += metrics.inputRows
-      streamPreProjectionInputVectors += metrics.inputVectors
-      streamPreProjectionInputBytes += metrics.inputBytes
-      streamPreProjectionRawInputRows += metrics.rawInputRows
-      streamPreProjectionRawInputBytes += metrics.rawInputBytes
-      streamPreProjectionOutputRows += metrics.outputRows
-      streamPreProjectionOutputVectors += metrics.outputVectors
-      streamPreProjectionOutputBytes += metrics.outputBytes
-      streamPreProjectionCount += metrics.count
-      streamPreProjectionWallNanos += metrics.wallNanos
-      streamPreProjectionPeakMemoryBytes += metrics.peakMemoryBytes
-      streamPreProjectionNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-
-    if (joinParams.isStreamedReadRel) {
-      val metrics = joinMetrics.get(idx)
-      streamInputRows += metrics.inputRows
-      streamInputVectors += metrics.inputVectors
-      streamInputBytes += metrics.inputBytes
-      streamRawInputRows += metrics.rawInputRows
-      streamRawInputBytes += metrics.rawInputBytes
-      streamOutputRows += metrics.outputRows
-      streamOutputVectors += metrics.outputVectors
-      streamOutputBytes += metrics.outputBytes
-      streamCount += metrics.count
-      streamWallNanos += metrics.wallNanos
-      streamVeloxToArrow += singleMetrics.veloxToArrow
-      streamPeakMemoryBytes += metrics.peakMemoryBytes
-      streamNumMemoryAllocations += metrics.numMemoryAllocations
-      idx += 1
-    }
-  }
+  override def metricsUpdater(): HashJoinMetricsUpdater = MetricsUpdaterImpl
 
   override def outputPartitioning: Partitioning = joinBuildSide match {
     case BuildLeft =>

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -64,35 +64,39 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  val inputRows: SQLMetric = longMetric("inputRows")
-  val inputVectors: SQLMetric = longMetric("inputVectors")
-  val inputBytes: SQLMetric = longMetric("inputBytes")
-  val rawInputRows: SQLMetric = longMetric("rawInputRows")
-  val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
-  val outputRows: SQLMetric = longMetric("outputRows")
-  val outputVectors: SQLMetric = longMetric("outputVectors")
-  val outputBytes: SQLMetric = longMetric("outputBytes")
-  val cpuCount: SQLMetric = longMetric("count")
-  val wallNanos: SQLMetric = longMetric("wallNanos")
-  val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
-  val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+  object MetricsUpdaterImpl extends MetricsUpdater {
+    val inputRows: SQLMetric = longMetric("inputRows")
+    val inputVectors: SQLMetric = longMetric("inputVectors")
+    val inputBytes: SQLMetric = longMetric("inputBytes")
+    val rawInputRows: SQLMetric = longMetric("rawInputRows")
+    val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
+    val outputRows: SQLMetric = longMetric("outputRows")
+    val outputVectors: SQLMetric = longMetric("outputVectors")
+    val outputBytes: SQLMetric = longMetric("outputBytes")
+    val cpuCount: SQLMetric = longMetric("count")
+    val wallNanos: SQLMetric = longMetric("wallNanos")
+    val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
+    val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
 
-  override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
-    if (operatorMetrics != null) {
-      inputRows += operatorMetrics.inputRows
-      inputVectors += operatorMetrics.inputVectors
-      inputBytes += operatorMetrics.inputBytes
-      rawInputRows += operatorMetrics.rawInputRows
-      rawInputBytes += operatorMetrics.rawInputBytes
-      outputRows += operatorMetrics.outputRows
-      outputVectors += operatorMetrics.outputVectors
-      outputBytes += operatorMetrics.outputBytes
-      cpuCount += operatorMetrics.count
-      wallNanos += operatorMetrics.wallNanos
-      peakMemoryBytes += operatorMetrics.peakMemoryBytes
-      numMemoryAllocations += operatorMetrics.numMemoryAllocations
+    override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
+      if (operatorMetrics != null) {
+        inputRows += operatorMetrics.inputRows
+        inputVectors += operatorMetrics.inputVectors
+        inputBytes += operatorMetrics.inputBytes
+        rawInputRows += operatorMetrics.rawInputRows
+        rawInputBytes += operatorMetrics.rawInputBytes
+        outputRows += operatorMetrics.outputRows
+        outputVectors += operatorMetrics.outputVectors
+        outputBytes += operatorMetrics.outputBytes
+        cpuCount += operatorMetrics.count
+        wallNanos += operatorMetrics.wallNanos
+        peakMemoryBytes += operatorMetrics.peakMemoryBytes
+        numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      }
     }
   }
+
+  override def metricsUpdater(): MetricsUpdater = MetricsUpdaterImpl
 
   val sparkConf = sparkContext.getConf
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -160,9 +160,9 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       printNodeId,
       indent)
     if (verbose && planJson.nonEmpty) {
-//      append(prefix + "Substrait plan:\n")
-//      append(planJson)
-//      append("\n")
+      append(prefix + "Substrait plan:\n")
+      append(planJson)
+      append("\n")
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -63,35 +63,39 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  val inputRows: SQLMetric = longMetric("inputRows")
-  val inputVectors: SQLMetric = longMetric("inputVectors")
-  val inputBytes: SQLMetric = longMetric("inputBytes")
-  val rawInputRows: SQLMetric = longMetric("rawInputRows")
-  val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
-  val outputRows: SQLMetric = longMetric("outputRows")
-  val outputVectors: SQLMetric = longMetric("outputVectors")
-  val outputBytes: SQLMetric = longMetric("outputBytes")
-  val cpuCount: SQLMetric = longMetric("count")
-  val wallNanos: SQLMetric = longMetric("wallNanos")
-  val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
-  val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
+  object MetricsUpdaterImpl extends MetricsUpdater {
+    val inputRows: SQLMetric = longMetric("inputRows")
+    val inputVectors: SQLMetric = longMetric("inputVectors")
+    val inputBytes: SQLMetric = longMetric("inputBytes")
+    val rawInputRows: SQLMetric = longMetric("rawInputRows")
+    val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
+    val outputRows: SQLMetric = longMetric("outputRows")
+    val outputVectors: SQLMetric = longMetric("outputVectors")
+    val outputBytes: SQLMetric = longMetric("outputBytes")
+    val cpuCount: SQLMetric = longMetric("count")
+    val wallNanos: SQLMetric = longMetric("wallNanos")
+    val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
+    val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
 
-  override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
-    if (operatorMetrics != null) {
-      inputRows += operatorMetrics.inputRows
-      inputVectors += operatorMetrics.inputVectors
-      inputBytes += operatorMetrics.inputBytes
-      rawInputRows += operatorMetrics.rawInputRows
-      rawInputBytes += operatorMetrics.rawInputBytes
-      outputRows += operatorMetrics.outputRows
-      outputVectors += operatorMetrics.outputVectors
-      outputBytes += operatorMetrics.outputBytes
-      cpuCount += operatorMetrics.count
-      wallNanos += operatorMetrics.wallNanos
-      peakMemoryBytes += operatorMetrics.peakMemoryBytes
-      numMemoryAllocations += operatorMetrics.numMemoryAllocations
+    override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
+      if (operatorMetrics != null) {
+        inputRows += operatorMetrics.inputRows
+        inputVectors += operatorMetrics.inputVectors
+        inputBytes += operatorMetrics.inputBytes
+        rawInputRows += operatorMetrics.rawInputRows
+        rawInputBytes += operatorMetrics.rawInputBytes
+        outputRows += operatorMetrics.outputRows
+        outputVectors += operatorMetrics.outputVectors
+        outputBytes += operatorMetrics.outputBytes
+        cpuCount += operatorMetrics.count
+        wallNanos += operatorMetrics.wallNanos
+        peakMemoryBytes += operatorMetrics.peakMemoryBytes
+        numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      }
     }
   }
+
+  override def metricsUpdater(): MetricsUpdater = MetricsUpdaterImpl
 
   override def supportsColumnar: Boolean = true
 

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -460,7 +460,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
       }
     } catch {
       case e: UnsupportedOperationException =>
-        logError(
+        logWarning(
           s"Fall back to use row-based operators, error is ${e.getMessage}," +
             s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
         TransformHints.tagNotTransformable(plan)

--- a/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenIteratorApi.scala
+++ b/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenIteratorApi.scala
@@ -220,7 +220,7 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
                                      context: TaskContext,
                                      pipelineTime: SQLMetric,
                                      updateOutputMetrics: (Long, Long) => Unit,
-                                     updateNativeMetrics: GeneralOutIterator => Unit,
+                                     updateNativeMetrics: Metrics => Unit,
                                      inputIterators: Seq[Iterator[ColumnarBatch]] = Seq())
   : Iterator[ColumnarBatch] = {
     val beforeBuild = System.nanoTime()
@@ -239,7 +239,7 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
       override def hasNext: Boolean = {
         val res = resIter.hasNext
         if (!res) {
-          updateNativeMetrics(resIter)
+          updateNativeMetrics(resIter.getMetrics)
         }
         res
       }
@@ -288,7 +288,7 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
                                      rootNode: PlanNode,
                                      pipelineTime: SQLMetric,
                                      updateOutputMetrics: (Long, Long) => Unit,
-                                     updateNativeMetrics: GeneralOutIterator => Unit,
+                                     updateNativeMetrics: Metrics => Unit,
                                      buildRelationBatchHolder: Seq[ColumnarBatch],
                                      dependentKernels: Seq[NativeExpressionEvaluator],
                                      dependentKernelIterators: Seq[GeneralOutIterator])
@@ -313,7 +313,7 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
       override def hasNext: Boolean = {
         val res = nativeResultIterator.hasNext
         if (!res) {
-          updateNativeMetrics(nativeResultIterator)
+          updateNativeMetrics(nativeResultIterator.getMetrics)
         }
         res
       }

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
@@ -22,7 +22,8 @@ import io.glutenproject.execution.GlutenColumnarToRowExecBase
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper}
-import org.apache.spark.TaskContext
+
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
@@ -30,9 +31,11 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
-
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.NANOSECONDS
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class GlutenColumnarToRowExec(child: SparkPlan)
   extends GlutenColumnarToRowExecBase(child = child) {
@@ -73,74 +76,8 @@ case class GlutenColumnarToRowExec(child: SparkPlan)
     val numInputBatches = longMetric("numInputBatches")
     val convertTime = longMetric("convertTime")
 
-    child.executeColumnar().mapPartitions { batches =>
-      // TODO:: pass the jni jniWrapper and arrowSchema  and serializeSchema method by broadcast
-      val jniWrapper = new NativeColumnarToRowJniWrapper()
-
-      batches.flatMap { batch =>
-        numInputBatches += 1
-        numOutputRows += batch.numRows()
-
-        if (batch.numRows == 0) {
-          logInfo(s"Skip ColumnarBatch of ${batch.numRows} rows, ${batch.numCols} cols")
-          Iterator.empty
-        } else if (this.output.isEmpty || (batch.numCols() > 0 &&
-          !batch.column(0).isInstanceOf[ArrowWritableColumnVector] &&
-          !batch.column(0).isInstanceOf[GlutenIndicatorVector])) {
-          // Fallback to ColumnarToRow
-          val localOutput = this.output
-          numInputBatches += 1
-          numOutputRows += batch.numRows()
-
-          val toUnsafe = UnsafeProjection.create(localOutput, localOutput)
-          ArrowColumnarBatches
-            .ensureLoaded(ArrowBufferAllocators.contextInstance(), batch)
-            .rowIterator().asScala.map(toUnsafe)
-        } else {
-          var info: NativeColumnarToRowInfo = null
-          val beforeConvert = System.nanoTime()
-          val offloaded =
-            ArrowColumnarBatches.ensureOffloaded(ArrowBufferAllocators.contextInstance(), batch)
-          val batchHandle = GlutenColumnarBatches.getNativeHandle(offloaded)
-          info = jniWrapper.nativeConvertColumnarToRow(
-            batchHandle,
-            NativeMemoryAllocators.contextInstance().getNativeInstanceId)
-
-          convertTime += NANOSECONDS.toMillis(System.nanoTime() - beforeConvert)
-
-          new Iterator[InternalRow] {
-            var rowId = 0
-            val row = new UnsafeRow(batch.numCols())
-            var closed = false
-
-            TaskContext.get().addTaskCompletionListener[Unit](_ => {
-              if (!closed) {
-                jniWrapper.nativeClose(info.instanceID)
-                closed = true
-              }
-            })
-
-            override def hasNext: Boolean = {
-              val result = rowId < batch.numRows()
-              if (!result && !closed) {
-                jniWrapper.nativeClose(info.instanceID)
-                closed = true
-              }
-              result
-            }
-
-            override def next: UnsafeRow = {
-              if (rowId >= batch.numRows()) throw new NoSuchElementException
-
-              val (offset, length) = (info.offsets(rowId), info.lengths(rowId))
-              row.pointTo(null, info.memoryAddress + offset, length.toInt)
-              rowId += 1
-              row
-            }
-          }
-        }
-      }
-    }
+    new GlutenColumnarToRowRDD(sparkContext, child.executeColumnar(), this.output,
+      numOutputRows, numInputBatches, convertTime)
   }
 
   override def inputRDDs(): Seq[RDD[InternalRow]] = {
@@ -155,4 +92,86 @@ case class GlutenColumnarToRowExec(child: SparkPlan)
 
   protected def withNewChildInternal(newChild: SparkPlan): GlutenColumnarToRowExec =
     copy(child = newChild)
+}
+
+class GlutenColumnarToRowRDD(@transient sc: SparkContext, rdd: RDD[ColumnarBatch],
+    output: Seq[Attribute], numOutputRows: SQLMetric, numInputBatches: SQLMetric,
+    convertTime: SQLMetric)
+  extends RDD[InternalRow](sc, Seq(new OneToOneDependency(rdd))) {
+
+  private val cleanedF = sc.clean(f)
+
+  override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
+    cleanedF(firstParent[ColumnarBatch].iterator(split, context))
+  }
+
+  private def f: Iterator[ColumnarBatch] => Iterator[InternalRow] = { batches =>
+    // TODO:: pass the jni jniWrapper and arrowSchema  and serializeSchema method by broadcast
+    val jniWrapper = new NativeColumnarToRowJniWrapper()
+
+    batches.flatMap { batch =>
+      numInputBatches += 1
+      numOutputRows += batch.numRows()
+
+      if (batch.numRows == 0) {
+        logInfo(s"Skip ColumnarBatch of ${batch.numRows} rows, ${batch.numCols} cols")
+        Iterator.empty
+      } else if (this.output.isEmpty || (batch.numCols() > 0 &&
+        !batch.column(0).isInstanceOf[ArrowWritableColumnVector] &&
+        !batch.column(0).isInstanceOf[GlutenIndicatorVector])) {
+        // Fallback to ColumnarToRow
+        val localOutput = this.output
+        numInputBatches += 1
+        numOutputRows += batch.numRows()
+
+        val toUnsafe = UnsafeProjection.create(localOutput, localOutput)
+        ArrowColumnarBatches
+          .ensureLoaded(ArrowBufferAllocators.contextInstance(), batch)
+          .rowIterator().asScala.map(toUnsafe)
+      } else {
+        var info: NativeColumnarToRowInfo = null
+        val beforeConvert = System.nanoTime()
+        val offloaded =
+          ArrowColumnarBatches.ensureOffloaded(ArrowBufferAllocators.contextInstance(), batch)
+        val batchHandle = GlutenColumnarBatches.getNativeHandle(offloaded)
+        info = jniWrapper.nativeConvertColumnarToRow(
+          batchHandle,
+          NativeMemoryAllocators.contextInstance().getNativeInstanceId)
+
+        convertTime += NANOSECONDS.toMillis(System.nanoTime() - beforeConvert)
+
+        new Iterator[InternalRow] {
+          var rowId = 0
+          val row = new UnsafeRow(batch.numCols())
+          var closed = false
+
+          TaskContext.get().addTaskCompletionListener[Unit](_ => {
+            if (!closed) {
+              jniWrapper.nativeClose(info.instanceID)
+              closed = true
+            }
+          })
+
+          override def hasNext: Boolean = {
+            val result = rowId < batch.numRows()
+            if (!result && !closed) {
+              jniWrapper.nativeClose(info.instanceID)
+              closed = true
+            }
+            result
+          }
+
+          override def next: UnsafeRow = {
+            if (rowId >= batch.numRows()) throw new NoSuchElementException
+            val (offset, length) = (info.offsets(rowId), info.lengths(rowId))
+            row.pointTo(null, info.memoryAddress + offset, length.toInt)
+            rowId += 1
+            row
+          }
+        }
+      }
+    }
+  }
+
+  override def getPartitions: Array[Partition] = firstParent[ColumnarBatch].partitions
 }

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.execution.python
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.columnarbatch.ArrowColumnarBatches
-import io.glutenproject.execution.{TransformContext, TransformSupport}
+import io.glutenproject.execution.{MetricsUpdater, NoopMetricsUpdater, TransformContext, TransformSupport}
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.substrait.SubstraitContext
-
 import org.apache.spark.TaskContext
 import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.rdd.RDD
@@ -132,4 +131,6 @@ case class ArrowEvalPythonExecTransformer(udfs: Seq[PythonUDF], resultAttrs: Seq
         (ChainedPythonFunctions(Seq(udf.func)), udf.children)
     }
   }
+
+  override def metricsUpdater(): MetricsUpdater = NoopMetricsUpdater
 }

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -75,6 +75,17 @@ object VeloxTestSettings extends BackendTestSettings {
       "replace nan with double"
     )
 
+  enableSuite[GlutenDynamicPartitionPruningV1SuiteAEOff].exclude(
+    // overwritten
+    "DPP should not be rewritten as an existential join",
+    "no partition pruning when the build side is a stream",
+    "Make sure dynamic pruning works on uncorrelated queries",
+    "SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
+      "canonicalization and exchange reuse",
+    "Subquery reuse across the whole plan",
+    "static scan metrics"
+  )
+
   enableSuite[GlutenLiteralExpressionSuite]
   enableSuite[GlutenIntervalExpressionsSuite]
   enableSuite[GlutenIntervalFunctionsSuite]

--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -18,7 +18,7 @@
 package io.glutenproject.utils.velox
 
 import io.glutenproject.utils.BackendTestSettings
-
+import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
 
@@ -83,7 +83,17 @@ object VeloxTestSettings extends BackendTestSettings {
     "SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
       "canonicalization and exchange reuse",
     "Subquery reuse across the whole plan",
-    "static scan metrics"
+    "static scan metrics",
+
+    // to be fixed
+    "SPARK-32659: Fix the data issue when pruning DPP on non-atomic type",
+    "partition pruning in broadcast hash joins with aliases",
+    "broadcast multiple keys in an UnsafeHashedRelation",
+    "different broadcast subqueries with identical children",
+    "avoid reordering broadcast join keys to match input hash partitioning",
+    "dynamic partition pruning ambiguity issue across nested joins",
+    "Plan broadcast pruning only when the broadcast can be reused",
+    GLUTEN_TEST + "Subquery reuse across the whole plan"
   )
 
   enableSuite[GlutenLiteralExpressionSuite]

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningV1SuiteAEOff.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningV1SuiteAEOff.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer, FilterExecBaseTransformer, FilterExecTransformer, GlutenFilterExecTransformer}
+import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer, FilterExecBaseTransformer, FilterExecTransformer}
 
 import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
 import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expression}

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningV1SuiteAEOff.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningV1SuiteAEOff.scala
@@ -17,16 +17,395 @@
 
 package org.apache.spark.sql
 
+import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer, FilterExecTransformer, GlutenBroadcastHashJoinExecTransformer, GlutenFilterExecTransformer}
+import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
+import org.apache.spark.sql.catalyst.expressions.{DynamicPruningExpression, Expression}
+import org.apache.spark.sql.catalyst.plans.ExistenceJoin
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec, DisableAdaptiveExecution}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ReusedExchangeExec}
+import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
+import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWrapper}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.internal.SQLConf
+
 class GlutenDynamicPartitionPruningV1SuiteAEOff extends DynamicPartitionPruningV1SuiteAEOff
   with GlutenSQLTestsTrait {
+
+  import testImplicits._
 
   override def beforeAll(): Unit = {
     prepareWorkDir()
     super.beforeAll()
-    spark.sparkContext.setLogLevel("WARN")
+    spark.sparkContext.setLogLevel("INFO")
   }
 
-  override def testNameBlackList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL
-  )
+  // === Following cases override super class's cases ===
+
+  ignore(GLUTEN_TEST + "DPP should not be rewritten as an existential join") {
+    // ignored: BroadcastHashJoinExec is from Vanilla Spark
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_FALLBACK_FILTER_RATIO.key -> "1.5",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      val df = sql(
+        s"""
+           |SELECT * FROM product p WHERE p.store_id NOT IN
+           | (SELECT f.store_id FROM fact_sk f JOIN dim_store d ON f.store_id = d.store_id
+           |    WHERE d.state_province = 'NL'
+           | )
+       """.stripMargin)
+
+      val found = df.queryExecution.executedPlan.find {
+        case _ @ BroadcastHashJoinExec(_, _, _: ExistenceJoin, _, _, _, _, _) => true
+        case _ => false
+      }
+
+      assert(found.isEmpty)
+    }
+  }
+
+  test(GLUTEN_TEST + "no partition pruning when the build side is a stream") {
+    withTable("fact") {
+      val input = MemoryStream[Int]
+      val stream = input.toDF.select($"value" as "one", ($"value" * 3) as "code")
+      spark.range(100).select(
+        $"id",
+        ($"id" + 1).as("one"),
+        ($"id" + 2).as("two"),
+        ($"id" + 3).as("three"))
+        .write.partitionBy("one")
+        .format(tableFormat).mode("overwrite").saveAsTable("fact")
+      val table = sql("SELECT * from fact f")
+
+      // join a partitioned table with a stream
+      val joined = table.join(stream, Seq("one")).where("code > 40")
+      val query = joined.writeStream.format("memory").queryName("test").start()
+      input.addData(1, 10, 20, 40, 50)
+      try {
+        query.processAllAvailable()
+      } finally {
+        query.stop()
+      }
+      // search dynamic pruning predicates on the executed plan
+      val plan = query.asInstanceOf[StreamingQueryWrapper].streamingQuery.lastExecution.executedPlan
+      val ret = plan.find {
+        case s: FileSourceScanExec => s.partitionFilters.exists {
+          case _: DynamicPruningExpression => true
+          case _ => false
+        }
+        case s: FileSourceScanExecTransformer => s.partitionFilters.exists {
+          case _: DynamicPruningExpression => true
+          case _ => false
+        }
+        case _ => false
+      }
+      assert(ret.isDefined == false)
+    }
+  }
+
+  test(GLUTEN_TEST + "Make sure dynamic pruning works on uncorrelated queries") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
+      val df = sql(
+        """
+          |SELECT d.store_id,
+          |       SUM(f.units_sold),
+          |       (SELECT SUM(f.units_sold)
+          |        FROM fact_stats f JOIN dim_stats d ON d.store_id = f.store_id
+          |        WHERE d.country = 'US') AS total_prod
+          |FROM fact_stats f JOIN dim_stats d ON d.store_id = f.store_id
+          |WHERE d.country = 'US'
+          |GROUP BY 1
+        """.stripMargin)
+      checkAnswer(df, Row(4, 50, 70) :: Row(5, 10, 70) :: Row(6, 10, 70) :: Nil)
+
+      val plan = df.queryExecution.executedPlan
+      val countSubqueryBroadcasts =
+        collectWithSubqueries(plan)({
+          case _: SubqueryBroadcastExec => 1
+          case _: ColumnarSubqueryBroadcastExec => 1
+        }).sum
+
+      val countReusedSubqueryBroadcasts =
+        collectWithSubqueries(plan)({
+          case ReusedSubqueryExec(_: SubqueryBroadcastExec) => 1
+          case ReusedSubqueryExec(_: ColumnarSubqueryBroadcastExec) => 1
+        }).sum
+
+      assert(countSubqueryBroadcasts == 1)
+      assert(countReusedSubqueryBroadcasts == 1)
+    }
+  }
+
+  test(GLUTEN_TEST + "SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
+    "canonicalization and exchange reuse") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        val df = sql(
+          """ WITH view1 as (
+            |   SELECT f.store_id FROM fact_stats f WHERE f.units_sold = 70
+            | )
+            |
+            | SELECT * FROM view1 v1 join view1 v2 WHERE v1.store_id = v2.store_id
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df, false, false)
+        val reuseExchangeNodes = collect(df.queryExecution.executedPlan) {
+          case se: ReusedExchangeExec => se
+        }
+        assert(reuseExchangeNodes.size == 1, "Expected plan to contain 1 ReusedExchangeExec " +
+          s"nodes. Found ${reuseExchangeNodes.size}")
+
+        checkAnswer(df, Row(15, 15) :: Nil)
+      }
+    }
+  }
+
+  test(GLUTEN_TEST + "Subquery reuse across the whole plan",
+    DisableAdaptiveExecution("DPP in AQE must reuse broadcast")) {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      withTable("df1", "df2") {
+        spark.range(100)
+          .select(col("id"), col("id").as("k"))
+          .write
+          .partitionBy("k")
+          .format(tableFormat)
+          .mode("overwrite")
+          .saveAsTable("df1")
+
+        spark.range(10)
+          .select(col("id"), col("id").as("k"))
+          .write
+          .partitionBy("k")
+          .format(tableFormat)
+          .mode("overwrite")
+          .saveAsTable("df2")
+
+        val df = sql(
+          """
+            |SELECT df1.id, df2.k
+            |FROM df1 JOIN df2 ON df1.k = df2.k
+            |WHERE df2.id < (SELECT max(id) FROM df2 WHERE id <= 2)
+            |""".stripMargin)
+
+        checkPartitionPruningPredicate(df, true, false)
+
+        checkAnswer(df, Row(0, 0) :: Row(1, 1) :: Nil)
+
+        val plan = df.queryExecution.executedPlan
+
+        val subqueryIds = plan.collectWithSubqueries { case s: SubqueryExec => s.id }
+        val reusedSubqueryIds = plan.collectWithSubqueries {
+          case rs: ReusedSubqueryExec => rs.child.id
+        }
+
+        assert(subqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+        assert(reusedSubqueryIds.size == 1, "Whole plan subquery reusing not working correctly")
+        assert(reusedSubqueryIds.forall(subqueryIds.contains(_)),
+          "ReusedSubqueryExec should reuse an existing subquery")
+      }
+    }
+  }
+
+  test(GLUTEN_TEST + "static scan metrics",
+    DisableAdaptiveExecution("DPP in AQE must reuse broadcast")) {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true",
+      SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "false",
+      SQLConf.EXCHANGE_REUSE_ENABLED.key -> "false") {
+      withTable("fact", "dim") {
+        val numPartitions = 10
+
+        spark.range(10)
+          .map { x => Tuple3(x, x + 1, 0) }
+          .toDF("did", "d1", "d2")
+          .write
+          .format(tableFormat)
+          .mode("overwrite")
+          .saveAsTable("dim")
+
+        spark.range(100)
+          .map { x => Tuple2(x, x % numPartitions) }
+          .toDF("f1", "fid")
+          .write.partitionBy("fid")
+          .format(tableFormat)
+          .mode("overwrite")
+          .saveAsTable("fact")
+
+        def getFactScan(plan: SparkPlan): SparkPlan = {
+          val scanOption =
+            find(plan) {
+              case s: FileSourceScanExec =>
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
+              case s: FileSourceScanExecTransformer =>
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("fid")).isDefined)
+              case s: BatchScanExec =>
+                // we use f1 col for v2 tables due to schema pruning
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
+              case s: BatchScanExecTransformer =>
+                // we use f1 col for v2 tables due to schema pruning
+                s.output.exists(_.find(_.argString(maxFields = 100).contains("f1")).isDefined)
+              case _ => false
+            }
+          assert(scanOption.isDefined)
+          scanOption.get
+        }
+
+        // No dynamic partition pruning, so no static metrics
+        // All files in fact table are scanned
+        val df1 = sql("SELECT sum(f1) FROM fact")
+        df1.collect()
+        val scan1 = getFactScan(df1.queryExecution.executedPlan)
+        assert(!scan1.metrics.contains("staticFilesNum"))
+        assert(!scan1.metrics.contains("staticFilesSize"))
+        val allFilesNum = scan1.metrics("numFiles").value
+        val allFilesSize = scan1.metrics("filesSize").value
+        assert(scan1.metrics("numPartitions").value === numPartitions)
+        assert(scan1.metrics("pruningTime").value === -1)
+
+        // No dynamic partition pruning, so no static metrics
+        // Only files from fid = 5 partition are scanned
+        val df2 = sql("SELECT sum(f1) FROM fact WHERE fid = 5")
+        df2.collect()
+        val scan2 = getFactScan(df2.queryExecution.executedPlan)
+        assert(!scan2.metrics.contains("staticFilesNum"))
+        assert(!scan2.metrics.contains("staticFilesSize"))
+        val partFilesNum = scan2.metrics("numFiles").value
+        val partFilesSize = scan2.metrics("filesSize").value
+        assert(0 < partFilesNum && partFilesNum < allFilesNum)
+        assert(0 < partFilesSize && partFilesSize < allFilesSize)
+        assert(scan2.metrics("numPartitions").value === 1)
+        assert(scan2.metrics("pruningTime").value === -1)
+
+        // Dynamic partition pruning is used
+        // Static metrics are as-if reading the whole fact table
+        // "Regular" metrics are as-if reading only the "fid = 5" partition
+        val df3 = sql("SELECT sum(f1) FROM fact, dim WHERE fid = did AND d1 = 6")
+        df3.collect()
+        val scan3 = getFactScan(df3.queryExecution.executedPlan)
+        assert(scan3.metrics("staticFilesNum").value == allFilesNum)
+        assert(scan3.metrics("staticFilesSize").value == allFilesSize)
+        assert(scan3.metrics("numFiles").value == partFilesNum)
+        assert(scan3.metrics("filesSize").value == partFilesSize)
+        assert(scan3.metrics("numPartitions").value === 1)
+        assert(scan3.metrics("pruningTime").value !== -1)
+      }
+    }
+  }
+
+  // === Following methods override super class's methods ===
+
+  private def collectDynamicPruningExpressions(plan: SparkPlan): Seq[Expression] = {
+    flatMap(plan) {
+      case s: FileSourceScanExec => s.partitionFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case s: FileSourceScanExecTransformer => s.partitionFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case s: BatchScanExec => s.runtimeFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case s: BatchScanExecTransformer => s.runtimeFilters.collect {
+        case d: DynamicPruningExpression => d.child
+      }
+      case _ => Nil
+    }
+  }
+
+  override def checkPartitionPruningPredicate(
+                                      df: DataFrame,
+                                      withSubquery: Boolean,
+                                      withBroadcast: Boolean): Unit = {
+    df.collect()
+
+    val plan = df.queryExecution.executedPlan
+    val dpExprs = collectDynamicPruningExpressions(plan)
+    val hasSubquery = dpExprs.exists {
+      case InSubqueryExec(_, _: SubqueryExec, _, _) => true
+      case _ => false
+    }
+    val subqueryBroadcast = dpExprs.collect {
+      case InSubqueryExec(_, b: SubqueryBroadcastExec, _, _) => b
+      case InSubqueryExec(_, b: ColumnarSubqueryBroadcastExec, _, _) => b
+    }
+
+    val hasFilter = if (withSubquery) "Should" else "Shouldn't"
+    assert(hasSubquery == withSubquery,
+      s"$hasFilter trigger DPP with a subquery duplicate:\n${df.queryExecution}")
+    val hasBroadcast = if (withBroadcast) "Should" else "Shouldn't"
+    assert(subqueryBroadcast.nonEmpty == withBroadcast,
+      s"$hasBroadcast trigger DPP with a reused broadcast exchange:\n${df.queryExecution}")
+
+    subqueryBroadcast.foreach { s =>
+      s.child match {
+        case _: ReusedExchangeExec => // reuse check ok.
+        case BroadcastQueryStageExec(_, _: ReusedExchangeExec, _) => // reuse check ok.
+        case b: BroadcastExchangeLike =>
+          val hasReuse = plan.find {
+            case ReusedExchangeExec(_, e) => e eq b
+            case _ => false
+          }.isDefined
+          assert(hasReuse, s"$s\nshould have been reused in\n$plan")
+        case a: AdaptiveSparkPlanExec =>
+          val broadcastQueryStage = collectFirst(a) {
+            case b: BroadcastQueryStageExec => b
+          }
+          val broadcastPlan = broadcastQueryStage.get.broadcast
+          val hasReuse = find(plan) {
+            case ReusedExchangeExec(_, e) => e eq broadcastPlan
+            case b: BroadcastExchangeLike => b eq broadcastPlan
+            case _ => false
+          }.isDefined
+          assert(hasReuse, s"$s\nshould have been reused in\n$plan")
+        case _ =>
+          fail(s"Invalid child node found in\n$s")
+      }
+    }
+
+    val isMainQueryAdaptive = plan.isInstanceOf[AdaptiveSparkPlanExec]
+    subqueriesAll(plan).filterNot(subqueryBroadcast.contains).foreach { s =>
+      val subquery = s match {
+        case r: ReusedSubqueryExec => r.child
+        case o => o
+      }
+      assert(subquery.find(_.isInstanceOf[AdaptiveSparkPlanExec]).isDefined == isMainQueryAdaptive)
+    }
+  }
+
+  override def checkDistinctSubqueries(df: DataFrame, n: Int): Unit = {
+    df.collect()
+
+    val buf = collectDynamicPruningExpressions(df.queryExecution.executedPlan).collect {
+      case InSubqueryExec(_, b: SubqueryBroadcastExec, _, _) =>
+        b.index
+      case InSubqueryExec(_, b: ColumnarSubqueryBroadcastExec, _, _) =>
+        b.index
+    }
+    assert(buf.distinct.size == n)
+  }
+
+  override def checkUnpushedFilters(df: DataFrame): Boolean = {
+    find(df.queryExecution.executedPlan) {
+      case FilterExec(condition, _) =>
+        splitConjunctivePredicates(condition).exists {
+          case _: DynamicPruningExpression => true
+          case _ => false
+        }
+      case FilterExecTransformer(condition, _) =>
+        splitConjunctivePredicates(condition).exists {
+          case _: DynamicPruningExpression => true
+          case _ => false
+        }
+      case GlutenFilterExecTransformer(condition, _) =>
+        // FIXME this is backend-specific code for Velox / Gazelle
+        splitConjunctivePredicates(condition).exists {
+          case _: DynamicPruningExpression => true
+          case _ => false
+        }
+      case _ => false
+    }.isDefined
+  }
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsBaseTrait.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenTestsBaseTrait.scala
@@ -33,9 +33,6 @@ trait GlutenTestsBaseTrait {
   def testNameBlackList: Seq[String] = Seq()
 
   def shouldRun(testName: String): Boolean = {
-    if (testName.startsWith(GLUTEN_TEST)) {
-      return true
-    }
     if (testNameBlackList.exists(_.equalsIgnoreCase(GlutenTestConstants.IGNORE_ALL))) {
       return false
     }


### PR DESCRIPTION
In vanilla Spark this is a common practice to exclude any possible plan (XXXExec) instances from RDD / task ser/de process. Probably by following reasons:

1. to minimize the serialized task size
2. to decouple execution from planning

If we don't follow the principle sometimes an error "-1 not equal 0" can easily be found in unit testing because:

1. by default, driver-side long metric is initialized as -1.
2. [-1 will be rewritten to 0](https://github.com/apache/spark/blob/05428c218444f4864f28ed83011ebcc5c75c80ba/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala#L56-L64) if we include the driver-side long metric in serialized task. Usually it could be because metrics are defined in the class scope of a Spark plan (XXXExec), and the plan is included in the serialized RDD / task which is mentioned above as sub-optimal.
3. in a test case, it asserts "plan.metric("\<the driver metric\>") === -1) because it assumes the driver metric didn't get updated.

GlutenDynamicPartitionPruningV1SuiteAEOff#test("static scan metrics") is an example of such type of UT.

The PR fixed the error by reworking some part of the plan code to follow Spark's serialization principle.

Same code issues may still be hidden because they were not covered by the test. Fortunately we can follow this PR's way to create a quick fix once we encountered them.