### PR TITLE
[CH-262] Skip memory copy between onheap and native when using columnar shuffle manager for Clickhouse backend

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentShuffleInputStream.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.vectorized;
+
+import io.netty.util.internal.PlatformDependent;
+import org.apache.spark.network.util.LimitedInputStream;
+import org.apache.spark.storage.CHShuffleReadStreamFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+public class LowCopyFileSegmentShuffleInputStream implements ShuffleInputStream {
+
+  private final InputStream in;
+  private final LimitedInputStream limitedInputStream;
+  private final FileChannel channel;
+  private final int bufferSize;
+  private final boolean isCompressed;
+
+  private long bytesRead = 0L;
+  private long left;
+
+  public LowCopyFileSegmentShuffleInputStream(
+      InputStream in,
+      InputStream limitedInputStream,
+      int bufferSize,
+      boolean isCompressed) {
+    // to prevent underlying netty buffer from being collected by GC
+    this.in = in;
+    this.limitedInputStream = (LimitedInputStream) limitedInputStream;
+    this.bufferSize = bufferSize;
+    this.isCompressed = isCompressed;
+    final FileInputStream fin;
+    try {
+      left = ((long) CHShuffleReadStreamFactory.FIELD_LimitedInputStream_left
+          .get(this.limitedInputStream));
+      fin = (FileInputStream) CHShuffleReadStreamFactory.FIELD_FilterInputStream_in
+          .get(this.limitedInputStream);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+    channel = fin.getChannel();
+  }
+
+  @Override
+  public long read(long destAddress, long maxReadSize) {
+    long bytesToRead = Math.min(left, maxReadSize);
+    int bytesToRead32 = Math.toIntExact(bytesToRead);
+    if (bytesToRead32 == 0) {
+      return 0;
+    }
+    ByteBuffer direct = PlatformDependent.directBuffer(destAddress, bytesToRead32);
+    try {
+      // read data from file channel to native address
+      int bytes = channel.read(direct);
+      if (bytes == -1) {
+        return 0;
+      }
+      bytesRead += bytes;
+      left -= bytes;
+      return bytes;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public long pos() {
+    return bytesRead;
+  }
+
+  @Override
+  public boolean isCompressed() {
+    return this.isCompressed;
+  }
+
+  @Override
+  public void close() {
+    try {
+      channel.close();
+      in.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyNettyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyNettyShuffleInputStream.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.vectorized;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public class LowCopyNettyShuffleInputStream implements ShuffleInputStream {
+
+  private final InputStream in;
+  private final int bufferSize;
+  private final boolean isCompressed;
+
+  private ByteBuf byteBuf;
+  private int readBytesCount = 0;
+
+  public LowCopyNettyShuffleInputStream(
+      InputStream in,
+      ByteBuf byteBuf,
+      int bufferSize,
+      boolean isCompressed) {
+    // to prevent underlying netty buffer from being collected by GC
+    this.in = in;
+    this.byteBuf = byteBuf;
+    this.bufferSize = bufferSize;
+    this.isCompressed = isCompressed;
+  }
+
+  @Override
+  public long read(long destAddress, long maxReadSize) {
+    long bytesToRead = Math.min(maxReadSize, this.byteBuf.readableBytes());
+    int bytesToRead32 = Math.toIntExact(bytesToRead);
+    if (bytesToRead32 == 0) {
+      return 0;
+    }
+    ByteBuffer direct = PlatformDependent.directBuffer(destAddress, bytesToRead32);
+    // read data directly from ByteBuf to native address
+    this.byteBuf.readBytes(direct);
+    readBytesCount += direct.position();
+    return direct.position();
+  }
+
+  @Override
+  public long pos() {
+    return readBytesCount;
+  }
+
+  @Override
+  public boolean isCompressed() {
+    return this.isCompressed;
+  }
+
+  @Override
+  public void close() {
+    try {
+      in.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.vectorized;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
+
+  private final InputStream in;
+  private final boolean isCompressed;
+  private int bufferSize;
+  private long bytesRead = 0L;
+
+  private byte[] buffer = null;
+
+  public OnHeapCopyShuffleInputStream(
+      InputStream in,
+      int bufferSize,
+      boolean isCompressed) {
+    this.in = in;
+    this.bufferSize = bufferSize;
+    this.isCompressed = isCompressed;
+    this.buffer = new byte[this.bufferSize];
+  }
+
+  @Override
+  public long read(long destAddress, long maxReadSize) {
+    int maxReadSize32 = Math.toIntExact(maxReadSize);
+    if (maxReadSize32 > this.bufferSize) {
+      this.bufferSize = maxReadSize32;
+      this.buffer = new byte[this.bufferSize];
+    }
+    try {
+      // The code conducts copy as long as 'in' wraps off-heap data,
+      // which is about to be moved to heap
+      int read = in.read(buffer, 0, maxReadSize32);
+      if (read == -1 || read == 0) {
+        return 0;
+      }
+      // The code conducts copy, from heap to off-heap
+      // memCopyFromHeap(buffer, destAddress, read);
+      PlatformDependent.copyMemory(buffer, 0, destAddress, read);
+      bytesRead += read;
+      return read;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public long pos() {
+    return bytesRead;
+  }
+
+  @Override
+  public boolean isCompressed() {
+    return this.isCompressed;
+  }
+
+  @Override
+  public void close() {
+    try {
+      in.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ShuffleInputStream.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.vectorized;
+
+public interface ShuffleInputStream {
+
+  /**
+   * Read fixed size of data into an offheap address.
+   * @return the read bytes; 0 if end of stream.
+   */
+  long read(long destAddress, long maxReadSize);
+
+  boolean isCompressed();
+
+  /**
+   * Position of this stream.
+   */
+  long pos();
+
+  /**
+   * Close and reclaim the resources.
+   */
+  void close();
+}

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.storage;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.FilterInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.zip.CheckedInputStream;
+
+import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
+import com.ning.compress.lzf.LZFInputStream;
+import io.glutenproject.vectorized.LowCopyFileSegmentShuffleInputStream;
+import io.glutenproject.vectorized.LowCopyNettyShuffleInputStream;
+import io.glutenproject.vectorized.OnHeapCopyShuffleInputStream;
+import io.glutenproject.vectorized.ShuffleInputStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import net.jpountz.lz4.LZ4BlockInputStream;
+import org.apache.spark.network.util.LimitedInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xerial.snappy.SnappyInputStream;
+
+public final class CHShuffleReadStreamFactory {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CHShuffleReadStreamFactory.class);
+
+  public static final Field FIELD_FilterInputStream_in;
+  public static final Field FIELD_ByteBufInputStream_buffer;
+  public static final Field FIELD_LimitedInputStream_left;
+
+  public static final Field FIELD_SnappyInputStream_in;
+  public static final Field FIELD_LZ4BlockInputStream_in;
+  public static final Field FIELD_BufferedInputStream_in;
+  public static final Field FIELD_ZstdInputStreamNoFinalizer_in;
+  public static final Field FIELD_LZFInputStream_in;
+
+  static {
+    try {
+      FIELD_FilterInputStream_in = FilterInputStream.class.getDeclaredField("in");
+      FIELD_FilterInputStream_in.setAccessible(true);
+      FIELD_ByteBufInputStream_buffer = ByteBufInputStream.class.getDeclaredField("buffer");
+      FIELD_ByteBufInputStream_buffer.setAccessible(true);
+      FIELD_LimitedInputStream_left = LimitedInputStream.class.getDeclaredField("left");
+      FIELD_LimitedInputStream_left.setAccessible(true);
+
+      FIELD_SnappyInputStream_in = SnappyInputStream.class.getDeclaredField("in");
+      FIELD_SnappyInputStream_in.setAccessible(true);
+      FIELD_LZ4BlockInputStream_in =
+          LZ4BlockInputStream.class.getSuperclass().getDeclaredField("in");
+      FIELD_LZ4BlockInputStream_in.setAccessible(true);
+      FIELD_BufferedInputStream_in =
+          BufferedInputStream.class.getSuperclass().getDeclaredField("in");
+      FIELD_BufferedInputStream_in.setAccessible(true);
+      FIELD_ZstdInputStreamNoFinalizer_in =
+          ZstdInputStreamNoFinalizer.class.getSuperclass().getDeclaredField("in");
+      FIELD_ZstdInputStreamNoFinalizer_in.setAccessible(true);
+      FIELD_LZFInputStream_in =
+          LZFInputStream.class.getDeclaredField("_inputStream");
+      FIELD_LZFInputStream_in.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      LOG.error("Can not get the field of the class: ", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private CHShuffleReadStreamFactory() {
+  }
+
+  public static ShuffleInputStream create(
+      InputStream in,
+      boolean forceCompress,
+      boolean isCustomizedShuffleCodec,
+      int bufferSize) {
+    // For native shuffle
+    if (forceCompress) {
+      // Unwrap BufferReleasingInputStream and CheckedInputStream
+      final InputStream unwrapped = unwrapSparkInputStream(in);
+      // Unwrap LimitedInputStream and get the FileInputStream
+      LimitedInputStream limitedInputStream = isReadFromFileSegment(unwrapped);
+      if (limitedInputStream != null) {
+        return new LowCopyFileSegmentShuffleInputStream(
+            in,
+            limitedInputStream,
+            bufferSize,
+            forceCompress);
+      }
+      // Unwrap ByteBufInputStream and get the ByteBuf
+      ByteBuf byteBuf = isReadFromNettySupported(unwrapped);
+      if (byteBuf != null) {
+        return new LowCopyNettyShuffleInputStream(in, byteBuf, bufferSize, forceCompress);
+      }
+      // Unwrap failed, use on heap copy method
+      return new OnHeapCopyShuffleInputStream(in, bufferSize, forceCompress);
+    } else if (isCustomizedShuffleCodec) {
+      // For Spark Sort Shuffle.
+      // Unwrap BufferReleasingInputStream and CheckedInputStream,
+      // if there is compression input stream, it will be unwrapped.
+      InputStream unwrapped = unwrapSparkWithCompressedInputStream(in);
+      if (unwrapped != null) {
+        // Unwrap LimitedInputStream and get the FileInputStream
+        LimitedInputStream limitedInputStream = isReadFromFileSegment(unwrapped);
+        if (limitedInputStream != null) {
+          return new LowCopyFileSegmentShuffleInputStream(
+              in,
+              limitedInputStream,
+              bufferSize,
+              isCustomizedShuffleCodec);
+        }
+        // Unwrap ByteBufInputStream and get the ByteBuf
+        ByteBuf byteBuf = isReadFromNettySupported(unwrapped);
+        if (byteBuf != null) {
+          return new LowCopyNettyShuffleInputStream(
+              in,
+              byteBuf,
+              bufferSize,
+              isCustomizedShuffleCodec);
+        }
+        // Unwrap failed, use on heap copy method
+        return new OnHeapCopyShuffleInputStream(unwrapped, bufferSize, isCustomizedShuffleCodec);
+      } else {
+        return new OnHeapCopyShuffleInputStream(in, bufferSize, false);
+      }
+    }
+    return new OnHeapCopyShuffleInputStream(in, bufferSize, false);
+  }
+
+  /**
+   * Unwrap BufferReleasingInputStream and CheckedInputStream
+   */
+  public static InputStream unwrapSparkInputStream(InputStream in) {
+    InputStream unwrapped = in;
+    if (unwrapped instanceof BufferReleasingInputStream) {
+      final BufferReleasingInputStream brin = (BufferReleasingInputStream) unwrapped;
+      unwrapped = brin.delegate();
+    }
+    if (unwrapped instanceof CheckedInputStream) {
+      final CheckedInputStream cin = (CheckedInputStream) unwrapped;
+      try {
+        unwrapped = ((InputStream) FIELD_FilterInputStream_in.get(cin));
+      } catch (IllegalAccessException e) {
+        LOG.error("Can not get the field 'in' from CheckedInputStream: ", e);
+        return in;
+      }
+    }
+    return unwrapped;
+  }
+
+  /**
+   * Unwrap BufferReleasingInputStream, CheckedInputStream and CompressionInputStream
+   */
+  public static InputStream unwrapSparkWithCompressedInputStream(
+      InputStream in) {
+    InputStream unwrapped = in;
+    if (unwrapped instanceof BufferReleasingInputStream) {
+      final BufferReleasingInputStream brin = (BufferReleasingInputStream) unwrapped;
+      unwrapped = brin.delegate();
+    }
+    InputStream unwrappedCompression = unwrapCompressionInputStream(unwrapped);
+    if (unwrappedCompression != null) {
+      if (unwrappedCompression instanceof CheckedInputStream) {
+        final CheckedInputStream cin = (CheckedInputStream) unwrappedCompression;
+        try {
+          return ((InputStream) FIELD_FilterInputStream_in.get(cin));
+        } catch (IllegalAccessException e) {
+          LOG.error("Can not get the field 'in' from CheckedInputStream: ", e);
+          return null;
+        }
+      }
+    } else {
+      return null;
+    }
+    return unwrapped;
+  }
+
+  /**
+   * Check whether support reading from file segment (local read)
+   */
+  public static LimitedInputStream isReadFromFileSegment(InputStream in) {
+    if (!(in instanceof LimitedInputStream)) {
+      return null;
+    }
+    LimitedInputStream lin = (LimitedInputStream) in;
+    InputStream wrapped = null;
+    try {
+      wrapped = (InputStream) FIELD_FilterInputStream_in.get(lin);
+      long left = ((long) FIELD_LimitedInputStream_left.get(lin));
+    } catch (IllegalAccessException e) {
+      LOG.error("Can not get the fields from LimitedInputStream: ", e);
+      return null;
+    }
+    if (!(wrapped instanceof FileInputStream)) {
+      return null;
+    }
+    return lin;
+  }
+
+  /**
+   * Check whether support reading from netty (remote read)
+   */
+  public static ByteBuf isReadFromNettySupported(InputStream in) {
+    if (!(in instanceof ByteBufInputStream)) {
+      return null;
+    }
+    ByteBufInputStream bbin = (ByteBufInputStream) in;
+    try {
+      ByteBuf byteBuf = (ByteBuf) FIELD_ByteBufInputStream_buffer.get(bbin);
+      if (!byteBuf.isDirect()) {
+        return null;
+      }
+      return byteBuf;
+    } catch (IllegalAccessException e) {
+      LOG.error("Can not get the field 'buffer' from ByteBufInputStream: ", e);
+      return null;
+    }
+  }
+
+  /**
+   * Unwrap Spark compression input stream.
+   */
+  public static InputStream unwrapCompressionInputStream(
+      InputStream is) {
+    InputStream unwrapped = is;
+    try {
+      if (unwrapped instanceof BufferedInputStream) {
+        final InputStream cis =
+            (InputStream) FIELD_BufferedInputStream_in.get(unwrapped);
+        if (cis instanceof ZstdInputStreamNoFinalizer) {
+          unwrapped = (InputStream) FIELD_ZstdInputStreamNoFinalizer_in.get(cis);
+        }
+      } else if (unwrapped instanceof SnappyInputStream) {
+        // unsupported
+        return null;
+      } else if (unwrapped instanceof LZ4BlockInputStream) {
+        unwrapped = (InputStream) FIELD_LZ4BlockInputStream_in.get(unwrapped);
+      } else if (unwrapped instanceof LZFInputStream) {
+        unwrapped = (InputStream) FIELD_LZFInputStream_in.get(unwrapped);
+      }
+    } catch (IllegalAccessException e) {
+      LOG.error("Can not get the field 'in' from compression input stream: ", e);
+      return null;
+    }
+    return unwrapped;
+  }
+}

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleWriteStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleWriteStreamFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.storage;
+
+import com.github.luben.zstd.ZstdOutputStreamNoFinalizer;
+import com.ning.compress.lzf.LZFOutputStream;
+import net.jpountz.lz4.LZ4BlockOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xerial.snappy.SnappyOutputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+
+public final class CHShuffleWriteStreamFactory {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CHShuffleReadStreamFactory.class);
+
+  public static final Field FIELD_SnappyOutputStream_out;
+  public static final Field FIELD_LZ4BlockOutputStream_out;
+  public static final Field FIELD_BufferedOutputStream_out;
+  public static final Field FIELD_ZstdOutputStreamNoFinalizer_out;
+  public static final Field FIELD_LZFOutputStream_out;
+
+  static {
+    try {
+      FIELD_SnappyOutputStream_out = SnappyOutputStream.class.getDeclaredField("out");
+      FIELD_SnappyOutputStream_out.setAccessible(true);
+      FIELD_LZ4BlockOutputStream_out =
+          LZ4BlockOutputStream.class.getSuperclass().getDeclaredField("out");
+      FIELD_LZ4BlockOutputStream_out.setAccessible(true);
+      FIELD_BufferedOutputStream_out =
+          BufferedOutputStream.class.getSuperclass().getDeclaredField("out");
+      FIELD_BufferedOutputStream_out.setAccessible(true);
+      FIELD_ZstdOutputStreamNoFinalizer_out =
+          ZstdOutputStreamNoFinalizer.class.getSuperclass().getDeclaredField("out");
+      FIELD_ZstdOutputStreamNoFinalizer_out.setAccessible(true);
+      FIELD_LZFOutputStream_out =
+          LZFOutputStream.class.getSuperclass().getDeclaredField("out");
+      FIELD_LZFOutputStream_out.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      LOG.error("Can not get the field of the class: ", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Unwrap Spark compression output stream.
+   */
+  public static OutputStream unwrapSparkCompressionOutputStream(
+      OutputStream os,
+      boolean isCustomizedShuffleCodec) {
+    if (!isCustomizedShuffleCodec) return os;
+    OutputStream out = null;
+    try {
+      if (os instanceof BufferedOutputStream) {
+        final OutputStream cos =
+            (OutputStream) FIELD_BufferedOutputStream_out.get(os);
+        if (cos instanceof ZstdOutputStreamNoFinalizer) {
+          out = (OutputStream) FIELD_ZstdOutputStreamNoFinalizer_out.get(cos);
+        }
+      } else if (os instanceof SnappyOutputStream) {
+        // unsupported
+        return null;
+      } else if (os instanceof LZ4BlockOutputStream) {
+        out = (OutputStream) FIELD_LZ4BlockOutputStream_out.get(os);
+      } else if (os instanceof LZFOutputStream) {
+        out = (OutputStream) FIELD_LZFOutputStream_out.get(os);
+      }
+    } catch (IllegalAccessException e) {
+      LOG.error("Can not get the field 'out' from compression output stream: ", e);
+      return out;
+    }
+    return out;
+  }
+}

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -46,6 +46,16 @@ object CHBackendSettings extends BackendSettings {
       ".files.per.partition.threshold"
   val GLUTEN_CLICKHOUSE_FILES_PER_PARTITION_THRESHOLD_DEFAULT = "-1"
 
+  val GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE =
+    GlutenConfig.GLUTEN_CONFIG_PREFIX + GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND +
+      ".customized.shuffle.codec.enable"
+  val GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE_DEFAULT = "false"
+
+  val GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE =
+    GlutenConfig.GLUTEN_CONFIG_PREFIX + GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND +
+      ".customized.buffer.size"
+  val GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE_DEFAULT = "4096"
+
   override def supportFileFormatRead(): FileFormat => Boolean = {
     case _: ParquetFileFormat => true
     case _: OrcFileFormat => true

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -44,14 +44,9 @@ class CHColumnarShuffleWriter[K, V](
   private val offheapSize = conf.getSizeAsBytes("spark.memory.offHeap.size", 0)
   private val executorNum = conf.getInt("spark.executor.cores", 1)
   private val offheapPerTask = offheapSize / executorNum;
-  private val nativeBufferSize = GlutenConfig.getConf.shuffleSplitDefaultSize
+  private val splitSize = GlutenConfig.getConf.shuffleSplitDefaultSize
   private val customizedCompressCodec =
     GlutenConfig.getConf.columnarShuffleUseCustomizedCompressionCodec
-  private val defaultCompressionCodec = if (conf.getBoolean("spark.shuffle.compress", true)) {
-    conf.get("spark.io.compression.codec", "lz4")
-  } else {
-    "uncompressed"
-  }
   private val batchCompressThreshold =
     GlutenConfig.getConf.columnarShuffleBatchCompressThreshold;
   private val preferSpill = GlutenConfig.getConf.columnarShufflePreferSpill
@@ -96,8 +91,8 @@ class CHColumnarShuffleWriter[K, V](
       nativeSplitter = splitterJniWrapper.make(
         dep.nativePartitioning,
         mapId,
-        nativeBufferSize,
-        defaultCompressionCodec,
+        splitSize,
+        customizedCompressCodec,
         dataTmp.getAbsolutePath,
         localDirs)
     }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -806,17 +806,6 @@ Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_close(JNIEnv* env, jo
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_LowCopyNettyJniByteInputStream_memCopy(
-    JNIEnv* env,
-    jobject,
-    jlong srcAddress,
-    jlong destAddress,
-    jlong size) {
-  JNI_METHOD_START
-  std::memcpy(reinterpret_cast<void*>(destAddress), reinterpret_cast<void*>(srcAddress), size);
-  JNI_METHOD_END()
-}
-
 JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_OnHeapJniByteInputStream_memCopyFromHeap(
     JNIEnv* env,
     jobject,

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -19,6 +19,8 @@ package io.glutenproject
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
 
+import java.util.Locale
+
 case class GlutenNumaBindingInfo(
     enableNumaBinding: Boolean,
     totalCoreRange: Array[String] = null,
@@ -155,7 +157,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   // The supported customized compression codec is lz4.
   val columnarShuffleUseCustomizedCompressionCodec: String =
-    conf.getConfString("spark.gluten.sql.columnar.shuffle.customizedCompression.codec", "lz4")
+    conf
+      .getConfString("spark.gluten.sql.columnar.shuffle.customizedCompression.codec", "lz4")
+      .toUpperCase(Locale.ROOT)
 
   val columnarShuffleBatchCompressThreshold: Int =
     conf.getConfString("spark.gluten.sql.columnar.shuffle.batchCompressThreshold", "100").toInt


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip memory copy between onheap and native when using columnar shuffle manager for Clickhouse backend.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

test by CH[[263]]