### PR TITLE
[Gluten-374] Add sql tests in the timestampNTZ and native folders for velox backend

### DIFF
--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -326,7 +326,28 @@ class GlutenSQLQueryTestSuite extends QueryTest with SharedSparkSession with SQL
     "postgreSQL/boolean.sql",
     "postgreSQL/case.sql",
     "postgreSQL/comments.sql",
-    "postgreSQL/create_view.sql"
+    "postgreSQL/create_view.sql",
+    "datetime-special.sql",
+    "timestamp-ansi.sql",
+    "timestamp.sql",
+    "arrayJoin.sql",
+    "binaryComparison.sql",
+    "booleanEquality.sql",
+    "caseWhenCoercion.sql",
+    "concat.sql",
+    "dateTimeOperations.sql",
+    "decimalPrecision.sql",
+    "division.sql",
+    "elt.sql",
+    "ifCoercion.sql",
+    "implicitTypeCasts.sql",
+    "inConversion.sql",
+    "mapZipWith.sql",
+    "mapconcat.sql",
+    "promoteStrings.sql",
+    "stringCastAndExpressions.sql",
+    "widenSetOperationTypes.sql",
+    "windowFrameCoercion.sql"
   )
 
   /** List of supported cases to run with Clickhouse backend, in lower case.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add sql tests in the timestampNTZ and native folders for velox backend


## How was this patch tested?
mvn clean install -pl gluten-ut -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark" -Dsuites="org.apache.spark.sql.GlutenSQLQueryTestSuite" -Darrow.version=10.0.0-SNAPSHOT

