### PR TITLE
[Gluten-986] Metric "time to collect" is always 0 in ColumnarBroadcastExchange

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -42,9 +42,9 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
   extends BroadcastExchangeLike {
   override lazy val metrics = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
-    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of Rows"),
-    "totalTime" -> SQLMetrics.createTimingMetric(sparkContext, "totaltime_broadcastExchange"),
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "collectTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to collect"),
+    "buildTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to build"),
     "broadcastTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to broadcast")
   )
 
@@ -66,6 +66,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
           runId.toString,
           s"broadcast exchange (runId $runId)",
           interruptOnCancel = true)
+        val beforeCollect = System.nanoTime()
 
         // this created relation ignore HashedRelationBroadcastMode isNullAware, because we cannot
         // get child output rows, then compare the hash key is null, if not null, compare the
@@ -76,16 +77,14 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
           child,
           longMetric("numOutputRows"),
           longMetric("dataSize"))
-        val beforeCollect = System.nanoTime()
         val beforeBroadcast = System.nanoTime()
 
         longMetric("collectTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeCollect)
+        longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeCollect)
 
         // Broadcast the relation
         val broadcasted = sparkContext.broadcast(relation.asInstanceOf[Any])
         longMetric("broadcastTime") += NANOSECONDS.toMillis(System.nanoTime() - beforeBroadcast)
-        longMetric("totalTime").merge(longMetric("collectTime"))
-        longMetric("totalTime").merge(longMetric("broadcastTime"))
 
         // Update driver metrics
         val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -44,7 +44,6 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "collectTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to collect"),
-    "buildTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to build"),
     "broadcastTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to broadcast")
   )
 
@@ -80,7 +79,6 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
         val beforeBroadcast = System.nanoTime()
 
         longMetric("collectTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeCollect)
-        longMetric("buildTime") += NANOSECONDS.toMillis(beforeBroadcast - beforeCollect)
 
         // Broadcast the relation
         val broadcasted = sparkContext.broadcast(relation.asInstanceOf[Any])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove `totalTime`, fix `collectTime`, add `buildTime`.
Gluten use `BackendsApiManager.getSparkPlanExecApiInstance.createBroadcastRelation` to collect data and build relation, we don't have to separate `collectTime` and `buildTime`, cause they are almost equal.

## How was this patch tested?

before this pr
![image](https://user-images.githubusercontent.com/34979747/220233750-d9e296ee-f0d0-4c8f-8ac6-2ba46f5688c8.png)

after this pr
![image](https://user-images.githubusercontent.com/34979747/220234979-7417160f-43d7-4c12-b951-7c686e5d3cad.png)

spark behavior
![image](https://user-images.githubusercontent.com/34979747/220233909-4fb6be73-96cf-4cec-a432-b952b60860be.png)

