### PR TITLE
[GLUTEN-1533][VL][Feat] Replace sort agg with gluten hash agg

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -166,7 +166,6 @@ object VeloxBackendSettings extends BackendSettings {
 
   override def recreateJoinExecOnFallback(): Boolean = true
   override def removeHashColumnFromColumnarShuffleExchangeExec(): Boolean = true
-
   override def rescaleDecimalLiteral(): Boolean = true
 
   override def replaceSortAggWithHashAgg: Boolean = GlutenConfig.getConf.forceToUseHashAgg

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -169,9 +169,7 @@ object VeloxBackendSettings extends BackendSettings {
 
   override def rescaleDecimalLiteral(): Boolean = true
 
-  override def replaceSortAggWithHashAgg: Boolean = {
-    GlutenConfig.getConf.forceToUseHashAgg
-  }
+  override def replaceSortAggWithHashAgg: Boolean = GlutenConfig.getConf.forceToUseHashAgg
 
   /**
    * Get the config prefix for each backend

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -166,7 +166,12 @@ object VeloxBackendSettings extends BackendSettings {
 
   override def recreateJoinExecOnFallback(): Boolean = true
   override def removeHashColumnFromColumnarShuffleExchangeExec(): Boolean = true
+
   override def rescaleDecimalLiteral(): Boolean = true
+
+  override def replaceSortAggWithHashAgg: Boolean = {
+    GlutenConfig.getConf.forceToUseHashAgg
+  }
 
   /**
    * Get the config prefix for each backend

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -6,9 +6,10 @@ nav_order: 4
 
 # Spark Configurations for Gluten Plugin
 
-There are many configuration could impact the Gluten Plugin performance and can be fine tune in Spark.
+There are many configuration could impact the Gluten Plugin performance and can be fine tuned in Spark.
 You can add these configuration into spark-defaults.conf to enable or disable the setting.
 
+<<<<<<< HEAD
 | Parameters                                | Description                                                                                                                                                                                                                                                                                                      | Recommend Setting                                    |
 |-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
 | spark.driver.extraClassPath               | To add Gluten Plugin jar file in Spark Driver                                                                                                                                                                                                                                                                    | /path/to/jar_file                                    |
@@ -44,6 +45,7 @@ You can add these configuration into spark-defaults.conf to enable or disable th
 | spark.gluten.sql.native.bloomFilter       | Enable of Disable native runtime bloomfilter                                                                                                                                                                                                                                                                     | true                                                 |
 | spark.gluten.sql.columnar.wholeStage.fallback.threshold       | Configure the threshold for whether whole stage will fall back in AQE supported case by counting the number of ColumnarToRow & vanilla leaf node                                                                                                                                             | \>= 3                                                |
 | spark.gluten.loadLibFromJar               | Gluten will load dynamic link library from jars for gluten/cpp.                                                                                                                                                                                                                                                  | false                                                |
+| spark.gluten.sql.columnar.force.hashagg   | Force to use hash agg to replace sort agg. | true |
 
 
 Below is an example for spark-default.conf, if you are using conda to install OAP project.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -9,7 +9,6 @@ nav_order: 4
 There are many configuration could impact the Gluten Plugin performance and can be fine tuned in Spark.
 You can add these configuration into spark-defaults.conf to enable or disable the setting.
 
-<<<<<<< HEAD
 | Parameters                                | Description                                                                                                                                                                                                                                                                                                      | Recommend Setting                                    |
 |-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
 | spark.driver.extraClassPath               | To add Gluten Plugin jar file in Spark Driver                                                                                                                                                                                                                                                                    | /path/to/jar_file                                    |

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -88,6 +88,12 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
       conf.set("spark.sql.orc.enableVectorizedReader", "false")
       conf.set("spark.sql.inMemoryColumnarStorage.enableVectorizedReader", "false")
     }
+    // We will apply another rule named GlutenRemoveRedundantSorts to remove redundant sort after
+    // columnar rule's TransformPreOverrides. Since sort can be removed from the use of hash
+    // agg to replace sort agg, but the sort order is not satisfied by latter executed operator.
+    if (conf.getBoolean("spark.gluten.sql.columnar.force.hashagg", true)) {
+      conf.set("spark.sql.execution.removeRedundantSorts", "false")
+    }
   }
 }
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettings.scala
@@ -68,6 +68,12 @@ trait BackendSettings {
   def rescaleDecimalLiteral(): Boolean = false
 
   /**
+   * Whether to replace sort agg with hash agg., e.g., sort agg will be used in
+   * spark's planning for string type input.
+   */
+  def replaceSortAggWithHashAgg: Boolean = false
+
+  /**
    * Get the config prefix for each backend
    */
   def getBackendConfigPrefix(): String

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -25,6 +25,7 @@ import io.glutenproject.extension.columnar._
 import io.glutenproject.utils.{ColumnarShuffleUtil, LogLevelUtil, PhysicalPlanSelector}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.GlutenRemoveRedundantSorts
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BindReferences, BoundReference, Expression, Murmur3Hash, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
@@ -650,7 +651,8 @@ case class ColumnarOverrideRules(session: SparkSession)
       (_: SparkSession) => AddTransformHintRule(),
       (_: SparkSession) => TransformPreOverrides(
         this.isTopParentExchange || this.isAdaptiveContext),
-      (_: SparkSession) => RemoveTransformHintRule()) :::
+      (_: SparkSession) => RemoveTransformHintRule(),
+      (_: SparkSession) => GlutenRemoveRedundantSorts) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarPreRules() :::
       SparkUtil.extendedColumnarRules(
         session,

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, BroadcastQueryStageExec}
-import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec}
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange._
@@ -350,6 +350,23 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
+        case plan: SortAggregateExec =>
+          if (!BackendsApiManager.getSettings.replaceSortAggWithHashAgg) {
+            TransformHints.tagNotTransformable(plan)
+          }
+          if (!enableColumnarHashAgg) {
+            TransformHints.tagNotTransformable(plan)
+          }
+          val transformer = BackendsApiManager.getSparkPlanExecApiInstance
+              .genHashAggregateExecTransformer(
+                plan.requiredChildDistributionExpressions,
+                plan.groupingExpressions,
+                plan.aggregateExpressions,
+                plan.aggregateAttributes,
+                plan.initialInputBufferOffset,
+                plan.resultExpressions,
+                plan.child)
+          TransformHints.tag(plan, transformer.doValidate().toTransformHint)
         case plan: ObjectHashAggregateExec =>
           if (!enableColumnarHashAgg) {
             TransformHints.tagNotTransformable(plan)

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenRemoveRedundantSorts.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenRemoveRedundantSorts.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.execution.SortExecTransformer
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+
+/**
+ * This rule is used to to remove redundant SortExec or SortExecTransformer, similar to vanilla
+ * spark's RemoveRedundantSorts. As the use of hash agg to replace sort agg will remove pre-node
+ * SortExec, to avoid the caused potential order issue for latter node, we disable vanilla spark's
+ * RemoveRedundantSorts which is applied before columnar rule.
+ * See the setting for "spark.sql.execution.removeRedundantSorts" in GlutenPlugin.scala.
+ * And instead, we have this similar rule applied after columnar rule's TransformPreOverrides.
+ */
+object GlutenRemoveRedundantSorts extends Rule[SparkPlan] {
+  lazy val forceToUseHashAgg =
+    GlutenConfig.getConf.forceToUseHashAgg
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!forceToUseHashAgg) {
+      plan
+    } else {
+      removeSorts(plan)
+    }
+  }
+
+  private def removeSorts(plan: SparkPlan): SparkPlan = plan transform {
+    case s@SortExec(orders, _, child, _)
+      if SortOrder.orderingSatisfies(child.outputOrdering, orders) &&
+          child.outputPartitioning.satisfies(s.requiredChildDistribution.head) =>
+      child
+    case st@SortExecTransformer(orders, _, child, _)
+      if SortOrder.orderingSatisfies(child.outputOrdering, orders) &&
+          child.outputPartitioning.satisfies(st.requiredChildDistribution.head) =>
+      child
+  }
+}

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -18,6 +18,7 @@
 package io.glutenproject.utils.clickhouse
 
 import io.glutenproject.utils.BackendTestSettings
+import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.extension.{GlutenCustomerExtensionSuite, GlutenSessionExtensionSuite}
@@ -44,7 +45,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
       " before using it", // [not urgent]
       "max_by", // [not urgent]
       "min_by", // [not urgent]
-      "aggregation with filter"
+      "aggregation with filter",
+      // replaceSortAggWithHashAgg is not turned on for CH backend.
+      GLUTEN_TEST + "Test using gluten hash agg to replace vanilla spark sort agg"
     )
     .excludeByPrefix(
       "SPARK-22951", // [not urgent] dropDuplicates

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -47,7 +47,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "min_by", // [not urgent]
       "aggregation with filter",
       // replaceSortAggWithHashAgg is not turned on for CH backend.
-      GLUTEN_TEST + "Test using gluten hash agg to replace vanilla spark sort agg"
+      GLUTEN_TEST + "use gluten hash agg to replace vanilla spark sort agg"
     )
     .excludeByPrefix(
       "SPARK-22951", // [not urgent] dropDuplicates

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -119,7 +119,8 @@ class VeloxTestSettings extends BackendTestSettings {
       // Rewrite this test because the describe functions creates unmatched plan.
       "describe",
       // decimal failed ut.
-      "SPARK-22271: mean overflows and returns null for some decimal variables"
+      "SPARK-22271: mean overflows and returns null for some decimal variables",
+      "Gluten - describe"
   )
 
   enableSuite[GlutenDataFrameNaFunctionsSuite]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -118,9 +118,11 @@ class VeloxTestSettings extends BackendTestSettings {
       "NaN is greater than all other non-NaN numeric values",
       // Rewrite this test because the describe functions creates unmatched plan.
       "describe",
+      // The describe issue is just fixed by https://github.com/apache/spark/pull/40914.
+      // We can enable the below test for spark 3.4 and higher versions.
+      "Gluten - describe",
       // decimal failed ut.
-      "SPARK-22271: mean overflows and returns null for some decimal variables",
-      "Gluten - describe"
+      "SPARK-22271: mean overflows and returns null for some decimal variables"
   )
 
   enableSuite[GlutenDataFrameNaFunctionsSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import io.glutenproject.execution.GlutenHashAggregateExecTransformer
+import io.glutenproject.execution.HashAggregateExecBaseTransformer
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.functions._
 
@@ -198,7 +198,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       checkAnswer(df, Row("D") :: Nil)
       // Sort agg is expected to be replaced by gluten's hash agg.
       assert(find(df.queryExecution.executedPlan)(
-        _.isInstanceOf[GlutenHashAggregateExecTransformer]).isDefined)
+        _.isInstanceOf[HashAggregateExecBaseTransformer]).isDefined)
     }
   }
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -56,7 +56,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
     conf.getConfString("spark.gluten.sql.columnar.hashagg", "true").toBoolean
 
   // Whether to force to use gluten's hash agg for replacing vanilla spark's sort agg.
-  val forceToUseHashAgg: Boolean =
+  def forceToUseHashAgg: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.force.hashagg", "true").toBoolean
 
   // enable or disable columnar project

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -55,6 +55,10 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableColumnarHashAgg: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.hashagg", "true").toBoolean
 
+  // Whether to force to use gluten's hash agg for replacing vanilla spark's sort agg.
+  val forceToUseHashAgg: Boolean =
+    conf.getConfString("spark.gluten.sql.columnar.force.hashagg", "true").toBoolean
+
   // enable or disable columnar project
   def enableColumnarProject: Boolean =
     conf.getConfString("spark.gluten.sql.columnar.project", "true").toBoolean


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark will plan a sort agg for string type input. We are proposing to replace sort agg with gluten hash agg. And a config will determine whether to do the replacement.

In this pr, sort op prior to sort agg is removed, considering it is not needed for hash agg. Vanilla spark has a rule named `RemoveRedundantSorts` applied before columnar rule to remove redundant sorts. So removing sort op in columnar rule can cause some potential issues. That's why we disabled spark's `RemoveRedundantSorts` and introduced a new rule named `GlutenRemoveRedundantSorts` to be applied after columnar transform overrides.

Currently, this functionality is only enabled for velox backend.

#### Example:
`SELECT max(str_col) from t1`, the DAG has the below changes:
![image](https://user-images.githubusercontent.com/13806761/219550577-ee595c0e-8d2d-46c9-8cc4-c71c710665e3.png)

After:
![image](https://user-images.githubusercontent.com/13806761/219550633-b1b452b3-9460-4bc6-affa-9135c71f204e.png)

