### PR TITLE
Enable GlutenEnsureRequirementsSuite.

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -230,7 +230,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenXPathFunctionsSuite]
   // enableSuite[GlutenFileBasedDataSourceSuite]
   enableSuite[GlutenEnsureRequirementsSuite]
-    .exclude("SPARK-35675: EnsureRequirements remove shuffle should respect PartitioningCollection")
+    // Rewrite to change the shuffle partitions for optimizing repartition
+    .excludeByPrefix("SPARK-35675")
   // enableSuite[GlutenCoalesceShufflePartitionsSuite]
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
   enableSuite[GlutenDSV2CharVarcharTestSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/exchange/GlutenEnsureRequirementsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/exchange/GlutenEnsureRequirementsSuite.scala
@@ -18,7 +18,24 @@
 package org.apache.spark.sql.execution.exchange
 
 import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
+import org.apache.spark.sql.internal.SQLConf
 
 class GlutenEnsureRequirementsSuite
   extends EnsureRequirementsSuite with GlutenSQLTestsBaseTrait {
+
+  test(GLUTEN_TEST +
+      "SPARK-35675: EnsureRequirements remove shuffle should respect PartitioningCollection") {
+    import testImplicits._
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      val df1 = Seq((1, 2)).toDF("c1", "c2")
+      val df2 = Seq((1, 3)).toDF("c3", "c4")
+      val res = df1.join(df2, $"c1" === $"c3").repartition($"c1")
+      assert(res.queryExecution.executedPlan.collect {
+        case s: ShuffleExchangeLike => s
+      }.size == 2)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
To enable repartition optimization by remove shuffle, update shuffle partitions to [default value](https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala#L64).  

## How was this patch tested?

Passed UT and CI.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

