### PR TITLE
 [OPPRO-797] Support to load the libparquet.so.1000 when we use Gluten with Velox backend.

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
@@ -31,6 +31,7 @@ class VeloxInitializerApi extends IInitializerApi {
     val loader = workspace.libLoader
     loader.newTransaction()
       .loadAndCreateLink("libarrow.so.1000.0.0", "libarrow.so.1000", false)
+      .loadAndCreateLink("libparquet.so.1000.0.0", "libparquet.so.1000", false)
       .commit()
     val libPath = conf.get(GlutenConfig.GLUTEN_LIB_PATH, StringUtils.EMPTY)
     if (StringUtils.isNotBlank(libPath)) { // Path based load. Ignore all other loadees.


### PR DESCRIPTION

## What changes were proposed in this pull request?

https://github.com/oap-project/gluten/issues/797


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

