### PR TITLE
Fix scan format validation for datasource v2

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -18,10 +18,9 @@ package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi._
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{OrcReadFormat, ParquetReadFormat}
 
-import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
 
 class CHBackend extends Backend {
@@ -56,10 +55,10 @@ object CHBackendSettings extends BackendSettings {
       ".customized.buffer.size"
   val GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE_DEFAULT = "4096"
 
-  override def supportFileFormatRead(): FileFormat => Boolean = {
-    case _: ParquetFileFormat => true
-    case _: OrcFileFormat => true
-    case _ => false
+  override def supportFileFormatRead: ReadFileFormat => Boolean = {
+    case ParquetReadFormat => true
+    case OrcReadFormat => true
+    case _ => true
   }
 
   override def utilizeShuffledHashJoinHint(): Boolean = true

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -22,6 +22,7 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{OrcReadFormat, ParquetReadFormat}
 
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{ArrayType, StructField}
 
 class CHBackend extends Backend {
   override def name(): String = GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND
@@ -55,10 +56,15 @@ object CHBackendSettings extends BackendSettings {
       ".customized.buffer.size"
   val GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE_DEFAULT = "4096"
 
-  override def supportFileFormatRead: ReadFileFormat => Boolean = {
-    case ParquetReadFormat => true
-    case OrcReadFormat => true
-    case _ => true
+  override def supportFileFormatRead(
+      format: ReadFileFormat,
+      fields: Array[StructField]): Boolean = {
+    format match {
+      case ParquetReadFormat => true
+      case OrcReadFormat => true
+      // True for CH backend for unknown type.
+      case _ => true
+    }
   }
 
   override def utilizeShuffledHashJoinHint(): Boolean = true

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partition
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.execution.datasources.v1.ClickHouseFileIndex
+import org.apache.spark.sql.types.{ArrayType, StructField}
 
 class CHTransformerApi extends ITransformerApi with Logging {
 
@@ -76,8 +77,8 @@ class CHTransformerApi extends ITransformerApi with Logging {
    * @return
    *   true if backend supports reading the file format.
    */
-  def supportsReadFileFormat(fileFormat: ReadFileFormat): Boolean =
-    BackendsApiManager.getSettings.supportFileFormatRead(fileFormat)
+  def supportsReadFileFormat(fileFormat: ReadFileFormat, fields: Array[StructField]): Boolean =
+    BackendsApiManager.getSettings.supportFileFormatRead(fileFormat, fields)
 
   /** Generate Seq[InputPartition] for FileSourceScanExecTransformer. */
   def genInputPartitionSeq(

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
@@ -21,6 +21,7 @@ import io.glutenproject.backendsapi.{BackendsApiManager, ITransformerApi}
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.SelectionNode
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.utils.CHInputPartitionsUtil
 
 import org.apache.spark.internal.Logging
@@ -75,7 +76,7 @@ class CHTransformerApi extends ITransformerApi with Logging {
    * @return
    *   true if backend supports reading the file format.
    */
-  def supportsReadFileFormat(fileFormat: FileFormat): Boolean =
+  def supportsReadFileFormat(fileFormat: ReadFileFormat): Boolean =
     BackendsApiManager.getSettings.supportFileFormatRead(fileFormat)
 
   /** Generate Seq[InputPartition] for FileSourceScanExecTransformer. */

--- a/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleBackend.scala
+++ b/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleBackend.scala
@@ -21,6 +21,7 @@ import io.glutenproject.backendsapi._
 
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.ParquetReadFormat
+import org.apache.spark.sql.types.{ArrayType, StructField}
 
 // FIXME The backend reuses some of Velox BE's code. Cleanup is needed
 //  to avoid this.
@@ -35,9 +36,12 @@ class GazelleBackend extends Backend {
 }
 
 object GazelleBackendSettings extends BackendSettings {
-  override def supportFileFormatRead: ReadFileFormat => Boolean = {
-    case ParquetReadFormat => true
-    case _ => false
+  override def supportFileFormatRead(format: ReadFileFormat,
+                                     fields: Array[StructField]): Boolean = {
+    format match {
+      case ParquetReadFormat => true
+      case _ => false
+    }
   }
 
   override def disableVanillaColumnarReaders(): Boolean = true

--- a/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleBackend.scala
+++ b/backends-gazelle/src/main/scala/io/glutenproject/backendsapi/gazelle/GazelleBackend.scala
@@ -18,8 +18,9 @@ package io.glutenproject.backendsapi.gazelle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi._
-import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.ParquetReadFormat
 
 // FIXME The backend reuses some of Velox BE's code. Cleanup is needed
 //  to avoid this.
@@ -34,8 +35,8 @@ class GazelleBackend extends Backend {
 }
 
 object GazelleBackendSettings extends BackendSettings {
-  override def supportFileFormatRead: FileFormat => Boolean = {
-    case _: ParquetFileFormat => true
+  override def supportFileFormatRead: ReadFileFormat => Boolean = {
+    case ParquetReadFormat => true
     case _ => false
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -19,12 +19,9 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi._
-
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
 import org.apache.spark.sql.catalyst.plans.JoinType
-import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
-import org.apache.spark.sql.execution.datasources.velox.DwrfFileFormat
 
 class VeloxBackend extends Backend {
   override def name: String = GlutenConfig.GLUTEN_VELOX_BACKEND
@@ -37,8 +34,9 @@ class VeloxBackend extends Backend {
 }
 
 object VeloxBackendSettings extends BackendSettings {
-  override def supportFileFormatRead(): FileFormat => Boolean = {
-    case _ : ParquetFileFormat  | _ : DwrfFileFormat => true
+  override def supportFileFormatRead: ReadFileFormat => Boolean = {
+    case ParquetReadFormat => true
+    case DwrfReadFormat => true
     case _ => false
   }
   override def supportExpandExec(): Boolean = true

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -20,8 +20,9 @@ package io.glutenproject.backendsapi.velox
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi._
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, ParquetReadFormat}
 import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.types.{ArrayType, BooleanType, ByteType, MapType, StructField, StructType}
 
 class VeloxBackend extends Backend {
   override def name: String = GlutenConfig.GLUTEN_VELOX_BACKEND
@@ -34,11 +35,23 @@ class VeloxBackend extends Backend {
 }
 
 object VeloxBackendSettings extends BackendSettings {
-  override def supportFileFormatRead: ReadFileFormat => Boolean = {
-    case ParquetReadFormat => true
-    case DwrfReadFormat => true
-    case _ => false
+  override def supportFileFormatRead(format: ReadFileFormat,
+                                     fields: Array[StructField]): Boolean = {
+    format match {
+      case ParquetReadFormat =>
+        // Unsupported types are prevented.
+        fields.map(_.dataType).collect {
+          case _: BooleanType =>
+          case _: ByteType =>
+          case _: ArrayType =>
+          case _: MapType =>
+          case _: StructType =>
+        }.isEmpty
+      case DwrfReadFormat => true
+      case _ => false
+    }
   }
+
   override def supportExpandExec(): Boolean = true
   override def needProjectExpandOutput: Boolean = true
   override def supportSortExec(): Boolean = true

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
@@ -20,9 +20,10 @@ import io.glutenproject.GlutenConfig
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.types.StructField
 
 trait BackendSettings {
-  def supportFileFormatRead: ReadFileFormat => Boolean = _ => false
+  def supportFileFormatRead(format: ReadFileFormat, fields: Array[StructField]): Boolean = false
   def supportExpandExec(): Boolean = false
   def needProjectExpandOutput: Boolean = false
   def supportSortExec(): Boolean = false

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
@@ -17,12 +17,12 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.GlutenConfig
-
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.datasources.FileFormat
 
 trait BackendSettings {
-  def supportFileFormatRead: FileFormat => Boolean = _ => false
+  def supportFileFormatRead: ReadFileFormat => Boolean = _ => false
   def supportExpandExec(): Boolean = false
   def needProjectExpandOutput: Boolean = false
   def supportSortExec(): Boolean = false

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
@@ -21,7 +21,8 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.types.StructField
 
 trait ITransformerApi {
 
@@ -38,7 +39,7 @@ trait ITransformerApi {
    *
    * @return true if backend supports reading the file format.
    */
-  def supportsReadFileFormat(fileFormat: ReadFileFormat): Boolean
+  def supportsReadFileFormat(fileFormat: ReadFileFormat, fields: Array[StructField]): Boolean
 
   /**
    * Generate Seq[InputPartition] for FileSourceScanExecTransformer.

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ITransformerApi.scala
@@ -17,6 +17,7 @@
 
 package io.glutenproject.backendsapi
 
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.connector.read.InputPartition
@@ -37,7 +38,7 @@ trait ITransformerApi {
    *
    * @return true if backend supports reading the file format.
    */
-  def supportsReadFileFormat(fileFormat: FileFormat): Boolean
+  def supportsReadFileFormat(fileFormat: ReadFileFormat): Boolean
 
   /**
    * Generate Seq[InputPartition] for FileSourceScanExecTransformer.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -18,7 +18,7 @@
 package io.glutenproject.execution
 
 import com.google.common.collect.Lists
-import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, ParquetReadFormat}
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.ParquetReadFormat
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter}
@@ -85,18 +85,19 @@ trait BasicScanExecTransformer extends TransformSupport {
   }
 
   override def doValidate(): Boolean = {
-    // TODO need also check orc file format and also move this check in native.
-    ConverterUtils.getFileFormat(this) match {
+    val fileFormat = ConverterUtils.getFileFormat(this)
+    if (!BackendsApiManager.getTransformerApiInstance.supportsReadFileFormat(fileFormat)) {
+      logDebug(
+        s"Validation failed for ${this.getClass.toString} due to $fileFormat is not supported.")
+      return false
+    }
+    fileFormat match {
       case ParquetReadFormat =>
         if (BackendsApiManager.getBackendName.equals("velox") &&
           unsupportedDataType()) {
           return false
         }
-      case DwrfReadFormat =>
       case _ =>
-        if (BackendsApiManager.getBackendName.equals("velox")) {
-          return false
-      }
     }
 
     val substraitContext = new SubstraitContext

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -18,7 +18,6 @@
 package io.glutenproject.execution
 
 import com.google.common.collect.Lists
-import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.ParquetReadFormat
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter}
@@ -74,41 +73,23 @@ trait BasicScanExecTransformer extends TransformSupport {
     )
   }
 
-  def unsupportedDataType () : Boolean = {
-    schema.fields.map(_.dataType).collect{
-      case byte: ByteType =>
-      case array: ArrayType =>
-      case bool: BooleanType =>
-      case map: MapType =>
-      case struct: StructType =>
-    }.nonEmpty
-  }
-
   override def doValidate(): Boolean = {
     val fileFormat = ConverterUtils.getFileFormat(this)
-    if (!BackendsApiManager.getTransformerApiInstance.supportsReadFileFormat(fileFormat)) {
+    if (!BackendsApiManager
+      .getTransformerApiInstance.supportsReadFileFormat(fileFormat, schema.fields)) {
       logDebug(
         s"Validation failed for ${this.getClass.toString} due to $fileFormat is not supported.")
       return false
     }
-    fileFormat match {
-      case ParquetReadFormat =>
-        if (BackendsApiManager.getBackendName.equals("velox") &&
-          unsupportedDataType()) {
-          return false
-        }
-      case _ =>
-    }
 
     val substraitContext = new SubstraitContext
-    val relNode =
-      try {
-        doTransform(substraitContext).root
-      } catch {
-        case e: Throwable =>
-          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
-          return false
-      }
+    val relNode = try {
+      doTransform(substraitContext).root
+    } catch {
+      case e: Throwable =>
+        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        return false
+    }
 
     if (GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
@@ -117,6 +98,7 @@ trait BasicScanExecTransformer extends TransformSupport {
       true
     }
   }
+
   def collectAttributesNamesDFS(attributes: Seq[Attribute]): java.util.ArrayList[String] = {
     val nameList = new java.util.ArrayList[String]()
     attributes.foreach(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -95,10 +95,11 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     }
   }
 
-  override def filterExprs(): Seq[Expression] = if (scan.isInstanceOf[FileScan]) {
-    scan.asInstanceOf[FileScan].dataFilters ++ pushdownFilters
-  } else {
-    throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
+  override def filterExprs(): Seq[Expression] = scan match {
+    case fileScan: FileScan =>
+      fileScan.dataFilters ++ pushdownFilters
+    case _ =>
+      throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
   }
 
   override def outputAttributes(): Seq[Attribute] = output

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -181,8 +181,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
 
   override def doValidate(): Boolean = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
-    if (BackendsApiManager.getTransformerApiInstance.supportsReadFileFormat(relation.fileFormat) &&
-    !bucketedScan) {
+    if (!bucketedScan) {
       super.doValidate()
     } else {
       false

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -367,8 +367,7 @@ object ConverterUtils extends Logging {
           case "DwrfFileFormat" => ReadFileFormat.DwrfReadFormat
           case _ => ReadFileFormat.UnknownFormat
         }
-      case other =>
-        throw new UnsupportedOperationException(s"$other not supported.")
+      case _ => ReadFileFormat.UnknownFormat
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenTransformerApi.scala
+++ b/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenTransformerApi.scala
@@ -18,13 +18,13 @@
 package io.glutenproject.backendsapi.glutendata
 
 import io.glutenproject.backendsapi.{BackendsApiManager, ITransformerApi}
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.utils.{GlutenArrowUtil, InputPartitionsUtil}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, PartitionDirectory}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 
 abstract class GlutenTransformerApi extends ITransformerApi with Logging {
@@ -62,7 +62,7 @@ abstract class GlutenTransformerApi extends ITransformerApi with Logging {
    *
    * @return true if backend supports reading the file format.
    */
-  override def supportsReadFileFormat(fileFormat: FileFormat): Boolean = {
+  override def supportsReadFileFormat(fileFormat: ReadFileFormat): Boolean = {
     BackendsApiManager.getSettings.supportFileFormatRead(fileFormat)
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenTransformerApi.scala
+++ b/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenTransformerApi.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
-import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
+import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
 
 abstract class GlutenTransformerApi extends ITransformerApi with Logging {
 
@@ -62,8 +62,9 @@ abstract class GlutenTransformerApi extends ITransformerApi with Logging {
    *
    * @return true if backend supports reading the file format.
    */
-  override def supportsReadFileFormat(fileFormat: ReadFileFormat): Boolean = {
-    BackendsApiManager.getSettings.supportFileFormatRead(fileFormat)
+  override def supportsReadFileFormat(fileFormat: ReadFileFormat,
+                                      fields: Array[StructField]): Boolean = {
+    BackendsApiManager.getSettings.supportFileFormatRead(fileFormat, fields)
   }
 
   /**

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -243,6 +243,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenNestedDataSourceV1Suite]
   enableSuite[GlutenNestedDataSourceV2Suite]
   enableSuite[GlutenBinaryFileFormatSuite]
+    .exclude("column pruning - non-readable file")
   enableSuite[GlutenCSVv1Suite]
   enableSuite[GlutenCSVv2Suite]
   enableSuite[GlutenCSVLegacyTimeParserSuite]
@@ -255,8 +256,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenOrcColumnarBatchReaderSuite]
   enableSuite[GlutenOrcFilterSuite]
     .exclude("SPARK-32622: case sensitivity in predicate pushdown")
-  // enableSuite[GlutenOrcPartitionDiscoverySuite]
-  // enableSuite[GlutenOrcV1PartitionDiscoverySuite]
+  enableSuite[GlutenOrcPartitionDiscoverySuite]
+  enableSuite[GlutenOrcV1PartitionDiscoverySuite]
   // enableSuite[GlutenOrcV1QuerySuite]
   // enableSuite[GlutenOrcV2QuerySuite]
   // enableSuite[GlutenOrcSourceSuite]
@@ -304,7 +305,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenFileIndexSuite]
   enableSuite[GlutenParquetCodecSuite]
     .exclude("write and read - file source parquet - codec: lz4")
-  // enableSuite[GlutenOrcCodecSuite]
+  enableSuite[GlutenOrcCodecSuite]
   enableSuite[GlutenFileSourceStrategySuite]
     .exclude("partitioned table - after scan filters")
     .exclude(
@@ -316,9 +317,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenCSVReadSchemaSuite]
   enableSuite[GlutenHeaderCSVReadSchemaSuite]
   enableSuite[GlutenJsonReadSchemaSuite]
-  // enableSuite[GlutenOrcReadSchemaSuite]
+  enableSuite[GlutenOrcReadSchemaSuite]
   // enableSuite[GlutenVectorizedOrcReadSchemaSuite]
-  // enableSuite[GlutenMergedOrcReadSchemaSuite]
+  enableSuite[GlutenMergedOrcReadSchemaSuite]
   enableSuite[GlutenParquetReadSchemaSuite]
   enableSuite[GlutenVectorizedParquetReadSchemaSuite]
   enableSuite[GlutenMergedParquetReadSchemaSuite]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -243,17 +243,15 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenNestedDataSourceV1Suite]
   enableSuite[GlutenNestedDataSourceV2Suite]
   enableSuite[GlutenBinaryFileFormatSuite]
-    .exclude("column pruning - non-readable file")
-  // enableSuite[GlutenCSVv1Suite]
-  // enableSuite[GlutenCSVv2Suite]
-  // enableSuite[GlutenCSVLegacyTimeParserSuite]
+  enableSuite[GlutenCSVv1Suite]
+  enableSuite[GlutenCSVv2Suite]
+  enableSuite[GlutenCSVLegacyTimeParserSuite]
   enableSuite[GlutenJsonV1Suite]
-    .exclude("SPARK-35047: Write Non-ASCII character as codepoint")
-    .exclude("SPARK-35104: Fix wrong indentation for multiple JSON even if `pretty` option is true")
-  // enableSuite[GlutenJsonV2Suite]
+  enableSuite[GlutenJsonV2Suite]
+    .exclude("SPARK-23772 ignore column of all null values or empty array during schema inference")
   enableSuite[GlutenJsonLegacyTimeParserSuite]
   enableSuite[GlutenTextV1Suite]
-  // enableSuite[GlutenTextV2Suite]
+  enableSuite[GlutenTextV2Suite]
   enableSuite[GlutenOrcColumnarBatchReaderSuite]
   enableSuite[GlutenOrcFilterSuite]
     .exclude("SPARK-32622: case sensitivity in predicate pushdown")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously, the scan format validation does not take effect for datasource v2. This PR aligned the validation logic for both v1 and v2.


## How was this patch tested?

under test

