### PR TITLE
[Gluten-986]Align and enrich Scan operator metrics

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -442,7 +442,7 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
   auto outputRows = env->NewLongArray(numMetrics);
   auto outputVectors = env->NewLongArray(numMetrics);
   auto outputBytes = env->NewLongArray(numMetrics);
-  auto count = env->NewLongArray(numMetrics);
+  auto cpuNanos = env->NewLongArray(numMetrics);
   auto wallNanos = env->NewLongArray(numMetrics);
   auto peakMemoryBytes = env->NewLongArray(numMetrics);
   auto numMemoryAllocations = env->NewLongArray(numMetrics);
@@ -465,7 +465,7 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
     env->SetLongArrayRegion(outputRows, 0, numMetrics, metrics->outputRows);
     env->SetLongArrayRegion(outputVectors, 0, numMetrics, metrics->outputVectors);
     env->SetLongArrayRegion(outputBytes, 0, numMetrics, metrics->outputBytes);
-    env->SetLongArrayRegion(count, 0, numMetrics, metrics->count);
+    env->SetLongArrayRegion(cpuNanos, 0, numMetrics, metrics->cpuNanos);
     env->SetLongArrayRegion(wallNanos, 0, numMetrics, metrics->wallNanos);
     env->SetLongArrayRegion(peakMemoryBytes, 0, numMetrics, metrics->peakMemoryBytes);
     env->SetLongArrayRegion(numMemoryAllocations, 0, numMetrics, metrics->numMemoryAllocations);
@@ -491,7 +491,7 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
       outputRows,
       outputVectors,
       outputBytes,
-      count,
+      cpuNanos,
       wallNanos,
       metrics ? metrics->veloxToArrow : -1,
       peakMemoryBytes,

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -269,7 +269,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   metrics_builder_class = CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/Metrics;");
 
   metrics_builder_constructor =
-      GetMethodIDOrError(env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J)V");
+      GetMethodIDOrError(env, metrics_builder_class, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J[J)V");
 
   serialized_arrow_array_iterator_class =
       CreateGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ArrowInIterator;");
@@ -454,6 +454,7 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
   auto numDynamicFiltersAccepted = env->NewLongArray(numMetrics);
   auto numReplacedWithDynamicFilterRows = env->NewLongArray(numMetrics);
   auto flushRowCount = env->NewLongArray(numMetrics);
+  auto scanTime = env->NewLongArray(numMetrics);
 
   if (metrics) {
     env->SetLongArrayRegion(inputRows, 0, numMetrics, metrics->inputRows);
@@ -476,6 +477,7 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
     env->SetLongArrayRegion(numDynamicFiltersAccepted, 0, numMetrics, metrics->numDynamicFiltersAccepted);
     env->SetLongArrayRegion(numReplacedWithDynamicFilterRows, 0, numMetrics, metrics->numReplacedWithDynamicFilterRows);
     env->SetLongArrayRegion(flushRowCount, 0, numMetrics, metrics->flushRowCount);
+    env->SetLongArrayRegion(scanTime, 0, numMetrics, metrics->scanTime);
   }
 
   return env->NewObject(
@@ -501,7 +503,8 @@ Java_io_glutenproject_vectorized_ArrowOutIterator_nativeFetchMetrics(JNIEnv* env
       numDynamicFiltersProduced,
       numDynamicFiltersAccepted,
       numReplacedWithDynamicFilterRows,
-      flushRowCount);
+      flushRowCount,
+      scanTime);
   JNI_METHOD_END(nullptr)
 }
 

--- a/cpp/core/utils/metrics.h
+++ b/cpp/core/utils/metrics.h
@@ -50,6 +50,7 @@ struct Metrics {
   long* numDynamicFiltersAccepted;
   long* numReplacedWithDynamicFilterRows;
   long* flushRowCount;
+  long* scanTime;
 
   Metrics(int size) : numMetrics(size) {
     inputRows = new long[numMetrics]();
@@ -72,6 +73,7 @@ struct Metrics {
     numDynamicFiltersAccepted = new long[numMetrics]();
     numReplacedWithDynamicFilterRows = new long[numMetrics]();
     flushRowCount = new long[numMetrics]();
+    scanTime = new long[numMetrics]();
   }
 
   Metrics(const Metrics&) = delete;
@@ -100,6 +102,7 @@ struct Metrics {
     delete[] numDynamicFiltersAccepted;
     delete[] numReplacedWithDynamicFilterRows;
     delete[] flushRowCount;
+    delete[] scanTime;
   }
 };
 

--- a/cpp/core/utils/metrics.h
+++ b/cpp/core/utils/metrics.h
@@ -32,7 +32,7 @@ struct Metrics {
   long* outputBytes;
 
   // CpuWallTiming.
-  long* count;
+  long* cpuNanos;
   long* wallNanos;
   long veloxToArrow;
 
@@ -61,7 +61,7 @@ struct Metrics {
     outputRows = new long[numMetrics]();
     outputVectors = new long[numMetrics]();
     outputBytes = new long[numMetrics]();
-    count = new long[numMetrics]();
+    cpuNanos = new long[numMetrics]();
     wallNanos = new long[numMetrics]();
     peakMemoryBytes = new long[numMetrics]();
     numMemoryAllocations = new long[numMetrics]();
@@ -90,7 +90,7 @@ struct Metrics {
     delete[] outputRows;
     delete[] outputVectors;
     delete[] outputBytes;
-    delete[] count;
+    delete[] cpuNanos;
     delete[] wallNanos;
     delete[] peakMemoryBytes;
     delete[] numMemoryAllocations;

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -126,7 +126,7 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->outputRows[metricsIdx] = entry.second->outputRows;
       metrics_->outputVectors[metricsIdx] = entry.second->outputVectors;
       metrics_->outputBytes[metricsIdx] = entry.second->outputBytes;
-      metrics_->count[metricsIdx] = entry.second->cpuWallTiming.count;
+      metrics_->cpuNanos[metricsIdx] = entry.second->cpuWallTiming.cpuNanos;
       metrics_->wallNanos[metricsIdx] = entry.second->cpuWallTiming.wallNanos;
       metrics_->peakMemoryBytes[metricsIdx] = entry.second->peakMemoryBytes;
       metrics_->numMemoryAllocations[metricsIdx] = entry.second->numMemoryAllocations;

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -18,6 +18,7 @@ const std::string kDynamicFiltersProduced = "dynamicFiltersProduced";
 const std::string kDynamicFiltersAccepted = "dynamicFiltersAccepted";
 const std::string kReplacedWithDynamicFilterRows = "replacedWithDynamicFilterRows";
 const std::string kFlushRowCount = "flushRowCount";
+const std::string kTotalScanTime = "totalScanTime";
 const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
 std::atomic<int32_t> taskSerial;
 } // namespace
@@ -140,6 +141,7 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->numReplacedWithDynamicFilterRows[metricsIdx] =
           runtimeMetric("sum", entry.second->customStats, kReplacedWithDynamicFilterRows);
       metrics_->flushRowCount[metricsIdx] = runtimeMetric("sum", entry.second->customStats, kFlushRowCount);
+      metrics_->scanTime[metricsIdx] = runtimeMetric("sum", entry.second->customStats, kTotalScanTime);
       metricsIdx += 1;
     }
   }

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/Metrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/Metrics.java
@@ -26,7 +26,7 @@ public class Metrics {
   public long[] outputRows;
   public long[] outputVectors;
   public long[] outputBytes;
-  public long[] count;
+  public long[] cpuNanos;
   public long[] wallNanos;
   public long[] scanTime;
   public long[] peakMemoryBytes;
@@ -53,7 +53,7 @@ public class Metrics {
       long[] outputRows,
       long[] outputVectors,
       long[] outputBytes,
-      long[] count,
+      long[] cpuNanos,
       long[] wallNanos,
       long veloxToArrow,
       long[] peakMemoryBytes,
@@ -75,7 +75,7 @@ public class Metrics {
     this.outputRows = outputRows;
     this.outputVectors = outputVectors;
     this.outputBytes = outputBytes;
-    this.count = count;
+    this.cpuNanos = cpuNanos;
     this.wallNanos = wallNanos;
     this.scanTime = scanTime;
     this.singleMetric.veloxToArrow = veloxToArrow;
@@ -105,7 +105,7 @@ public class Metrics {
         outputRows[index],
         outputVectors[index],
         outputBytes[index],
-        count[index],
+        cpuNanos[index],
         wallNanos[index],
         peakMemoryBytes[index],
         numMemoryAllocations[index],

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/Metrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/Metrics.java
@@ -28,6 +28,7 @@ public class Metrics {
   public long[] outputBytes;
   public long[] count;
   public long[] wallNanos;
+  public long[] scanTime;
   public long[] peakMemoryBytes;
   public long[] numMemoryAllocations;
   public long[] spilledBytes;
@@ -64,7 +65,8 @@ public class Metrics {
       long[] numDynamicFiltersProduced,
       long[] numDynamicFiltersAccepted,
       long[] numReplacedWithDynamicFilterRows,
-      long[] flushRowCount) {
+      long[] flushRowCount,
+      long[] scanTime) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -75,6 +77,7 @@ public class Metrics {
     this.outputBytes = outputBytes;
     this.count = count;
     this.wallNanos = wallNanos;
+    this.scanTime = scanTime;
     this.singleMetric.veloxToArrow = veloxToArrow;
     this.peakMemoryBytes = peakMemoryBytes;
     this.numMemoryAllocations = numMemoryAllocations;
@@ -113,7 +116,8 @@ public class Metrics {
         numDynamicFiltersProduced[index],
         numDynamicFiltersAccepted[index],
         numReplacedWithDynamicFilterRows[index],
-        flushRowCount[index]);
+        flushRowCount[index],
+        scanTime[index]);
   }
 
   public SingleMetric getSingleMetrics() {

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
@@ -26,7 +26,7 @@ public class OperatorMetrics {
   public long outputRows;
   public long outputVectors;
   public long outputBytes;
-  public long count;
+  public long cpuNanos;
   public long wallNanos;
   public long scanTime;
   public long peakMemoryBytes;
@@ -54,7 +54,7 @@ public class OperatorMetrics {
       long outputRows,
       long outputVectors,
       long outputBytes,
-      long count,
+      long cpuNanos,
       long wallNanos,
       long peakMemoryBytes,
       long numMemoryAllocations,
@@ -75,7 +75,7 @@ public class OperatorMetrics {
     this.outputRows = outputRows;
     this.outputVectors = outputVectors;
     this.outputBytes = outputBytes;
-    this.count = count;
+    this.cpuNanos = cpuNanos;
     this.wallNanos = wallNanos;
     this.scanTime = scanTime;
     this.peakMemoryBytes = peakMemoryBytes;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/OperatorMetrics.java
@@ -28,6 +28,7 @@ public class OperatorMetrics {
   public long outputBytes;
   public long count;
   public long wallNanos;
+  public long scanTime;
   public long peakMemoryBytes;
   public long numMemoryAllocations;
   public long spilledBytes;
@@ -64,7 +65,8 @@ public class OperatorMetrics {
       long numDynamicFiltersProduced,
       long numDynamicFiltersAccepted,
       long numReplacedWithDynamicFilterRows,
-      long flushRowCount) {
+      long flushRowCount,
+      long scanTime) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -75,6 +77,7 @@ public class OperatorMetrics {
     this.outputBytes = outputBytes;
     this.count = count;
     this.wallNanos = wallNanos;
+    this.scanTime = scanTime;
     this.peakMemoryBytes = peakMemoryBytes;
     this.numMemoryAllocations = numMemoryAllocations;
     this.spilledBytes = spilledBytes;

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -60,8 +60,8 @@ abstract class FilterExecBaseTransformer(val cond: Expression,
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_filter"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -75,7 +75,7 @@ abstract class FilterExecBaseTransformer(val cond: Expression,
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val count: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -95,7 +95,7 @@ abstract class FilterExecBaseTransformer(val cond: Expression,
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        count += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations
@@ -295,8 +295,8 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_project"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -310,7 +310,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val count: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -325,7 +325,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        count += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -45,9 +45,9 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_batchscan"),
-    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "total scan time"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
+    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"),
@@ -63,7 +63,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val count: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -86,7 +86,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        count += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -56,8 +56,8 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_expand"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -71,7 +71,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val cpuCount: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -86,7 +86,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        cpuCount += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -66,7 +66,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
     "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
     "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_filescan"),
-    "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "total scan time"),
+    "scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "total scan time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files read"),
     "metadataTime" -> SQLMetrics.createTimingMetric(sparkContext, "metadata time"),
@@ -101,6 +101,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     val outputBytes: SQLMetric = longMetric("outputBytes")
     val count: SQLMetric = longMetric("count")
     val wallNanos: SQLMetric = longMetric("wallNanos")
+    val scanTime: SQLMetric = longMetric("scanTime")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
 
@@ -124,6 +125,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
         outputBytes += operatorMetrics.outputBytes
         count += operatorMetrics.count
         wallNanos += operatorMetrics.wallNanos
+        scanTime += operatorMetrics.scanTime
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations
         numDynamicFiltersAccepted += operatorMetrics.numDynamicFiltersAccepted

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -56,16 +56,14 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     with BasicScanExecTransformer {
 
   override lazy val metrics = Map(
-    "inputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
     "inputVectors" -> SQLMetrics.createMetric(sparkContext, "number of input vectors"),
-    "inputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of input bytes"),
     "rawInputRows" -> SQLMetrics.createMetric(sparkContext, "number of raw input rows"),
     "rawInputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of raw input bytes"),
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
     "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_filescan"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "total wall time"),
     "scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "total scan time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files read"),
@@ -91,9 +89,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
   }
 
   object MetricsUpdaterImpl extends MetricsUpdater {
-    val inputRows: SQLMetric = longMetric("inputRows")
     val inputVectors: SQLMetric = longMetric("inputVectors")
-    val inputBytes: SQLMetric = longMetric("inputBytes")
     val rawInputRows: SQLMetric = longMetric("rawInputRows")
     val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
     val outputRows: SQLMetric = longMetric("outputRows")
@@ -115,9 +111,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
 
     override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
       if (operatorMetrics != null) {
-        inputRows += operatorMetrics.inputRows
         inputVectors += operatorMetrics.inputVectors
-        inputBytes += operatorMetrics.inputBytes
         rawInputRows += operatorMetrics.rawInputRows
         rawInputBytes += operatorMetrics.rawInputBytes
         outputRows += operatorMetrics.outputRows

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -56,15 +56,14 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     with BasicScanExecTransformer {
 
   override lazy val metrics = Map(
-    "inputVectors" -> SQLMetrics.createMetric(sparkContext, "number of input vectors"),
     "rawInputRows" -> SQLMetrics.createMetric(sparkContext, "number of raw input rows"),
     "rawInputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of raw input bytes"),
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "total wall time"),
-    "scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "total scan time"),
+    "scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "scan time"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files read"),
     "metadataTime" -> SQLMetrics.createTimingMetric(sparkContext, "metadata time"),
@@ -89,14 +88,13 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
   }
 
   object MetricsUpdaterImpl extends MetricsUpdater {
-    val inputVectors: SQLMetric = longMetric("inputVectors")
     val rawInputRows: SQLMetric = longMetric("rawInputRows")
     val rawInputBytes: SQLMetric = longMetric("rawInputBytes")
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val count: SQLMetric = longMetric("count")
     val wallNanos: SQLMetric = longMetric("wallNanos")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val scanTime: SQLMetric = longMetric("scanTime")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -111,14 +109,13 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
 
     override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
       if (operatorMetrics != null) {
-        inputVectors += operatorMetrics.inputVectors
         rawInputRows += operatorMetrics.rawInputRows
         rawInputBytes += operatorMetrics.rawInputBytes
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        count += operatorMetrics.count
         wallNanos += operatorMetrics.wallNanos
+        cpuNanos += operatorMetrics.cpuNanos
         scanTime += operatorMetrics.scanTime
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -77,8 +77,8 @@ abstract class HashAggregateExecBaseTransformer(
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_input"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"),
@@ -99,7 +99,7 @@ abstract class HashAggregateExecBaseTransformer(
       sparkContext, "number of preProjection output vectors"),
     "preProjectionOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of preProjection output bytes"),
-    "preProjectionCount" -> SQLMetrics.createMetric(
+    "preProjectionCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "preProjection cpu wall time count"),
     "preProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_preProjection"),
@@ -124,7 +124,7 @@ abstract class HashAggregateExecBaseTransformer(
       sparkContext, "number of aggregation output vectors"),
     "aggOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of aggregation output bytes"),
-    "aggCount" -> SQLMetrics.createMetric(
+    "aggCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "aggregation cpu wall time count"),
     "aggWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_aggregation"),
@@ -159,7 +159,7 @@ abstract class HashAggregateExecBaseTransformer(
       sparkContext, "number of extraction output vectors"),
     "extractionOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of extraction output bytes"),
-    "extractionCount" -> SQLMetrics.createMetric(
+    "extractionCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "extraction cpu wall time count"),
     "extractionWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_extraction"),
@@ -184,7 +184,7 @@ abstract class HashAggregateExecBaseTransformer(
       sparkContext, "number of postProjection output vectors"),
     "postProjectionOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of postProjection output bytes"),
-    "postProjectionCount" -> SQLMetrics.createMetric(
+    "postProjectionCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "postProjection cpu wall time count"),
     "postProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_postProjection"),
@@ -206,7 +206,7 @@ abstract class HashAggregateExecBaseTransformer(
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val count: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -292,7 +292,7 @@ abstract class HashAggregateExecBaseTransformer(
         postProjectionOutputRows += metrics.outputRows
         postProjectionOutputVectors += metrics.outputVectors
         postProjectionOutputBytes += metrics.outputBytes
-        postProjectionCount += metrics.count
+        postProjectionCount += metrics.cpuNanos
         postProjectionWallNanos += metrics.wallNanos
         postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
         postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
@@ -309,7 +309,7 @@ abstract class HashAggregateExecBaseTransformer(
         extractionOutputRows += metrics.outputRows
         extractionOutputVectors += metrics.outputVectors
         extractionOutputBytes += metrics.outputBytes
-        extractionCount += metrics.count
+        extractionCount += metrics.cpuNanos
         extractionWallNanos += metrics.wallNanos
         extractionPeakMemoryBytes += metrics.peakMemoryBytes
         extractionNumMemoryAllocations += metrics.numMemoryAllocations
@@ -325,7 +325,7 @@ abstract class HashAggregateExecBaseTransformer(
       aggOutputRows += aggMetrics.outputRows
       aggOutputVectors += aggMetrics.outputVectors
       aggOutputBytes += aggMetrics.outputBytes
-      aggCount += aggMetrics.count
+      aggCount += aggMetrics.cpuNanos
       aggWallNanos += aggMetrics.wallNanos
       aggPeakMemoryBytes += aggMetrics.peakMemoryBytes
       aggNumMemoryAllocations += aggMetrics.numMemoryAllocations
@@ -346,7 +346,7 @@ abstract class HashAggregateExecBaseTransformer(
         preProjectionOutputRows += metrics.outputRows
         preProjectionOutputVectors += metrics.outputVectors
         preProjectionOutputBytes += metrics.outputBytes
-        preProjectionCount += metrics.count
+        preProjectionCount += metrics.cpuNanos
         preProjectionWallNanos += metrics.wallNanos
         preProjectionPeakMemoryBytes += metrics.peakMemoryBytes
         preProjectionNumMemoryAllocations += metrics.numMemoryAllocations
@@ -363,7 +363,7 @@ abstract class HashAggregateExecBaseTransformer(
         outputRows += metrics.outputRows
         outputVectors += metrics.outputVectors
         outputBytes += metrics.outputBytes
-        count += metrics.count
+        cpuNanos += metrics.cpuNanos
         wallNanos += metrics.wallNanos
         peakMemoryBytes += metrics.peakMemoryBytes
         numMemoryAllocations += metrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -129,7 +129,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of stream side output vectors"),
     "streamOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of stream side output bytes"),
-    "streamCount" -> SQLMetrics.createMetric(
+    "streamCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "stream side cpu wall time count"),
     "streamWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_stream_input"),
@@ -156,7 +156,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of stream preProjection output vectors"),
     "streamPreProjectionOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of stream preProjection output bytes"),
-    "streamPreProjectionCount" -> SQLMetrics.createMetric(
+    "streamPreProjectionCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "stream preProjection cpu wall time count"),
     "streamPreProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_stream_preProjection"),
@@ -181,7 +181,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of build side output vectors"),
     "buildOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of build side output bytes"),
-    "buildCount" -> SQLMetrics.createMetric(
+    "buildCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "build side cpu wall time count"),
     "buildWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_build_input"),
@@ -206,7 +206,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of build preProjection output vectors"),
     "buildPreProjectionOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of build preProjection output bytes"),
-    "buildPreProjectionCount" -> SQLMetrics.createMetric(
+    "buildPreProjectionCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "build preProjection cpu wall time count"),
     "buildPreProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_build_preProjection"),
@@ -231,7 +231,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of hash build output vectors"),
     "hashBuildOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of hash build output bytes"),
-    "hashBuildCount" -> SQLMetrics.createMetric(
+    "hashBuildCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "hash build cpu wall time count"),
     "hashBuildWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_hashbuild"),
@@ -264,7 +264,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of hash probe output vectors"),
     "hashProbeOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of hash probe output bytes"),
-    "hashProbeCount" -> SQLMetrics.createMetric(
+    "hashProbeCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "hash probe cpu wall time count"),
     "hashProbeWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_hashprobe"),
@@ -301,7 +301,7 @@ trait HashJoinLikeExecTransformer
       sparkContext, "number of postProjection output vectors"),
     "postProjectionOutputBytes" -> SQLMetrics.createSizeMetric(
       sparkContext, "number of postProjection output bytes"),
-    "postProjectionCount" -> SQLMetrics.createMetric(
+    "postProjectionCount" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "postProjection cpu wall time count"),
     "postProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
       sparkContext, "totaltime_postProjection"),
@@ -456,7 +456,7 @@ trait HashJoinLikeExecTransformer
         postProjectionOutputRows += metrics.outputRows
         postProjectionOutputVectors += metrics.outputVectors
         postProjectionOutputBytes += metrics.outputBytes
-        postProjectionCount += metrics.count
+        postProjectionCount += metrics.cpuNanos
         postProjectionWallNanos += metrics.wallNanos
         postProjectionPeakMemoryBytes += metrics.peakMemoryBytes
         postProjectionNumMemoryAllocations += metrics.numMemoryAllocations
@@ -473,7 +473,7 @@ trait HashJoinLikeExecTransformer
       hashProbeOutputRows += hashProbeMetrics.outputRows
       hashProbeOutputVectors += hashProbeMetrics.outputVectors
       hashProbeOutputBytes += hashProbeMetrics.outputBytes
-      hashProbeCount += hashProbeMetrics.count
+      hashProbeCount += hashProbeMetrics.cpuNanos
       hashProbeWallNanos += hashProbeMetrics.wallNanos
       hashProbePeakMemoryBytes += hashProbeMetrics.peakMemoryBytes
       hashProbeNumMemoryAllocations += hashProbeMetrics.numMemoryAllocations
@@ -495,7 +495,7 @@ trait HashJoinLikeExecTransformer
       hashBuildOutputRows += hashBuildMetrics.outputRows
       hashBuildOutputVectors += hashBuildMetrics.outputVectors
       hashBuildOutputBytes += hashBuildMetrics.outputBytes
-      hashBuildCount += hashBuildMetrics.count
+      hashBuildCount += hashBuildMetrics.cpuNanos
       hashBuildWallNanos += hashBuildMetrics.wallNanos
       hashBuildPeakMemoryBytes += hashBuildMetrics.peakMemoryBytes
       hashBuildNumMemoryAllocations += hashBuildMetrics.numMemoryAllocations
@@ -515,7 +515,7 @@ trait HashJoinLikeExecTransformer
         buildPreProjectionOutputRows += metrics.outputRows
         buildPreProjectionOutputVectors += metrics.outputVectors
         buildPreProjectionOutputBytes += metrics.outputBytes
-        buildPreProjectionCount += metrics.count
+        buildPreProjectionCount += metrics.cpuNanos
         buildPreProjectionWallNanos += metrics.wallNanos
         buildPreProjectionPeakMemoryBytes += metrics.peakMemoryBytes
         buildPreProjectionNumMemoryAllocations += metrics.numMemoryAllocations
@@ -532,7 +532,7 @@ trait HashJoinLikeExecTransformer
         buildOutputRows += metrics.outputRows
         buildOutputVectors += metrics.outputVectors
         buildOutputBytes += metrics.outputBytes
-        buildCount += metrics.count
+        buildCount += metrics.cpuNanos
         buildWallNanos += metrics.wallNanos
         buildPeakMemoryBytes += metrics.peakMemoryBytes
         buildNumMemoryAllocations += metrics.numMemoryAllocations
@@ -549,7 +549,7 @@ trait HashJoinLikeExecTransformer
         streamPreProjectionOutputRows += metrics.outputRows
         streamPreProjectionOutputVectors += metrics.outputVectors
         streamPreProjectionOutputBytes += metrics.outputBytes
-        streamPreProjectionCount += metrics.count
+        streamPreProjectionCount += metrics.cpuNanos
         streamPreProjectionWallNanos += metrics.wallNanos
         streamPreProjectionPeakMemoryBytes += metrics.peakMemoryBytes
         streamPreProjectionNumMemoryAllocations += metrics.numMemoryAllocations
@@ -566,7 +566,7 @@ trait HashJoinLikeExecTransformer
         streamOutputRows += metrics.outputRows
         streamOutputVectors += metrics.outputVectors
         streamOutputBytes += metrics.outputBytes
-        streamCount += metrics.count
+        streamCount += metrics.cpuNanos
         streamWallNanos += metrics.wallNanos
         streamVeloxToArrow += singleMetrics.veloxToArrow
         streamPeakMemoryBytes += metrics.peakMemoryBytes

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -55,8 +55,8 @@ case class LimitTransformer(child: SparkPlan,
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_limit"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -70,7 +70,7 @@ case class LimitTransformer(child: SparkPlan,
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val cpuCount: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -85,7 +85,7 @@ case class LimitTransformer(child: SparkPlan,
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        cpuCount += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -62,8 +62,8 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_sort"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"),
@@ -86,7 +86,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val cpuCount: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -105,7 +105,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        cpuCount += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -484,6 +484,7 @@ object WholeStageTransformerExec extends Logging {
     var numDynamicFiltersAccepted: Long = 0
     var numReplacedWithDynamicFilterRows: Long = 0
     var flushRowCount: Long = 0
+    var scanTime: Long = 0
 
     val metricsIterator = operatorMetrics.iterator()
     while (metricsIterator.hasNext) {
@@ -500,6 +501,7 @@ object WholeStageTransformerExec extends Logging {
       numDynamicFiltersAccepted += metrics.numDynamicFiltersAccepted
       numReplacedWithDynamicFilterRows += metrics.numReplacedWithDynamicFilterRows
       flushRowCount += metrics.flushRowCount
+      scanTime += metrics.scanTime
     }
 
     new OperatorMetrics(
@@ -522,7 +524,8 @@ object WholeStageTransformerExec extends Logging {
       numDynamicFiltersProduced,
       numDynamicFiltersAccepted,
       numReplacedWithDynamicFilterRows,
-      flushRowCount
+      flushRowCount,
+      scanTime
     )
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -472,7 +472,7 @@ object WholeStageTransformerExec extends Logging {
     val outputVectors = operatorMetrics.get(0).outputVectors
     val outputBytes = operatorMetrics.get(0).outputBytes
 
-    var count: Long = 0
+    var cpuNanos: Long = 0
     var wallNanos: Long = 0
     var peakMemoryBytes: Long = 0
     var numMemoryAllocations: Long = 0
@@ -489,7 +489,7 @@ object WholeStageTransformerExec extends Logging {
     val metricsIterator = operatorMetrics.iterator()
     while (metricsIterator.hasNext) {
       val metrics = metricsIterator.next()
-      count += metrics.count
+      cpuNanos += metrics.cpuNanos
       wallNanos += metrics.wallNanos
       peakMemoryBytes = peakMemoryBytes.max(metrics.peakMemoryBytes)
       numMemoryAllocations += metrics.numMemoryAllocations
@@ -513,7 +513,7 @@ object WholeStageTransformerExec extends Logging {
       outputRows,
       outputVectors,
       outputBytes,
-      count,
+      cpuNanos,
       wallNanos,
       peakMemoryBytes,
       numMemoryAllocations,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -57,8 +57,8 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
     "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
-    "count" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_window"),
+    "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "wall time"),
+    "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time"),
     "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
     "numMemoryAllocations" -> SQLMetrics.createMetric(
       sparkContext, "number of memory allocations"))
@@ -72,7 +72,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     val outputRows: SQLMetric = longMetric("outputRows")
     val outputVectors: SQLMetric = longMetric("outputVectors")
     val outputBytes: SQLMetric = longMetric("outputBytes")
-    val cpuCount: SQLMetric = longMetric("count")
+    val cpuNanos: SQLMetric = longMetric("cpuNanos")
     val wallNanos: SQLMetric = longMetric("wallNanos")
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
@@ -87,7 +87,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
         outputRows += operatorMetrics.outputRows
         outputVectors += operatorMetrics.outputVectors
         outputBytes += operatorMetrics.outputBytes
-        cpuCount += operatorMetrics.count
+        cpuNanos += operatorMetrics.cpuNanos
         wallNanos += operatorMetrics.wallNanos
         peakMemoryBytes += operatorMetrics.peakMemoryBytes
         numMemoryAllocations += operatorMetrics.numMemoryAllocations


### PR DESCRIPTION
## What changes were proposed in this pull request?
Velox has supports to count scan IO time in this pr https://github.com/facebookincubator/velox/pull/4026.

Gluten's Scan operator lack of `scanTime` metric, this pr will fix this problem.
Use cpu nanos instead of cpu count.


## How was this patch tested?
![image](https://user-images.githubusercontent.com/34979747/220000870-18393776-df67-4170-8bb6-22142184afb7.png)
![image](https://user-images.githubusercontent.com/34979747/220000934-69ee2b60-e98e-4310-836a-778b3be0d75c.png)

