### PR TITLE
[cpp] unify the C++ standard for all backends

### DIFF
--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FindPkgConfig)
 include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -1150,7 +1150,7 @@ arrow::Status Splitter::SplitBinaryType(
     auto size = reducer_offset_offset_[pid + 1] - r;
 
     auto multiply = 1;
-    for (register uint32_t x = 0; x < size; x++) {
+    for (uint32_t x = 0; x < size; x++) {
       auto src_offset = reducer_offsets_[x + r]; /*128k*/
       auto strlength = src_offset_addr[src_offset + 1] - src_offset_addr[src_offset];
       value_offset = dst_offset_base[x + 1] = value_offset + strlength;

--- a/cpp/gazelle-cpp/CMakeLists.txt
+++ b/cpp/gazelle-cpp/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FindPkgConfig)
 include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_arrow_lib(${ARROW_SUBSTRAIT_LIB_NAME})


### PR DESCRIPTION
## What changes were proposed in this pull request?

The C++ standard of three backends supported by Gluten is not unified.

The standard `c++17` is configured for the backend Velox, the standard `c++14` is configured for the backend GazelleCpp and for module `cpp/core`.

This difference brings a mess, let's unify to the C++ standard 17, it's also aligned with the Velox configure requirement.

Because the `register` storage class is deprecated from `c++17`, I modified the corresponding code using `register`, it does not matter.

I'm not sure if this change brings errors for `gazelle_cpp` or not, but let's make a try. unit-test will tell us.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

