### PR TITLE
Support set spark session config to native query context

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHInitializerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHInitializerApi.scala
@@ -17,7 +17,6 @@
 package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.GlutenConfig
-import io.glutenproject.GlutenPlugin.buildNativeConfNode
 import io.glutenproject.backendsapi.IInitializerApi
 import io.glutenproject.vectorized.{CHNativeExpressionEvaluator, JniLibLoader}
 
@@ -36,6 +35,6 @@ class CHInitializerApi extends IInitializerApi {
     // Path based load. Ignore all other loadees.
     JniLibLoader.loadFromPath(libPath, true)
     val initKernel = new CHNativeExpressionEvaluator()
-    initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
+    initKernel.initNative(conf)
   }
 }

--- a/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleInitializerApi.scala
+++ b/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleInitializerApi.scala
@@ -20,7 +20,6 @@ package io.glutenproject.backendsapi.gazelle
 import io.glutenproject.vectorized.{GlutenNativeExpressionEvaluator, JniLibLoader, JniWorkspace}
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.IInitializerApi
-import io.glutenproject.GlutenPlugin.buildNativeConfNode
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.spark.SparkConf
@@ -44,6 +43,6 @@ class GazelleInitializerApi extends IInitializerApi {
     loader.mapAndLoad(baseLibName, true)
     loader.mapAndLoad(GlutenConfig.GLUTEN_GAZELLE_BACKEND, false)
     val initKernel = new GlutenNativeExpressionEvaluator()
-    initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
+    initKernel.initNative(conf)
   }
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
@@ -19,7 +19,6 @@ package io.glutenproject.backendsapi.velox
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.IInitializerApi
 import io.glutenproject.vectorized.{GlutenNativeExpressionEvaluator, JniLibLoader, JniWorkspace}
-import io.glutenproject.GlutenPlugin.buildNativeConfNode
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.spark.SparkConf
@@ -42,6 +41,6 @@ class VeloxInitializerApi extends IInitializerApi {
     loader.mapAndLoad(baseLibName, true)
     loader.mapAndLoad(GlutenConfig.GLUTEN_VELOX_BACKEND, true)
     val initKernel = new GlutenNativeExpressionEvaluator()
-    initKernel.initNative(buildNativeConfNode(conf).toProtobuf.toByteArray)
+    initKernel.initNative(conf)
   }
 }

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -168,6 +168,7 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
         jni/JniWrapper.cc
         compute/Backend.cc
         compute/ResultIterator.cc
+        config/GlutenConfig.cc
         memory/MemoryAllocator.cc
         memory/ArrowMemoryPool.cc
         ${PROTO_SRCS}

--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -36,7 +36,8 @@ class Backend : public std::enable_shared_from_this<Backend> {
 
   virtual std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<ResultIterator>> inputs = {}) = 0;
+      std::vector<std::shared_ptr<ResultIterator>> inputs = {},
+      std::unordered_map<std::string, std::string> sessionConf = {}) = 0;
 
   bool ParsePlan(const uint8_t* data, int32_t size) {
     return ParsePlan(data, size, -1, -1, -1);
@@ -61,10 +62,6 @@ class Backend : public std::enable_shared_from_this<Backend> {
 
   const ::substrait::Plan& GetPlan() const {
     return plan_;
-  }
-
-  std::unordered_map<std::string, std::string> GetConf() const {
-    return confMap_;
   }
 
   /// This function is used to create certain converter from the format used by
@@ -93,6 +90,7 @@ class Backend : public std::enable_shared_from_this<Backend> {
 
  protected:
   ::substrait::Plan plan_;
+  // static conf map
   std::unordered_map<std::string, std::string> confMap_;
 };
 

--- a/cpp/core/compute/BackendTest.cc
+++ b/cpp/core/compute/BackendTest.cc
@@ -25,7 +25,8 @@ class DummyBackend final : public Backend {
  public:
   std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<ResultIterator>> inputs = {}) override {
+      std::vector<std::shared_ptr<ResultIterator>> inputs = {},
+      std::unordered_map<std::string, std::string> sessionConf = {}) override {
     auto res_iter = std::make_unique<DummyResultIterator>();
     return std::make_shared<ResultIterator>(std::move(res_iter));
   }

--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include "compute/ProtobufUtils.h"
+#include "jni/JniErrors.h"
+#include "substrait/plan.pb.h"
+
+namespace gluten {
+std::unordered_map<std::string, std::string> getConfMap(JNIEnv* env, jbyteArray planArray) {
+  std::unordered_map<std::string, std::string> sparkConfs;
+  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
+  auto planSize = env->GetArrayLength(planArray);
+  ::substrait::Plan subPlan;
+  gluten::ParseProtobuf(planData, planSize, &subPlan);
+
+  if (subPlan.has_advanced_extensions()) {
+    auto extension = subPlan.advanced_extensions();
+    if (extension.has_enhancement()) {
+      const auto& enhancement = extension.enhancement();
+      ::substrait::Expression expression;
+      if (!enhancement.UnpackTo(&expression)) {
+        std::string error_message =
+            "Can't Unapck the Any object to Expression Literal when passing the spark conf to velox";
+        gluten::JniThrow(error_message);
+      }
+      if (expression.has_literal()) {
+        auto literal = expression.literal();
+        if (literal.has_map()) {
+          auto literal_map = literal.map();
+          auto size = literal_map.key_values_size();
+          for (auto i = 0; i < size; i++) {
+            ::substrait::Expression_Literal_Map_KeyValue keyValue = literal_map.key_values(i);
+            sparkConfs.emplace(keyValue.key().string(), keyValue.value().string());
+          }
+        }
+      }
+    }
+  }
+  return sparkConfs;
+}
+} // namespace gluten

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -21,4 +21,6 @@
 
 namespace gluten {
 const std::string kGlutenSaveDir = "spark.gluten.saveDir";
-}
+
+std::unordered_map<std::string, std::string> getConfMap(JNIEnv* env, jbyteArray planArray);
+} // namespace gluten

--- a/cpp/gazelle-cpp/compute/SubstraitArrow.cc
+++ b/cpp/gazelle-cpp/compute/SubstraitArrow.cc
@@ -49,7 +49,8 @@ ArrowBackend::~ArrowBackend() {
 
 std::shared_ptr<gluten::ResultIterator> ArrowBackend::GetResultIterator(
     gluten::MemoryAllocator* allocator,
-    std::vector<std::shared_ptr<gluten::ResultIterator>> inputs) {
+    std::vector<std::shared_ptr<gluten::ResultIterator>> inputs,
+    std::unordered_map<std::string, std::string> sessionConf) {
   GLUTEN_ASSIGN_OR_THROW(auto decls, arrow::engine::ConvertPlan(plan_));
   if (decls.size() != 1) {
     throw gluten::GlutenException("Expected 1 decl, but got " + std::to_string(decls.size()));

--- a/cpp/gazelle-cpp/compute/SubstraitArrow.h
+++ b/cpp/gazelle-cpp/compute/SubstraitArrow.h
@@ -33,7 +33,8 @@ class ArrowBackend final : public Backend {
 
   std::shared_ptr<gluten::ResultIterator> GetResultIterator(
       gluten::MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<gluten::ResultIterator>> inputs = {}) override;
+      std::vector<std::shared_ptr<gluten::ResultIterator>> inputs = {},
+      std::unordered_map<std::string, std::string> sessionConf = {}) override;
 
   std::shared_ptr<arrow::Schema> GetOutputSchema() override;
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -378,7 +378,8 @@ void VeloxBackend::getInfoAndIds(
 
 std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
     MemoryAllocator* allocator,
-    std::vector<std::shared_ptr<ResultIterator>> inputs) {
+    std::vector<std::shared_ptr<ResultIterator>> inputs,
+    std::unordered_map<std::string, std::string> sessionConf) {
   if (inputs.size() > 0) {
     arrowInputIters_ = std::move(inputs);
   }
@@ -396,18 +397,19 @@ std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter =
-        std::make_unique<WholeStageResultIteratorMiddleStage>(veloxPool, planNode_, streamIds, confMap_);
+        std::make_unique<WholeStageResultIteratorMiddleStage>(veloxPool, planNode_, streamIds, sessionConf);
     return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
   } else {
     auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
-        veloxPool, planNode_, scanIds, scanInfos, streamIds, confMap_);
+        veloxPool, planNode_, scanIds, scanInfos, streamIds, sessionConf);
     return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
   }
 }
 
 std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
     MemoryAllocator* allocator,
-    const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& setScanInfos) {
+    const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& setScanInfos,
+    std::unordered_map<std::string, std::string> sessionConf) {
   planNode_ = getVeloxPlanNode(plan_);
 
   // In test, use setScanInfos to replace the one got from Substrait.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -68,12 +68,14 @@ class VeloxBackend final : public Backend {
 
   std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      std::vector<std::shared_ptr<ResultIterator>> inputs = {}) override;
+      std::vector<std::shared_ptr<ResultIterator>> inputs = {},
+      std::unordered_map<std::string, std::string> sessionConf = {}) override;
 
   // Used by unit test and benchmark.
   std::shared_ptr<ResultIterator> GetResultIterator(
       MemoryAllocator* allocator,
-      const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos);
+      const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos,
+      std::unordered_map<std::string, std::string> sessionConf = {});
 
   arrow::Result<std::shared_ptr<ColumnarToRowConverter>> getColumnar2RowConverter(
       MemoryAllocator* allocator,

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -25,6 +25,7 @@
 #include "compute/DwrfDatasource.h"
 #include "compute/RegistrationAllFunctions.h"
 #include "compute/VeloxBackend.h"
+#include "config/GlutenConfig.h"
 #include "jni/JniErrors.h"
 #include "memory/VeloxMemoryPool.h"
 #include "velox/substrait/SubstraitToVeloxPlanValidator.h"
@@ -34,42 +35,6 @@
 using namespace facebook::velox;
 
 static std::unordered_map<std::string, std::string> sparkConfs_;
-
-// Extract Spark confs from Substrait plan and set them to the conf map.
-void setUpConfMap(JNIEnv* env, jobject obj, jbyteArray planArray) {
-  if (sparkConfs_.size() != 0) {
-    return;
-  }
-
-  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
-  auto planSize = env->GetArrayLength(planArray);
-  ::substrait::Plan subPlan;
-  gluten::ParseProtobuf(planData, planSize, &subPlan);
-
-  if (subPlan.has_advanced_extensions()) {
-    auto extension = subPlan.advanced_extensions();
-    if (extension.has_enhancement()) {
-      const auto& enhancement = extension.enhancement();
-      ::substrait::Expression expression;
-      if (!enhancement.UnpackTo(&expression)) {
-        std::string error_message =
-            "Can't Unapck the Any object to Expression Literal when passing the spark conf to velox";
-        gluten::JniThrow(error_message);
-      }
-      if (expression.has_literal()) {
-        auto literal = expression.literal();
-        if (literal.has_map()) {
-          auto literal_map = literal.map();
-          auto size = literal_map.key_values_size();
-          for (auto i = 0; i < size; i++) {
-            ::substrait::Expression_Literal_Map_KeyValue keyValue = literal_map.key_values(i);
-            sparkConfs_.emplace(keyValue.key().string(), keyValue.value().string());
-          }
-        }
-      }
-    }
-  }
-}
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,7 +62,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWr
     jobject obj,
     jbyteArray planArray) {
   JNI_METHOD_START
-  setUpConfMap(env, obj, planArray);
+  sparkConfs_ = gluten::getConfMap(env, planArray);
   gluten::SetBackendFactory([] { return std::make_shared<gluten::VeloxBackend>(sparkConfs_); });
   static auto veloxInitializer = std::make_shared<gluten::VeloxInitializer>(sparkConfs_);
   JNI_METHOD_END()

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -55,7 +55,8 @@ public class ExpressionEvaluatorJniWrapper {
                                                     int stageId,
                                                     int partitionId,
                                                     long taskId,
-                                                    boolean saveInputToFile
+                                                    boolean saveInputToFile,
+                                                    byte[] confPlan
   ) throws RuntimeException;
 
   /**

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -20,18 +20,14 @@ package io.glutenproject
 import java.util
 import java.util.{Collections, Objects}
 import scala.language.implicitConversions
-import com.google.protobuf.Any
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.{ColumnarOverrides, ColumnarQueryStagePrepOverrides, OthersExtensionOverrides, StrategyOverrides}
-import io.glutenproject.substrait.expression.ExpressionBuilder
-import io.glutenproject.substrait.extensions.ExtensionBuilder
-import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.internal.StaticSQLConf
 
 class GlutenPlugin extends SparkPlugin {
   override def driverPlugin(): DriverPlugin = {
@@ -152,65 +148,5 @@ private[glutenproject] object GlutenPlugin {
 
   implicit def sparkConfImplicit(conf: SparkConf): SparkConfImplicits = {
     new SparkConfImplicits(conf)
-  }
-
-  def buildNativeConfNode(conf: SparkConf): PlanNode = {
-    val nativeConfMap = new util.HashMap[String, String]()
-
-    if (conf.contains(GlutenConfig.SPARK_HIVE_EXEC_ORC_STRIPE_SIZE)) {
-      nativeConfMap.put(
-        GlutenConfig.HIVE_EXEC_ORC_STRIPE_SIZE,
-        conf.get(GlutenConfig.SPARK_HIVE_EXEC_ORC_STRIPE_SIZE))
-    }
-    if (conf.contains(GlutenConfig.SPARK_HIVE_EXEC_ORC_ROW_INDEX_STRIDE)) {
-      nativeConfMap.put(
-        GlutenConfig.HIVE_EXEC_ORC_ROW_INDEX_STRIDE,
-        conf.get(GlutenConfig.SPARK_HIVE_EXEC_ORC_ROW_INDEX_STRIDE))
-    }
-    if (conf.contains(GlutenConfig.SPARK_HIVE_EXEC_ORC_COMPRESS)) {
-      nativeConfMap.put(
-        GlutenConfig.HIVE_EXEC_ORC_COMPRESS, conf.get(GlutenConfig.SPARK_HIVE_EXEC_ORC_COMPRESS))
-    }
-
-    // HDFS config
-    nativeConfMap.put(
-      GlutenConfig.SPARK_HDFS_URI, conf.get(GlutenConfig.SPARK_HDFS_URI, "hdfs://localhost:9000"))
-
-    // S3 config
-    nativeConfMap.put(
-      GlutenConfig.SPARK_S3_ACCESS_KEY, conf.get(GlutenConfig.SPARK_S3_ACCESS_KEY, "minio"))
-    nativeConfMap.put(
-      GlutenConfig.SPARK_S3_SECRET_KEY, conf.get(GlutenConfig.SPARK_S3_SECRET_KEY, "miniopass"))
-    nativeConfMap.put(
-      GlutenConfig.SPARK_S3_ENDPOINT, conf.get(GlutenConfig.SPARK_S3_ENDPOINT, "localhost:9000"))
-    nativeConfMap.put(GlutenConfig.SPARK_S3_CONNECTION_SSL_ENABLED,
-      conf.get(GlutenConfig.SPARK_S3_CONNECTION_SSL_ENABLED, "false"))
-    nativeConfMap.put(GlutenConfig.SPARK_S3_PATH_STYLE_ACCESS,
-      conf.get(GlutenConfig.SPARK_S3_PATH_STYLE_ACCESS, "true"))
-    nativeConfMap.put(GlutenConfig.SPARK_S3_USE_INSTANCE_CREDENTIALS,
-      conf.get(GlutenConfig.SPARK_S3_USE_INSTANCE_CREDENTIALS, "false"))
-
-    conf.getAll.filter {
-      case (k, v) => k.startsWith(BackendsApiManager.getSettings.getBackendConfigPrefix())
-    }.foreach {
-      case (k, v) => nativeConfMap.put(k, v)
-    }
-
-    nativeConfMap.put(
-      SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key,
-      conf.get(SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key, "32768"))
-
-    if (conf.contains(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)) {
-      nativeConfMap.put(
-        GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY,
-        conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY).toString)
-    }
-
-    nativeConfMap.put(GlutenConfig.GLUTEN_SAVE_DIR, conf.get(GlutenConfig.GLUTEN_SAVE_DIR, ""))
-
-    val stringMapNode = ExpressionBuilder.makeStringMap(nativeConfMap)
-    val extensionNode = ExtensionBuilder
-      .makeAdvancedExtension(Any.pack(stringMapNode.toProtobuf))
-    PlanBuilder.makePlan(extensionNode)
   }
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -345,7 +345,9 @@ object GlutenConfig {
     nativeConfMap
   }
 
-  def getNativeStaticConf(conf: SparkConf, backendsPrefix: String): util.Map[String, String] = {
+  // TODO: some of the config is dynamic in spark, but is static in gluten, because it should be
+  //  used to construct HiveConnector which intends reused in velox
+  def getNativeStaticConf(conf: SparkConf, backendPrefix: String): util.Map[String, String] = {
     val nativeConfMap = new util.HashMap[String, String]()
     val keys = ImmutableList.of(
       // DWRF datasource config
@@ -373,7 +375,7 @@ object GlutenConfig {
     keyWithDefault.forEach(e => nativeConfMap.put(e._1, conf.get(e._1, e._2)))
     // velox cache and HiveConnector config
     conf.getAll
-      .filter(_._1.startsWith(backendsPrefix))
+      .filter(_._1.startsWith(backendPrefix))
       .foreach(entry => nativeConfMap.put(entry._1, entry._2))
 
     // for further use


### PR DESCRIPTION
Move some configs from static config to session config
Some configs in spark is not static, such as `hadoop.fs.defaultFS`,  but in gluten, it is static, because it should be used to register Hive connector which should be reused in velox