### PR TITLE
Partial enable GlutenDatasetSuite

### DIFF
--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
@@ -373,7 +373,7 @@ case class GlutenHashAggregateExecTransformer(
           childrenNodes.add(ExpressionBuilder.makeSelection(colIdx))
           colIdx += 1
         case _ =>
-          aggregateFunc.children.toList.map(_ => {
+          aggregateFunc.inputAggBufferAttributes.toList.map(_ => {
             childrenNodes.add(ExpressionBuilder.makeSelection(colIdx))
             colIdx += 1
             aggExpr

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -209,10 +209,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDatasetPrimitiveSuite]
     .exclude("special floating point values")
   enableSuite[GlutenDatasetSuite]
-    .exclude("typed aggregation: expr, expr, expr, expr, expr")
-    .exclude("typed aggregation: expr, expr, expr, expr, expr, expr")
-    .exclude("typed aggregation: expr, expr, expr, expr, expr, expr, expr")
-    .exclude("typed aggregation: expr, expr, expr, expr, expr, expr, expr, expr")
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
   enableSuite[GlutenJsonFunctionsSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?
The aggregateFunc.inputAggBufferAttributes size is different with aggregateFunc.children size in the count distinct agg expression. This PR fix the mismatch column index issue in [preproject ](https://github.com/oap-project/gluten/blob/05421d735e0f5373c25b36a09a0c2e88e0aee7dc/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala#L274)and [agg ](https://github.com/oap-project/gluten/blob/05421d735e0f5373c25b36a09a0c2e88e0aee7dc/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala#L376)node by both using the aggregateFunc.inputAggBufferAttributes.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

