### PR TITLE
Enable maven cache from GHA CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Setup docker container
         run: |
           EXTRA_DOCKER_OPTIONS="--name arrow-backend-test-$GITHUB_RUN_ID -v /mnt/tpcds:/mnt/tpcds -v /home/sparkuser:/home/sparkuser -v /tmp:/tmp --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
+      - name: Setup maven cache
+        run: |
+          docker cp ~/.m2 arrow-backend-test-$GITHUB_RUN_ID:~/
       - name: Install Gluten Arrow-backend
         run: |
-          docker exec arrow-backend-test-$GITHUB_RUN_ID bash -c "
-          tar -zxvf /home/sparkuser/repo.tar.gz -C ~/ && \
-          cd /opt/gluten/ep/build-arrow/src && \
+          docker exec arrow-backend-test-$GITHUB_RUN_ID bash -c "cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh --arrow_branch=arrow-8.0.0-gluten-20220427a && \
           ./build_arrow_for_gazelle.sh && \
           cd /opt/gluten/cpp && mkdir build && cd build && \
@@ -62,7 +63,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup docker container
         run: |
-          EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID -v /home/sparkuser:/home/sparkuser -e NUM_THREADS=30 --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
+          EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
+      - name: Setup maven cache
+        run: |
+          docker cp ~/.m2 velox-backend-test-$GITHUB_RUN_ID:~/
       - name: Build Gluten Velox-backend third party
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c '

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup docker container
         run: |
-          EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
+          EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID -v /home/sparkuser:/home/sparkuser -e NUM_THREADS=30 --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Build Gluten Velox-backend third party
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c '

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -35,7 +35,7 @@ jobs:
           EXTRA_DOCKER_OPTIONS="--name arrow-backend-test-$GITHUB_RUN_ID -v /mnt/tpcds:/mnt/tpcds -v /home/sparkuser:/home/sparkuser -v /tmp:/tmp --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Setup maven cache
         run: |
-          docker cp ~/.m2/repository arrow-backend-test-$GITHUB_RUN_ID:~/.m2/
+          docker cp ~/.m2/repository arrow-backend-test-$GITHUB_RUN_ID:/root/.m2/
       - name: Install Gluten Arrow-backend
         run: |
           docker exec arrow-backend-test-$GITHUB_RUN_ID bash -c "cd /opt/gluten/ep/build-arrow/src && \
@@ -66,7 +66,7 @@ jobs:
           EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Setup maven cache
         run: |
-          docker cp ~/.m2/repository velox-backend-test-$GITHUB_RUN_ID:~/.m2/
+          docker cp ~/.m2/repository velox-backend-test-$GITHUB_RUN_ID:/root/.m2/
       - name: Build Gluten Velox-backend third party
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c '

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Build Gluten Velox-backend third party
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c '
-          tar -zxvf /home/sparkuser/repo.tar.gz -C ~/ && \
           cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh  && \
           ./build_arrow_for_velox.sh --build_test=ON --build_benchmarks=ON && \

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -35,7 +35,7 @@ jobs:
           EXTRA_DOCKER_OPTIONS="--name arrow-backend-test-$GITHUB_RUN_ID -v /mnt/tpcds:/mnt/tpcds -v /home/sparkuser:/home/sparkuser -v /tmp:/tmp --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Setup maven cache
         run: |
-          docker cp ~/.m2 arrow-backend-test-$GITHUB_RUN_ID:~/
+          docker cp ~/.m2/repository arrow-backend-test-$GITHUB_RUN_ID:~/.m2/
       - name: Install Gluten Arrow-backend
         run: |
           docker exec arrow-backend-test-$GITHUB_RUN_ID bash -c "cd /opt/gluten/ep/build-arrow/src && \
@@ -66,7 +66,7 @@ jobs:
           EXTRA_DOCKER_OPTIONS="--name velox-backend-test-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Setup maven cache
         run: |
-          docker cp ~/.m2 velox-backend-test-$GITHUB_RUN_ID:~/
+          docker cp ~/.m2/repository velox-backend-test-$GITHUB_RUN_ID:~/.m2/
       - name: Build Gluten Velox-backend third party
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c '

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -35,7 +35,9 @@ jobs:
           EXTRA_DOCKER_OPTIONS="--name arrow-backend-test-$GITHUB_RUN_ID -v /mnt/tpcds:/mnt/tpcds -v /home/sparkuser:/home/sparkuser -v /tmp:/tmp --detach" NON_INTERACTIVE=ON MOUNT_MAVEN_CACHE=OFF tools/gluten-te/cbash.sh sleep 14400
       - name: Install Gluten Arrow-backend
         run: |
-          docker exec arrow-backend-test-$GITHUB_RUN_ID bash -c "cd /opt/gluten/ep/build-arrow/src && \
+          docker exec arrow-backend-test-$GITHUB_RUN_ID bash -c "
+          tar -zxvf /home/sparkuser/repo.tar.gz -C ~/ && \
+          cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh --arrow_branch=arrow-8.0.0-gluten-20220427a && \
           ./build_arrow_for_gazelle.sh && \
           cd /opt/gluten/cpp && mkdir build && cd build && \
@@ -64,6 +66,7 @@ jobs:
       - name: Build Gluten Velox-backend third party
         run: |
           docker exec velox-backend-test-$GITHUB_RUN_ID bash -c '
+          tar -zxvf /home/sparkuser/repo.tar.gz -C ~/ && \
           cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh  && \
           ./build_arrow_for_velox.sh --build_test=ON --build_benchmarks=ON && \


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. enable maven cache to accelerate CI.
2. docker only have read permission of maven cache.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

