### PR TITLE
[GLUTEN-374] Fix hashjoin Keys check inaccuracy and SPARK-32693 UT

### DIFF
--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -152,5 +152,6 @@ object VeloxTestSettings extends BackendTestSettings {
       // Sort spill is not supported.
       .exclude("sorting does not crash for large inputs")
   enableSuite[GlutenExistenceJoinSuite]
+  enableSuite[GlutenDataFrameJoinSuite]
 
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
@@ -31,7 +31,6 @@ class GlutenDataFrameJoinSuite extends DataFrameJoinSuite with GlutenSQLTestsTra
     // there is issue when executing this test case with velox backend
     "SPARK-24690 enables star schema detection even if CBO disabled",
     "Supports multi-part names for broadcast hint resolution",
-    "SPARK-32693: Compare two dataframes with same schema except nullable property",
     "SPARK-34527: Resolve common columns from USING JOIN",
     "SPARK-39376: Hide duplicated columns in star expansion of subquery alias from USING JOIN",
     "SPARK-17685: WholeStageCodegenExec throws IndexOutOfBoundsException"


### PR DESCRIPTION
## What changes were proposed in this pull request?


This issue is exposed from :
```
   GlutenDataFrameJoinSuite:
   "SPARK-32693: Compare two dataframes with same schema except nullable property"
```

Fix the keys  check inaccuracy and enable this UT.

## How was this patch tested?

unit tests, integration tests, manual tests

