### PR TITLE
[CPP] Add debug compiling configurations and open the warning options `-Wall/-Werror`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -51,12 +51,14 @@ set(root_directory ${PROJECT_BINARY_DIR})
 # Compiler flags
 #
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_BUILD_TYPE)
-if (${LOWERCASE_BUILD_TYPE} STREQUAL "debug" OR ${LOWERCASE_BUILD_TYPE} STREQUAL "relwithdebinfo")
-  set(CMAKE_BUILD_TYPE Debug)
 
+if (${LOWERCASE_BUILD_TYPE} STREQUAL "relwithdebinfo")
+  add_definitions(-DGLUTEN_PRINT_DEBUG) // this is the original logic, right?
+  message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
+elseif (${LOWERCASE_BUILD_TYPE} STREQUAL "debug")
   add_definitions(-DGLUTEN_PRINT_DEBUG)
   message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
-
+  set(CMAKE_BUILD_TYPE Debug) // is this really needed?
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -O0")
   message(STATUS "CMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
 else ()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,13 +53,13 @@ set(root_directory ${PROJECT_BINARY_DIR})
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_BUILD_TYPE)
 
 if (${LOWERCASE_BUILD_TYPE} STREQUAL "relwithdebinfo")
-  # keep this original logic
+# keep this original logic
   add_definitions(-DGLUTEN_PRINT_DEBUG)
   message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
 elseif (${LOWERCASE_BUILD_TYPE} STREQUAL "debug")
   add_definitions(-DGLUTEN_PRINT_DEBUG)
   message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
-  # set CMAKE_BUILD_TYPE to Debug according to the CMake tutorial
+# set CMAKE_BUILD_TYPE to Debug according to the CMake tutorial
   set(CMAKE_BUILD_TYPE Debug)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -O0")
   message(STATUS "CMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+
 project(spark_columnar_plugin)
 
 option(BUILD_TESTS "Build Tests" OFF)
@@ -51,8 +52,27 @@ set(root_directory ${PROJECT_BINARY_DIR})
 #
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_BUILD_TYPE)
 if (${LOWERCASE_BUILD_TYPE} STREQUAL "debug" OR ${LOWERCASE_BUILD_TYPE} STREQUAL "relwithdebinfo")
+  set(CMAKE_BUILD_TYPE Debug)
+
   add_definitions(-DGLUTEN_PRINT_DEBUG)
+  message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
+
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -O0")
+  message(STATUS "CMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
+else ()
+  add_definitions(-DNDEBUG)
+  message(STATUS "Add definition NDEBUG")
 endif()
+
+add_compile_options(-Wall)
+add_compile_options(-Wno-sign-compare)
+add_compile_options(-Wno-comment)
+
+add_compile_options(-Werror)
+add_compile_options(-Wno-error=parentheses)
+add_compile_options(-Wno-error=unused-function)
+add_compile_options(-Wno-error=unused-variable)
+add_compile_options(-Wno-error=unused-but-set-variable)
 
 #
 # Dependencies

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,12 +53,14 @@ set(root_directory ${PROJECT_BINARY_DIR})
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_BUILD_TYPE)
 
 if (${LOWERCASE_BUILD_TYPE} STREQUAL "relwithdebinfo")
-  add_definitions(-DGLUTEN_PRINT_DEBUG) // this is the original logic, right?
+  # keep this original logic
+  add_definitions(-DGLUTEN_PRINT_DEBUG)
   message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
 elseif (${LOWERCASE_BUILD_TYPE} STREQUAL "debug")
   add_definitions(-DGLUTEN_PRINT_DEBUG)
   message(STATUS "Add definition GLUTEN_PRINT_DEBUG")
-  set(CMAKE_BUILD_TYPE Debug) // is this really needed?
+  # set CMAKE_BUILD_TYPE to Debug according to the CMake tutorial
+  set(CMAKE_BUILD_TYPE Debug)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -O0")
   message(STATUS "CMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
 else ()

--- a/cpp/core/benchmarks/CompressionBenchmark.cc
+++ b/cpp/core/benchmarks/CompressionBenchmark.cc
@@ -69,7 +69,7 @@ class MyMemoryPool : public arrow::MemoryPool {
   }
 
   Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
-    auto old_ptr = *ptr;
+    // auto old_ptr = *ptr;
     RETURN_NOT_OK(pool_->Reallocate(old_size, new_size, ptr));
     stats_.UpdateAllocatedBytes(new_size - old_size);
     // std::cout << "Reallocate: old_size = " << old_size << " old_ptr = " <<
@@ -120,7 +120,7 @@ class LargePageMemoryPool : public arrow::MemoryPool {
       Status st = pool_->AlignAllocate(size, out, ALIGNMENT);
       madvise(*out, size, /*MADV_HUGEPAGE */ 14);
       //std::cout << "Allocate: size = " << size << " addr = "  \
-     //    << std::hex << (uint64_t)*out  << " end = " << std::hex << (uint64_t)(*out+size) << std::dec << std::endl;
+         << std::hex << (uint64_t)*out  << " end = " << std::hex << (uint64_t)(*out+size) << std::dec << std::endl;
       return st;
     }
 #else

--- a/cpp/core/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/core/benchmarks/ShuffleSplitBenchmark.cc
@@ -73,7 +73,7 @@ class MyMemoryPool : public arrow::MemoryPool {
   }
 
   Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
-    auto old_ptr = *ptr;
+    // auto old_ptr = *ptr;
     RETURN_NOT_OK(pool_->Reallocate(old_size, new_size, ptr));
     stats_.UpdateAllocatedBytes(new_size - old_size);
     // std::cout << "Reallocate: old_size = " << old_size << " old_ptr = " <<
@@ -124,7 +124,7 @@ class LargePageMemoryPool : public arrow::MemoryPool {
       Status st = pool_->AlignAllocate(size, out, ALIGNMENT);
       madvise(*out, size, /*MADV_HUGEPAGE */ 14);
       //std::cout << "Allocate: size = " << size << " addr = "  \
-      //    << std::hex << (uint64_t)*out  << " end = " << std::hex << (uint64_t)(*out+size) << std::dec << std::endl;
+          << std::hex << (uint64_t)*out  << " end = " << std::hex << (uint64_t)(*out+size) << std::dec << std::endl;
       return st;
     }
 #else

--- a/cpp/core/operators/c2r/ColumnarToRow.cc
+++ b/cpp/core/operators/c2r/ColumnarToRow.cc
@@ -190,8 +190,6 @@ std::vector<uint32_t> ColumnarToRowConverter::ConvertMagArray(int64_t new_high, 
  *  This method refer to the BigInterger#toByteArray() method in Java side.
  */
 std::array<uint8_t, 16> ColumnarToRowConverter::ToByteArray(arrow::Decimal128 value, int32_t* length) {
-  int64_t high = value.high_bits();
-  uint64_t low = value.low_bits();
   arrow::Decimal128 new_value;
   int32_t sig;
   if (value > 0) {

--- a/cpp/core/operators/shuffle/reader.cc
+++ b/cpp/core/operators/shuffle/reader.cc
@@ -28,7 +28,7 @@ ReaderOptions ReaderOptions::Defaults() {
 }
 
 Reader::Reader(std::shared_ptr<arrow::io::InputStream> in, std::shared_ptr<arrow::Schema> schema, ReaderOptions options)
-    : in_(std::move(in)), schema_(std::move(schema)), options_(std::move(options)) {
+    : in_(std::move(in)), options_(std::move(options)), schema_(std::move(schema)) {
   GLUTEN_ASSIGN_OR_THROW(first_message_, arrow::ipc::ReadMessage(in_.get()))
   if (first_message_->type() == arrow::ipc::MessageType::SCHEMA) {
     GLUTEN_ASSIGN_OR_THROW(schema_, arrow::ipc::ReadSchema(*first_message_, nullptr))

--- a/cpp/core/operators/shuffle/splitter.h
+++ b/cpp/core/operators/shuffle/splitter.h
@@ -136,7 +136,7 @@ class Splitter {
 
  protected:
   Splitter(int32_t num_partitions, std::shared_ptr<arrow::Schema> schema, SplitOptions options)
-      : num_partitions_(num_partitions), schema_(std::move(schema)), options_(std::move(options)) {}
+      : num_partitions_(num_partitions), options_(std::move(options)), schema_(std::move(schema)) {}
 
   virtual arrow::Status Init();
 
@@ -208,6 +208,8 @@ class Splitter {
 
   class PartitionWriter;
 
+  int32_t num_partitions_;
+
   // Check whether support AVX512 instructions
   bool support_avx512_;
   // options
@@ -270,7 +272,6 @@ class Splitter {
   // rownum < 64k
   std::vector<row_offset_type> partition_id_cnt_;
 
-  int32_t num_partitions_;
   std::shared_ptr<arrow::Schema> schema_;
 
   // write options for tiny batches

--- a/cpp/core/operators/shuffle/utils.h
+++ b/cpp/core/operators/shuffle/utils.h
@@ -35,23 +35,23 @@ namespace gluten {
 
 #define EVAL_START(name, thread_id) \
   //  auto eval_start = std::chrono::duration_cast<std::chrono::nanoseconds>(    \
-//                        std::chrono::system_clock::now().time_since_epoch()) \
-//                        .count();
+                        std::chrono::system_clock::now().time_since_epoch()) \
+                        .count();
 
 #define EVAL_END(name, thread_id, task_attempt_id) \
   //  std::cout << "xgbtck " << name << " " << eval_start << " "            \
-//            << std::chrono::duration_cast<std::chrono::nanoseconds>(    \
-//                   std::chrono::system_clock::now().time_since_epoch()) \
-//                       .count() -                                       \
-//                   eval_start                                           \
-//            << " " << thread_id << " " << task_attempt_id << std::endl;
+            << std::chrono::duration_cast<std::chrono::nanoseconds>(    \
+                   std::chrono::system_clock::now().time_since_epoch()) \
+                       .count() -                                       \
+                   eval_start                                           \
+            << " " << thread_id << " " << task_attempt_id << std::endl;
 
-static std::string GenerateUUID() {
+static inline std::string GenerateUUID() {
   boost::uuids::random_generator generator;
   return boost::uuids::to_string(generator());
 }
 
-static std::string GetSpilledShuffleFileDir(const std::string& configured_dir, int32_t sub_dir_id) {
+static inline std::string GetSpilledShuffleFileDir(const std::string& configured_dir, int32_t sub_dir_id) {
   auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(2) << std::hex << sub_dir_id;
@@ -59,7 +59,7 @@ static std::string GetSpilledShuffleFileDir(const std::string& configured_dir, i
   return dir;
 }
 
-static arrow::Result<std::vector<std::string>> GetConfiguredLocalDirs() {
+static inline arrow::Result<std::vector<std::string>> GetConfiguredLocalDirs() {
   auto joined_dirs_c = std::getenv("NATIVESQL_SPARK_LOCAL_DIRS");
   if (joined_dirs_c != nullptr && strcmp(joined_dirs_c, "") > 0) {
     auto joined_dirs = std::string(joined_dirs_c);
@@ -84,7 +84,7 @@ static arrow::Result<std::vector<std::string>> GetConfiguredLocalDirs() {
   }
 }
 
-static arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) {
+static inline arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) {
   if (dir.length() == 0) {
     return arrow::Status::Invalid("Failed to create spilled file, got empty path.");
   }
@@ -109,7 +109,7 @@ static arrow::Result<std::string> CreateTempShuffleFile(const std::string& dir) 
   return file_path;
 }
 
-static arrow::Result<std::vector<std::shared_ptr<arrow::DataType>>> ToSplitterTypeId(
+static inline arrow::Result<std::vector<std::shared_ptr<arrow::DataType>>> ToSplitterTypeId(
     const std::vector<std::shared_ptr<arrow::Field>>& fields) {
   std::vector<std::shared_ptr<arrow::DataType>> splitter_type_id;
   std::pair<std::string, arrow::Type::type> field_type_not_implemented;
@@ -152,7 +152,7 @@ static arrow::Result<std::vector<std::shared_ptr<arrow::DataType>>> ToSplitterTy
   return splitter_type_id;
 }
 
-static int64_t GetBufferSizes(const std::shared_ptr<arrow::Array>& array) {
+static inline int64_t GetBufferSizes(const std::shared_ptr<arrow::Array>& array) {
   const auto& buffers = array->data()->buffers;
   return std::accumulate(
       std::cbegin(buffers), std::cend(buffers), 0LL, [](int64_t sum, const std::shared_ptr<arrow::Buffer>& buf) {

--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -138,7 +138,7 @@ std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& typeName
           }
         }
         // If not reach to end of string, next character must be ','.
-        if (numLeft != numRight || i < innerType.length() && innerType[i] != ',') {
+        if (numLeft != numRight || (i < innerType.length() && innerType[i] != ',')) {
           throw std::runtime_error("Invalid struct type: " + typeName);
         }
         tokenPos = i;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -562,7 +562,7 @@ void WholeStageResIter::setConfToQueryContext(const std::shared_ptr<core::QueryC
       // Set the max memory of partial aggregation as 3/4 of offheap size.
       auto maxMemory = (long)(0.75 * std::stol(got->second));
       configs[core::QueryConfig::kMaxPartialAggregationMemory] = std::to_string(maxMemory);
-    } catch (const std::invalid_argument) {
+    } catch (const std::invalid_argument&) {
       throw std::runtime_error("Invalid offheap size.");
     }
   }

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -90,7 +90,7 @@ class WholeStageResIter {
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
       std::shared_ptr<const facebook::velox::core::PlanNode> planNode,
       const std::unordered_map<std::string, std::string>& confMap)
-      : pool_(pool), planNode_(planNode), confMap_(confMap) {
+      : planNode_(planNode), pool_(pool), confMap_(confMap) {
     getOrderedNodeIds(planNode_, orderedNodeIds_);
   }
 

--- a/cpp/velox/compute/VeloxToRowConverter.cc
+++ b/cpp/velox/compute/VeloxToRowConverter.cc
@@ -98,7 +98,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<TinyintType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<TinyintType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -112,7 +112,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<SmallintType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<SmallintType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -126,7 +126,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<IntegerType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<IntegerType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -140,7 +140,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<BigintType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<BigintType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -154,7 +154,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<DateType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<DateType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -168,7 +168,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<RealType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<RealType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -182,7 +182,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<DoubleType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<DoubleType>(vec, write_address, row_idx);
           }
         }
         break;
@@ -196,7 +196,7 @@ arrow::Status VeloxToRowConverter::Write() {
           } else {
             // Will use Velox's conversion.
             auto write_address = (char*)(buffer_address_ + offsets_[row_idx] + field_offset);
-            auto serialized = row::UnsafeRowSerializer::serialize<BooleanType>(vec, write_address, row_idx);
+            row::UnsafeRowSerializer::serialize<BooleanType>(vec, write_address, row_idx);
           }
         }
         break;

--- a/cpp/velox/tests/ShuffleSplitTest.cc
+++ b/cpp/velox/tests/ShuffleSplitTest.cc
@@ -65,7 +65,7 @@ class MyMemoryPool : public arrow::MemoryPool {
     if (new_size > capacity_) {
       return Status::OutOfMemory("malloc of size ", new_size, " failed");
     }
-    auto old_ptr = *ptr;
+    // auto old_ptr = *ptr;
     RETURN_NOT_OK(pool_->Reallocate(old_size, new_size, ptr));
     stats_.UpdateAllocatedBytes(new_size - old_size);
     // std::cout << "Reallocate: old_size = " << old_size << " old_ptr = " <<
@@ -278,7 +278,7 @@ TEST_F(SplitterTest, TestSingleSplitter) {
   ASSERT_EQ(batches.size(), 3);
 
   std::vector<arrow::RecordBatch*> expected = {input_batch_1_.get(), input_batch_2_.get(), input_batch_1_.get()};
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -325,7 +325,7 @@ TEST_F(SplitterTest, TestRoundRobinSplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 3);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -346,7 +346,7 @@ TEST_F(SplitterTest, TestRoundRobinSplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 3);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -459,7 +459,7 @@ TEST_F(SplitterTest, TestFallbackRangeSplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 3);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -480,7 +480,7 @@ TEST_F(SplitterTest, TestFallbackRangeSplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 3);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), schema_->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -569,7 +569,7 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -589,7 +589,7 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -639,7 +639,7 @@ TEST_F(SplitterTest, TestRoundRobinNestListArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -659,7 +659,7 @@ TEST_F(SplitterTest, TestRoundRobinNestListArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -709,7 +709,7 @@ TEST_F(SplitterTest, TestRoundRobinNestLargeListArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -729,7 +729,7 @@ TEST_F(SplitterTest, TestRoundRobinNestLargeListArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -779,7 +779,7 @@ TEST_F(SplitterTest, TestRoundRobinListStructArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -799,7 +799,7 @@ TEST_F(SplitterTest, TestRoundRobinListStructArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -849,7 +849,7 @@ TEST_F(SplitterTest, TestRoundRobinListMapArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -869,7 +869,7 @@ TEST_F(SplitterTest, TestRoundRobinListMapArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -919,7 +919,7 @@ TEST_F(SplitterTest, TestRoundRobinStructArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -939,7 +939,7 @@ TEST_F(SplitterTest, TestRoundRobinStructArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -989,7 +989,7 @@ TEST_F(SplitterTest, TestRoundRobinMapArraySplitter) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -1009,7 +1009,7 @@ TEST_F(SplitterTest, TestRoundRobinMapArraySplitter) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -1108,7 +1108,7 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitterwithCompression) {
   // verify first block
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {
@@ -1128,7 +1128,7 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitterwithCompression) {
   ASSERT_NOT_OK(file_->Advance(lengths[0]));
   ASSERT_NOT_OK(file_reader->ReadAll(&batches));
   ASSERT_EQ(batches.size(), 1);
-  for (auto i = 0; i < batches.size(); ++i) {
+  for (size_t i = 0; i < batches.size(); ++i) {
     const auto& rb = batches[i];
     ASSERT_EQ(rb->num_columns(), rb_schema->num_fields());
     for (auto j = 0; j < rb->num_columns(); ++j) {

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -29,29 +29,47 @@ JNI is a programming technology of invoking C++ from Java. All JNI interfaces ar
 If you don't concern about the Scala/Java codes and just want to debug the C++ codes executed in native engine, you may debug the C++ via benchmarks
 with GDB.
 
+<<<<<<< HEAD
 To debug C++, you have to generate the example files, the example files consist of:
 - A file contained Substrait plan in JSON format
 - One or more input data files in Parquet format
+=======
+To debug C++, the first step is to generate the example files, The example files consist of:
+- A file contained Substrait plan in JSON format
+- One or more input data files in parqut format
+>>>>>>> 3d1486d (update howto)
 
 You can generate the example files by the following steps:
 
 1. get and build Arrow
 ```
+<<<<<<< HEAD
 cd gluten_home/ep/build-arrow/src
+=======
+cd /gluten_home/ep/build-arrow/src
+>>>>>>> 3d1486d (update howto)
 ./get_arrow.sh
 ./build_arrow_for_velox.sh --build_test=ON --build_benchmarks=ON
 ```
 
 2. get and build Velox
 ```
+<<<<<<< HEAD
 cd gluten_home/ep/build-velox/src
+=======
+cd /gluten_home/ep/build-velox/src
+>>>>>>> 3d1486d (update howto)
 ./get_velox.sh
 ./build_velox.sh
 ```
 
 3. compile the CPP
 ```
+<<<<<<< HEAD
 cd gluten_home/cpp
+=======
+cd /gluten_home/cpp
+>>>>>>> 3d1486d (update howto)
 ./compile.sh --build_type=debug --build_velox_backend=ON --build_test=ON --build_benchmarks=ON
 ```
 - Compiling with `--build_type=debug` is good for debugging.
@@ -59,6 +77,7 @@ cd gluten_home/cpp
 
 4. build Gluten and generate the example files
 ```
+<<<<<<< HEAD
 cd gluten_home
 mvn clean package -Pspark-3.2 -Pbackends-velox
 mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=10.0.0-SNAPSHOT -Dexec.skip
@@ -69,6 +88,18 @@ mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io
 ```shell
 $ tree gluten_home/backends-velox/generated-native-benchmark/
 gluten_home/backends-velox/generated-native-benchmark/
+=======
+cd /gluten_home
+mvn clean package -Pspark-3.2 -Pbackends-velox
+mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=10.0.0-SNAPSHOT -Dexec.skip
+# You can replace `-Pspark-3.2` with `-Pspark-3.3` if the spark's version is 3.3
+```
+- After the above operations, the examples files are generated under `/gluten_home/backends-velox`
+- You can check it by the command `tree /gluten_home/backends-velox/generated-native-benchmark/`
+```shell
+$ tree /gluten_home/backends-velox/generated-native-benchmark/
+/gluten_home/backends-velox/generated-native-benchmark/
+>>>>>>> 3d1486d (update howto)
 ├── example.json
 ├── example_lineitem
 │   ├── part-00000-3ec19189-d20e-4240-85ae-88631d46b612-c000.snappy.parquet
@@ -86,9 +117,14 @@ gdb generic_benchmark
 - When GDB load `generic_benchmark` successfully, you can set `breakpoint` on the `main` function with command `b main`, and then run with command `r`,
   then the process `generic_benchmark` will start and stop at the `main` function.
 - You can check the variables' state with command `p variable_name`, or execute the program line by line with command `n`, or step-in the function been
+<<<<<<< HEAD
   called with command `s`.
 - Actually, you can debug `generic_benchmark` with any gdb commands as debugging normal C++ program, because the `generic_benchmark` is a pure C++
   executable file in fact.
+=======
+  called with command `s`. actually, you can debug `generic_benchmark` with any valid gdb commands as debugging normal C++ program, because the
+  `generic_benchmark` is a pure C++ executable file in fact.
+>>>>>>> 3d1486d (update howto)
 
 5. `gdb-tui` is a valuable feature and is worth trying. You can get more help from the online docs.
 [gdb-tui](https://sourceware.org/gdb/current/onlinedocs/gdb/TUI.html#TUI)

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -29,47 +29,29 @@ JNI is a programming technology of invoking C++ from Java. All JNI interfaces ar
 If you don't concern about the Scala/Java codes and just want to debug the C++ codes executed in native engine, you may debug the C++ via benchmarks
 with GDB.
 
-<<<<<<< HEAD
 To debug C++, you have to generate the example files, the example files consist of:
 - A file contained Substrait plan in JSON format
 - One or more input data files in Parquet format
-=======
-To debug C++, the first step is to generate the example files, The example files consist of:
-- A file contained Substrait plan in JSON format
-- One or more input data files in parqut format
->>>>>>> 3d1486d (update howto)
 
 You can generate the example files by the following steps:
 
 1. get and build Arrow
 ```
-<<<<<<< HEAD
 cd gluten_home/ep/build-arrow/src
-=======
-cd /gluten_home/ep/build-arrow/src
->>>>>>> 3d1486d (update howto)
 ./get_arrow.sh
 ./build_arrow_for_velox.sh --build_test=ON --build_benchmarks=ON
 ```
 
 2. get and build Velox
 ```
-<<<<<<< HEAD
 cd gluten_home/ep/build-velox/src
-=======
-cd /gluten_home/ep/build-velox/src
->>>>>>> 3d1486d (update howto)
 ./get_velox.sh
 ./build_velox.sh
 ```
 
 3. compile the CPP
 ```
-<<<<<<< HEAD
 cd gluten_home/cpp
-=======
-cd /gluten_home/cpp
->>>>>>> 3d1486d (update howto)
 ./compile.sh --build_type=debug --build_velox_backend=ON --build_test=ON --build_benchmarks=ON
 ```
 - Compiling with `--build_type=debug` is good for debugging.
@@ -77,7 +59,6 @@ cd /gluten_home/cpp
 
 4. build Gluten and generate the example files
 ```
-<<<<<<< HEAD
 cd gluten_home
 mvn clean package -Pspark-3.2 -Pbackends-velox
 mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=10.0.0-SNAPSHOT -Dexec.skip
@@ -88,18 +69,6 @@ mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io
 ```shell
 $ tree gluten_home/backends-velox/generated-native-benchmark/
 gluten_home/backends-velox/generated-native-benchmark/
-=======
-cd /gluten_home
-mvn clean package -Pspark-3.2 -Pbackends-velox
-mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=10.0.0-SNAPSHOT -Dexec.skip
-# You can replace `-Pspark-3.2` with `-Pspark-3.3` if the spark's version is 3.3
-```
-- After the above operations, the examples files are generated under `/gluten_home/backends-velox`
-- You can check it by the command `tree /gluten_home/backends-velox/generated-native-benchmark/`
-```shell
-$ tree /gluten_home/backends-velox/generated-native-benchmark/
-/gluten_home/backends-velox/generated-native-benchmark/
->>>>>>> 3d1486d (update howto)
 ├── example.json
 ├── example_lineitem
 │   ├── part-00000-3ec19189-d20e-4240-85ae-88631d46b612-c000.snappy.parquet
@@ -117,14 +86,9 @@ gdb generic_benchmark
 - When GDB load `generic_benchmark` successfully, you can set `breakpoint` on the `main` function with command `b main`, and then run with command `r`,
   then the process `generic_benchmark` will start and stop at the `main` function.
 - You can check the variables' state with command `p variable_name`, or execute the program line by line with command `n`, or step-in the function been
-<<<<<<< HEAD
   called with command `s`.
 - Actually, you can debug `generic_benchmark` with any gdb commands as debugging normal C++ program, because the `generic_benchmark` is a pure C++
   executable file in fact.
-=======
-  called with command `s`. actually, you can debug `generic_benchmark` with any valid gdb commands as debugging normal C++ program, because the
-  `generic_benchmark` is a pure C++ executable file in fact.
->>>>>>> 3d1486d (update howto)
 
 5. `gdb-tui` is a valuable feature and is worth trying. You can get more help from the online docs.
 [gdb-tui](https://sourceware.org/gdb/current/onlinedocs/gdb/TUI.html#TUI)


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. configure debug compiling settings: modify the CMakeList.txt, add `-ggdb -O0`  to `CMAKE_CXX_FLAGS_DEBUG`
2. open the warning options: add compile_options `-Wall -Werror`, and make the source files comply the rules


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

