### PR TITLE
Fix the NPE when updating metrics

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
@@ -252,8 +252,7 @@ abstract class VeloxTPCHSuite extends WholeStageTransformerSuite {
     runTPCHQuery(21, veloxTPCHQueries, queriesResults, compareResult = false) { _ => }
   }
 
-  // TODO: fix q21 with partitions size == 1 when bhj enabled.
-  ignore("TPC-H q21 - bhj enable") {
+  test("TPC-H q21 - bhj enable") {
     withSQLConf(("spark.sql.autoBroadcastJoinThreshold", "30M")) {
       runTPCHQuery(21, veloxTPCHQueries, queriesResults, compareResult = false) { _ => }
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -38,6 +38,10 @@ import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+trait LimitMetricsUpdater extends MetricsUpdater {
+  def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit
+}
+
 case class LimitTransformer(child: SparkPlan,
                             offset: Long,
                             count: Long) extends UnaryExecNode with TransformSupport {
@@ -57,7 +61,7 @@ case class LimitTransformer(child: SparkPlan,
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  object MetricsUpdaterImpl extends MetricsUpdater {
+  object MetricsUpdaterImpl extends LimitMetricsUpdater {
     val inputRows: SQLMetric = longMetric("inputRows")
     val inputVectors: SQLMetric = longMetric("inputVectors")
     val inputBytes: SQLMetric = longMetric("inputBytes")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -43,6 +43,10 @@ import java.util
 import scala.collection.JavaConverters._
 import scala.util.control.Breaks.{break, breakable}
 
+trait SortMetricsUpdater extends MetricsUpdater {
+  def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit
+}
+
 case class SortExecTransformer(sortOrder: Seq[SortOrder],
                                global: Boolean,
                                child: SparkPlan,
@@ -64,7 +68,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
 
-  object MetricsUpdaterImpl extends MetricsUpdater {
+  object MetricsUpdaterImpl extends SortMetricsUpdater {
     val inputRows: SQLMetric = longMetric("inputRows")
     val inputVectors: SQLMetric = longMetric("inputVectors")
     val inputBytes: SQLMetric = longMetric("inputBytes")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Limit over Sort is converted to TopN node in Velox, so there is only one suite of metrics for the two transformers. This PR fixed the NPE caused by metrics missing.


## How was this patch tested?

Locally tested.

