### PR TITLE
[VL] Enable serializing timestamp type for UnsafeRow

### DIFF
--- a/cpp/velox/compute/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/compute/VeloxColumnarToRowConverter.cc
@@ -170,6 +170,10 @@ arrow::Status VeloxColumnarToRowConverter::Write() {
         }
         break;
       }
+      case arrow::TimestampType::type_id: {
+         SERIALIZE_COLUMN(TimestampType);
+         break;
+      }
       default:
         return arrow::Status::Invalid(
             "Type " + schema_->field(col_idx)->type()->name() + " is not supported in VeloxToRow conversion.");

--- a/cpp/velox/compute/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/compute/VeloxColumnarToRowConverter.cc
@@ -171,8 +171,8 @@ arrow::Status VeloxColumnarToRowConverter::Write() {
         break;
       }
       case arrow::TimestampType::type_id: {
-         SERIALIZE_COLUMN(TimestampType);
-         break;
+        SERIALIZE_COLUMN(TimestampType);
+        break;
       }
       default:
         return arrow::Status::Invalid(


### PR DESCRIPTION
## What changes were proposed in this pull request?

For velox to row conversion, the scala code already allows timestamp type in the build checking. Here, we are enabling this type in native code.