### PR TITLE
Add outputPartitioning & outputOrdering for C2R

### DIFF
--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
@@ -22,18 +22,18 @@ import io.glutenproject.execution.GlutenColumnarToRowExecBase
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper}
-
 import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.NANOSECONDS
-
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -114,6 +114,10 @@ case class GlutenColumnarToRowExec(child: SparkPlan)
   }
 
   override def output: Seq[Attribute] = child.output
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
 
   protected def doProduce(ctx: CodegenContext): String = {
     throw new RuntimeException("Codegen is not supported!")

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenColumnarToRowExec.scala
@@ -22,6 +22,7 @@ import io.glutenproject.execution.GlutenColumnarToRowExecBase
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper}
+
 import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.NANOSECONDS
+
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
@@ -51,7 +51,7 @@ trait GlutenSQLTestsBaseTrait extends SharedSparkSession with GlutenTestsBaseTra
       .set("spark.sql.files.maxPartitionBytes", "134217728")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
-      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
+//      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.sql.warehouse.dir", warehouse)
       // Avoid static evaluation by spark catalyst. But there are some UT issues

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
@@ -51,7 +51,7 @@ trait GlutenSQLTestsBaseTrait extends SharedSparkSession with GlutenTestsBaseTra
       .set("spark.sql.files.maxPartitionBytes", "134217728")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
-//      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
+      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.sql.warehouse.dir", warehouse)
       // Avoid static evaluation by spark catalyst. But there are some UT issues

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -239,7 +239,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
     .excludeByPrefix("SPARK-35675")
-  enableSuite[GlutenCoalesceShufflePartitionsSuite]
+//  enableSuite[GlutenCoalesceShufflePartitionsSuite]
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
   enableSuite[GlutenDSV2CharVarcharTestSuite]
     .exclude("char type values should be padded: nested in struct")
@@ -367,11 +367,11 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("partitioning reporting")
   enableSuite[GlutenApproxCountDistinctForIntervalsQuerySuite]
   enableSuite[GlutenCachedTableSuite]
-    .exclude("A cached table preserves the partitioning and ordering of its cached SparkPlan")
+    .include("Gluten: A cached table preserves the partitioning and ordering of its cached SparkPlan")
   enableSuite[GlutenConfigBehaviorSuite]
   enableSuite[GlutenCountMinSketchAggQuerySuite]
   enableSuite[GlutenCsvFunctionsSuite]
-    .exclude("roundtrip to_csv -> from_csv")
+    .include("roundtrip to_csv -> from_csv")
   enableSuite[GlutenCTEHintSuite]
   enableSuite[GlutenCTEInlineSuiteAEOff]
   enableSuite[GlutenCTEInlineSuiteAEOn]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -239,7 +239,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
     .excludeByPrefix("SPARK-35675")
-//  enableSuite[GlutenCoalesceShufflePartitionsSuite]
+  // enableSuite[GlutenCoalesceShufflePartitionsSuite]
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
   enableSuite[GlutenDSV2CharVarcharTestSuite]
     .exclude("char type values should be padded: nested in struct")
@@ -367,11 +367,10 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("partitioning reporting")
   enableSuite[GlutenApproxCountDistinctForIntervalsQuerySuite]
   enableSuite[GlutenCachedTableSuite]
-//    .include("A cached table preserves the partitioning and ordering of its cached SparkPlan")
   enableSuite[GlutenConfigBehaviorSuite]
   enableSuite[GlutenCountMinSketchAggQuerySuite]
   enableSuite[GlutenCsvFunctionsSuite]
-    .include("roundtrip to_csv -> from_csv")
+    .exclude("roundtrip to_csv -> from_csv")
   enableSuite[GlutenCTEHintSuite]
   enableSuite[GlutenCTEInlineSuiteAEOff]
   enableSuite[GlutenCTEInlineSuiteAEOn]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -239,7 +239,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
     .excludeByPrefix("SPARK-35675")
-  // enableSuite[GlutenCoalesceShufflePartitionsSuite]
+  enableSuite[GlutenCoalesceShufflePartitionsSuite]
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
   enableSuite[GlutenDSV2CharVarcharTestSuite]
     .exclude("char type values should be padded: nested in struct")

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -367,7 +367,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("partitioning reporting")
   enableSuite[GlutenApproxCountDistinctForIntervalsQuerySuite]
   enableSuite[GlutenCachedTableSuite]
-    .include("Gluten: A cached table preserves the partitioning and ordering of its cached SparkPlan")
+//    .include("A cached table preserves the partitioning and ordering of its cached SparkPlan")
   enableSuite[GlutenConfigBehaviorSuite]
   enableSuite[GlutenCountMinSketchAggQuerySuite]
   enableSuite[GlutenCsvFunctionsSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenCachedTableSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenCachedTableSuite.scala
@@ -17,61 +17,10 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.SparkConf
 
 class GlutenCachedTableSuite extends CachedTableSuite with GlutenSQLTestsTrait {
-  import testImplicits._
-
-  private def verifyNumExchanges(df: DataFrame, expected: Int): Unit = {
-    assert(
-      collect(df.queryExecution.executedPlan) {
-        case e: ShuffleExchangeExec =>
-          print("### exchange: " + e)
-          e
-        case p =>
-          print("###: " + p)
-      }.size == expected)
-  }
-
-  test("Gluten: A cached table preserves the partitioning and ordering of its cached SparkPlan") {
-    val table3x = testData.union(testData).union(testData)
-    table3x.createOrReplaceTempView("testData3x")
-
-    sql("SELECT key, value FROM testData3x ORDER BY key").createOrReplaceTempView("orderedTable")
-    spark.catalog.cacheTable("orderedTable")
-    assertCached(spark.table("orderedTable"))
-    // Should not have an exchange as the query is already sorted on the group by key.
-    val df = sql("SELECT key, count(*) FROM orderedTable GROUP BY key")
-    print(df.queryExecution.executedPlan)
-    verifyNumExchanges(sql("SELECT key, count(*) FROM orderedTable GROUP BY key"), 0)
-    checkAnswer(
-      sql("SELECT key, count(*) FROM orderedTable GROUP BY key ORDER BY key"),
-      sql("SELECT key, count(*) FROM testData3x GROUP BY key ORDER BY key").collect())
-    uncacheTable("orderedTable")
-    spark.catalog.dropTempView("orderedTable")
-
-    // Set up two tables distributed in the same way. Try this with the data distributed into
-    // different number of partitions.
-    for (numPartitions <- 1 until 10 by 4) {
-      withTempView("t1", "t2") {
-        testData.repartition(numPartitions, $"key").createOrReplaceTempView("t1")
-        testData2.repartition(numPartitions, $"a").createOrReplaceTempView("t2")
-        spark.catalog.cacheTable("t1")
-        spark.catalog.cacheTable("t2")
-
-        // Joining them should result in no exchanges.
-        verifyNumExchanges(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"), 0)
-        checkAnswer(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"),
-          sql("SELECT * FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a"))
-
-        // Grouping on the partition key should result in no exchanges
-        verifyNumExchanges(sql("SELECT count(*) FROM t1 GROUP BY key"), 0)
-        checkAnswer(sql("SELECT count(*) FROM t1 GROUP BY key"),
-          sql("SELECT count(*) FROM testData GROUP BY key"))
-
-        uncacheTable("t1")
-        uncacheTable("t2")
-      }
-    }
+  override def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.sql.shuffle.partitions", "5")
   }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenCachedTableSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenCachedTableSuite.scala
@@ -17,5 +17,61 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+
 class GlutenCachedTableSuite extends CachedTableSuite with GlutenSQLTestsTrait {
+  import testImplicits._
+
+  private def verifyNumExchanges(df: DataFrame, expected: Int): Unit = {
+    assert(
+      collect(df.queryExecution.executedPlan) {
+        case e: ShuffleExchangeExec =>
+          print("### exchange: " + e)
+          e
+        case p =>
+          print("###: " + p)
+      }.size == expected)
+  }
+
+  test("Gluten: A cached table preserves the partitioning and ordering of its cached SparkPlan") {
+    val table3x = testData.union(testData).union(testData)
+    table3x.createOrReplaceTempView("testData3x")
+
+    sql("SELECT key, value FROM testData3x ORDER BY key").createOrReplaceTempView("orderedTable")
+    spark.catalog.cacheTable("orderedTable")
+    assertCached(spark.table("orderedTable"))
+    // Should not have an exchange as the query is already sorted on the group by key.
+    val df = sql("SELECT key, count(*) FROM orderedTable GROUP BY key")
+    print(df.queryExecution.executedPlan)
+    verifyNumExchanges(sql("SELECT key, count(*) FROM orderedTable GROUP BY key"), 0)
+    checkAnswer(
+      sql("SELECT key, count(*) FROM orderedTable GROUP BY key ORDER BY key"),
+      sql("SELECT key, count(*) FROM testData3x GROUP BY key ORDER BY key").collect())
+    uncacheTable("orderedTable")
+    spark.catalog.dropTempView("orderedTable")
+
+    // Set up two tables distributed in the same way. Try this with the data distributed into
+    // different number of partitions.
+    for (numPartitions <- 1 until 10 by 4) {
+      withTempView("t1", "t2") {
+        testData.repartition(numPartitions, $"key").createOrReplaceTempView("t1")
+        testData2.repartition(numPartitions, $"a").createOrReplaceTempView("t2")
+        spark.catalog.cacheTable("t1")
+        spark.catalog.cacheTable("t2")
+
+        // Joining them should result in no exchanges.
+        verifyNumExchanges(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"), 0)
+        checkAnswer(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"),
+          sql("SELECT * FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a"))
+
+        // Grouping on the partition key should result in no exchanges
+        verifyNumExchanges(sql("SELECT count(*) FROM t1 GROUP BY key"), 0)
+        checkAnswer(sql("SELECT count(*) FROM t1 GROUP BY key"),
+          sql("SELECT count(*) FROM testData GROUP BY key"))
+
+        uncacheTable("t1")
+        uncacheTable("t2")
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a ut, we found the missing `outputPartitioning` for C2R can get an unnecessary shuffle exchange kept in the subsequent plans, e.g, the output partition already satisfies the requirements, so no more shuffle exchange is needed.


## How was this patch tested?

A spark ut can cover it in testing cached table.

