### PR TITLE
[VL] Add the input type info in AggregateFunctionNode

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,10 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+#VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_REPO=https://github.com/JkSelf/velox.git
+#VELOX_BRANCH=main
+VELOX_BRANCH=validation-aggFunction-with-input-type
 ENABLE_EP_CACHE=OFF
 
 for arg in "$@"

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
@@ -30,12 +30,16 @@ public class AggregateFunctionNode implements Serializable {
   private final String phase;
   private final TypeNode outputTypeNode;
 
+  private final ArrayList<TypeNode> inputTypeNodes;
+
   AggregateFunctionNode(Long functionId, ArrayList<ExpressionNode> expressionNodes,
-                        String phase, TypeNode outputTypeNode) {
+                        String phase, TypeNode outputTypeNode,
+                        ArrayList<TypeNode> inputTypeNodes) {
     this.functionId = functionId;
     this.expressionNodes.addAll(expressionNodes);
     this.phase = phase;
     this.outputTypeNode = outputTypeNode;
+    this.inputTypeNodes = inputTypeNodes;
   }
 
   public AggregateFunction toProtobuf() {
@@ -61,7 +65,13 @@ public class AggregateFunctionNode implements Serializable {
     }
     for (ExpressionNode expressionNode : expressionNodes) {
       FunctionArgument.Builder functionArgument = FunctionArgument.newBuilder();
+      // functionArgument.setType();
       functionArgument.setValue(expressionNode.toProtobuf());
+      aggBuilder.addArguments(functionArgument.build());
+    }
+    for (TypeNode inputTypeNode: inputTypeNodes) {
+      FunctionArgument.Builder functionArgument = FunctionArgument.newBuilder();
+      functionArgument.setType(inputTypeNode.toProtobuf());
       aggBuilder.addArguments(functionArgument.build());
     }
     aggBuilder.setOutputType(outputTypeNode.toProtobuf());

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
@@ -65,7 +65,6 @@ public class AggregateFunctionNode implements Serializable {
     }
     for (ExpressionNode expressionNode : expressionNodes) {
       FunctionArgument.Builder functionArgument = FunctionArgument.newBuilder();
-      // functionArgument.setType();
       functionArgument.setValue(expressionNode.toProtobuf());
       aggBuilder.addArguments(functionArgument.build());
     }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -256,8 +256,10 @@ public class ExpressionBuilder {
       Long functionId,
       ArrayList<ExpressionNode> expressionNodes,
       String phase,
-      TypeNode outputTypeNode) {
-    return new AggregateFunctionNode(functionId, expressionNodes, phase, outputTypeNode);
+      TypeNode outputTypeNode,
+      ArrayList<TypeNode> inputTypeNodes) {
+    return new AggregateFunctionNode(
+        functionId, expressionNodes, phase, outputTypeNode, inputTypeNodes);
   }
 
   public static CastNode makeCast(TypeNode typeNode, ExpressionNode expressionNode,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -689,7 +689,9 @@ abstract class HashAggregateExecBaseTransformer(
         AggregateFunctionsBuilder.create(args, aggregateFunction),
         childrenNodeList,
         modeToKeyWord(aggregateMode),
-        ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable)))
+        ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable),
+        ConverterUtils.getTypeNodeFromAttributes(
+          aggregateFunction.inputAggBufferAttributes)))
   }
 
   protected def applyPostProjection(context: SubstraitContext,

--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
@@ -166,14 +166,18 @@ case class GlutenHashAggregateExecTransformer(
               AggregateFunctionsBuilder.create(args, aggregateFunction),
               childrenNodeList,
               modeToKeyWord(aggregateMode),
-              getIntermediateTypeNode(aggregateFunction))
+              getIntermediateTypeNode(aggregateFunction),
+              ConverterUtils.getTypeNodeFromAttributes(
+                aggregateFunction.inputAggBufferAttributes))
             aggregateNodeList.add(partialNode)
           case Final =>
             val aggFunctionNode = ExpressionBuilder.makeAggregateFunction(
               AggregateFunctionsBuilder.create(args, aggregateFunction),
               childrenNodeList,
               modeToKeyWord(aggregateMode),
-              ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable))
+              ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable),
+              ConverterUtils.getTypeNodeFromAttributes(
+                aggregateFunction.inputAggBufferAttributes))
             aggregateNodeList.add(aggFunctionNode)
           case other =>
             throw new UnsupportedOperationException(s"$other is not supported.")
@@ -183,7 +187,9 @@ case class GlutenHashAggregateExecTransformer(
           AggregateFunctionsBuilder.create(args, aggregateFunction),
           childrenNodeList,
           modeToKeyWord(aggregateMode),
-          ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable))
+          ConverterUtils.getTypeNode(aggregateFunction.dataType, aggregateFunction.nullable),
+          ConverterUtils.getTypeNodeFromAttributes(
+            aggregateFunction.inputAggBufferAttributes))
         aggregateNodeList.add(aggFunctionNode)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
We need the input type node of `AggregateFunction `to distinguish the `SHROT_DECIMAL `or `LONG_DECIMAL `type in velox.


## How was this patch tested?
existing uts