### PR TITLE
[Gluten-788] Pass hadoop config from driver to executor.

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -80,7 +80,7 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   filesystems::registerHdfsFileSystem();
   // TODO(yuan): should read hdfs client conf from hdfs-client.xml from
   // LIBHDFS3_CONF
-  std::string hdfsUri = conf["spark.fs.defaultFS"];
+  std::string hdfsUri = conf["spark.hadoop.fs.defaultFS"];
   const char* envHdfsUri = std::getenv("VELOX_HDFS");
   if (envHdfsUri != nullptr) {
     hdfsUri = std::string(envHdfsUri);

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -80,13 +80,14 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
   filesystems::registerHdfsFileSystem();
   // TODO(yuan): should read hdfs client conf from hdfs-client.xml from
   // LIBHDFS3_CONF
-  std::string hdfsUri = "localhost:9000";
+  std::string hdfsUri = conf["spark.fs.defaultFS"];
   const char* envHdfsUri = std::getenv("VELOX_HDFS");
   if (envHdfsUri != nullptr) {
     hdfsUri = std::string(envHdfsUri);
   }
-  auto hdfsPort = hdfsUri.substr(hdfsUri.find(":") + 1);
-  auto hdfsHost = hdfsUri.substr(0, hdfsUri.find(":"));
+  auto hdfsHostWithPort = hdfsUri.substr(hdfsUri.find(":") + 3);
+  auto hdfsPort = hdfsHostWithPort.substr(hdfsHostWithPort.find(":") + 1);
+  auto hdfsHost = hdfsHostWithPort.substr(0, hdfsHostWithPort.find(":"));
   std::unordered_map<std::string, std::string> hdfsConfig({{"hive.hdfs.host", hdfsHost}, {"hive.hdfs.port", hdfsPort}});
   configurationValues.merge(hdfsConfig);
 #endif

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -73,7 +73,9 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
       conf.set("spark.sql.inMemoryColumnarStorage.enableVectorizedReader", "false")
     }
     val hdfsUri = sc.hadoopConfiguration.get("fs.defaultFS", "hdfs://localhost:9000")
-    conf.set(GlutenConfig.SPARK_HDFS_URI, hdfsUri)
+    if (!conf.contains(GlutenConfig.SPARK_HDFS_URI)) {
+      conf.set(GlutenConfig.SPARK_HDFS_URI, hdfsUri)
+    }
   }
 }
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -217,7 +217,7 @@ object GlutenConfig {
   val SPARK_HIVE_EXEC_ORC_COMPRESS: String = "spark." + HIVE_EXEC_ORC_COMPRESS
 
   // Hadoop config
-  val HDFS_URI = "fs.defaultFS"
+  val HDFS_URI = "hadoop.fs.defaultFS"
   val SPARK_HDFS_URI = "spark." + HDFS_URI
 
   // S3 config

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -216,6 +216,10 @@ object GlutenConfig {
   val HIVE_EXEC_ORC_COMPRESS = "hive.exec.orc.compress"
   val SPARK_HIVE_EXEC_ORC_COMPRESS: String = "spark." + HIVE_EXEC_ORC_COMPRESS
 
+  // Hadoop config
+  val HDFS_URI = "fs.defaultFS"
+  val SPARK_HDFS_URI = "spark." + HDFS_URI
+
   // S3 config
   val S3_ACCESS_KEY = "hadoop.fs.s3a.access.key"
   val SPARK_S3_ACCESS_KEY: String = "spark." + S3_ACCESS_KEY


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this pr, we need set extra env variable `VELOX_HDFS` in driver or executor, but that way does not make sense, we should read it from HADOOP_CONFIG eg `core-site.xml` directly.

Spark executor's `SparkConf` is initialized from driver's `SparkConf`, so we could use DriverPlugin to inject configs of what we need to used in executor.

## How was this patch tested?

manual test with hadoop cluster.

I would glad to hear your opinions. :)
