### PR TITLE
Imrove formatcppcode.sh

### DIFF
--- a/dev/formatcppcode.sh
+++ b/dev/formatcppcode.sh
@@ -1,1 +1,3 @@
-find cpp/ -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format -style=file -i {} \;
+find cpp/core -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-11 -style=file -i {} \;
+find cpp/velox -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-11 -style=file -i {} \;
+find cpp/gazelle-cpp -regex '.*\.\(cc\|hpp\|cu\|c\|h\)' -exec clang-format-11 -style=file -i {} \;


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. make executing the `format` script faster by specifying `cpp` code's subdirectories.
2. specifying the version for `clang-format`.

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

