### PR TITLE
[Gluten-826] ch_backend support inset is empty

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -171,4 +171,9 @@ object ClickHouseTestSettings extends BackendTestSettings {
       "pivot with datatype not supported by PivotFirst 2",
       "pivot with null and aggregate type not supported by PivotFirst returns correct result"
     )
+
+  enableSuite[GlutenPredicateSuite]
+    .includeByPrefix(
+      "SPARK-29100"
+    )
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
ch_backend support inset is empty

## How was this patch tested?
test by CH[[258]]
