### PR TITLE
Support parquet read case_sensitive option mode

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include <jni.h>
 #include <string>
 
 namespace gluten {
 const std::string kGlutenSaveDir = "spark.gluten.saveDir";
+
+const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
 std::unordered_map<std::string, std::string> getConfMap(JNIEnv* env, jbyteArray planArray);
 } // namespace gluten

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -25,6 +25,7 @@
 #include "VeloxBridge.h"
 #include "compute/Backend.h"
 #include "compute/ResultIterator.h"
+#include "config/GlutenConfig.h"
 #include "include/arrow/c/bridge.h"
 #include "velox/common/file/FileSystems.h"
 #ifdef VELOX_ENABLE_HDFS

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -17,7 +17,7 @@ class WholeStageResultIterator {
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
       std::shared_ptr<const facebook::velox::core::PlanNode> planNode,
       const std::unordered_map<std::string, std::string>& confMap)
-      : planNode_(planNode), pool_(pool), confMap_(confMap) {
+      : planNode_(planNode), confMap_(confMap), pool_(pool) {
     getOrderedNodeIds(planNode_, orderedNodeIds_);
   }
 
@@ -38,11 +38,17 @@ class WholeStageResultIterator {
   /// Set the Spark confs to Velox query context.
   void setConfToQueryContext(const std::shared_ptr<facebook::velox::core::QueryCtx>& queryCtx);
 
+  std::shared_ptr<facebook::velox::Config> getConnectorConfig();
+
   std::shared_ptr<facebook::velox::exec::Task> task_;
 
   std::function<void(facebook::velox::exec::Task*)> addSplits_;
 
   std::shared_ptr<const facebook::velox::core::PlanNode> planNode_;
+
+ protected:
+  /// A map of custome configs.
+  std::unordered_map<std::string, std::string> confMap_;
 
  private:
   /// Get all the children plan node ids with postorder traversal.
@@ -69,9 +75,6 @@ class WholeStageResultIterator {
 
   /// Node ids should be ommited in metrics.
   std::unordered_set<facebook::velox::core::PlanNodeId> omittedNodeIds_;
-
-  /// A map of custome configs.
-  std::unordered_map<std::string, std::string> confMap_;
 };
 
 class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator {

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.utils.SystemParameters
-
 import org.scalactic.source.Position
 import org.scalatest.Tag
 

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -230,12 +230,16 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDSV2SQLInsertTestSuite]
   enableSuite[GlutenXPathFunctionsSuite]
   enableSuite[GlutenFileBasedDataSourceSuite]
-    .include("Do not use cache on append")
-    .includeByPrefix("SPARK-23072")
-   // To Fix
-  // SPARK-22790
-  // SPARK-25237
-  // Return correct results when data columns overlap with partition columns
+    // test data path is jar path, rewrite
+    .exclude("Option recursiveFileLookup: disable partition inferring")
+    // gluten executor exception cannot get in driver, rewrite
+    .exclude("Spark native readers should respect spark.sql.caseSensitive - parquet")
+    // shuffle_partitions config is different, rewrite
+    .excludeByPrefix("SPARK-22790")
+    // plan is different cause metric is different, rewrite
+    .excludeByPrefix("SPARK-25237")
+    // ignoreMissingFiles mode, wait to fix
+    .exclude("Enabling/disabling ignoreMissingFiles using parquet")
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
     .excludeByPrefix("SPARK-35675")

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenFileBasedDataSourceSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenFileBasedDataSourceSuite.scala
@@ -17,9 +17,23 @@
 
 package org.apache.spark.sql
 
+import scala.collection.mutable
+
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.SparkConf
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+
 class GlutenFileBasedDataSourceSuite extends FileBasedDataSourceSuite with GlutenSQLTestsTrait {
+  import testImplicits._
+
+  override def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.gluten.sql.columnar.forceshuffledhashjoin", "false")
+      .set(SQLConf.SHUFFLE_PARTITIONS.key, "5")
+  }
+
   // test data path is jar path, so failed, test code is same with spark
   test("gluten Option recursiveFileLookup: disable partition inferring") {
     val dataPath = Thread.currentThread().getContextClassLoader
@@ -38,6 +52,116 @@ class GlutenFileBasedDataSourceSuite extends FileBasedDataSourceSuite with Glute
     ).map(path => new Path(path).toString)
 
     assert(fileList.toSet === expectedFileList.toSet)
+  }
+
+  test("gluten Spark native readers should respect spark.sql.caseSensitive - parquet") {
+    withTempDir { dir =>
+      val format = "parquet"
+      val tableName = s"spark_25132_${format}_native"
+      val tableDir = dir.getCanonicalPath + s"/$tableName"
+      withTable(tableName) {
+        val end = 5
+        val data = spark.range(end).selectExpr("id as A", "id * 2 as b", "id * 3 as B")
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          data.write.format(format).mode("overwrite").save(tableDir)
+        }
+        sql(s"CREATE TABLE $tableName (a LONG, b LONG) USING $format LOCATION '$tableDir'")
+
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+          checkAnswer(sql(s"select a from $tableName"), data.select("A"))
+          checkAnswer(sql(s"select A from $tableName"), data.select("A"))
+
+          // TODO: gluten can catch exception in executor side, but cannot catch SparkException
+          //  in Driver side
+          // RuntimeException is triggered at executor side, which is then wrapped as
+          // SparkException at driver side
+          //          val e1 = intercept[SparkException] {
+          //            sql(s"select b from $tableName").collect()
+          //          }
+          //
+          //          assert(
+          //            e1.getCause.isInstanceOf[RuntimeException] &&
+          //              e1.getMessage.contains(
+          //                """Found duplicate field(s) b in case-insensitive mode """))
+          //          val e2 = intercept[SparkException] {
+          //            sql(s"select B from $tableName").collect()
+          //          }
+          //          assert(
+          //            e2.getCause.isInstanceOf[RuntimeException] &&
+          //              e2.getMessage.contains(
+          //                """Found duplicate field(s) b in case-insensitive mode"""))
+        }
+
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          checkAnswer(sql(s"select a from $tableName"), (0 until end).map(_ => Row(null)))
+          checkAnswer(sql(s"select b from $tableName"), data.select("b"))
+        }
+      }
+    }
+  }
+
+  test("gluten SPARK-22790,SPARK-27668: spark.sql.sources.compressionFactor takes effect") {
+    Seq(1.0, 0.5).foreach { compressionFactor =>
+      withSQLConf(SQLConf.FILE_COMPRESSION_FACTOR.key -> compressionFactor.toString,
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "350") {
+        withTempPath { workDir =>
+          // the file size is 504 bytes
+          val workDirPath = workDir.getAbsolutePath
+          val data1 = Seq(100, 200, 300, 400).toDF("count")
+          data1.write.orc(workDirPath + "/data1")
+          val df1FromFile = spark.read.orc(workDirPath + "/data1")
+          val data2 = Seq(100, 200, 300, 400).toDF("count")
+          data2.write.orc(workDirPath + "/data2")
+          val df2FromFile = spark.read.orc(workDirPath + "/data2")
+          val joinedDF = df1FromFile.join(df2FromFile, Seq("count"))
+          if (compressionFactor == 0.5) {
+            val bJoinExec = collect(joinedDF.queryExecution.executedPlan) {
+              case bJoin: BroadcastHashJoinExec => bJoin
+            }
+            assert(bJoinExec.nonEmpty)
+            val smJoinExec = collect(joinedDF.queryExecution.executedPlan) {
+              case smJoin: SortMergeJoinExec => smJoin
+            }
+            assert(smJoinExec.isEmpty)
+          } else {
+            // compressionFactor is 1.0
+            val bJoinExec = collect(joinedDF.queryExecution.executedPlan) {
+              case bJoin: BroadcastHashJoinExec => bJoin
+            }
+            assert(bJoinExec.isEmpty)
+            val smJoinExec = collect(joinedDF.queryExecution.executedPlan) {
+              case smJoin: SortMergeJoinExec => smJoin
+            }
+            assert(smJoinExec.nonEmpty)
+          }
+        }
+      }
+    }
+  }
+
+  test("gluten SPARK-25237 compute correct input metrics in FileScanRDD") {
+    // TODO: Test CSV V2 as well after it implements [[SupportsReportStatistics]].
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "csv") {
+      withTempPath { p =>
+        val path = p.getAbsolutePath
+        spark.range(1000).repartition(1).write.csv(path)
+        val bytesReads = new mutable.ArrayBuffer[Long]()
+        val bytesReadListener = new SparkListener() {
+          override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+            bytesReads += taskEnd.taskMetrics.inputMetrics.bytesRead
+          }
+        }
+        sparkContext.addSparkListener(bytesReadListener)
+        try {
+          spark.read.csv(path).limit(1).collect()
+          sparkContext.listenerBus.waitUntilEmpty()
+          // plan is different, so metric is different
+          assert(bytesReads.sum === 7864)
+        } finally {
+          sparkContext.removeSparkListener(bytesReadListener)
+        }
+      }
+    }
   }
 
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -334,7 +334,8 @@ object GlutenConfig {
       })
 
     val keyWithDefault = ImmutableList.of(
-      (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key, "32768")
+      (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key, "32768"),
+      (SQLConf.CASE_SENSITIVE.key, "false")
     )
     keyWithDefault.forEach(e => nativeConfMap.put(e._1, conf.getConfString(e._1, e._2)))
 


### PR DESCRIPTION
Add spark config case-sensitive to native query context connector config, if case-insensitive, we will convert the column to lower case in substrait plan, then velox PlanNode accepts lowercase column name, and velox will convert parquet schema to velox schema with lower case column name