### PR TITLE
[GLUTEN-374] Enable UT SPARK-24690 and GlutenJoinSuite after Velox hashjoin fix

### DIFF
--- a/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -156,6 +156,7 @@ object VeloxTestSettings extends BackendTestSettings {
       .exclude("sorting does not crash for large inputs")
   enableSuite[GlutenExistenceJoinSuite]
   enableSuite[GlutenDataFrameJoinSuite]
+  enableSuite[GlutenJoinSuite]
   enableSuite[GlutenOuterJoinSuite]
   enableSuite[GlutenInnerJoinSuite]
     // The following tests will be re-run in GlutenInnerJoinSuite by

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenJoinSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenJoinSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql
 import org.apache.spark.sql.internal.SQLConf
 
 class GlutenJoinSuite extends JoinSuite with GlutenSQLTestsTrait {
-  import testImplicits._
 
   override def testNameBlackList: Seq[String] = Seq(
     // Below tests are to verify operators, just skip.
@@ -41,5 +40,6 @@ class GlutenJoinSuite extends JoinSuite with GlutenSQLTestsTrait {
     "SPARK-35984: Config to force applying shuffled hash join",
     "test SortMergeJoin (with spill)",
     // NaN is not supported currently, just skip.
-    "NaN and -0.0 in join keys",
+    "NaN and -0.0 in join keys"
   )
+}

--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenJoinSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenJoinSuite.scala
@@ -17,13 +17,29 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.internal.SQLConf
+
 class GlutenJoinSuite extends JoinSuite with GlutenSQLTestsTrait {
+  import testImplicits._
 
   override def testNameBlackList: Seq[String] = Seq(
-    GlutenTestConstants.IGNORE_ALL,
+    // Below tests are to verify operators, just skip.
+    "join operator selection",
     "broadcasted hash join operator selection",
     "broadcasted hash outer join operator selection",
+    "broadcasted existence join operator selection",
     "SPARK-28323: PythonUDF should be able to use in join condition",
-    "SPARK-28345: PythonUDF predicate should be able to pushdown to join"
+    "SPARK-28345: PythonUDF predicate should be able to pushdown to join",
+    "cross join with broadcast",
+    "test SortMergeJoin output ordering",
+    "SPARK-22445 Respect stream-side child's needCopyResult in BroadcastHashJoin",
+    "SPARK-32330: Preserve shuffled hash join build side partitioning",
+    "SPARK-32383: Preserve hash join (BHJ and SHJ) stream side ordering",
+    "SPARK-32399: Full outer shuffled hash join",
+    "SPARK-32649: Optimize BHJ/SHJ inner/semi join with empty hashed relation",
+    "SPARK-34593: Preserve broadcast nested loop join partitioning and ordering",
+    "SPARK-35984: Config to force applying shuffled hash join",
+    "test SortMergeJoin (with spill)",
+    // NaN is not supported currently, just skip.
+    "NaN and -0.0 in join keys",
   )
-}


### PR DESCRIPTION
https://github.com/oap-project/velox/pull/106 has fixed Velox hashjoin bugs，
So  enable remaining UTs in GlutenJoinSuite.
