### PR TITLE
[Follow up #632] dump cache stats on exit

### DIFF
--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -34,6 +34,11 @@ class VeloxInitializer {
   VeloxInitializer(const std::unordered_map<std::string, std::string>& conf) {
     Init(conf);
   }
+  ~VeloxInitializer() {
+    if (dynamic_cast<facebook::velox::cache::AsyncDataCache*>(mappedMemory_.get())) {
+      std::cout << mappedMemory_->toString() << std::endl;
+    }
+  }
   void Init(std::unordered_map<std::string, std::string> conf);
 
   void InitCache();
@@ -52,7 +57,7 @@ class VeloxInitializer {
   const std::string kVeloxCacheSizeDefault = "1073741824";
   const std::string kVeloxCacheShards = "spark.gluten.sql.columnar.backend.velox.cacheShards";
   const std::string kVeloxCacheShardsDefault = "1";
-  const std::string kVeloxCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.ioTHreads";
+  const std::string kVeloxCacheIOThreads = "spark.gluten.sql.columnar.backend.velox.cacheIOTHreads";
   const std::string kVeloxCacheIOThreadsDefault = "1";
 };
 


### PR DESCRIPTION


## What changes were proposed in this pull request?

Follow up #632, this patch dumps the cache stats on exit if cache is enabled

Here's one example:
```
AsyncDataCache: 354440788 / 214748364800 bytes
Miss: 108 Hit 83 evict 0
 read pins 0 write pins 0 unused prefetch 0 Alloc Megaclocks 3892336519 allocated pages 86533 cached pages 86533
Backing: [Memory capacity 52428800 free 52342267 mapped 86565 [size 1: 65(0MB) allocated 65 mapped]
[size 2: 50(0MB) allocated 50 mapped]
[size 4: 12(0MB) allocated 12 mapped]
[size 8: 46(1MB) allocated 46 mapped]
[size 16: 58(3MB) allocated 60 mapped]
[size 32: 37(4MB) allocated 37 mapped]
[size 64: 48(12MB) allocated 48 mapped]
[size 128: 57(28MB) allocated 57 mapped]
[size 256: 287(287MB) allocated 287 mapped]
]

SSD: Ssd cache IO: Write 0MB read 0MB Size 0GB Occupied 0GB0K entries.
GroupStats: <dummy FileGroupStats>
```
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>


## How was this patch tested?

manually tested
