### PR TITLE
[GLUTEN-374] Enable UT SPARK-24690 after Velox parquet reader fixes

### DIFF
--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHash
 class GlutenDataFrameJoinSuite extends DataFrameJoinSuite with GlutenSQLTestsTrait {
 
   override def testNameBlackList: Seq[String] = Seq(
-    "broadcast join hint using Dataset.hint",
     "Supports multi-part names for broadcast hint resolution"
   )
 }

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
@@ -22,18 +22,8 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHash
 class GlutenDataFrameJoinSuite extends DataFrameJoinSuite with GlutenSQLTestsTrait {
 
   override def testNameBlackList: Seq[String] = Seq(
-    "join - sorted columns not in join's outputSet",
-    "join - join using multiple columns and specifying join type",
-    "broadcast join hint using broadcast function",
     "broadcast join hint using Dataset.hint",
-    "process outer join results using the non-nullable columns in the join input",
-    "SPARK-16991: Full outer join followed by inner join produces wrong results",
-    // there is issue when executing this test case with velox backend
-    "SPARK-24690 enables star schema detection even if CBO disabled",
     "Supports multi-part names for broadcast hint resolution",
-    "SPARK-34527: Resolve common columns from USING JOIN",
-    "SPARK-39376: Hide duplicated columns in star expansion of subquery alias from USING JOIN",
-    "SPARK-17685: WholeStageCodegenExec throws IndexOutOfBoundsException"
   )
 
   /**

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenDataFrameJoinSuite.scala
@@ -23,7 +23,7 @@ class GlutenDataFrameJoinSuite extends DataFrameJoinSuite with GlutenSQLTestsTra
 
   override def testNameBlackList: Seq[String] = Seq(
     "broadcast join hint using Dataset.hint",
-    "Supports multi-part names for broadcast hint resolution",
+    "Supports multi-part names for broadcast hint resolution"
   )
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/oap-project/velox/pull/105 has fixed parquet reader bugs，
So  enable remaining UTs in GlutenDataFrameJoinSuite.


## How was this patch tested?

unit tests, integration tests, manual tests


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

