### PR TITLE
[Gluten-core] Upgrade scala-maven-plugin from 4.3.0 to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
     <!-- plugin version-->
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-    <scala.compiler.version>4.3.0</scala.compiler.version>
+    <scala.compiler.version>4.8.0</scala.compiler.version>
     <maven.compiler.plugin>3.8.0</maven.compiler.plugin>
     <maven.jar.plugin>3.2.2</maven.jar.plugin>
     <scalastyle.version>1.0.0</scalastyle.version>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -147,7 +147,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.3.0</version>
+        <version>${scala.compiler.version}</version>
         <configuration>
           <recompileMode>all</recompileMode>
         </configuration>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -147,7 +147,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>${scala.compiler.version}</version>
+        <version>4.8.0</version>
         <configuration>
           <recompileMode>all</recompileMode>
         </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are some vulnerabilities from dependencies: [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250). At the same time, the version of log4j-core, included in its dependencies, is 2.11.2, which also has a large number of vulnerabilities. Thus we upgrade the scala-maven-plugin version from 4.3.0 to 4.8.0.

## How was this patch tested?
Unit tests.

