### PR TITLE
[Cpp Refactor] tidy up file including for cpp module

### DIFF
--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -17,23 +17,12 @@
 
 #pragma once
 
-#include <arrow/c/abi.h>
-#include <arrow/c/bridge.h>
-#include <arrow/record_batch.h>
-#include <arrow/util/iterator.h>
-
 #include "compute/ProtobufUtils.h"
 #include "compute/ResultIterator.h"
 #include "memory/ArrowMemoryPool.h"
 #include "memory/ColumnarBatch.h"
 #include "operators/c2r/ArrowColumnarToRowConverter.h"
 #include "substrait/plan.pb.h"
-#include "utils/exception.h"
-#include "utils/metrics.h"
-
-#ifdef GLUTEN_PRINT_DEBUG
-#include <iostream>
-#endif
 
 namespace gluten {
 

--- a/cpp/core/compute/BackendTest.cc
+++ b/cpp/core/compute/BackendTest.cc
@@ -17,7 +17,6 @@
 
 #include "Backend.h"
 
-#include <arrow/c/bridge.h>
 #include <gtest/gtest.h>
 
 namespace gluten {

--- a/cpp/core/compute/ProtobufUtils.cc
+++ b/cpp/core/compute/ProtobufUtils.cc
@@ -17,13 +17,9 @@
 
 #include "ProtobufUtils.h"
 
-#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/util/json_util.h>
-#include <google/protobuf/util/type_resolver.h>
 #include <google/protobuf/util/type_resolver_util.h>
 #include <fstream>
-#include <iostream>
-#include <string>
 
 // Common for both projector and filters.
 

--- a/cpp/core/compute/ProtobufUtils.h
+++ b/cpp/core/compute/ProtobufUtils.h
@@ -20,13 +20,7 @@
 #include <arrow/type.h>
 
 #include <google/protobuf/message.h>
-#include <map>
-#include <memory>
-#include <mutex>
-#include <sstream>
 #include <string>
-#include <utility>
-#include <vector>
 
 // Common for both projector and filters.
 bool ParseProtobuf(const uint8_t* buf, int bufLen, google::protobuf::Message* msg);

--- a/cpp/core/compute/ResultIterator.h
+++ b/cpp/core/compute/ResultIterator.h
@@ -17,17 +17,8 @@
 
 #pragma once
 
-#include <arrow/c/abi.h>
-#include <arrow/c/bridge.h>
-#include <arrow/record_batch.h>
-#include <arrow/util/iterator.h>
-
 #include "memory/ColumnarBatch.h"
 #include "utils/metrics.h"
-
-#ifdef GLUTEN_PRINT_DEBUG
-#include <iostream>
-#endif
 
 namespace gluten {
 

--- a/cpp/core/compute/ResultIterator.h
+++ b/cpp/core/compute/ResultIterator.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/record_batch.h>
+#include <arrow/util/iterator.h>
+
 #include "memory/ColumnarBatch.h"
 #include "utils/metrics.h"
 

--- a/cpp/core/jni/ConcurrentMap.h
+++ b/cpp/core/jni/ConcurrentMap.h
@@ -22,8 +22,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "arrow/util/macros.h"
-
 namespace gluten {
 
 /**

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -17,25 +17,10 @@
 
 #pragma once
 
-#include <arrow/builder.h>
-#include <arrow/io/memory.h>
 #include <arrow/ipc/reader.h>
 #include <arrow/ipc/writer.h>
-#include <arrow/pretty_print.h>
-#include <arrow/record_batch.h>
-#include <arrow/status.h>
-#include <arrow/type.h>
 #include <arrow/util/parallel.h>
-#include <google/protobuf/io/coded_stream.h>
 #include <jni.h>
-
-#include <map>
-#include <memory>
-#include <mutex>
-#include <sstream>
-#include <string>
-#include <utility>
-#include <vector>
 
 #include "compute/ProtobufUtils.h"
 #include "memory/ArrowMemoryPool.h"

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -15,36 +15,18 @@
  * limitations under the License.
  */
 
-#include <arrow/buffer.h>
-#include <arrow/c/bridge.h>
-#include <arrow/c/helpers.h>
-#include <arrow/filesystem/filesystem.h>
-#include <arrow/ipc/api.h>
-#include <arrow/record_batch.h>
-#include <arrow/util/compression.h>
 #include <jni.h>
 #include <malloc.h>
-
 #include <filesystem>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <utility>
 
 #include "compute/Backend.h"
 #include "compute/ProtobufUtils.h"
-#include "compute/ResultIterator.h"
 #include "config/GlutenConfig.h"
 #include "jni/ConcurrentMap.h"
 #include "jni/JniCommon.h"
 #include "jni/JniErrors.h"
-#include "memory/ColumnarBatch.h"
-#include "operators/c2r/ColumnarToRow.h"
 #include "operators/shuffle/reader.h"
 #include "operators/shuffle/splitter.h"
-#include "operators/writer/ArrowWriter.h"
-#include "utils/exception.h"
-#include "utils/metrics.h"
 
 namespace types {
 class ExpressionList;

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -16,7 +16,6 @@
  */
 
 #include "MemoryAllocator.h"
-#include <iostream>
 #include "HbwAllocator.h"
 
 namespace gluten {

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -24,7 +24,6 @@
 #include <utility>
 
 #include "arrow/memory_pool.h"
-#include "arrow/util/memory.h"
 
 namespace gluten {
 

--- a/cpp/core/operators/c2r/ArrowColumnarToRowConverter.cc
+++ b/cpp/core/operators/c2r/ArrowColumnarToRowConverter.cc
@@ -20,7 +20,6 @@
 #include <arrow/array/array_decimal.h>
 #include <arrow/util/decimal.h>
 #include <immintrin.h>
-#include <iostream>
 
 namespace gluten {
 

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -25,14 +25,7 @@
 #include <immintrin.h>
 #include <x86intrin.h>
 
-#include <cstring>
-#include <memory>
-#include <sstream>
-#include <string>
-#include <utility>
-
 #include "compute/ProtobufUtils.h"
-#include "operators/shuffle/utils.h"
 #include "utils/macros.h"
 
 namespace gluten {

--- a/cpp/core/operators/shuffle/splitter.h
+++ b/cpp/core/operators/shuffle/splitter.h
@@ -23,9 +23,7 @@
 #include <arrow/record_batch.h>
 #include <arrow/type_traits.h>
 
-#include <numeric>
 #include <random>
-#include <utility>
 
 #include "operators/shuffle/type.h"
 #include "operators/shuffle/utils.h"

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -164,6 +164,7 @@ endmacro()
 set(VELOX_SRCS
     jni/JniWrapper.cc
     compute/VeloxBackend.cc
+    compute/RegistrationAllFunctions.cc
     compute/ArrowTypeUtils.cc
     compute/VeloxToRowConverter.cc
     compute/RowConstructor.cc

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -21,6 +21,7 @@
 #include <gflags/gflags.h>
 #include <operators/writer/ArrowWriter.h>
 #include <velox/exec/PlanNodeStats.h>
+#include <velox/exec/Task.h>
 
 #include <chrono>
 

--- a/cpp/velox/compute/RegistrationAllFunctions.cc
+++ b/cpp/velox/compute/RegistrationAllFunctions.cc
@@ -17,6 +17,7 @@
 #include "RegistrationAllFunctions.h"
 #include "RowConstructor.cc"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 #include "velox/functions/sparksql/Register.h"
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -19,18 +19,18 @@
 #include <folly/executors/IOThreadPoolExecutor.h>
 
 #include "ArrowTypeUtils.h"
-#include "VeloxBridge.h"
-#include "velox/common/file/FileSystems.h"
-#include "velox/exec/Operator.h"
-#include "velox/exec/Task.h"
 #include "RegistrationAllFunctions.h"
+#include "VeloxBridge.h"
 #include "compute/Backend.h"
 #include "compute/ResultIterator.h"
 #include "include/arrow/c/bridge.h"
-#include "velox/exec/PlanNodeStats.h"
-#include "velox/vector/arrow/Bridge.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Task.h"
+#include "velox/vector/arrow/Bridge.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -16,22 +16,21 @@
  */
 #include "VeloxBackend.h"
 
-#include <arrow/type_fwd.h>
-#include <arrow/util/iterator.h>
-
-#include <string>
+#include <folly/executors/IOThreadPoolExecutor.h>
 
 #include "ArrowTypeUtils.h"
-#include "RegistrationAllFunctions.cc"
 #include "VeloxBridge.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/Task.h"
+#include "RegistrationAllFunctions.h"
 #include "compute/Backend.h"
 #include "compute/ResultIterator.h"
 #include "include/arrow/c/bridge.h"
-#include "velox/buffer/Buffer.h"
 #include "velox/exec/PlanNodeStats.h"
-#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
-#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 #include "velox/vector/arrow/Bridge.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -17,31 +17,11 @@
 
 #pragma once
 
-#include <arrow/array/array_binary.h>
-#include <arrow/array/array_primitive.h>
-#include <arrow/array/data.h>
-#include <arrow/array/util.h>
-#include <arrow/record_batch.h>
-#include <arrow/type_fwd.h>
-#include <folly/executors/IOThreadPoolExecutor.h>
 
 #include "VeloxToRowConverter.h"
-#include "arrow/c/abi.h"
 #include "compute/Backend.h"
-#include "include/arrow/c/bridge.h"
-#include "memory/ColumnarBatch.h"
 #include "memory/VeloxColumnarBatch.h"
-#include "memory/VeloxMemoryPool.h"
-#include "substrait/algebra.pb.h"
-#include "substrait/capabilities.pb.h"
-#include "substrait/extensions/extensions.pb.h"
-#include "substrait/function.pb.h"
-#include "substrait/parameterized_types.pb.h"
 #include "substrait/plan.pb.h"
-#include "substrait/type.pb.h"
-#include "substrait/type_expressions.pb.h"
-#include "utils/metrics.h"
-#include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
@@ -51,24 +31,9 @@
 #ifdef VELOX_ENABLE_S3
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 #endif
-#include "velox/core/Expressions.h"
-#include "velox/core/ITypedExpr.h"
 #include "velox/core/PlanNode.h"
-#include "velox/dwio/common/Options.h"
-#include "velox/dwio/common/ScanSpec.h"
-#include "velox/dwio/dwrf/reader/DwrfReader.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
-#include "velox/exec/Operator.h"
-#include "velox/exec/OperatorUtils.h"
-#include "velox/exec/tests/utils/Cursor.h"
-#include "velox/expression/Expr.h"
-#include "velox/functions/prestosql/aggregates/SumAggregate.h"
-#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/substrait/SubstraitToVeloxPlan.h"
-#include "velox/substrait/TypeUtils.h"
-#include "velox/type/Filter.h"
-#include "velox/type/Subfield.h"
 
 namespace gluten {
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include "VeloxToRowConverter.h"
 #include "compute/Backend.h"
 #include "memory/VeloxColumnarBatch.h"


### PR DESCRIPTION
## What changes were proposed in this pull request?

We include too many unnecessary header files, too much `#include` will lead to longer compilation time and more dependence.

How to check whether the file `test.h` includes appropriate header files or not?
1. create a new source file named `x.cc`
2. add `#include test.h` to `x.cc`, and make sure the file `x.cc` contains the only line `#include test.h`
3. compile x.cc, if OK, then `test.h` must include all the header files required by itself
4. delete a line such as '#include a.h' from `test.h`, if recompiled successfully, then `#include a.h` is redundant including, just remove it, and repeat this step to delete all unnecessary including statements.

I did as above and then create this PR, that's also the CppCoreGuidelines required.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

