### PR TITLE
Partial enable GlutenDatasetSuite

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -218,7 +218,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDatasetOptimizationSuite]
   enableSuite[GlutenDatasetPrimitiveSuite]
   enableSuite[GlutenDatasetSuite]
-    // the result is same with vanilla spark after sort.
+    // Rewrite the following two tests in GlutenDatasetSuite.
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
   enableSuite[GlutenJsonFunctionsSuite]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -218,6 +218,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDatasetOptimizationSuite]
   enableSuite[GlutenDatasetPrimitiveSuite]
   enableSuite[GlutenDatasetSuite]
+    // the result is same with vanilla spark after sort.
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
   enableSuite[GlutenJsonFunctionsSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDatasetSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDatasetSuite.scala
@@ -17,16 +17,42 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.execution.ColumnarShuffleExchangeAdaptor
+
 class GlutenDatasetSuite extends DatasetSuite with GlutenSQLTestsTrait {
   import testImplicits._
 
-  test("dropDuplicates: columns with same column name after sort") {
+  test("Gluten: dropDuplicates: columns with same column name") {
     val ds1 = Seq(("a", 1), ("a", 2), ("b", 1), ("a", 1)).toDS()
     val ds2 = Seq(("a", 1), ("a", 2), ("b", 1), ("a", 1)).toDS()
     // The dataset joined has two columns of the same name "_2".
     val joined = ds1.join(ds2, "_1").select(ds1("_2").as[Int], ds2("_2").as[Int])
+    // Using the checkDatasetUnorderly method to sort the result in Gluten.
     checkDatasetUnorderly(
       joined.dropDuplicates(),
       (1, 2), (1, 1), (2, 1), (2, 2))
+  }
+
+  test("Gluten: groupBy.as") {
+    val df1 = Seq(DoubleData(1, "one"), DoubleData(2, "two"), DoubleData(3, "three")).toDS()
+      .repartition($"id").sortWithinPartitions("id")
+    val df2 = Seq(DoubleData(5, "one"), DoubleData(1, "two"), DoubleData(3, "three")).toDS()
+      .repartition($"id").sortWithinPartitions("id")
+
+    val df3 = df1.groupBy("id").as[Int, DoubleData]
+      .cogroup(df2.groupBy("id").as[Int, DoubleData]) { case (key, data1, data2) =>
+        if (key == 1) {
+          Iterator(DoubleData(key, (data1 ++ data2).foldLeft("")((cur, next) => cur + next.val1)))
+        } else Iterator.empty
+      }
+    checkDataset(df3, DoubleData(1, "onetwo"))
+
+    // Assert that no extra shuffle introduced by cogroup.
+    val exchanges = collect(df3.queryExecution.executedPlan) {
+      case h: ColumnarShuffleExchangeAdaptor => h
+    }
+    // Assert the number of ColumnarShuffleExchangeAdaptor
+    // instead of ShuffleExchangeExec in Gluten.
+    assert(exchanges.size == 2)
   }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDatasetSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDatasetSuite.scala
@@ -18,4 +18,15 @@
 package org.apache.spark.sql
 
 class GlutenDatasetSuite extends DatasetSuite with GlutenSQLTestsTrait {
+  import testImplicits._
+
+  test("dropDuplicates: columns with same column name after sort") {
+    val ds1 = Seq(("a", 1), ("a", 2), ("b", 1), ("a", 1)).toDS()
+    val ds2 = Seq(("a", 1), ("a", 2), ("b", 1), ("a", 1)).toDS()
+    // The dataset joined has two columns of the same name "_2".
+    val joined = ds1.join(ds2, "_1").select(ds1("_2").as[Int], ds2("_2").as[Int])
+    checkDatasetUnorderly(
+      joined.dropDuplicates(),
+      (1, 2), (1, 1), (2, 1), (2, 2))
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include `test("dropDuplicates: columns with same column name")` in GlutenDatasetSuite to sort the result by using `checkDatasetUnorderly ` method instead of  `checkDataset ` method to check the result.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

