### PR TITLE
[Gluten-374] Add sql tests in the timestampNTZ and native folders for velox backend

### DIFF
--- a/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -229,7 +229,28 @@ class GlutenSQLQueryTestSuite extends QueryTest with SharedSparkSession with SQL
     "cte-nested.sql",
     "cte-nonlegacy.sql",
     "cte.sql",
-    "current_database_catalog.sql"
+    "current_database_catalog.sql",
+    "datetime-special.sql",
+    "timestamp-ansi.sql",
+    "timestamp.sql",
+    "arrayJoin.sql",
+    "binaryComparison.sql",
+    "booleanEquality.sql",
+    "caseWhenCoercion.sql",
+    "concat.sql",
+    "dateTimeOperations.sql",
+    "decimalPrecision.sql",
+    "division.sql",
+    "elt.sql",
+    "ifCoercion.sql",
+    "implicitTypeCasts.sql",
+    "inConversion.sql",
+    "mapZipWith.sql",
+    "mapconcat.sql",
+    "promoteStrings.sql",
+    "stringCastAndExpressions.sql",
+    "widenSetOperationTypes.sql",
+    "windowFrameCoercion.sql"
   )
 
   /** List of supported cases to run with Clickhouse backend, in lower case.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add sql tests in the timestampNTZ and native folders for velox backend


## How was this patch tested?
mvn clean install -pl gluten-ut -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark" -Dsuites="org.apache.spark.sql.GlutenSQLQueryTestSuite" -Darrow.version=10.0.0-SNAPSHOT

