### PR TITLE
[VL] [DNM] try to fix the fallback behavior on ubuntu 22.04

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -48,8 +48,8 @@ done
 function process_setup_ubuntu {
       # make this function Reentrantly
       git checkout scripts/setup-ubuntu.sh
-      sed -i '/libprotobuf-dev/d' scripts/setup-ubuntu.sh
-      sed -i '/protobuf-compiler/d' scripts/setup-ubuntu.sh
+      sed -i '/libgoogle-glog-dev/d' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt install/a\  libunwind8 \\' scripts/setup-ubuntu.sh
       sed -i '/^sudo --preserve-env apt install/a\  *thrift* \\' scripts/setup-ubuntu.sh
       sed -i '/^sudo --preserve-env apt install/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
       sed -i '/^sudo --preserve-env apt install/a\  libxml2-dev \\' scripts/setup-ubuntu.sh
@@ -71,6 +71,8 @@ function process_setup_ubuntu {
         sed -i '/^function install_fmt.*/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-ubuntu.sh
         sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_awssdk' scripts/setup-ubuntu.sh
       fi
+      sed -i '/^function install_fmt.*/i function install_glog {\n  github_checkout google/glog v0.4.0 \n  ./autogen.sh && ./configure && make && sudo make install \n} \n' scripts/setup-ubuntu.sh
+      sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_glog' scripts/setup-ubuntu.sh
       sed -i 's/run_and_time install_conda/#run_and_time install_conda/' scripts/setup-ubuntu.sh
       
 }

--- a/tools/gluten-te/dockerfile-buildenv
+++ b/tools/gluten-te/dockerfile-buildenv
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS gluten-buildenv
+FROM ubuntu:22.04 AS gluten-buildenv
 MAINTAINER Hongze Zhang<hongze.zhang@intel.com>
 
 SHELL ["/bin/bash", "-c"]

--- a/tools/patches/libhdfs3.patch
+++ b/tools/patches/libhdfs3.patch
@@ -1,0 +1,51 @@
+diff --git a/depends/libhdfs3/CMake/Platform.cmake b/depends/libhdfs3/CMake/Platform.cmake
+index ea00fa3f..6538e84d 100644
+--- a/depends/libhdfs3/CMake/Platform.cmake
++++ b/depends/libhdfs3/CMake/Platform.cmake
+@@ -7,7 +7,7 @@ ELSE(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+ ENDIF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+ 
+ IF(CMAKE_COMPILER_IS_GNUCXX)
+-    EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_COMPILER_VERSION)
++    EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpfullversion OUTPUT_VARIABLE GCC_COMPILER_VERSION)
+     
+     IF (NOT GCC_COMPILER_VERSION)
+         MESSAGE(FATAL_ERROR "Cannot get gcc version")
+diff --git a/depends/libhdfs3/CMakeLists.txt b/depends/libhdfs3/CMakeLists.txt
+index f49e68dc..ec5650ec 100644
+--- a/depends/libhdfs3/CMakeLists.txt
++++ b/depends/libhdfs3/CMakeLists.txt
+@@ -22,7 +22,6 @@ FIND_PACKAGE(LibXml2 REQUIRED)
+ FIND_PACKAGE(Protobuf REQUIRED)
+ FIND_PACKAGE(KERBEROS REQUIRED)
+ FIND_PACKAGE(GSasl REQUIRED)
+-FIND_PACKAGE(GoogleTest REQUIRED)
+ INCLUDE_DIRECTORIES(${GoogleTest_INCLUDE_DIR})
+ LINK_LIBRARIES(${GoogleTest_LIBRARIES})
+ 
+diff --git a/depends/libhdfs3/src/client/InputStreamImpl.cpp b/depends/libhdfs3/src/client/InputStreamImpl.cpp
+index 05f27a5a..6ea9ab48 100644
+--- a/depends/libhdfs3/src/client/InputStreamImpl.cpp
++++ b/depends/libhdfs3/src/client/InputStreamImpl.cpp
+@@ -734,7 +734,7 @@ void InputStreamImpl::seekInternal(int64_t pos) {
+     }
+ 
+     try {
+-        if (blockReader && pos > cursor && pos < endOfCurBlock) {
++        if (blockReader && pos > cursor && pos < endOfCurBlock && pos - cursor <= 128 * 1024) {
+             blockReader->skip(pos - cursor);
+             cursor = pos;
+             return;
+diff --git a/depends/libhdfs3/src/common/SessionConfig.cpp b/depends/libhdfs3/src/common/SessionConfig.cpp
+index 632009ec..27e1ad30 100644
+--- a/depends/libhdfs3/src/common/SessionConfig.cpp
++++ b/depends/libhdfs3/src/common/SessionConfig.cpp
+@@ -138,7 +138,7 @@ SessionConfig::SessionConfig(const Config & conf) {
+         {&rpcAuthMethod, "hadoop.security.authentication", "simple" },
+         {&kerberosCachePath, "hadoop.security.kerberos.ticket.cache.path", "" },
+         {&logSeverity, "dfs.client.log.severity", "INFO" },
+-        {&domainSocketPath, "dfs.domain.socket.path", ""}
++        {&domainSocketPath, "dfs.domain.socket.path", "/var/lib/hadoop-hdfs/dn_socket"}
+     };
+ 
+     for (size_t i = 0; i < ARRAYSIZE(boolValues); ++i) {


### PR DESCRIPTION
on ubuntu22.04 libgoogle-glog-dev depdens on libubinwd-dev, which introduced unspecified behavior on catching exceptions

this patch manually installed glog libs to avoid the issue

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

