### PR TITLE
Upgrade substrait-core to 0.5.0 to avoid failing download in the US

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <fasterxml.version>${fasterxml.spark33.version}</fasterxml.version>
     <junit.version>4.13.1</junit.version>
 
-    <substrait.version>gluten-0.1</substrait.version>
+    <substrait.version>0.5.0</substrait.version>
     <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.16.3</protobuf.version>
     <protobuf.substrait.version>3.21.7</protobuf.substrait.version>
@@ -691,19 +691,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>Kyligence</id>
-      <name>Kyligence Repository</name>
-      <url>https://repository.kyligence.io/repository/maven-public/
-      </url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/substrait/substrait-spark/src/test/scala/io/substrait/spark/expression/ArithmeticExpressionSuite.scala
+++ b/substrait/substrait-spark/src/test/scala/io/substrait/spark/expression/ArithmeticExpressionSuite.scala
@@ -27,7 +27,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with SubstraitExpressionTe
 
   test("+ (Add)") {
     runTest(
-      "add:opt_i64_i64",
+      "add:i64_i64",
       Add(Literal(1), Literal(2L)),
       func => {
         assertResult(true)(func.arguments().get(1).isInstanceOf[SExpression.I64Literal])
@@ -38,15 +38,15 @@ class ArithmeticExpressionSuite extends SparkFunSuite with SubstraitExpressionTe
     ) // TODO: implicit calcite cast
 
     runTest(
-      "add:opt_i64_i64",
+      "add:i64_i64",
       Add(Cast(Literal(1), LongType), Literal(2L)),
       func => {},
       bidirectional = true)
 
-    runTest("add:opt_i32_i32", Add(Literal(1), Cast(Literal(2L), IntegerType)))
+    runTest("add:i32_i32", Add(Literal(1), Cast(Literal(2L), IntegerType)))
 
     runTest(
-      "add:opt_i32_i32",
+      "add:i32_i32",
       Add(Literal(1), Literal(2)),
       func => {
         assertResult(true)(func.arguments().get(0).isInstanceOf[SExpression.I32Literal])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Substrait didn't push to the public repo when substrait-spark is added to gluten last year.

Let's upgrade substrait-core to 0.5.0 to avoid failing download in the US.


## How was this patch tested?

Using existed UT

