### PR TITLE
[CH-239]Support queries on struct fields 

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -60,6 +60,8 @@ object CHBackendSettings extends BackendSettings {
 
   override def supportWindowExec(): Boolean = true
 
+  override def supportStructType(): Boolean = true
+
   override def excludeScanExecFromCollapsedStage(): Boolean =
     SQLConf.get
       .getConfString(GLUTEN_CLICKHOUSE_SEP_SCAN_RDD, GLUTEN_CLICKHOUSE_SEP_SCAN_RDD_DEFAULT)

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -18,7 +18,7 @@ package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.backendsapi.ISparkPlanExecApi
 import io.glutenproject.execution._
-import io.glutenproject.expression.{AliasBaseTransformer, AliasTransformer, ExpressionTransformer}
+import io.glutenproject.expression.{AliasBaseTransformer, AliasTransformer, ExpressionTransformer, GetStructFieldTransformer}
 import io.glutenproject.vectorized.{BlockNativeWriter, CHColumnarBatchSerializer}
 
 import org.apache.spark.{ShuffleDependency, SparkException}
@@ -376,4 +376,12 @@ class CHSparkPlanExecApi extends ISparkPlanExecApi with AdaptiveSparkPlanHelper 
    * @return
    */
   override def genExtendedStrategies(): List[SparkSession => Strategy] = List()
+
+  /** Generate an ExpressionTransformer to transform GetStructFiled expression. */
+  override def genGetStructFieldTransformer(
+      substraitExprName: String,
+      childTransformer: ExpressionTransformer,
+      ordinal: Int,
+      original: GetStructField): ExpressionTransformer =
+    new GetStructFieldTransformer(substraitExprName, childTransformer, ordinal, original)
 }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/StructExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/StructExpressionTransformer.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.expression
+
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
+import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.GetStructField
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+
+import com.google.common.collect.Lists
+
+class GetStructFieldTransformer(
+    substraitExprName: String,
+    childTransformer: ExpressionTransformer,
+    ordinal: Int,
+    original: GetStructField)
+  extends ExpressionTransformer
+  with Logging {
+
+  override def doTransform(args: Object): ExpressionNode = {
+    val childNode = childTransformer.doTransform(args)
+    // FIXME: Not sure which argument type velox support. ClickHouse supports both field name
+    // and field ordinal. Since ClickHouse require the ordinal argument must be an unsigned
+    // integer, but substrait doesn't support unsigned types, so we choose to use field name
+    // here.
+    val fieldName = original.child.dataType.asInstanceOf[StructType].names(ordinal)
+    if (fieldName.isEmpty()) {
+      throw new IllegalArgumentException(s"Field name should not be null.")
+    }
+    val ordinalNode = ExpressionBuilder.makeLiteral(fieldName, StringType, false)
+    val exprNodes = Lists.newArrayList(childNode, ordinalNode)
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val fieldDataType = original.dataType
+    val functionName = ConverterUtils.makeFuncName(
+      substraitExprName,
+      Seq(original.child.dataType, fieldDataType),
+      FunctionConfig.OPT)
+    val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
+    val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)
+    ExpressionBuilder.makeScalarFunction(functionId, exprNodes, typeNode)
+  }
+}

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -17,6 +17,7 @@
 
 package io.glutenproject.substrait.rel;
 
+import io.glutenproject.backendsapi.BackendsApiManager;
 import io.glutenproject.expression.ConverterUtils$;
 import io.glutenproject.substrait.SubstraitContext;
 import io.glutenproject.substrait.expression.AggregateFunctionNode;
@@ -29,6 +30,9 @@ import io.glutenproject.substrait.type.TypeNode;
 import io.substrait.proto.JoinRel;
 import io.substrait.proto.SortField;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 
 import java.util.ArrayList;
 
@@ -121,6 +125,17 @@ public class RelBuilder {
     return new ReadRelNode(types, names, context, filter, iteratorIndex);
   }
 
+  public static ArrayList<String> collectStructFieldNamesDFS(DataType dataType) {
+    ArrayList<String> names = new ArrayList<>();
+    if (dataType instanceof StructType && BackendsApiManager.getSettings().supportStructType()) {
+      for (StructField field : ((StructType) dataType).fields()) {
+        names.add(field.name());
+        ArrayList<String> nestedNames = collectStructFieldNamesDFS(field.dataType());
+        names.addAll(nestedNames);
+      }
+    }
+    return names;
+  }
   public static RelNode makeReadRel(ArrayList<Attribute> attributes,
                                     SubstraitContext context,
                                     Long operatorId) {
@@ -135,6 +150,7 @@ public class RelBuilder {
     for (Attribute attr : attributes) {
       typeList.add(converter.getTypeNode(attr.dataType(), attr.nullable()));
       nameList.add(converter.genColumnNameWithExprId(attr));
+      nameList.addAll(collectStructFieldNamesDFS(attr.dataType()));
     }
 
     // The iterator index will be added in the path of LocalFiles.

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
@@ -37,6 +37,7 @@ trait BackendSettings {
     case _: InnerLike | LeftOuter | FullOuter | LeftSemi | LeftAnti | _: ExistenceJoin => true
     case _ => false
   }
+  def supportStructType(): Boolean = false
   def fallbackOnEmptySchema(): Boolean = false
   def disableVanillaColumnarReaders(): Boolean = false
   def recreateJoinExecOnFallback(): Boolean = false

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ISparkPlanExecApi.scala
@@ -19,13 +19,13 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.execution._
 import io.glutenproject.expression.{AliasBaseTransformer, ExpressionTransformer}
-
+import io.glutenproject.substrait.expression.ExpressionNode
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.{SparkSession, Strategy}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GetStructField, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.optimizer.BuildSide
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -205,4 +205,11 @@ trait ISparkPlanExecApi {
    * @return
    */
   def genExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
+
+  /**
+   * Generate an ExpressionTransformer to transform GetStructFiled expression.
+   */
+  def genGetStructFieldTransformer(substraitExprName: String,
+                                 childTransformer: ExpressionTransformer, ordinal: Int,
+                                 original: GetStructField): ExpressionTransformer = null
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -112,6 +112,39 @@ trait BasicScanExecTransformer extends TransformSupport {
       true
     }
   }
+  def collectAttributesNamesDFS(attributes: Seq[Attribute]): java.util.ArrayList[String] = {
+    val nameList = new java.util.ArrayList[String]()
+    attributes.foreach(
+      attr => {
+        nameList.add(attr.name)
+        if (BackendsApiManager.getSettings.supportStructType()) {
+          attr.dataType match {
+            case struct: StructType =>
+              val nestedNames = collectDataTypeNamesDFS(struct)
+              nameList.addAll(nestedNames)
+            case _ =>
+          }
+        }
+      }
+    )
+    nameList
+  }
+
+  def collectDataTypeNamesDFS(dataType: DataType): java.util.ArrayList[String] = {
+    val nameList = new java.util.ArrayList[String]()
+    dataType match {
+      case structType: StructType =>
+        structType.fields.foreach(
+          field => {
+            nameList.add(field.name)
+            val nestedNames = collectDataTypeNamesDFS(field.dataType)
+            nameList.addAll(nestedNames);
+          }
+        )
+      case _ =>
+    }
+    nameList
+  }
 
   override def doTransform(context: SubstraitContext): TransformContext = {
     val output = outputAttributes()
@@ -119,8 +152,8 @@ trait BasicScanExecTransformer extends TransformSupport {
     val partitionSchemas = getPartitionSchemas
     val nameList = new java.util.ArrayList[String]()
     val columnTypeNodes = new java.util.ArrayList[ColumnTypeNode]()
+    nameList.addAll(collectAttributesNamesDFS(output))
     for (attr <- output) {
-      nameList.add(attr.name)
       if (partitionSchemas.exists(_.name.equals(attr.name))) {
         columnTypeNodes.add(new ColumnTypeNode(1))
       } else {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -165,6 +165,9 @@ object ExpressionMappings {
   final val CREATE_MAP = "map"
   final val GET_MAP_VALUE = "get_map_value"
 
+  // struct functions
+  final val GET_STRUCT_FIELD = "get_struct_field"
+
   // Spark 3.3
   final val SPLIT_PART = "split_part"
 
@@ -309,6 +312,8 @@ object ExpressionMappings {
     // Map functions
     Sig[CreateMap](CREATE_MAP),
     Sig[GetMapValue](GET_MAP_VALUE),
+    // Struct functions
+    Sig[GetStructField](GET_STRUCT_FIELD),
     // Directly use child expression transformer
     Sig[KnownFloatingPointNormalized](KNOWN_FLOATING_POINT_NORMALIZED),
     Sig[NormalizeNaNAndZero](NORMALIZE_NANAND_ZERO),

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenComplexTypesSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenComplexTypesSuite.scala
@@ -32,7 +32,7 @@ class GlutenComplexTypesSuite extends ComplexTypesSuite with GlutenSQLTestsTrait
       "cast(cast(id as BYTE) as BINARY) as vbin",
       "map_from_arrays(array(id),array(id+2)) as map",
       "array(id, id+1, id+2) as list",
-      "struct(cast(id as LONG), cast(id+1 as STRING)) as struct"
+      "struct(cast(id as LONG) as a, cast(id+1 as STRING) as b) as struct"
     ).write.saveAsTable("tab_types")
   }
 
@@ -55,6 +55,7 @@ class GlutenComplexTypesSuite extends ComplexTypesSuite with GlutenSQLTestsTrait
       "dec",
       "vbin",
       "struct",
+      "struct.a",
       "list",
       "map"
     ).sort("i8").limit(1)
@@ -69,6 +70,7 @@ class GlutenComplexTypesSuite extends ComplexTypesSuite with GlutenSQLTestsTrait
         BigDecimal(0),
         Array[Byte](0.toByte),
         Row(0.toLong, "1"),
+        0.toLong,
         Array(0, 1, 2),
         Map(0 -> 2)
       )))


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Currently, `ClickHouse` backend has supported struct type, but we cannot run queries on specified struct fields. for example
```SQL
seelct s.a from t
```
where `s` is a struct column.

In this pr, we make a change on `NamedStruct.names` based on `type.proto`'s comments. 
```
// A message for modeling name/type pairs.
//
// Useful for representing relation schemas.
//
// Notes:
//
// * The names field is in depth-first order.
//
// For example a schema such as:
//
// a: int64
// b: struct<c: float32, d: string>
//
// would have a `names` field that looks like:
//
// ["a", "b", "c", "d"]
//
// * Only struct fields are contained in this field's elements,
// * Map keys should be traversed first, then values when producing/consuming
message NamedStruct {
  // list of names in dfs order
  repeated string names = 1;
  Type.Struct struct = 2;
  PartitionColumns partition_columns = 3;
}

``` 
In previous implementation, the `names` only contains columns' top level names. In this pr, we visit named structs in depth-first order, and put all names in a flatten array. This may have different behaviors with previous implementation, and we should be careful with this.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
unit test


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
test by CH[[244]]
