### PR TITLE
[GLUTEN-1250][CORE] feat: Support Complete HashAgg mode

### DIFF
--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
@@ -55,6 +55,9 @@ public class AggregateFunctionNode implements Serializable {
         case "FINAL":
           aggBuilder.setPhase(AggregationPhase.AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT);
           break;
+        case "COMPLETE":
+          aggBuilder.setPhase(AggregationPhase.AGGREGATION_PHASE_INITIAL_TO_RESULT);
+          break;
         default:
           aggBuilder.setPhase(AggregationPhase.AGGREGATION_PHASE_UNSPECIFIED);
       }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -306,8 +306,10 @@ abstract class HashAggregateExecBaseTransformer(
       aggExpr.mode match {
         case Partial =>
           aggregateFunc.children.foreach(expression => appendIfNotFound(expression))
+        case Complete =>
+          aggregateFunc.children.foreach(expression => appendIfNotFound(expression))
         case other =>
-          throw new UnsupportedOperationException(s"$other not supported.")
+          throw new UnsupportedOperationException(s"getAggRelWithPreProjection $other not supported.")
       }
     })
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -290,6 +290,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           BindReferences.bindReference(expr, attributeSeq, allowFailures = true)
         if (bindReference == expr) {
           // This means bind failure.
+          logDebug(s"not able to found the matching attribute in $expr")
           throw new UnsupportedOperationException(s"$expr attribute binding failed.")
         } else {
           val b = bindReference.asInstanceOf[BoundReference]

--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
@@ -264,7 +264,6 @@ case class GlutenHashAggregateExecTransformer(
               modeKeyWord,
               getIntermediateTypeNode(aggregateFunction))
             aggregateNodeList.add(partialNode)
-<<<<<<< HEAD
           case PartialMerge =>
             val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
               VeloxAggregateFunctionsBuilder
@@ -272,14 +271,12 @@ case class GlutenHashAggregateExecTransformer(
               childrenNodeList,
               modeKeyWord,
               getIntermediateTypeNode(aggregateFunction))
-=======
           case Complete =>
             val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
               AggregateFunctionsBuilder.create(args, aggregateFunction),
               childrenNodeList,
-              modeToKeyWord(aggregateMode),
+              modeKeyWord,
               ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable))
->>>>>>> 95dc63d59... Support Complete mode in Hashagg
             aggregateNodeList.add(aggFunctionNode)
           case Final =>
             val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(

--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
@@ -264,6 +264,7 @@ case class GlutenHashAggregateExecTransformer(
               modeKeyWord,
               getIntermediateTypeNode(aggregateFunction))
             aggregateNodeList.add(partialNode)
+<<<<<<< HEAD
           case PartialMerge =>
             val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
               VeloxAggregateFunctionsBuilder
@@ -271,6 +272,14 @@ case class GlutenHashAggregateExecTransformer(
               childrenNodeList,
               modeKeyWord,
               getIntermediateTypeNode(aggregateFunction))
+=======
+          case Complete =>
+            val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
+              AggregateFunctionsBuilder.create(args, aggregateFunction),
+              childrenNodeList,
+              modeToKeyWord(aggregateMode),
+              ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable))
+>>>>>>> 95dc63d59... Support Complete mode in Hashagg
             aggregateNodeList.add(aggFunctionNode)
           case Final =>
             val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch adds support for "complete" hashagg mode

Usually hashagg will use "partial" plus "final" modes, the complete mode is used when direct hashagg result is expected, e.g., when pushing partial hashagg thru join

fixes: #1250 

## How was this patch tested?

pass GHA

