### PR TITLE
[GLUTEN-934][CH] Enhance trim function

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -200,31 +200,59 @@ object ExpressionConverter extends Logging {
             attributeSeq),
           n)
       case t: StringTrim =>
-        if (t.trimStr != None) {
-          // todo: to be remove and deal all these three exprs together
-          //  when Velox support this argument
+        if (t.srcStr.isInstanceOf[Literal]) {
           throw new UnsupportedOperationException(s"not supported yet.")
         }
-        new String2TrimExpressionTransformer(
-          substraitExprName,
-          replaceWithExpressionTransformer(t.srcStr, attributeSeq),
-          t)
+        t.trimStr match {
+          case Some(e) =>
+            new String2TrimExpressionTransformer(
+              substraitExprName,
+              replaceWithExpressionTransformer(t.srcStr, attributeSeq),
+              Some(replaceWithExpressionTransformer(e, attributeSeq)),
+              t)
+          case None =>
+            new String2TrimExpressionTransformer(
+              substraitExprName,
+              replaceWithExpressionTransformer(t.srcStr, attributeSeq),
+              None,
+              t)
+        }
       case l: StringTrimLeft =>
-        if (l.trimStr != None) {
+        if (l.srcStr.isInstanceOf[Literal]) {
           throw new UnsupportedOperationException(s"not supported yet.")
         }
-        new String2TrimExpressionTransformer(
-          substraitExprName,
-          replaceWithExpressionTransformer(l.srcStr, attributeSeq),
-          l)
+        l.trimStr match {
+          case Some(e) =>
+            new String2TrimExpressionTransformer(
+              substraitExprName,
+              replaceWithExpressionTransformer(l.srcStr, attributeSeq),
+              Some(replaceWithExpressionTransformer(e, attributeSeq)),
+              l)
+          case None =>
+            new String2TrimExpressionTransformer(
+              substraitExprName,
+              replaceWithExpressionTransformer(l.srcStr, attributeSeq),
+              None,
+              l)
+        }
       case r: StringTrimRight =>
-        if (r.trimStr != None) {
+        if (r.srcStr.isInstanceOf[Literal]) {
           throw new UnsupportedOperationException(s"not supported yet.")
         }
-        new String2TrimExpressionTransformer(
-          substraitExprName,
-          replaceWithExpressionTransformer(r.srcStr, attributeSeq),
-          r)
+        r.trimStr match {
+          case Some(e) =>
+            new String2TrimExpressionTransformer(
+              substraitExprName,
+              replaceWithExpressionTransformer(r.srcStr, attributeSeq),
+              Some(replaceWithExpressionTransformer(e, attributeSeq)),
+              r)
+          case None =>
+            new String2TrimExpressionTransformer(
+              substraitExprName,
+              replaceWithExpressionTransformer(r.srcStr, attributeSeq),
+              None,
+              r)
+        }
       case m: HashExpression[_] =>
         new HashExpressionTransformer(
           substraitExprName,

--- a/gluten-core/src/main/scala/io/glutenproject/expression/String2TrimExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/String2TrimExpressionTransformer.scala
@@ -18,18 +18,17 @@
 package io.glutenproject.expression
 
 import com.google.common.collect.Lists
-
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression._
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Expression
 
 class String2TrimExpressionTransformer(
-    substraitExprName: String,
-    srcStr: ExpressionTransformer,
-    original: Expression)
-    extends ExpressionTransformer with Logging {
+                                        substraitExprName: String,
+                                        srcStr: ExpressionTransformer,
+                                        trimTransformer: Option[ExpressionTransformer],
+                                        original: Expression)
+  extends ExpressionTransformer with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     val srcStrNode = srcStr.doTransform(args)
@@ -41,6 +40,9 @@ class String2TrimExpressionTransformer(
         FunctionConfig.REQ)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
     val expressNodes = Lists.newArrayList(srcStrNode)
+    if (trimTransformer.isDefined) {
+      expressNodes.add(trimTransformer.get.doTransform(args))
+    }
     val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)
     ExpressionBuilder.makeScalarFunction(functionId, expressNodes, typeNode)
   }

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -141,7 +141,10 @@ class ClickHouseTestSettings extends BackendTestSettings {
 
   enableSuite[GlutenStringExpressionsSuite]
     .include(
-      "concat_ws"
+      "concat_ws",
+      "TRIM",
+      "LTRIM",
+      "RTRIM"
     )
 
   enableSuite[GlutenStringFunctionsSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?

The functions in clickhouse can only trim whitespace, and the syntax of 'trim([[LEADING|TRAILING|BOTH] trim_character FROM] input_string)' is parsed into replaceRegexpAll in ExpressionListParsers.cpp, the logic is completely different from spark trim, sparkTrim is not It is easy to abstract with the trim function, because trim comes from a template class of FunctionStringToString, which only accepts one parameter, so I added a sparkTrim function to the backend, and use different functions according to different parameters.


## How was this patch tested?

GlutenStringExpressionsSuite can test this

