### PR TITLE
Add some sql-tests for CI, because related bugs have fixed

### DIFF
--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -380,7 +380,19 @@ class GlutenSQLQueryTestSuite extends QueryTest with SharedSparkSession with SQL
     "promoteStrings.sql",
     "stringCastAndExpressions.sql",
     "widenSetOperationTypes.sql",
-    "windowFrameCoercion.sql"
+    "windowFrameCoercion.sql",
+    "timestamp-ltz.sql",
+    "timestamp-ntz.sql",
+    "timezone.sql",
+    "transform.sql",
+    "try_arithmetic.sql",
+    "try_cast.sql",
+    "udaf.sql",
+    "union.sql",
+    "using-join.sql",
+    "window.sql",
+    "udf-union.sql",
+    "udf-window.sql"
   )
 
   /** List of supported cases to run with Clickhouse backend, in lower case.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just add some SQL cases into GlutenSQLQueryTestSuite for CI, because related bugfixes patches have merged: 
https://github.com/oap-project/velox/pull/106
https://github.com/oap-project/velox/pull/122
https://github.com/oap-project/gluten/pull/879



## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

