### PR TITLE
[Gluten-986] Support task input metrics, fix wrong output metrics.

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util.concurrent.TimeUnit
@@ -158,6 +159,7 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
       context: TaskContext,
       pipelineTime: SQLMetric,
       updateOutputMetrics: (Long, Long) => Unit,
+      updateInputMetrics: (InputMetricsWrapper) => Unit,
       updateNativeMetrics: Metrics => Unit,
       inputIterators: Seq[Iterator[ColumnarBatch]] = Seq()): Iterator[ColumnarBatch] = {
     val beforeBuild = System.nanoTime()

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -158,7 +158,6 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
       outputAttributes: Seq[Attribute],
       context: TaskContext,
       pipelineTime: SQLMetric,
-      updateOutputMetrics: (Long, Long) => Unit,
       updateInputMetrics: (InputMetricsWrapper) => Unit,
       updateNativeMetrics: Metrics => Unit,
       inputIterators: Seq[Iterator[ColumnarBatch]] = Seq()): Iterator[ColumnarBatch] = {
@@ -181,7 +180,6 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
 
       override def next(): Any = {
         val cb = resIter.next()
-        updateOutputMetrics(1, cb.numRows())
         cb
       }
     }
@@ -203,7 +201,6 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
       outputAttributes: Seq[Attribute],
       rootNode: PlanNode,
       pipelineTime: SQLMetric,
-      updateOutputMetrics: (Long, Long) => Unit,
       updateNativeMetrics: Metrics => Unit,
       buildRelationBatchHolder: Seq[ColumnarBatch]): Iterator[ColumnarBatch] = {
     // scalastyle:on argcount
@@ -227,7 +224,6 @@ class CHIteratorApi extends IIteratorApi with Logging with LogLevelUtil {
 
       override def next(): ColumnarBatch = {
         val cb = nativeIterator.next()
-        updateOutputMetrics(1, cb.numRows())
         cb
       }
     }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -30,6 +30,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 trait IIteratorApi {
@@ -74,6 +75,7 @@ trait IIteratorApi {
                             outputAttributes: Seq[Attribute], context: TaskContext,
                             pipelineTime: SQLMetric,
                             updateOutputMetrics: (Long, Long) => Unit,
+                            updateInputMetrics: (InputMetricsWrapper) => Unit,
                             updateNativeMetrics: Metrics => Unit,
                             inputIterators: Seq[Iterator[ColumnarBatch]] = Seq())
   : Iterator[ColumnarBatch]

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IIteratorApi.scala
@@ -74,7 +74,6 @@ trait IIteratorApi {
   def genFirstStageIterator(inputPartition: BaseGlutenPartition,
                             outputAttributes: Seq[Attribute], context: TaskContext,
                             pipelineTime: SQLMetric,
-                            updateOutputMetrics: (Long, Long) => Unit,
                             updateInputMetrics: (InputMetricsWrapper) => Unit,
                             updateNativeMetrics: Metrics => Unit,
                             inputIterators: Seq[Iterator[ColumnarBatch]] = Seq())
@@ -93,7 +92,6 @@ trait IIteratorApi {
                             outputAttributes: Seq[Attribute],
                             rootNode: PlanNode,
                             pipelineTime: SQLMetric,
-                            updateOutputMetrics: (Long, Long) => Unit,
                             updateNativeMetrics: Metrics => Unit,
                             buildRelationBatchHolder: Seq[ColumnarBatch])
   : Iterator[ColumnarBatch]

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -80,11 +80,6 @@ abstract class FilterExecBaseTransformer(val cond: Expression,
     val peakMemoryBytes: SQLMetric = longMetric("peakMemoryBytes")
     val numMemoryAllocations: SQLMetric = longMetric("numMemoryAllocations")
 
-    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-      outputVectors += outNumBatches
-      outputRows += outNumRows
-    }
-
     override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
       if (operatorMetrics != null) {
         inputRows += operatorMetrics.inputRows

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExecShim, FileScan}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan: Scan,
@@ -71,9 +72,9 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     // Number of dynamic filters received.
     val numDynamicFiltersAccepted: SQLMetric = longMetric("numDynamicFiltersAccepted")
 
-    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-      outputVectors += outNumBatches
-      outputRows += outNumRows
+    override def updateInputMetrics(inputMetrics: InputMetricsWrapper): Unit = {
+      inputMetrics.bridgeIncBytesRead(rawInputBytes.value)
+      inputMetrics.bridgeIncRecordsRead(rawInputRows.value)
     }
 
     override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -47,7 +47,7 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
     throw new UnsupportedOperationException(s"This operator doesn't support getBuildPlans.")
   }
 
-  override def getStreamedLeafPlan: SparkPlan = {
+  override def getStreamedLeafPlan: SparkPlan = child match {
     case c: TransformSupport =>
       c.getStreamedLeafPlan
     case _ =>

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -48,7 +48,10 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
   }
 
   override def getStreamedLeafPlan: SparkPlan = {
-    throw new UnsupportedOperationException(s"This operator doesn't support getStreamedLeafPlan.")
+    case c: TransformSupport =>
+      c.getStreamedLeafPlan
+    case _ =>
+      this
   }
 
   override def getChild: SparkPlan = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -115,7 +115,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     throw new UnsupportedOperationException(s"This operator doesn't support getBuildPlans.")
   }
 
-  override def getStreamedLeafPlan: SparkPlan = {
+  override def getStreamedLeafPlan: SparkPlan = child match {
     case c: TransformSupport =>
       c.getStreamedLeafPlan
     case _ =>

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -116,7 +116,10 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
   }
 
   override def getStreamedLeafPlan: SparkPlan = {
-    throw new UnsupportedOperationException(s"This operator doesn't support getStreamedLeafPlan.")
+    case c: TransformSupport =>
+      c.getStreamedLeafPlan
+    case _ =>
+      this
   }
 
   override def getChild: SparkPlan = child

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.{FileSourceScanExec, InSubqueryExec, SQLEx
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.collection.BitSet
 
@@ -102,9 +103,9 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     // Number of dynamic filters received.
     val numDynamicFiltersAccepted: SQLMetric = longMetric("numDynamicFiltersAccepted")
 
-    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-      outputVectors += outNumBatches
-      outputRows += outNumRows
+    override def updateInputMetrics(inputMetrics: InputMetricsWrapper): Unit = {
+      inputMetrics.bridgeIncBytesRead(rawInputBytes.value)
+      inputMetrics.bridgeIncRecordsRead(rawInputRows.value)
     }
 
     override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util._
 
@@ -101,6 +102,7 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
                                   var rdds: Seq[RDD[ColumnarBatch]],
                                   pipelineTime: SQLMetric,
                                   updateOutputMetrics: (Long, Long) => Unit,
+                                  updateInputMetrics: (InputMetricsWrapper) => Unit,
                                   updateNativeMetrics: Metrics => Unit)
   extends RDD[ColumnarBatch](sc, rdds.map(x => new OneToOneDependency(x))) {
   val numaBindingInfo = GlutenConfig.getConf.numaBindingInfo
@@ -116,6 +118,7 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
         context,
         pipelineTime,
         updateOutputMetrics,
+        updateInputMetrics,
         updateNativeMetrics)
     } else {
       val partitions = split.asInstanceOf[FirstZippedPartitionsPartition].partitions
@@ -128,6 +131,7 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
         context,
         pipelineTime,
         updateOutputMetrics,
+        updateInputMetrics,
         updateNativeMetrics,
         inputIterators)
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
@@ -101,7 +101,6 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
                                   outputAttributes: Seq[Attribute],
                                   var rdds: Seq[RDD[ColumnarBatch]],
                                   pipelineTime: SQLMetric,
-                                  updateOutputMetrics: (Long, Long) => Unit,
                                   updateInputMetrics: (InputMetricsWrapper) => Unit,
                                   updateNativeMetrics: Metrics => Unit)
   extends RDD[ColumnarBatch](sc, rdds.map(x => new OneToOneDependency(x))) {
@@ -117,7 +116,6 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
         outputAttributes,
         context,
         pipelineTime,
-        updateOutputMetrics,
         updateInputMetrics,
         updateNativeMetrics)
     } else {
@@ -130,7 +128,6 @@ class GlutenWholeStageColumnarRDD(sc: SparkContext,
         outputAttributes,
         context,
         pipelineTime,
-        updateOutputMetrics,
         updateInputMetrics,
         updateNativeMetrics,
         inputIterators)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -274,11 +274,6 @@ abstract class HashAggregateExecBaseTransformer(
     val finalOutputRows: SQLMetric = longMetric("finalOutputRows")
     val finalOutputVectors: SQLMetric = longMetric("finalOutputVectors")
 
-    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-      finalOutputVectors += outNumBatches
-      finalOutputRows += outNumRows
-    }
-
     override def updateAggregationMetrics(aggregationMetrics: java.util.ArrayList[OperatorMetrics],
                                  aggParams: AggregationParams): Unit = {
       var idx = 0

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -433,11 +433,6 @@ trait HashJoinLikeExecTransformer
     val finalOutputRows: SQLMetric = longMetric("finalOutputRows")
     val finalOutputVectors: SQLMetric = longMetric("finalOutputVectors")
 
-    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-      finalOutputVectors += outNumBatches
-      finalOutputRows += outNumRows
-    }
-
     override def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {
       throw new UnsupportedOperationException(s"updateNativeMetrics is not supported for join.")
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -70,11 +70,6 @@ case class SortMergeJoinExecTransformer(
     val joinTime = longMetric("joinTime")
     val prepareTime = longMetric("prepareTime")
     val totaltime_sortmegejoin = longMetric("totaltime_sortmergejoin")
-
-    override def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {
-      numOutputBatches += outNumBatches
-      numOutputRows += outNumRows
-    }
   }
 
   val resultSchema = this.schema

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -60,7 +60,6 @@ case class WholestageTransformContext(
  * TODO place it to some other where since it's used not only by whole stage facilities
  */
 trait MetricsUpdater extends Serializable {
-  def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {}
   def updateInputMetrics(inputMetrics: InputMetricsWrapper): Unit = {}
   def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {}
 }
@@ -313,7 +312,6 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
         wsCxt.outputAttributes,
         genFirstNewRDDsForBroadcast(inputRDDs, partitionLength),
         pipelineTime,
-        metricsUpdater().updateOutputMetrics,
         leafMetricsUpdater().updateInputMetrics,
         metricsUpdatingFunction
       )
@@ -348,7 +346,6 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
         resCtx,
         pipelineTime,
         buildRelationBatchHolder,
-        metricsUpdater().updateOutputMetrics,
         metricsUpdatingFunction)
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -314,7 +314,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
         genFirstNewRDDsForBroadcast(inputRDDs, partitionLength),
         pipelineTime,
         metricsUpdater().updateOutputMetrics,
-        leafMetricsUpdate().updateInputMetrics,
+        leafMetricsUpdater().updateInputMetrics,
         metricsUpdatingFunction
       )
     } else {
@@ -364,7 +364,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
     }
   }
 
-  def leafMetricsUpdate(): MetricsUpdater = {
+  def leafMetricsUpdater(): MetricsUpdater = {
     getStreamedLeafPlan match {
       case transformer: TransformSupport => transformer.metricsUpdater()
       case _ => NoopMetricsUpdater

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class TransformContext(
@@ -60,6 +61,7 @@ case class WholestageTransformContext(
  */
 trait MetricsUpdater extends Serializable {
   def updateOutputMetrics(outNumBatches: Long, outNumRows: Long): Unit = {}
+  def updateInputMetrics(inputMetrics: InputMetricsWrapper): Unit = {}
   def updateNativeMetrics(operatorMetrics: OperatorMetrics): Unit = {}
 }
 
@@ -312,6 +314,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
         genFirstNewRDDsForBroadcast(inputRDDs, partitionLength),
         pipelineTime,
         metricsUpdater().updateOutputMetrics,
+        leafMetricsUpdate().updateInputMetrics,
         metricsUpdatingFunction
       )
     } else {
@@ -356,6 +359,13 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
 
   override def metricsUpdater(): MetricsUpdater = {
     child match {
+      case transformer: TransformSupport => transformer.metricsUpdater()
+      case _ => NoopMetricsUpdater
+    }
+  }
+
+  def leafMetricsUpdate(): MetricsUpdater = {
+    getStreamedLeafPlan match {
       case transformer: TransformSupport => transformer.metricsUpdater()
       case _ => NoopMetricsUpdater
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
@@ -45,7 +45,6 @@ class WholeStageZippedPartitionsRDD(@transient private val sc: SparkContext,
     resCtx: WholestageTransformContext,
     pipelineTime: SQLMetric,
     buildRelationBatchHolder: mutable.ListBuffer[ColumnarBatch],
-    updateOutputMetrics: (Long, Long) => Unit,
     updateNativeMetrics: Metrics => Unit)
   extends RDD[ColumnarBatch](sc, rdds.map(x => new OneToOneDependency(x))) {
 
@@ -58,7 +57,6 @@ class WholeStageZippedPartitionsRDD(@transient private val sc: SparkContext,
         resCtx.outputAttributes,
         resCtx.root,
         pipelineTime,
-        updateOutputMetrics,
         updateNativeMetrics,
         buildRelationBatchHolder
       )

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -153,7 +153,10 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
   }
 
   override def getStreamedLeafPlan: SparkPlan = {
-    throw new UnsupportedOperationException(s"This operator doesn't support getStreamedLeafPlan.")
+    case c: TransformSupport =>
+      c.getStreamedLeafPlan
+    case _ =>
+      this
   }
 
   override def getChild: SparkPlan = child

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -152,7 +152,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     throw new UnsupportedOperationException(s"This operator doesn't support getBuildPlans.")
   }
 
-  override def getStreamedLeafPlan: SparkPlan = {
+  override def getStreamedLeafPlan: SparkPlan = child match {
     case c: TransformSupport =>
       c.getStreamedLeafPlan
     case _ =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/utils/OASPackageBridge.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/utils/OASPackageBridge.scala
@@ -27,5 +27,9 @@ object OASPackageBridge {
     def bridgeIncBytesRead(v: Long): Unit = {
       m.incBytesRead(v)
     }
+
+    def bridgeIncRecordsRead(v: Long): Unit = {
+      m.incRecordsRead(v)
+    }
   }
 }

--- a/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenIteratorApi.scala
+++ b/gluten-data/src/main/java/io/glutenproject/backendsapi/glutendata/GlutenIteratorApi.scala
@@ -219,6 +219,7 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
                                      context: TaskContext,
                                      pipelineTime: SQLMetric,
                                      updateOutputMetrics: (Long, Long) => Unit,
+                                     updateInputMetrics: (InputMetricsWrapper) => Unit,
                                      updateNativeMetrics: Metrics => Unit,
                                      inputIterators: Seq[Iterator[ColumnarBatch]] = Seq())
   : Iterator[ColumnarBatch] = {
@@ -239,6 +240,7 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
         val res = resIter.hasNext
         if (!res) {
           updateNativeMetrics(resIter.getMetrics)
+          updateInputMetrics(inputMetrics)
         }
         res
       }
@@ -260,7 +262,6 @@ abstract class GlutenIteratorApi extends IIteratorApi with Logging {
             }.sum
           case _ => 0L
         }
-        inputMetrics.bridgeIncBytesRead(bytes)
         updateOutputMetrics(1, cb.numRows())
         cb
       }

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
@@ -58,7 +58,10 @@ case class ArrowEvalPythonExecTransformer(udfs: Seq[PythonUDF], resultAttrs: Seq
   }
 
   override def getStreamedLeafPlan: SparkPlan = {
-    throw new UnsupportedOperationException(s"This operator doesn't support getStreamedLeafPlan.")
+    case c: TransformSupport =>
+      c.getStreamedLeafPlan
+    case _ =>
+      this
   }
 
   override def getChild: SparkPlan = {

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
@@ -57,7 +57,7 @@ case class ArrowEvalPythonExecTransformer(udfs: Seq[PythonUDF], resultAttrs: Seq
     throw new UnsupportedOperationException(s"This operator doesn't support getBuildPlans.")
   }
 
-  override def getStreamedLeafPlan: SparkPlan = {
+  override def getStreamedLeafPlan: SparkPlan = child match {
     case c: TransformSupport =>
       c.getStreamedLeafPlan
     case _ =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current `MetricsUpdater::updateOutputMetrics` is unnecessary and has bug, it will count twice output metrics.

![image](https://user-images.githubusercontent.com/34979747/220350266-9531f5a0-8a63-4066-ae9d-7024dcabe73c.png)

Implement task input metrics, only Scan operator could update that.

![image](https://user-images.githubusercontent.com/34979747/220350823-1ead6a29-8d8b-4c0a-9b8d-c24c31ac953d.png)
