### PR TITLE
[GLUTEN-946] Upgrade arrow version to 10.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <scala.version>${spark32.scala}</scala.version>
     <spark.version>${spark32.version}</spark.version>
     <sparkbundle.version>${spark32bundle.version}</sparkbundle.version>
-    <arrow.version>10.0.0-SNAPSHOT</arrow.version>
+    <arrow.version>10.0.1</arrow.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
     <hadoop.version>${hadoop.version}</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -190,7 +190,6 @@
       </modules>
       <properties>
         <backend_type>velox</backend_type>
-        <arrow.version>10.0.0-SNAPSHOT</arrow.version>
         <build_velox_backend>ON</build_velox_backend>
       </properties>
     </profile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current arrow version of 10.0.0-SNAPSHOT does not exist in [Maven Central Repository](https://search.maven.org/), so upgrade to 10.0.1.

Fix https://github.com/oap-project/gluten/issues/946

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

