### PR TITLE
[VL shuffle] Add VeloxSplitter to split with velox::RowVector

### DIFF
--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -421,13 +421,6 @@ int64_t batch_nbytes(const arrow::RecordBatch& batch) {
   }
   return accumulated;
 }
-
-int64_t batch_nbytes(std::shared_ptr<arrow::RecordBatch> batch) {
-  if (batch == nullptr) {
-    return 0;
-  }
-  return batch_nbytes(*batch);
-}
 } // anonymous namespace
 
 arrow::Status Splitter::CacheRecordBatch(int32_t partition_id, const arrow::RecordBatch& batch) {

--- a/cpp/core/tests/TestUtils.h
+++ b/cpp/core/tests/TestUtils.h
@@ -31,11 +31,10 @@
 #include <sstream>
 
 #include "utils/macros.h"
-using namespace arrow;
 
 #define ASSERT_NOT_OK(status)                  \
   do {                                         \
-    ::arrow::Status __s = (status);            \
+    arrow::Status __s = (status);              \
     if (!__s.ok()) {                           \
       throw std::runtime_error(__s.message()); \
     }                                          \
@@ -57,20 +56,20 @@ using namespace arrow;
   ARROW_ASSIGN_OR_THROW_IMPL(ARROW_ASSIGN_OR_THROW_NAME(_error_or_value, __COUNTER__), lhs, rexpr);
 
 template <typename T>
-Status Equals(const T& expected, const T& actual) {
+arrow::Status Equals(const T& expected, const T& actual) {
   if (expected.Equals(actual)) {
     return arrow::Status::OK();
   }
   std::stringstream pp_expected;
   std::stringstream pp_actual;
-  ::arrow::PrettyPrintOptions options(/*indent=*/2);
+  arrow::PrettyPrintOptions options(/*indent=*/2);
   options.window = 50;
   ASSERT_NOT_OK(PrettyPrint(expected, options, &pp_expected));
   ASSERT_NOT_OK(PrettyPrint(actual, options, &pp_actual));
   if (pp_expected.str() == pp_actual.str()) {
     return arrow::Status::OK();
   }
-  return Status::Invalid(
+  return arrow::Status::Invalid(
       "Expected RecordBatch is ",
       pp_expected.str(),
       " with schema ",
@@ -86,11 +85,11 @@ void MakeInputBatch(
     std::shared_ptr<arrow::Schema> sch,
     std::shared_ptr<arrow::RecordBatch>* input_batch) {
   // prepare input record Batch
-  std::vector<std::shared_ptr<Array>> array_list;
+  std::vector<std::shared_ptr<arrow::Array>> array_list;
   int length = -1;
   int i = 0;
   for (auto data : input_data) {
-    std::shared_ptr<Array> a0;
+    std::shared_ptr<arrow::Array> a0;
     ARROW_ASSIGN_OR_THROW(a0, arrow::ipc::internal::json::ArrayFromJSON(sch->field(i++)->type(), data.c_str()));
     if (length == -1) {
       length = a0->length();
@@ -99,6 +98,6 @@ void MakeInputBatch(
     array_list.push_back(a0);
   }
 
-  *input_batch = RecordBatch::Make(sch, length, array_list);
+  *input_batch = arrow::RecordBatch::Make(sch, length, array_list);
   return;
 }

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -158,6 +158,7 @@ endmacro()
 
 # Build Velox backend.
 set(VELOX_SRCS
+    shuffle/VeloxSplitter.cc
     jni/JniWrapper.cc
     compute/VeloxBackend.cc
     compute/WholeStageResultIterator.cc
@@ -191,6 +192,10 @@ find_package(gflags REQUIRED COMPONENTS shared CONFIG)
 target_link_libraries(velox PUBLIC spark_columnar_jni)
 add_velox_dependencies()
 target_link_libraries(velox PUBLIC Folly::folly)
+
+if(BUILD_TESTS)
+  add_test_case(velox_splitter_test SOURCES tests/VeloxSplitterTest.cc EXTRA_LINK_LIBS velox)
+endif()
 
 if(VELOX_ENABLE_HDFS)
   add_definitions(-DVELOX_ENABLE_HDFS)

--- a/cpp/velox/shuffle/VeloxSplitter.cc
+++ b/cpp/velox/shuffle/VeloxSplitter.cc
@@ -1,0 +1,1360 @@
+#include "VeloxSplitter.h"
+#include "VeloxSplitterPartitionWriter.h"
+#include "velox/vector/arrow/Bridge.h"
+
+#include "utils/compression.h"
+#include "utils/macros.h"
+
+#include "include/arrow/c/bridge.h"
+
+#if defined(__x86_64__)
+#include <immintrin.h>
+#include <x86intrin.h>
+#elif defined(__aarch64__)
+#include <arm_neon.h>
+#endif
+
+#include <iostream>
+
+using namespace facebook;
+
+#ifndef SPLIT_BUFFER_SIZE
+// by default, allocate 8M block, 2M page size
+#define SPLIT_BUFFER_SIZE 16 * 1024 * 1024
+#endif
+
+namespace gluten {
+
+// VeloxSplitter
+arrow::Result<std::shared_ptr<VeloxSplitter>>
+VeloxSplitter::Make(const std::string& name, uint32_t num_partitions, SplitOptions options) {
+  std::shared_ptr<VeloxSplitter> splitter = nullptr;
+  if (name == "hash") {
+    splitter = VeloxSplitter::Create<VeloxHashSplitter>(num_partitions, options);
+  } else if (name == "rr") {
+    splitter = VeloxSplitter::Create<VeloxRoundRobinSplitter>(num_partitions, options);
+  } else if (name == "range") {
+    splitter = VeloxSplitter::Create<VeloxFallbackRangeSplitter>(num_partitions, options);
+  } else if (name == "single") {
+    splitter = VeloxSplitter::Create<VeloxSinglePartSplitter>(num_partitions, options);
+  }
+
+  if (splitter) {
+    return splitter->Init();
+  }
+  return arrow::Status::NotImplemented("Partitioning " + name + " not supported yet.");
+}
+
+arrow::Status VeloxSplitter::Init() {
+#if defined(__x86_64__)
+  support_avx512_ = __builtin_cpu_supports("avx512bw");
+#else
+  support_avx512_ = false;
+#endif
+
+  // partition number should be less than 64k
+  ARROW_CHECK_LE(num_partitions_, 64 * 1024);
+
+  // split record batch size should be less than 32k
+  ARROW_CHECK_LE(options_.buffer_size, 32 * 1024);
+
+  // moved to InitColumnTypes()
+  // ARROW_ASSIGN_OR_RAISE(column_type_id_, ToSplitterTypeId(schema_->fields()));
+
+  partition_writer_.resize(num_partitions_);
+
+  partition_2_row_count_.resize(num_partitions_);
+
+  // pre-allocated buffer size for each partition, unit is row count
+  partition_2_buffer_size_.resize(num_partitions_);
+
+  partition_buffer_idx_base_.resize(num_partitions_);
+  partition_buffer_idx_offset_.resize(num_partitions_);
+
+  partition_cached_recordbatch_.resize(num_partitions_);
+  partition_cached_recordbatch_size_.resize(num_partitions_);
+
+  partition_lengths_.resize(num_partitions_);
+  raw_partition_lengths_.resize(num_partitions_);
+
+  partition_2_row_offset_.resize(num_partitions_ + 1);
+
+  // column related statements are moved to InitColumnTypes()
+
+  ARROW_ASSIGN_OR_RAISE(configured_dirs_, GetConfiguredLocalDirs());
+  sub_dir_selection_.assign(configured_dirs_.size(), 0);
+
+  // Both data_file and shuffle_index_file should be set through jni.
+  // For test purpose, Create a temporary subdirectory in the system temporary
+  // dir with prefix "columnar-shuffle"
+  if (options_.data_file.length() == 0) {
+    ARROW_ASSIGN_OR_RAISE(options_.data_file, CreateTempShuffleFile(configured_dirs_[0]));
+  }
+
+  RETURN_NOT_OK(SetCompressType(options_.compression_type));
+
+  RETURN_NOT_OK(InitIpcWriteOptions());
+
+  // Allocate first buffer for split reducer
+  ARROW_ASSIGN_OR_RAISE(combine_buffer_, arrow::AllocateResizableBuffer(0, options_.memory_pool.get()));
+  RETURN_NOT_OK(combine_buffer_->Resize(0, /*shrink_to_fit =*/false));
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::InitIpcWriteOptions() {
+  auto& ipc_write_options = options_.ipc_write_options;
+  ipc_write_options.memory_pool = options_.memory_pool.get();
+  ipc_write_options.use_threads = false;
+
+  tiny_batch_write_options_ = ipc_write_options;
+  tiny_batch_write_options_.codec = nullptr;
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::InitPartitions(const velox::RowVector& rv) {
+  auto simple_column_count = simple_column_indices_.size();
+  assert(simple_column_count > 0);
+
+  partition_validity_addrs_.resize(simple_column_count);
+  std::for_each(partition_validity_addrs_.begin(), partition_validity_addrs_.end(), [this](std::vector<uint8_t*>& v) {
+    v.resize(num_partitions_, nullptr);
+  });
+
+  partition_fixed_width_value_addrs_.resize(fixed_width_column_count_);
+  std::for_each(
+      partition_fixed_width_value_addrs_.begin(),
+      partition_fixed_width_value_addrs_.end(),
+      [this](std::vector<uint8_t*>& v) { v.resize(num_partitions_, nullptr); });
+
+  partition_buffers_.resize(simple_column_count);
+  std::for_each(partition_buffers_.begin(), partition_buffers_.end(), [this](std::vector<arrow::BufferVector>& v) {
+    v.resize(num_partitions_);
+  });
+
+  partition_binary_addrs_.resize(binary_column_indices_.size());
+  std::for_each(partition_binary_addrs_.begin(), partition_binary_addrs_.end(), [this](std::vector<BinaryBuff>& v) {
+    v.resize(num_partitions_);
+  });
+
+  partition_list_builders_.resize(complex_column_indices_.size());
+  for (size_t i = 0; i < complex_column_indices_.size(); ++i) {
+    partition_list_builders_[i].resize(num_partitions_);
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SetCompressType(arrow::Compression::type compressed_type) {
+  ARROW_ASSIGN_OR_RAISE(options_.ipc_write_options.codec, CreateArrowIpcCodec(compressed_type));
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::Split(const velox::RowVector& rv) {
+  RETURN_NOT_OK(InitFromRowVector(rv));
+  RETURN_NOT_OK(Partition(rv));
+  RETURN_NOT_OK(DoSplit(rv));
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::Stop() {
+  // open data file output stream
+  std::shared_ptr<arrow::io::FileOutputStream> fout;
+  ARROW_ASSIGN_OR_RAISE(fout, arrow::io::FileOutputStream::Open(options_.data_file, true));
+  if (options_.buffered_write) {
+    ARROW_ASSIGN_OR_RAISE(
+        data_file_os_, arrow::io::BufferedOutputStream::Create(16384, options_.memory_pool.get(), fout));
+  } else {
+    data_file_os_ = fout;
+  }
+
+  // stop PartitionWriter and collect metrics
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, true));
+
+    if (partition_cached_recordbatch_size_[pid] > 0) {
+      if (partition_writer_[pid] == nullptr) {
+        partition_writer_[pid] = std::make_shared<PartitionWriter>(this, pid);
+      }
+    }
+
+    const auto& writer = partition_writer_[pid];
+    if (writer) {
+      TIME_NANO_OR_RAISE(total_write_time_, writer->WriteCachedRecordBatchAndClose());
+      partition_lengths_[pid] = writer->partition_length;
+      total_bytes_written_ += writer->partition_length;
+      total_bytes_spilled_ += writer->bytes_spilled;
+      total_compress_time_ += writer->compress_time;
+    } else {
+      partition_lengths_[pid] = 0;
+    }
+  }
+
+  combine_buffer_.reset();
+  schema_payload_.reset();
+  partition_buffers_.clear();
+
+  // close data file output Stream
+  RETURN_NOT_OK(data_file_os_->Close());
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::CreatePartition2Row(uint32_t row_num) {
+  // calc partition_2_row_offset_
+  partition_2_row_offset_[0] = 0;
+  for (auto pid = 1; pid <= num_partitions_; ++pid) {
+    partition_2_row_offset_[pid] = partition_2_row_offset_[pid - 1] + partition_2_row_count_[pid - 1];
+  }
+
+  // get a copy of partition_2_row_offset_
+  auto partition_2_row_offset_copy = partition_2_row_offset_;
+
+  // calc row_offset_2_row_id_
+  row_offset_2_row_id_.resize(row_num);
+  for (auto row = 0; row < row_num; ++row) {
+    auto pid = row_2_partition_[row];
+    row_offset_2_row_id_[partition_2_row_offset_copy[pid]++] = row;
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::UpdateInputHasNull(const velox::RowVector& rv) {
+  for (size_t col = 0; col < simple_column_indices_.size(); ++col) {
+    // check input_has_null_[col] is cheaper than GetNullCount()
+    // once input_has_null_ is set to true, we didn't reset it after spill
+    if (!input_has_null_[col]) {
+      auto col_idx = simple_column_indices_[col];
+      auto nullcount = rv.childAt(col_idx)->getNullCount();
+      if (nullcount.has_value() && nullcount.value() > 0) {
+        input_has_null_[col] = true;
+      }
+    }
+  }
+
+  return arrow::Status::OK();
+}
+
+std::string VeloxSplitter::NextSpilledFileDir() {
+  auto spilled_file_dir =
+      GetSpilledShuffleFileDir(configured_dirs_[dir_selection_], sub_dir_selection_[dir_selection_]);
+  sub_dir_selection_[dir_selection_] = (sub_dir_selection_[dir_selection_] + 1) % options_.num_sub_dirs;
+  dir_selection_ = (dir_selection_ + 1) % configured_dirs_.size();
+  return spilled_file_dir;
+}
+
+arrow::Result<std::shared_ptr<arrow::ipc::IpcPayload>> VeloxSplitter::GetSchemaPayload() {
+  if (schema_payload_ != nullptr) {
+    return schema_payload_;
+  }
+  schema_payload_ = std::make_shared<arrow::ipc::IpcPayload>();
+  arrow::ipc::DictionaryFieldMapper dict_file_mapper; // unused
+
+  RETURN_NOT_OK(
+      arrow::ipc::GetSchemaPayload(*schema_, options_.ipc_write_options, dict_file_mapper, schema_payload_.get()));
+
+  return schema_payload_;
+}
+
+arrow::Status VeloxSplitter::DoSplit(const velox::RowVector& rv) {
+  auto row_num = rv.size();
+
+  RETURN_NOT_OK(CreatePartition2Row(row_num));
+
+  RETURN_NOT_OK(UpdateInputHasNull(rv));
+
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    if (partition_2_row_count_[pid] > 0) {
+      // make sure the size to be allocated is larger than the size to be filled
+      if (partition_2_buffer_size_[pid] == 0) {
+        // allocate buffer if it's not yet allocated
+        auto new_size = std::max(CalculatePartitionBufferSize(rv), partition_2_row_count_[pid]);
+        RETURN_NOT_OK(AllocatePartitionBuffers(pid, new_size));
+      } else if (partition_buffer_idx_base_[pid] + partition_2_row_count_[pid] > partition_2_buffer_size_[pid]) {
+        auto new_size = std::max(CalculatePartitionBufferSize(rv), partition_2_row_count_[pid]);
+        // if the size to be filled + allready filled > the buffer size, need to allocate new buffer
+        if (options_.prefer_spill) {
+          // if prefer_spill is set, spill current RowVector, we may reuse the buffers
+          if (new_size > partition_2_buffer_size_[pid]) {
+            // if the partition size after split is already larger than
+            // allocated buffer size, need reallocate
+            RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, /*reset_buffers = */ true));
+
+            // splill immediately
+            RETURN_NOT_OK(SpillPartition(pid));
+            RETURN_NOT_OK(AllocatePartitionBuffers(pid, new_size));
+          } else {
+            // partition size after split is smaller than buffer size, no need
+            // to reset buffer, reuse it.
+            RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, /*reset_buffers = */ false));
+            RETURN_NOT_OK(SpillPartition(pid));
+          }
+        } else {
+          // if prefer_spill is disabled, cache the record batch
+          RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, /*reset_buffers = */ true));
+          // allocate partition buffer with retries
+          RETURN_NOT_OK(AllocateNew(pid, new_size));
+        }
+      }
+    }
+  }
+
+  RETURN_NOT_OK(SplitRowVector(rv));
+
+  // update partition buffer base after split
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    partition_buffer_idx_base_[pid] += partition_2_row_count_[pid];
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitRowVector(const velox::RowVector& rv) {
+  // now start to split the RowVector
+  RETURN_NOT_OK(SplitFixedWidthValueBuffer(rv));
+  RETURN_NOT_OK(SplitValidityBuffer(rv));
+  RETURN_NOT_OK(SplitBinaryArray(rv));
+  RETURN_NOT_OK(SplitListArray(rv));
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitFixedWidthValueBuffer(const velox::RowVector& rv) {
+  for (auto col = 0; col < fixed_width_column_count_; ++col) {
+    auto col_idx = simple_column_indices_[col];
+    auto column = rv.childAt(col_idx);
+    assert(column->isFlatEncoding());
+
+    const uint8_t* src_addr = (const uint8_t*)column->valuesAsVoid();
+    const auto& dst_addrs = partition_fixed_width_value_addrs_[col];
+
+    switch (arrow::bit_width(arrow_column_types_[col_idx]->id())) {
+      case 8:
+        RETURN_NOT_OK(SplitFixedType<uint8_t>(src_addr, dst_addrs));
+        break;
+      case 16:
+        RETURN_NOT_OK(SplitFixedType<uint16_t>(src_addr, dst_addrs));
+        break;
+      case 32:
+        RETURN_NOT_OK(SplitFixedType<uint32_t>(src_addr, dst_addrs));
+        break;
+      case 64:
+#ifdef PROCESSAVX
+        std::transform(
+            dst_addrs.begin(),
+            dst_addrs.end(),
+            partition_buffer_idx_base_.begin(),
+            partition_buffer_idx_offset_.begin(),
+            [](uint8_t* x, row_offset_type y) { return x + y * sizeof(uint64_t); });
+        for (auto pid = 0; pid < num_partitions_; pid++) {
+          auto dst_pid_base = reinterpret_cast<uint64_t*>(partition_buffer_idx_offset_[pid]); /*32k*/
+          auto r = partition_2_row_offset_[pid]; /*8k*/
+          auto size = partition_2_row_offset_[pid + 1];
+#if 1
+          for (r; r < size && (((uint64_t)dst_pid_base & 0x1f) > 0); r++) {
+            auto src_offset = row_offset_2_row_id_[r]; /*16k*/
+            *dst_pid_base = reinterpret_cast<uint64_t*>(src_addr)[src_offset]; /*64k*/
+            _mm_prefetch(&(src_addr)[src_offset * sizeof(uint64_t) + 64], _MM_HINT_T2);
+            dst_pid_base += 1;
+          }
+#if 0
+          for (r; r+4<size; r+=4)                              
+          {                                                                                    
+            auto src_offset = row_offset_2_row_id_[r];                                 /*16k*/ 
+            __m128i src_ld = _mm_loadl_epi64((__m128i*)(&row_offset_2_row_id_[r]));    
+            __m128i src_offset_4x = _mm_cvtepu16_epi32(src_ld);
+            
+            __m256i src_4x = _mm256_i32gather_epi64((const long long int*)src_addr,src_offset_4x,8);
+            //_mm256_store_si256((__m256i*)dst_pid_base,src_4x); 
+            _mm_stream_si128((__m128i*)dst_pid_base,src_2x);
+                                                         
+            _mm_prefetch(&(src_addr)[(uint32_t)row_offset_2_row_id_[r]*sizeof(uint64_t)+64], _MM_HINT_T2);              
+            _mm_prefetch(&(src_addr)[(uint32_t)row_offset_2_row_id_[r+1]*sizeof(uint64_t)+64], _MM_HINT_T2);              
+            _mm_prefetch(&(src_addr)[(uint32_t)row_offset_2_row_id_[r+2]*sizeof(uint64_t)+64], _MM_HINT_T2);              
+            _mm_prefetch(&(src_addr)[(uint32_t)row_offset_2_row_id_[r+3]*sizeof(uint64_t)+64], _MM_HINT_T2);              
+            dst_pid_base+=4;                                                                   
+          }
+#endif
+          for (r; r + 2 < size; r += 2) {
+            __m128i src_offset_2x = _mm_cvtsi32_si128(*((int32_t*)(row_offset_2_row_id_.data() + r)));
+            src_offset_2x = _mm_shufflelo_epi16(src_offset_2x, 0x98);
+
+            __m128i src_2x = _mm_i32gather_epi64((const long long int*)src_addr, src_offset_2x, 8);
+            _mm_store_si128((__m128i*)dst_pid_base, src_2x);
+            //_mm_stream_si128((__m128i*)dst_pid_base,src_2x);
+
+            _mm_prefetch(&(src_addr)[(uint32_t)row_offset_2_row_id_[r] * sizeof(uint64_t) + 64], _MM_HINT_T2);
+            _mm_prefetch(&(src_addr)[(uint32_t)row_offset_2_row_id_[r + 1] * sizeof(uint64_t) + 64], _MM_HINT_T2);
+            dst_pid_base += 2;
+          }
+#endif
+          for (r; r < size; r++) {
+            auto src_offset = row_offset_2_row_id_[r]; /*16k*/
+            *dst_pid_base = reinterpret_cast<const uint64_t*>(src_addr)[src_offset]; /*64k*/
+            _mm_prefetch(&(src_addr)[src_offset * sizeof(uint64_t) + 64], _MM_HINT_T2);
+            dst_pid_base += 1;
+          }
+        }
+        break;
+#else
+        RETURN_NOT_OK(SplitFixedType<uint64_t>(src_addr, dst_addrs));
+#endif
+        break;
+#if defined(__x86_64__)
+      case 128: // arrow::Decimal128Type::type_id
+        // too bad gcc generates movdqa even we use __m128i_u data type.
+        // SplitFixedType<__m128i_u>(src_addr, dst_addrs);
+        {
+          std::transform(
+              dst_addrs.begin(),
+              dst_addrs.end(),
+              partition_buffer_idx_base_.begin(),
+              partition_buffer_idx_offset_.begin(),
+              [](uint8_t* x, row_offset_type y) { return x + y * sizeof(__m128i_u); });
+          // assume batch size = 32k; reducer# = 4K; row/reducer = 8
+          for (auto pid = 0; pid < num_partitions_; pid++) {
+            auto dst_pid_base = reinterpret_cast<__m128i_u*>(partition_buffer_idx_offset_[pid]); /*32k*/
+            auto r = partition_2_row_offset_[pid]; /*8k*/
+            auto size = partition_2_row_offset_[pid + 1];
+            for (; r < size; r++) {
+              auto src_offset = row_offset_2_row_id_[r]; /*16k*/
+              __m128i value = _mm_loadu_si128(reinterpret_cast<const __m128i_u*>(src_addr) + src_offset);
+              _mm_storeu_si128(dst_pid_base, value);
+              _mm_prefetch(src_addr + src_offset * sizeof(__m128i_u) + 64, _MM_HINT_T2);
+              dst_pid_base += 1;
+            }
+          }
+        }
+#elif defined(__aarch64__)
+      case 128:
+        RETURN_NOT_OK(SplitFixedType<uint32x4_t>(src_addr, dst_addrs));
+#endif
+        break;
+      case 1: // arrow::BooleanType::type_id:
+        RETURN_NOT_OK(SplitBoolType(src_addr, dst_addrs));
+        break;
+      default:
+        return arrow::Status::Invalid(
+            "Column type " + schema_->field(col_idx)->type()->ToString() + " is not fixed width");
+    }
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitBoolType(const uint8_t* src_addr, const std::vector<uint8_t*>& dst_addrs) {
+  // assume batch size = 32k; reducer# = 4K; row/reducer = 8
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    // set the last byte
+    auto dstaddr = dst_addrs[pid];
+    if (partition_2_row_count_[pid] > 0 && dstaddr != nullptr) {
+      auto r = partition_2_row_offset_[pid]; /*8k*/
+      auto size = partition_2_row_offset_[pid + 1];
+      uint32_t dst_offset = partition_buffer_idx_base_[pid];
+      uint32_t dst_offset_in_byte = (8 - (dst_offset & 0x7)) & 0x7;
+      uint32_t dst_idx_byte = dst_offset_in_byte;
+      uint8_t dst = dstaddr[dst_offset >> 3];
+      if (pid + 1 < num_partitions_) {
+        // PREFETCHT1((&dstaddr[partition_buffer_idx_base_[pid + 1] >> 3]));
+      }
+      for (; r < size && dst_idx_byte > 0; r++, dst_idx_byte--) {
+        auto src_offset = row_offset_2_row_id_[r]; /*16k*/
+        uint8_t src = src_addr[src_offset >> 3];
+        src = src >> (src_offset & 7) | 0xfe; // get the bit in bit 0, other bits set to 1
+#if defined(__x86_64__)
+        src = __rolb(src, 8 - dst_idx_byte);
+#else
+        src = rotateLeft(src, (8 - dst_idx_byte));
+#endif
+        dst = dst & src; // only take the useful bit.
+      }
+      dstaddr[dst_offset >> 3] = dst;
+      if (r == size) {
+        continue;
+      }
+      dst_offset += dst_offset_in_byte;
+      // now dst_offset is 8 aligned
+      for (; r + 8 < size; r += 8) {
+        uint8_t src = 0;
+        auto src_offset = row_offset_2_row_id_[r]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        // PREFETCHT0((&(src_addr)[(src_offset >> 3) + 64]));
+        dst = src >> (src_offset & 7) | 0xfe; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 1]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 1 | 0xfd; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 2]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 2 | 0xfb; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 3]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 3 | 0xf7; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 4]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 4 | 0xef; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 5]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 5 | 0xdf; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 6]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 6 | 0xbf; // get the bit in bit 0, other bits set to 1
+
+        src_offset = row_offset_2_row_id_[r + 7]; /*16k*/
+        src = src_addr[src_offset >> 3];
+        dst &= src >> (src_offset & 7) << 7 | 0x7f; // get the bit in bit 0, other bits set to 1
+
+        dstaddr[dst_offset >> 3] = dst;
+        dst_offset += 8;
+        //_mm_prefetch(dstaddr + (dst_offset >> 3) + 64, _MM_HINT_T0);
+      }
+      // last byte, set it to 0xff is ok
+      dst = 0xff;
+      dst_idx_byte = 0;
+      for (; r < size; r++, dst_idx_byte++) {
+        auto src_offset = row_offset_2_row_id_[r]; /*16k*/
+        uint8_t src = src_addr[src_offset >> 3];
+        src = src >> (src_offset & 7) | 0xfe; // get the bit in bit 0, other bits set to 1
+#if defined(__x86_64__)
+        src = __rolb(src, dst_idx_byte);
+#else
+        src = rotateLeft(src, dst_idx_byte);
+#endif
+        dst = dst & src; // only take the useful bit.
+      }
+      dstaddr[dst_offset >> 3] = dst;
+    }
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitValidityBuffer(const velox::RowVector& rv) {
+  for (size_t col = 0; col < simple_column_indices_.size(); ++col) {
+    auto col_idx = simple_column_indices_[col];
+    auto column = rv.childAt(col_idx);
+    auto null_count = column->getNullCount().value_or(0);
+
+    auto& dst_addrs = partition_validity_addrs_[col];
+
+    if (null_count > 0) {
+      for (auto pid = 0; pid < num_partitions_; ++pid) {
+        if (partition_2_row_count_[pid] > 0 && dst_addrs[pid] == nullptr) {
+          // init bitmap if it's null, initialize the buffer as true
+          auto new_size = std::max(partition_2_row_count_[pid], (uint32_t)options_.buffer_size);
+          std::shared_ptr<arrow::Buffer> validity_buffer;
+          auto status = AllocateBufferFromPool(validity_buffer, arrow::bit_util::BytesForBits(new_size));
+          ARROW_RETURN_NOT_OK(status);
+          dst_addrs[pid] = const_cast<uint8_t*>(validity_buffer->data());
+          memset(validity_buffer->mutable_data(), 0xff, validity_buffer->capacity());
+          partition_buffers_[col][pid][VALIDITY_BUFFER_INDEX] = std::move(validity_buffer);
+        }
+      }
+
+      const uint8_t* src_addr = (const uint8_t*)(column->rawNulls());
+
+      RETURN_NOT_OK(SplitBoolType(src_addr, dst_addrs));
+    }
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitBinaryType(
+    uint32_t binary_idx,
+    const velox::FlatVector<velox::StringView>& src,
+    std::vector<BinaryBuff>& dst) {
+  auto raw_values = src.rawValues();
+
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    auto& binary_buf = dst[pid];
+
+    using offset_type = arrow::BinaryType::offset_type;
+    auto dst_offset_base = (offset_type*)(binary_buf.offset_ptr) + partition_buffer_idx_base_[pid];
+
+    auto value_offset = binary_buf.value_offset;
+    auto dst_value_ptr = binary_buf.value_ptr + value_offset;
+    auto capacity = binary_buf.value_capacity;
+
+    auto r = partition_2_row_offset_[pid];
+    auto size = partition_2_row_offset_[pid + 1] - r;
+    auto multiply = 1;
+
+    for (uint32_t x = 0; x < size; x++) {
+      auto row_id = row_offset_2_row_id_[x + r];
+      auto& string_view = raw_values[row_id];
+      auto string_len = string_view.size();
+
+      // 1. copy offset
+      value_offset = dst_offset_base[x + 1] = value_offset + string_len;
+
+      if (value_offset >= capacity) {
+        auto old_capacity = capacity;
+        capacity = capacity + std::max((capacity >> multiply), (uint64_t)string_len);
+        multiply = std::min(3, multiply + 1);
+
+        auto value_buffer = std::static_pointer_cast<arrow::ResizableBuffer>(
+            partition_buffers_[fixed_width_column_count_ + binary_idx][pid][VALUE_BUFFER_INEDX]);
+
+        RETURN_NOT_OK(value_buffer->Reserve(capacity));
+
+        binary_buf.value_ptr = value_buffer->mutable_data();
+        binary_buf.value_capacity = capacity;
+        dst_value_ptr = binary_buf.value_ptr + value_offset - string_len;
+
+        std::cout << "Split value buffer resized col_idx = " << binary_idx << " dst_start " << dst_offset_base[x]
+                  << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity
+                  << " new size = " << capacity << " row = " << partition_buffer_idx_base_[pid]
+                  << " strlen = " << string_len << std::endl;
+      }
+
+      // 2. copy value
+      memcpy(dst_value_ptr, string_view.data(), string_len);
+
+      dst_value_ptr += string_len;
+    }
+
+    binary_buf.value_offset = value_offset;
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitListArray(const facebook::velox::RowVector& rv) {
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SplitBinaryArray(const velox::RowVector& rv) {
+  // TODO
+  for (auto col = fixed_width_column_count_; col < simple_column_indices_.size(); ++col) {
+    auto binary_idx = col - fixed_width_column_count_;
+    auto& dst_addrs = partition_binary_addrs_[binary_idx];
+    auto col_idx = simple_column_indices_[col];
+    auto column = rv.childAt(col_idx);
+    auto type_kind = column->typeKind();
+    if (type_kind == velox::TypeKind::VARCHAR || type_kind == velox::TypeKind::VARBINARY) {
+      auto string_column = rv.asFlatVector<velox::StringView>();
+      RETURN_NOT_OK(SplitBinaryType(binary_idx, *string_column, dst_addrs));
+    } else {
+      assert(false);
+    }
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::TransferSchema(const velox::RowVector& rv, std::shared_ptr<arrow::Schema>& input_schema) {
+  if (rv.childrenSize() == 0) {
+    return arrow::Status::Invalid("has not child.");
+  }
+
+  if (!rv.childAt(0)->type()->isInteger()) {
+    return arrow::Status::Invalid("RowVector field 0 should be integer");
+  }
+
+  auto out = std::make_shared<ArrowSchema>();
+  // need this following loop?
+  // Make sure to load lazy vector if not loaded already.
+  for (auto& child : rv.children()) {
+    child->loadedVector();
+  }
+
+  // TODO: need recheck
+  auto rvp = velox::RowVector::createEmpty(rv.type(), rv.pool());
+
+  // get ArrowSchema from velox::RowVector
+  velox::exportToArrow(rvp, *out);
+
+  // convert ArrowSchema to arrow::Schema
+  ARROW_ASSIGN_OR_RAISE(input_schema, arrow::ImportSchema(out.get()));
+
+  // remove the first column，then schema_'s column is one less than input_schema_'s
+  ARROW_ASSIGN_OR_RAISE(schema_, input_schema->RemoveField(0));
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::InitColumnTypes(const velox::RowVector& rv) {
+  if (velox_column_types_.empty()) {
+    for (size_t i = 0; i < rv.childrenSize(); ++i) {
+      velox_column_types_.push_back(rv.childAt(i)->type());
+    }
+  }
+
+  // get arrow_column_types_ from schema
+  ARROW_ASSIGN_OR_RAISE(arrow_column_types_, ToSplitterTypeId(schema_->fields()));
+
+  for (size_t i = 0; i < arrow_column_types_.size(); ++i) {
+    switch (arrow_column_types_[i]->id()) {
+      case arrow::BinaryType::type_id:
+      case arrow::StringType::type_id:
+      case arrow::LargeBinaryType::type_id:
+      case arrow::LargeStringType::type_id:
+        binary_column_indices_.push_back(i);
+        break;
+      case arrow::StructType::type_id:
+      case arrow::MapType::type_id:
+      case arrow::LargeListType::type_id:
+      case arrow::ListType::type_id:
+        complex_column_indices_.push_back(i);
+        break;
+      case arrow::NullType::type_id:
+        break;
+      default:
+        simple_column_indices_.push_back(i);
+        break;
+    }
+  }
+
+  fixed_width_column_count_ = simple_column_indices_.size();
+
+  simple_column_indices_.insert(
+      simple_column_indices_.end(), binary_column_indices_.begin(), binary_column_indices_.end());
+
+  assert(!simple_column_indices_.empty());
+
+  binary_array_empirical_size_.resize(binary_column_indices_.size(), 0);
+
+  input_has_null_.resize(simple_column_indices_.size(), false);
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::InitFromRowVector(const velox::RowVector& rv) {
+  if (velox_column_types_.empty()) {
+    RETURN_NOT_OK(InitColumnTypes(rv));
+    RETURN_NOT_OK(InitPartitions(rv));
+  }
+  return arrow::Status::OK();
+}
+
+velox::RowVector VeloxSplitter::GetStrippedRowVector(const velox::RowVector& rv) const {
+  // get new row type
+  auto row_type = rv.type()->asRow();
+  auto type_children = row_type.children();
+  type_children.erase(type_children.begin());
+  auto new_row_type = velox::ROW(std::move(type_children));
+
+  // get null buffers
+  const auto& nullbuffers = rv.nulls();
+
+  // get length
+  auto length = rv.size();
+
+  // get children
+  auto children = rv.children();
+  children.erase(children.begin());
+
+  // get nullcount
+  auto nullcount = rv.getNullCount();
+
+  return velox::RowVector(rv.pool(), new_row_type, nullbuffers, length, children, nullcount);
+}
+
+uint32_t VeloxSplitter::CalculatePartitionBufferSize(const velox::RowVector& rv) {
+  uint32_t size_per_row = 0;
+  auto num_rows = rv.size();
+  for (size_t i = fixed_width_column_count_; i < simple_column_indices_.size(); ++i) {
+    auto index = i - fixed_width_column_count_;
+    if (binary_array_empirical_size_[index] == 0) {
+      auto column = rv.childAt(simple_column_indices_[i]);
+      auto string_view_column = column->asFlatVector<velox::StringView>();
+      assert(string_view_column);
+
+      // accumulate length
+      uint64_t length = 0;
+      auto string_views = string_view_column->rawValues<velox::StringView>();
+      for (size_t row = 0; row != num_rows; ++row) {
+        length += string_views[row].size();
+      }
+
+      binary_array_empirical_size_[index] = length % num_rows == 0 ? length / num_rows : length / num_rows + 1;
+    }
+  }
+
+  size_per_row = std::accumulate(binary_array_empirical_size_.begin(), binary_array_empirical_size_.end(), 0);
+
+  for (size_t col = 0; col < simple_column_indices_.size(); ++col) {
+    auto col_idx = simple_column_indices_[col];
+    size_per_row += arrow::bit_width(arrow_column_types_[col_idx]->id()) >> 3;
+  }
+
+  uint64_t prealloc_row_cnt = options_.offheap_per_task > 0 && size_per_row > 0
+      ? options_.offheap_per_task / size_per_row / num_partitions_ >> 2
+      : options_.buffer_size;
+  prealloc_row_cnt = std::min(prealloc_row_cnt, (uint64_t)options_.buffer_size);
+
+  return prealloc_row_cnt;
+}
+
+arrow::Status VeloxSplitter::AllocateBufferFromPool(std::shared_ptr<arrow::Buffer>& buffer, uint32_t size) {
+  // if size is already larger than buffer pool size, allocate it directly
+  // make size 64byte aligned
+  auto reminder = size & 0x3f;
+  size += (64 - reminder) & ((reminder == 0) - 1);
+  if (size > SPLIT_BUFFER_SIZE) {
+    ARROW_ASSIGN_OR_RAISE(buffer, arrow::AllocateResizableBuffer(size, options_.memory_pool.get()));
+    return arrow::Status::OK();
+  } else if (combine_buffer_->capacity() - combine_buffer_->size() < size) {
+    // memory pool is not enough
+    ARROW_ASSIGN_OR_RAISE(
+        combine_buffer_, arrow::AllocateResizableBuffer(SPLIT_BUFFER_SIZE, options_.memory_pool.get()));
+    RETURN_NOT_OK(combine_buffer_->Resize(0, /*shrink_to_fit = */ false));
+  }
+  buffer = arrow::SliceMutableBuffer(combine_buffer_, combine_buffer_->size(), size);
+  RETURN_NOT_OK(combine_buffer_->Resize(combine_buffer_->size() + size, /*shrink_to_fit = */ false));
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::AllocatePartitionBuffers(uint32_t partition_id, uint32_t new_size) {
+  // try to allocate new
+  auto num_fields = schema_->num_fields();
+  assert(num_fields == arrow_column_types_.size());
+
+  auto fixed_width_idx = 0;
+  auto binary_idx = 0;
+  auto list_idx = 0;
+
+  std::vector<std::shared_ptr<arrow::ArrayBuilder>> new_list_builders;
+
+  for (auto i = 0; i < num_fields; ++i) {
+    size_t sizeof_binary_offset = -1;
+    switch (arrow_column_types_[i]->id()) {
+      case arrow::BinaryType::type_id:
+      case arrow::StringType::type_id:
+        sizeof_binary_offset = sizeof(arrow::StringType::offset_type);
+      case arrow::LargeBinaryType::type_id:
+      case arrow::LargeStringType::type_id: {
+        if (sizeof_binary_offset == -1) {
+          sizeof_binary_offset = sizeof(arrow::LargeStringType::offset_type);
+        }
+
+        std::shared_ptr<arrow::Buffer> offset_buffer;
+        std::shared_ptr<arrow::Buffer> validity_buffer = nullptr;
+        auto value_buf_size = binary_array_empirical_size_[binary_idx] * new_size + 1024;
+        ARROW_ASSIGN_OR_RAISE(
+            std::shared_ptr<arrow::Buffer> value_buffer,
+            arrow::AllocateResizableBuffer(value_buf_size, options_.memory_pool.get()));
+        ARROW_RETURN_NOT_OK(AllocateBufferFromPool(offset_buffer, new_size * sizeof_binary_offset + 1));
+
+        // set the first offset to 0
+        uint8_t* offsetaddr = offset_buffer->mutable_data();
+        memset(offsetaddr, 0, 8);
+
+        partition_binary_addrs_[binary_idx][partition_id] =
+            BinaryBuff(value_buffer->mutable_data(), offset_buffer->mutable_data(), value_buf_size);
+
+        auto index = fixed_width_column_count_ + binary_idx;
+        if (input_has_null_[index]) {
+          ARROW_RETURN_NOT_OK(AllocateBufferFromPool(validity_buffer, arrow::bit_util::BytesForBits(new_size)));
+          // initialize all true once allocated
+          memset(validity_buffer->mutable_data(), 0xff, validity_buffer->capacity());
+          partition_validity_addrs_[index][partition_id] = validity_buffer->mutable_data();
+        } else {
+          partition_validity_addrs_[index][partition_id] = nullptr;
+        }
+        partition_buffers_[index][partition_id] = {
+            std::move(validity_buffer), std::move(offset_buffer), std::move(value_buffer)};
+        binary_idx++;
+        break;
+      }
+      case arrow::StructType::type_id:
+      case arrow::MapType::type_id:
+      case arrow::LargeListType::type_id:
+      case arrow::ListType::type_id: {
+        std::unique_ptr<arrow::ArrayBuilder> array_builder;
+        RETURN_NOT_OK(MakeBuilder(options_.memory_pool.get(), arrow_column_types_[i], &array_builder));
+        assert(array_builder != nullptr);
+        RETURN_NOT_OK(array_builder->Reserve(new_size));
+        partition_list_builders_[list_idx][partition_id] = std::move(array_builder);
+        list_idx++;
+        break;
+      }
+      case arrow::NullType::type_id:
+        break;
+      default: {
+        std::shared_ptr<arrow::Buffer> value_buffer;
+        std::shared_ptr<arrow::Buffer> validity_buffer = nullptr;
+        if (arrow_column_types_[i]->id() == arrow::BooleanType::type_id) {
+          ARROW_RETURN_NOT_OK(AllocateBufferFromPool(value_buffer, arrow::bit_util::BytesForBits(new_size)));
+        } else {
+          ARROW_RETURN_NOT_OK(
+              AllocateBufferFromPool(value_buffer, new_size * (arrow::bit_width(arrow_column_types_[i]->id()) >> 3)));
+        }
+        partition_fixed_width_value_addrs_[fixed_width_idx][partition_id] = value_buffer->mutable_data();
+
+        if (input_has_null_[fixed_width_idx]) {
+          ARROW_RETURN_NOT_OK(AllocateBufferFromPool(validity_buffer, arrow::bit_util::BytesForBits(new_size)));
+          // initialize all true once allocated
+          memset(validity_buffer->mutable_data(), 0xff, validity_buffer->capacity());
+          partition_validity_addrs_[fixed_width_idx][partition_id] = validity_buffer->mutable_data();
+        } else {
+          partition_validity_addrs_[fixed_width_idx][partition_id] = nullptr;
+        }
+        partition_buffers_[fixed_width_idx][partition_id] = {std::move(validity_buffer), std::move(value_buffer)};
+        fixed_width_idx++;
+        break;
+      }
+    }
+  }
+
+  partition_2_buffer_size_[partition_id] = new_size;
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::AllocateNew(uint32_t partition_id, uint32_t new_size) {
+  auto retry = 0;
+  auto status = AllocatePartitionBuffers(partition_id, new_size);
+  while (status.IsOutOfMemory() && retry < 3) {
+    // retry allocate
+    ++retry;
+    std::cout << status.ToString() << std::endl
+              << std::to_string(retry) << " retry to allocate new buffer for partition " << std::to_string(partition_id)
+              << std::endl;
+
+    int64_t spilled_size;
+    ARROW_ASSIGN_OR_RAISE(auto partition_to_spill, SpillLargestPartition(&spilled_size));
+    if (partition_to_spill == -1) {
+      std::cout << "Failed to allocate new buffer for partition " << std::to_string(partition_id)
+                << ". No partition buffer to spill." << std::endl;
+      return status;
+    }
+
+    status = AllocatePartitionBuffers(partition_id, new_size);
+  }
+
+  if (status.IsOutOfMemory()) {
+    std::cout << "Failed to allocate new buffer for partition " << std::to_string(partition_id) << ". Out of memory."
+              << std::endl;
+  }
+
+  return status;
+}
+
+arrow::Status VeloxSplitter::CreateRecordBatchFromBuffer(uint32_t partition_id, bool reset_buffers) {
+  if (partition_buffer_idx_base_[partition_id] <= 0) {
+    return arrow::Status::OK();
+  }
+
+  // already filled
+  auto fixed_width_idx = 0;
+  auto binary_idx = 0;
+  auto list_idx = 0;
+  auto num_fields = schema_->num_fields();
+  auto num_rows = partition_buffer_idx_base_[partition_id];
+
+  std::vector<std::shared_ptr<arrow::Array>> arrays(num_fields);
+  for (int i = 0; i < num_fields; ++i) {
+    size_t sizeof_binary_offset = -1;
+    switch (arrow_column_types_[i]->id()) {
+      case arrow::BinaryType::type_id:
+      case arrow::StringType::type_id:
+        sizeof_binary_offset = sizeof(arrow::BinaryType::offset_type);
+      case arrow::LargeBinaryType::type_id:
+      case arrow::LargeStringType::type_id: {
+        if (sizeof_binary_offset == -1)
+          sizeof_binary_offset = sizeof(arrow::LargeBinaryType::offset_type);
+
+        auto buffers = partition_buffers_[fixed_width_column_count_ + binary_idx][partition_id];
+        // validity buffer
+        if (buffers[VALIDITY_BUFFER_INDEX] != nullptr) {
+          buffers[VALIDITY_BUFFER_INDEX] =
+              arrow::SliceBuffer(buffers[VALIDITY_BUFFER_INDEX], 0, arrow::bit_util::BytesForBits(num_rows));
+        }
+        // offset buffer
+        if (buffers[OFFSET_BUFFER_INDEX] != nullptr) {
+          buffers[OFFSET_BUFFER_INDEX] =
+              arrow::SliceBuffer(buffers[OFFSET_BUFFER_INDEX], 0, (num_rows + 1) * sizeof_binary_offset);
+        }
+        // value buffer
+        if (buffers[VALUE_BUFFER_INEDX] != nullptr) {
+          ARROW_CHECK_NE(buffers[OFFSET_BUFFER_INDEX], nullptr);
+          buffers[VALUE_BUFFER_INEDX] = arrow::SliceBuffer(
+              buffers[VALUE_BUFFER_INEDX],
+              0,
+              sizeof_binary_offset == 4 ? reinterpret_cast<const arrow::BinaryType::offset_type*>(
+                                              buffers[OFFSET_BUFFER_INDEX]->data())[num_rows]
+                                        : reinterpret_cast<const arrow::LargeBinaryType::offset_type*>(
+                                              buffers[OFFSET_BUFFER_INDEX]->data())[num_rows]);
+        }
+
+        arrays[i] = arrow::MakeArray(arrow::ArrayData::Make(
+            schema_->field(i)->type(),
+            num_rows,
+            {buffers[VALIDITY_BUFFER_INDEX], buffers[OFFSET_BUFFER_INDEX], buffers[VALUE_BUFFER_INEDX]}));
+
+        uint64_t dst_offset0 = sizeof_binary_offset == 4
+            ? reinterpret_cast<const arrow::BinaryType::offset_type*>(buffers[OFFSET_BUFFER_INDEX]->data())[0]
+            : reinterpret_cast<const arrow::LargeBinaryType::offset_type*>(buffers[OFFSET_BUFFER_INDEX]->data())[0];
+        ARROW_CHECK_EQ(dst_offset0, 0);
+
+        if (reset_buffers) {
+          partition_validity_addrs_[fixed_width_column_count_ + binary_idx][partition_id] = nullptr;
+          partition_binary_addrs_[binary_idx][partition_id] = BinaryBuff();
+          partition_buffers_[fixed_width_column_count_ + binary_idx][partition_id].clear();
+        } else {
+          // reset the offset
+          partition_binary_addrs_[binary_idx][partition_id].value_offset = 0;
+        }
+        binary_idx++;
+        break;
+      }
+      case arrow::StructType::type_id:
+      case arrow::MapType::type_id:
+      case arrow::LargeListType::type_id:
+      case arrow::ListType::type_id: {
+        auto& builder = partition_list_builders_[list_idx][partition_id];
+        if (reset_buffers) {
+          RETURN_NOT_OK(builder->Finish(&arrays[i]));
+          builder->Reset();
+        } else {
+          RETURN_NOT_OK(builder->Finish(&arrays[i]));
+          builder->Reset();
+          RETURN_NOT_OK(builder->Reserve(num_rows));
+        }
+        list_idx++;
+        break;
+      }
+      case arrow::NullType::type_id: {
+        arrays[i] = arrow::MakeArray(arrow::ArrayData::Make(arrow::null(), num_rows, {nullptr, nullptr}, num_rows));
+        break;
+      }
+      default: {
+        auto buffers = partition_buffers_[fixed_width_idx][partition_id];
+        if (buffers[0] != nullptr) {
+          buffers[0] = arrow::SliceBuffer(buffers[0], 0, arrow::bit_util::BytesForBits(num_rows));
+        }
+        if (buffers[1] != nullptr) {
+          if (arrow_column_types_[i]->id() == arrow::BooleanType::type_id)
+            buffers[1] = arrow::SliceBuffer(buffers[1], 0, arrow::bit_util::BytesForBits(num_rows));
+          else
+            buffers[1] =
+                arrow::SliceBuffer(buffers[1], 0, num_rows * (arrow::bit_width(arrow_column_types_[i]->id()) >> 3));
+        }
+
+        arrays[i] =
+            arrow::MakeArray(arrow::ArrayData::Make(schema_->field(i)->type(), num_rows, {buffers[0], buffers[1]}));
+        if (reset_buffers) {
+          partition_validity_addrs_[fixed_width_idx][partition_id] = nullptr;
+          partition_fixed_width_value_addrs_[fixed_width_idx][partition_id] = nullptr;
+          partition_buffers_[fixed_width_idx][partition_id].clear();
+        }
+        fixed_width_idx++;
+        break;
+      }
+    }
+  }
+  auto rb = arrow::RecordBatch::Make(schema_, num_rows, std::move(arrays));
+  return CacheRecordBatch(partition_id, *rb);
+}
+
+namespace {
+
+int64_t get_batch_nbytes(const arrow::RecordBatch& rb) {
+  int64_t accumulated = 0L;
+
+  for (const auto& array : rb.columns()) {
+    if (array == nullptr || array->data() == nullptr) {
+      continue;
+    }
+    for (const auto& buf : array->data()->buffers) {
+      if (buf == nullptr) {
+        continue;
+      }
+      accumulated += buf->size();
+    }
+  }
+  return accumulated;
+}
+
+} // namespace
+
+arrow::Status VeloxSplitter::CacheRecordBatch(uint32_t partition_id, const arrow::RecordBatch& rb) {
+  int64_t raw_size = get_batch_nbytes(rb);
+  raw_partition_lengths_[partition_id] += raw_size;
+  auto payload = std::make_shared<arrow::ipc::IpcPayload>();
+#ifndef SKIPCOMPRESS
+  if (rb.num_rows() <= (uint32_t)options_.batch_compress_threshold) {
+    TIME_NANO_OR_RAISE(
+        total_compress_time_, arrow::ipc::GetRecordBatchPayload(rb, tiny_batch_write_options_, payload.get()));
+  } else {
+    TIME_NANO_OR_RAISE(
+        total_compress_time_, arrow::ipc::GetRecordBatchPayload(rb, options_.ipc_write_options, payload.get()));
+  }
+#else
+  // for test reason
+  TIME_NANO_OR_RAISE(
+      total_compress_time_, arrow::ipc::GetRecordBatchPayload(*rb, tiny_bach_write_options_, payload.get()));
+#endif
+
+  partition_cached_recordbatch_size_[partition_id] += payload->body_length;
+  partition_cached_recordbatch_[partition_id].push_back(std::move(payload));
+  partition_buffer_idx_base_[partition_id] = 0;
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSplitter::SpillFixedSize(int64_t size, int64_t* actual) {
+  int64_t current_spilled = 0L;
+  auto try_count = 0;
+  while (current_spilled < size && try_count < 5) {
+    try_count++;
+    int64_t single_call_spilled;
+    ARROW_ASSIGN_OR_RAISE(int32_t spilled_partition_id, SpillLargestPartition(&single_call_spilled))
+    if (spilled_partition_id == -1) {
+      break;
+    }
+    current_spilled += single_call_spilled;
+  }
+  *actual = current_spilled;
+  return arrow::Status::OK();
+}
+
+arrow::Result<int32_t> VeloxSplitter::SpillLargestPartition(int64_t* size) {
+  // spill the largest partition
+  auto max_size = 0;
+  int32_t partition_to_spill = -1;
+  for (auto i = 0; i < num_partitions_; ++i) {
+    if (partition_cached_recordbatch_size_[i] > max_size) {
+      max_size = partition_cached_recordbatch_size_[i];
+      partition_to_spill = i;
+    }
+  }
+  if (partition_to_spill != -1) {
+    RETURN_NOT_OK(SpillPartition(partition_to_spill));
+#ifdef GLUTEN_PRINT_DEBUG
+    std::cout << "Spilled partition " << std::to_string(partition_to_spill) << ", " << std::to_string(max_size)
+              << " bytes released" << std::endl;
+#endif
+    *size = max_size;
+  } else {
+    *size = 0;
+  }
+  return partition_to_spill;
+}
+
+arrow::Status VeloxSplitter::SpillPartition(uint32_t partition_id) {
+  if (partition_writer_[partition_id] == nullptr) {
+    partition_writer_[partition_id] = std::make_shared<PartitionWriter>(this, partition_id);
+  }
+  TIME_NANO_OR_RAISE(total_spill_time_, partition_writer_[partition_id]->Spill());
+
+  // reset validity buffer after spill
+  std::for_each(
+      partition_buffers_.begin(), partition_buffers_.end(), [partition_id](std::vector<arrow::BufferVector>& bufs) {
+        if (bufs[partition_id].size() != 0 && bufs[partition_id][0] != nullptr) {
+          // initialize all true once allocated
+          auto addr = bufs[partition_id][0]->mutable_data();
+          memset(addr, 0xff, bufs[partition_id][0]->capacity());
+        }
+      });
+
+  return arrow::Status::OK();
+}
+
+// VeloxRoundRobinSplitter
+arrow::Status VeloxRoundRobinSplitter::Partition(const velox::RowVector& rv) {
+  std::fill(std::begin(partition_2_row_count_), std::end(partition_2_row_count_), 0);
+  row_2_partition_.resize(rv.size());
+  for (auto& pid : row_2_partition_) {
+    pid = pid_selection_;
+    partition_2_row_count_[pid_selection_]++;
+    pid_selection_ = (pid_selection_ + 1) == num_partitions_ ? 0 : (pid_selection_ + 1);
+  }
+  return arrow::Status::OK();
+}
+
+// VeloxSinglePartSplitter
+arrow::Status VeloxSinglePartSplitter::Init() {
+  partition_writer_.resize(num_partitions_);
+  partition_buffer_idx_base_.resize(num_partitions_);
+  partition_cached_recordbatch_.resize(num_partitions_);
+  partition_cached_recordbatch_size_.resize(num_partitions_);
+  partition_lengths_.resize(num_partitions_);
+  raw_partition_lengths_.resize(num_partitions_);
+
+  ARROW_ASSIGN_OR_RAISE(configured_dirs_, GetConfiguredLocalDirs());
+  sub_dir_selection_.assign(configured_dirs_.size(), 0);
+
+  // Both data_file and shuffle_index_file should be set through jni.
+  // For test purpose, Create a temporary subdirectory in the system temporary
+  // dir with prefix "columnar-shuffle"
+  if (options_.data_file.length() == 0) {
+    ARROW_ASSIGN_OR_RAISE(options_.data_file, CreateTempShuffleFile(configured_dirs_[0]));
+  }
+
+  RETURN_NOT_OK(SetCompressType(options_.compression_type));
+
+  RETURN_NOT_OK(InitIpcWriteOptions());
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSinglePartSplitter::Partition(const velox::RowVector& rv) {
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSinglePartSplitter::Split(const velox::RowVector& rv) {
+  // TODO
+  // CacheRecordBatch(0, rv);
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxSinglePartSplitter::Stop() {
+  // open data file output stream
+  std::shared_ptr<arrow::io::FileOutputStream> fout;
+  ARROW_ASSIGN_OR_RAISE(fout, arrow::io::FileOutputStream::Open(options_.data_file, true));
+  if (options_.buffered_write) {
+    ARROW_ASSIGN_OR_RAISE(
+        data_file_os_, arrow::io::BufferedOutputStream::Create(16384, options_.memory_pool.get(), fout));
+  } else {
+    data_file_os_ = fout;
+  }
+
+  // stop PartitionWriter and collect metrics
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    if (partition_cached_recordbatch_size_[pid] > 0) {
+      if (partition_writer_[pid] == nullptr) {
+        partition_writer_[pid] = std::make_shared<PartitionWriter>(this, pid);
+      }
+    }
+    if (partition_writer_[pid] != nullptr) {
+      const auto& writer = partition_writer_[pid];
+      TIME_NANO_OR_RAISE(total_write_time_, writer->WriteCachedRecordBatchAndClose());
+      partition_lengths_[pid] = writer->partition_length;
+      total_bytes_written_ += writer->partition_length;
+      total_bytes_spilled_ += writer->bytes_spilled;
+      total_compress_time_ += writer->compress_time;
+    } else {
+      partition_lengths_[pid] = 0;
+    }
+  }
+  this->schema_payload_.reset();
+
+  // close data file output Stream
+  RETURN_NOT_OK(data_file_os_->Close());
+
+  return arrow::Status::OK();
+}
+
+// VeloxHashSplitter
+arrow::Status VeloxHashSplitter::Init() {
+  // this logic is moved to InitColumnTypes()
+  // input_schema_ = std::move(schema_);
+  // ARROW_ASSIGN_OR_RAISE(schema_, input_schema_->RemoveField(0))
+  return VeloxSplitter::Init();
+}
+
+arrow::Status VeloxHashSplitter::Partition(const velox::RowVector& rv) {
+  if (rv.childrenSize() == 0) {
+    return arrow::Status::Invalid("RowVector missing partition id column.");
+  }
+
+  auto& firstChild = rv.childAt(0);
+  if (!firstChild->type()->isInteger()) {
+    return arrow::Status::Invalid("RecordBatch field 0 should be integer");
+  }
+
+  // first column is partition key hash value
+  using NativeType = velox::TypeTraits<velox::TypeKind::INTEGER>::NativeType;
+  auto pid_flat_vector = firstChild->asFlatVector<NativeType>();
+  if (pid_flat_vector == nullptr) {
+    return arrow::Status::Invalid("failed to cast rv.column(0), this column should be hash_partition_key");
+  }
+
+  auto num_rows = rv.size();
+  row_2_partition_.resize(num_rows);
+  std::fill(std::begin(partition_2_row_count_), std::end(partition_2_row_count_), 0);
+
+  auto raw_values = pid_flat_vector->rawValues();
+  for (auto i = 0; i < num_rows; ++i) {
+    uint32_t pid = raw_values[i] % num_partitions_;
+    row_2_partition_[i] = pid;
+    partition_2_row_count_[pid]++;
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxHashSplitter::InitColumnTypes(const velox::RowVector& rv) {
+  RETURN_NOT_OK(TransferSchema(rv, input_schema_));
+
+  // skip the first column
+  for (size_t i = 1; i < rv.childrenSize(); ++i) {
+    velox_column_types_.push_back(rv.childAt(i)->type());
+  }
+
+  return VeloxSplitter::InitColumnTypes(rv);
+}
+
+arrow::Status VeloxHashSplitter::Split(const velox::RowVector& rv) {
+  RETURN_NOT_OK(InitFromRowVector(rv));
+  RETURN_NOT_OK(Partition(rv));
+  auto stripped_rv = GetStrippedRowVector(rv);
+  RETURN_NOT_OK(DoSplit(stripped_rv));
+  return arrow::Status::OK();
+}
+
+// VeloxFallbackRangeSplitter
+arrow::Status VeloxFallbackRangeSplitter::Init() {
+  // this logic is moved to InitColumnTypes()
+  // input_schema_ = std::move(schema_);
+  // ARROW_ASSIGN_OR_RAISE(schema_, input_schema_->RemoveField(0))
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxFallbackRangeSplitter::InitColumnTypes(const velox::RowVector& rv) {
+  RETURN_NOT_OK(TransferSchema(rv, input_schema_));
+
+  // skip the first column
+  for (size_t i = 1; i < rv.childrenSize(); ++i) {
+    velox_column_types_.push_back(rv.childAt(i)->type());
+  }
+
+  return VeloxSplitter::InitColumnTypes(rv);
+}
+
+arrow::Status VeloxFallbackRangeSplitter::Partition(const velox::RowVector& rv) {
+  if (rv.childrenSize() == 0) {
+    return arrow::Status::Invalid("RowVector missing partition id column.");
+  }
+
+  auto& firstChild = rv.childAt(0);
+  if (!firstChild->type()->isInteger()) {
+    return arrow::Status::Invalid("RowVector field 0 should be integer");
+  }
+
+  using NativeType = velox::TypeTraits<velox::TypeKind::INTEGER>::NativeType;
+  auto pid_flat_vector = firstChild->asFlatVector<NativeType>();
+  if (pid_flat_vector == nullptr) {
+    return arrow::Status::Invalid("failed to cast rv.column(0), this column should be hash_partition_key");
+  }
+
+  auto num_rows = rv.size();
+  row_2_partition_.resize(num_rows);
+  std::fill(std::begin(partition_2_row_count_), std::end(partition_2_row_count_), 0);
+
+  auto raw_values = pid_flat_vector->rawValues();
+  for (auto i = 0; i < num_rows; ++i) {
+    uint32_t pid = raw_values[i];
+    if (pid >= num_partitions_) {
+      return arrow::Status::Invalid(
+          "Partition id ", std::to_string(pid), " is equal or greater than ", std::to_string(num_partitions_));
+    }
+    row_2_partition_[i] = pid;
+    partition_2_row_count_[pid]++;
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VeloxFallbackRangeSplitter::Split(const velox::RowVector& rv) {
+  RETURN_NOT_OK(InitFromRowVector(rv));
+  RETURN_NOT_OK(Partition(rv));
+  auto stripped_rv = GetStrippedRowVector(rv);
+  RETURN_NOT_OK(DoSplit(stripped_rv));
+  return arrow::Status::OK();
+}
+
+} // namespace gluten

--- a/cpp/velox/shuffle/VeloxSplitter.h
+++ b/cpp/velox/shuffle/VeloxSplitter.h
@@ -1,0 +1,370 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/io/api.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/memory_pool.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <arrow/type_traits.h>
+#include <arrow/util/bit_util.h>
+#include <arrow/util/checked_cast.h>
+#include "arrow/array/builder_base.h"
+
+#include "arrow/array/util.h"
+#include "arrow/result.h"
+
+#include "operators/shuffle/type.h"
+#include "operators/shuffle/utils.h"
+
+namespace gluten {
+
+class VeloxSplitter {
+  enum { VALIDITY_BUFFER_INDEX = 0, OFFSET_BUFFER_INDEX = 1, VALUE_BUFFER_INEDX = 2 };
+
+ public:
+  struct BinaryBuff {
+    BinaryBuff(uint8_t* value, uint8_t* offset, uint64_t value_capacity, uint64_t value_offset)
+        : value_ptr(value), offset_ptr(offset), value_capacity(value_capacity), value_offset(value_offset) {}
+
+    BinaryBuff(uint8_t* value, uint8_t* offset, uint64_t value_capacity)
+        : BinaryBuff(value, offset, value_capacity, 0) {}
+
+    BinaryBuff() : BinaryBuff(nullptr, nullptr, 0, 0) {}
+
+    uint8_t* value_ptr;
+    uint8_t* offset_ptr;
+    uint64_t value_capacity;
+    uint64_t value_offset;
+  };
+
+  template <typename SPLITTER>
+  static std::shared_ptr<SPLITTER> Create(uint32_t num_partitions, const SplitOptions& options) {
+    return std::make_shared<SPLITTER>(num_partitions, options);
+  }
+
+  static arrow::Result<std::shared_ptr<VeloxSplitter>>
+  Make(const std::string& name, uint32_t num_partitions, SplitOptions options = SplitOptions::Defaults());
+
+  virtual const std::shared_ptr<arrow::Schema>& input_schema() const {
+    return schema_;
+  }
+
+  virtual arrow::Status Split(const facebook::velox::RowVector& rv);
+
+  virtual arrow::Status Stop();
+
+  arrow::Status SpillFixedSize(int64_t size, int64_t* actual);
+
+  int64_t TotalBytesWritten() const {
+    return total_bytes_written_;
+  }
+
+  int64_t TotalBytesSpilled() const {
+    return total_bytes_spilled_;
+  }
+
+  int64_t TotalWriteTime() const {
+    return total_write_time_;
+  }
+
+  int64_t TotalSpillTime() const {
+    return total_spill_time_;
+  }
+
+  int64_t TotalCompressTime() const {
+    return total_compress_time_;
+  }
+
+  const std::vector<int64_t>& PartitionLengths() const {
+    return partition_lengths_;
+  }
+
+  const std::vector<int64_t>& RawPartitionLengths() const {
+    return raw_partition_lengths_;
+  }
+
+  int64_t RawPartitionBytes() const {
+    return std::accumulate(raw_partition_lengths_.begin(), raw_partition_lengths_.end(), 0LL);
+  }
+
+  // for testing
+  const std::string& DataFile() const {
+    return options_.data_file;
+  }
+
+  arrow::Status SetCompressType(arrow::Compression::type compressed_type);
+
+ protected:
+  VeloxSplitter(uint32_t num_partitions, const SplitOptions& options)
+      : num_partitions_(num_partitions), options_(options) {}
+
+  virtual arrow::Status Init();
+
+  arrow::Status InitIpcWriteOptions();
+
+  arrow::Status InitPartitions(const facebook::velox::RowVector& rv);
+
+  virtual arrow::Status InitColumnTypes(const facebook::velox::RowVector& rv);
+
+  virtual arrow::Status Partition(const facebook::velox::RowVector& rv) = 0;
+
+  virtual arrow::Status TransferSchema(
+      const facebook::velox::RowVector& rv,
+      std::shared_ptr<arrow::Schema>& input_schema);
+
+  facebook::velox::RowVector GetStrippedRowVector(const facebook::velox::RowVector& rv) const;
+
+  arrow::Status SplitRowVector(const facebook::velox::RowVector& rv);
+
+  arrow::Status InitFromRowVector(const facebook::velox::RowVector& rv);
+
+  arrow::Status CreatePartition2Row(uint32_t row_num);
+
+  arrow::Status UpdateInputHasNull(const facebook::velox::RowVector& rv);
+
+  arrow::Status DoSplit(const facebook::velox::RowVector& rv);
+
+  std::string NextSpilledFileDir();
+
+  arrow::Result<std::shared_ptr<arrow::ipc::IpcPayload>> GetSchemaPayload();
+
+  uint32_t CalculatePartitionBufferSize(const facebook::velox::RowVector& rv);
+
+  arrow::Status AllocatePartitionBuffers(uint32_t partition_id, uint32_t new_size);
+
+  arrow::Status AllocateBufferFromPool(std::shared_ptr<arrow::Buffer>& buffer, uint32_t size);
+
+  arrow::Status AllocateNew(uint32_t partition_id, uint32_t new_size);
+
+  arrow::Status CreateRecordBatchFromBuffer(uint32_t partition_id, bool reset_buffers);
+
+  arrow::Status CacheRecordBatch(uint32_t partition_id, const arrow::RecordBatch& rb);
+
+  arrow::Status SplitFixedWidthValueBuffer(const facebook::velox::RowVector& rv);
+
+  arrow::Status SplitBoolType(const uint8_t* src_addr, const std::vector<uint8_t*>& dst_addrs);
+
+  arrow::Status SplitValidityBuffer(const facebook::velox::RowVector& rv);
+
+  arrow::Status SplitBinaryArray(const facebook::velox::RowVector& rv);
+
+  template <typename T>
+  arrow::Status SplitFixedType(const uint8_t* src_addr, const std::vector<uint8_t*>& dst_addrs) {
+    std::transform(
+        dst_addrs.begin(),
+        dst_addrs.end(),
+        partition_buffer_idx_base_.begin(),
+        partition_buffer_idx_offset_.begin(),
+        [](uint8_t* x, uint32_t y) { return x + y * sizeof(T); });
+
+    for (uint32_t pid = 0; pid < num_partitions_; ++pid) {
+      auto dst_pid_base = reinterpret_cast<T*>(partition_buffer_idx_offset_[pid]);
+      auto pos = partition_2_row_offset_[pid];
+      auto end = partition_2_row_offset_[pid + 1];
+      for (; pos < end; ++pos) {
+        auto row_id = row_offset_2_row_id_[pos];
+        *dst_pid_base++ = reinterpret_cast<const T*>(src_addr)[row_id]; // copy
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status SplitBinaryType(
+      uint32_t binary_idx,
+      const facebook::velox::FlatVector<facebook::velox::StringView>& src,
+      std::vector<BinaryBuff>& dst);
+
+  arrow::Status SplitListArray(const facebook::velox::RowVector& rv);
+
+  arrow::Result<int32_t> SpillLargestPartition(int64_t* size);
+
+  arrow::Status SpillPartition(uint32_t partition_id);
+
+ protected:
+  bool support_avx512_ = false;
+
+  uint32_t num_partitions_ = 0;
+
+  // options
+  SplitOptions options_;
+
+  // the first column may be stripped if hash split
+  std::shared_ptr<arrow::Schema> schema_;
+
+  // store arrow column types
+  std::vector<std::shared_ptr<arrow::DataType>> arrow_column_types_; // column_type_id_
+
+  // store velox column types
+  std::vector<std::shared_ptr<const facebook::velox::Type>> velox_column_types_;
+
+  // write options for tiny batches
+  arrow::ipc::IpcWriteOptions tiny_batch_write_options_;
+
+  // Row ID -> Partition ID
+  // subscript: Row ID
+  // value: Partition ID
+  // TODO: rethink, is uint16_t better?
+  std::vector<uint32_t> row_2_partition_; // note: partition_id_
+
+  // Partition ID -> Row Count
+  // subscript: Partition ID
+  // value: how many rows does this partition have
+  std::vector<uint32_t> partition_2_row_count_; // note: partition_id_cnt_
+
+  // Partition ID -> Buffer Size(unit is row)
+  std::vector<uint32_t> partition_2_buffer_size_;
+
+  // Partition ID -> Row offset
+  // elements num: Partition num + 1
+  // subscript: Partition ID
+  // value: the row offset of this Partition
+  std::vector<uint32_t> partition_2_row_offset_; // note: reducer_offset_offset_
+
+  // Row offset -> Row ID
+  // elements num: Row Num
+  // subscript: Row offset
+  // value: Row ID
+  std::vector<uint32_t> row_offset_2_row_id_; // note: reducer_offsets_
+
+  // Partition ID -> length
+  std::vector<int64_t> partition_lengths_;
+
+  // Partition ID -> raw length
+  std::vector<int64_t> raw_partition_lengths_;
+
+  uint32_t fixed_width_column_count_ = 0;
+
+  std::vector<uint32_t> binary_column_indices_;
+
+  // fixed columns + binary columns
+  std::vector<uint32_t> simple_column_indices_;
+
+  // struct、map、list、large list columns
+  std::vector<uint32_t> complex_column_indices_;
+
+  // partid, value is reducer batch's offset, output rb rownum < 64k
+  std::vector<uint32_t> partition_buffer_idx_base_;
+
+  // temp array to hold the destination pointer
+  std::vector<uint8_t*> partition_buffer_idx_offset_;
+
+  typedef uint32_t row_offset_type;
+
+  class PartitionWriter;
+
+  std::vector<std::shared_ptr<PartitionWriter>> partition_writer_;
+
+  std::vector<std::vector<uint8_t*>> partition_validity_addrs_;
+  std::vector<std::vector<uint8_t*>> partition_fixed_width_value_addrs_;
+
+  std::vector<std::vector<std::vector<std::shared_ptr<arrow::Buffer>>>> partition_buffers_;
+  std::vector<std::vector<std::shared_ptr<arrow::ArrayBuilder>>> partition_list_builders_;
+
+  // slice the buffer for each reducer's column, in this way we can combine into large page
+  std::shared_ptr<arrow::ResizableBuffer> combine_buffer_;
+
+  // partid
+  std::vector<std::vector<std::shared_ptr<arrow::ipc::IpcPayload>>> partition_cached_recordbatch_;
+
+  // partid
+  std::vector<int64_t> partition_cached_recordbatch_size_; // in bytes
+
+  std::vector<uint64_t> binary_array_empirical_size_;
+
+  std::vector<std::vector<BinaryBuff>> partition_binary_addrs_;
+
+  std::vector<bool> input_has_null_;
+
+  int64_t total_bytes_written_ = 0;
+  int64_t total_bytes_spilled_ = 0;
+  int64_t total_write_time_ = 0;
+  int64_t total_spill_time_ = 0;
+  int64_t total_compress_time_ = 0;
+
+  int32_t dir_selection_ = 0;
+  std::vector<int32_t> sub_dir_selection_;
+
+  std::vector<std::string> configured_dirs_;
+
+  std::shared_ptr<arrow::io::OutputStream> data_file_os_;
+
+  // shared by all partition writers
+  std::shared_ptr<arrow::ipc::IpcPayload> schema_payload_;
+}; // class VeloxSplitter
+
+class VeloxRoundRobinSplitter final : public VeloxSplitter {
+ public:
+  VeloxRoundRobinSplitter(uint32_t num_partitions, const SplitOptions& options)
+      : VeloxSplitter(num_partitions, std::move(options)) {}
+
+  arrow::Status Partition(const facebook::velox::RowVector& rv) override;
+
+  uint32_t pid_selection_ = 0;
+}; // class VeloxRoundRobinSplitter
+
+class VeloxSinglePartSplitter final : public VeloxSplitter {
+ public:
+  VeloxSinglePartSplitter(uint32_t num_partitions, const SplitOptions& options)
+      : VeloxSplitter(num_partitions, options) {}
+
+  arrow::Status Init() override;
+
+  arrow::Status Partition(const facebook::velox::RowVector& rv) override;
+
+  arrow::Status Split(const facebook::velox::RowVector& rv) override;
+
+  arrow::Status Stop() override;
+}; // class VeloxSinglePartSplitter
+
+class VeloxHashSplitter final : public VeloxSplitter {
+  // original schema
+  std::shared_ptr<arrow::Schema> input_schema_;
+
+ public:
+  VeloxHashSplitter(uint32_t num_partitions, const SplitOptions& options) : VeloxSplitter(num_partitions, options) {}
+
+  arrow::Status Init() override;
+
+  arrow::Status InitColumnTypes(const facebook::velox::RowVector& rv) override;
+
+  arrow::Status Split(const facebook::velox::RowVector& rv) override;
+
+  arrow::Status Partition(const facebook::velox::RowVector& rv) override;
+
+  const std::shared_ptr<arrow::Schema>& input_schema() const override {
+    return input_schema_;
+  }
+}; // class VeloxHashSplitter
+
+class VeloxFallbackRangeSplitter final : public VeloxSplitter {
+  std::shared_ptr<arrow::Schema> input_schema_;
+
+ public:
+  VeloxFallbackRangeSplitter(uint32_t num_partitions, const SplitOptions& options)
+      : VeloxSplitter(num_partitions, options) {}
+
+  arrow::Status Init() override;
+
+  arrow::Status InitColumnTypes(const facebook::velox::RowVector& rv) override;
+
+  arrow::Status Split(const facebook::velox::RowVector& rv) override;
+
+  const std::shared_ptr<arrow::Schema>& input_schema() const override {
+    return input_schema_;
+  }
+
+  arrow::Status Partition(const facebook::velox::RowVector& rv) override;
+}; // class VeloxFallbackRangeSplitter
+
+} // namespace gluten

--- a/cpp/velox/shuffle/VeloxSplitterPartitionWriter.h
+++ b/cpp/velox/shuffle/VeloxSplitterPartitionWriter.h
@@ -1,0 +1,115 @@
+#pragma once
+
+namespace gluten {
+
+class VeloxSplitter::PartitionWriter {
+ public:
+  PartitionWriter(VeloxSplitter* splitter, uint32_t partition_id) : splitter_(splitter), partition_id_(partition_id) {}
+
+  arrow::Status Spill() {
+#ifndef SKIPWRITE
+    RETURN_NOT_OK(EnsureOpened());
+#endif
+    RETURN_NOT_OK(WriteRecordBatchPayload(spilled_file_os_.get()));
+    ClearCache();
+    return arrow::Status::OK();
+  }
+
+  arrow::Status WriteCachedRecordBatchAndClose() {
+    const auto& data_file_os = splitter_->data_file_os_;
+    ARROW_ASSIGN_OR_RAISE(auto before_write, data_file_os->Tell());
+
+    if (splitter_->options_.write_schema) {
+      RETURN_NOT_OK(WriteSchemaPayload(data_file_os.get()));
+    }
+
+    if (spilled_file_opened_) {
+      RETURN_NOT_OK(spilled_file_os_->Close());
+      RETURN_NOT_OK(MergeSpilled());
+    } else {
+      if (splitter_->partition_cached_recordbatch_size_[partition_id_] == 0) {
+        return arrow::Status::Invalid("Partition writer got empty partition");
+      }
+    }
+
+    RETURN_NOT_OK(WriteRecordBatchPayload(data_file_os.get()));
+    RETURN_NOT_OK(WriteEOS(data_file_os.get()));
+    ClearCache();
+
+    ARROW_ASSIGN_OR_RAISE(auto after_write, data_file_os->Tell());
+    partition_length = after_write - before_write;
+
+    return arrow::Status::OK();
+  }
+
+  // metrics
+  int64_t bytes_spilled = 0;
+  int64_t partition_length = 0;
+  int64_t compress_time = 0;
+
+ private:
+  arrow::Status EnsureOpened() {
+    if (!spilled_file_opened_) {
+      ARROW_ASSIGN_OR_RAISE(spilled_file_, CreateTempShuffleFile(splitter_->NextSpilledFileDir()));
+      ARROW_ASSIGN_OR_RAISE(spilled_file_os_, arrow::io::FileOutputStream::Open(spilled_file_, true));
+      spilled_file_opened_ = true;
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status MergeSpilled() {
+    ARROW_ASSIGN_OR_RAISE(
+        auto spilled_file_is_, arrow::io::MemoryMappedFile::Open(spilled_file_, arrow::io::FileMode::READ));
+    // copy spilled data blocks
+    ARROW_ASSIGN_OR_RAISE(auto nbytes, spilled_file_is_->GetSize());
+    ARROW_ASSIGN_OR_RAISE(auto buffer, spilled_file_is_->Read(nbytes));
+    RETURN_NOT_OK(splitter_->data_file_os_->Write(buffer));
+
+    // close spilled file streams and delete the file
+    RETURN_NOT_OK(spilled_file_is_->Close());
+    auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
+    RETURN_NOT_OK(fs->DeleteFile(spilled_file_));
+    bytes_spilled += nbytes;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status WriteSchemaPayload(arrow::io::OutputStream* os) {
+    ARROW_ASSIGN_OR_RAISE(auto payload, splitter_->GetSchemaPayload());
+    int32_t metadata_length = 0; // unused
+    RETURN_NOT_OK(arrow::ipc::WriteIpcPayload(*payload, splitter_->options_.ipc_write_options, os, &metadata_length));
+    return arrow::Status::OK();
+  }
+
+  arrow::Status WriteRecordBatchPayload(arrow::io::OutputStream* os) {
+    int32_t metadata_length = 0; // unused
+#ifndef SKIPWRITE
+    for (auto& payload : splitter_->partition_cached_recordbatch_[partition_id_]) {
+      RETURN_NOT_OK(arrow::ipc::WriteIpcPayload(*payload, splitter_->options_.ipc_write_options, os, &metadata_length));
+      payload = nullptr;
+    }
+#endif
+    return arrow::Status::OK();
+  }
+
+  arrow::Status WriteEOS(arrow::io::OutputStream* os) {
+    // write EOS
+    constexpr int32_t kZeroLength = 0;
+    RETURN_NOT_OK(os->Write(&kIpcContinuationToken, sizeof(int32_t)));
+    RETURN_NOT_OK(os->Write(&kZeroLength, sizeof(int32_t)));
+    return arrow::Status::OK();
+  }
+
+  void ClearCache() {
+    splitter_->partition_cached_recordbatch_[partition_id_].clear();
+    splitter_->partition_cached_recordbatch_size_[partition_id_] = 0;
+  }
+
+  VeloxSplitter* splitter_;
+  uint32_t partition_id_;
+  std::string spilled_file_;
+  std::shared_ptr<arrow::io::FileOutputStream> spilled_file_os_;
+
+  bool spilled_file_opened_ = false;
+}; // class PartitionWriter
+
+} // namespace gluten

--- a/cpp/velox/tests/VeloxSplitterTest.cc
+++ b/cpp/velox/tests/VeloxSplitterTest.cc
@@ -387,8 +387,8 @@ TEST_F(VeloxSplitterTest, TestSplitterMemoryLeak) {
 }
 #endif
 
-#if 1
 TEST_F(VeloxSplitterTest, TestHashSplitter) {
+#if 0
   uint32_t num_partitions = 2;
   split_options_.buffer_size = 4;
 
@@ -398,7 +398,6 @@ TEST_F(VeloxSplitterTest, TestHashSplitter) {
   // ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_2_));
   // ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_1_));
 
-#if 0
   ASSERT_NOT_OK(splitter_->Stop());
 
   const auto& lengths = splitter_->PartitionLengths();
@@ -424,7 +423,6 @@ TEST_F(VeloxSplitterTest, TestHashSplitter) {
   }
 #endif
 }
-#endif
 
 #if 0
 TEST_F(VeloxSplitterTest, TestFallbackRangeSplitter) {

--- a/cpp/velox/tests/VeloxSplitterTest.cc
+++ b/cpp/velox/tests/VeloxSplitterTest.cc
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#include "shuffle/VeloxSplitter.h"
+#include "tests/TestUtils.h"
+
 #include <arrow/compute/api.h>
 #include <arrow/datum.h>
 #include <arrow/io/api.h>
@@ -26,7 +29,8 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
-void print_trace(void) {
+
+static void print_trace(void) {
   char** strings;
   size_t i, size;
   enum Constexpr { MAX_SIZE = 1024 };
@@ -39,11 +43,7 @@ void print_trace(void) {
   free(strings);
 }
 
-#include "TestUtils.h"
-#include "operators/shuffle/splitter.h"
-
 namespace gluten {
-namespace shuffle {
 
 class MyMemoryPool final : public arrow::MemoryPool {
  public:
@@ -104,23 +104,23 @@ class MyMemoryPool final : public arrow::MemoryPool {
   arrow::internal::MemoryPoolStats stats_;
 };
 
-class SplitterTest : public ::testing::Test {
+class VeloxSplitterTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    auto hash_partition_key = field("hash_partition_key", arrow::int32());
-    auto f_na = field("f_na", arrow::null());
-    auto f_int8_a = field("f_int8_a", arrow::int8());
-    auto f_int8_b = field("f_int8_b", arrow::int8());
-    auto f_int32 = field("f_int32", arrow::int32());
-    auto f_uint64 = field("f_uint64", arrow::uint64());
-    auto f_double = field("f_double", arrow::float64());
-    auto f_bool = field("f_bool", arrow::boolean());
-    auto f_string = field("f_string", arrow::utf8());
-    auto f_nullable_string = field("f_nullable_string", arrow::utf8());
-    auto f_decimal = field("f_decimal128", arrow::decimal(10, 2));
+  void SetUp() {
+    auto hash_partition_key = arrow::field("hash_partition_key", arrow::int32());
+    auto f_na = arrow::field("f_na", arrow::null());
+    auto f_int8_a = arrow::field("f_int8_a", arrow::int8());
+    auto f_int8_b = arrow::field("f_int8_b", arrow::int8());
+    auto f_int32 = arrow::field("f_int32", arrow::int32());
+    auto f_uint64 = arrow::field("f_uint64", arrow::uint64());
+    auto f_double = arrow::field("f_double", arrow::float64());
+    auto f_bool = arrow::field("f_bool", arrow::boolean());
+    auto f_string = arrow::field("f_string", arrow::utf8());
+    auto f_nullable_string = arrow::field("f_nullable_string", arrow::utf8());
+    auto f_decimal = arrow::field("f_decimal128", arrow::decimal(10, 2));
 
-    ARROW_ASSIGN_OR_THROW(tmp_dir_1_, arrow::internal::TemporaryDir::Make(tmp_dir_prefix))
-    ARROW_ASSIGN_OR_THROW(tmp_dir_2_, arrow::internal::TemporaryDir::Make(tmp_dir_prefix))
+    ARROW_ASSIGN_OR_THROW(tmp_dir_1_, std::move(arrow::internal::TemporaryDir::Make(tmp_dir_prefix)))
+    ARROW_ASSIGN_OR_THROW(tmp_dir_2_, std::move(arrow::internal::TemporaryDir::Make(tmp_dir_prefix)))
     auto config_dirs = tmp_dir_1_->path().ToString() + "," + tmp_dir_2_->path().ToString();
 
     setenv("NATIVESQL_SPARK_LOCAL_DIRS", config_dirs.c_str(), 1);
@@ -137,12 +137,14 @@ class SplitterTest : public ::testing::Test {
         input_data_1.begin(),
         input_data_1.end(),
         back_inserter(hash_input_data_1));
+
     std::merge(
         hash_key_2.begin(),
         hash_key_2.end(),
         input_data_2.begin(),
         input_data_2.end(),
         back_inserter(hash_input_data_2));
+
     hash_schema_ = arrow::schema(
         {hash_partition_key,
          f_na,
@@ -155,6 +157,7 @@ class SplitterTest : public ::testing::Test {
          f_string,
          f_nullable_string,
          f_decimal});
+
     MakeInputBatch(hash_input_data_1, hash_schema_, &hash_input_batch_1_);
     MakeInputBatch(hash_input_data_2, hash_schema_, &hash_input_batch_2_);
     split_options_ = SplitOptions::Defaults();
@@ -202,7 +205,7 @@ class SplitterTest : public ::testing::Test {
   std::shared_ptr<arrow::internal::TemporaryDir> tmp_dir_2_;
 
   std::shared_ptr<arrow::Schema> schema_;
-  std::shared_ptr<Splitter> splitter_;
+  std::shared_ptr<VeloxSplitter> splitter_;
   SplitOptions split_options_;
 
   std::shared_ptr<arrow::RecordBatch> input_batch_1_;
@@ -221,8 +224,9 @@ class SplitterTest : public ::testing::Test {
   std::shared_ptr<arrow::io::ReadableFile> file_;
 };
 
-const std::string SplitterTest::tmp_dir_prefix = "columnar-shuffle-test";
-const std::vector<std::string> SplitterTest::input_data_1 = {
+const std::string VeloxSplitterTest::tmp_dir_prefix = "columnar-shuffle-test";
+
+const std::vector<std::string> VeloxSplitterTest::input_data_1 = {
     "[null, null, null, null, null, null, null, null, null, null]",
     "[1, 2, 3, null, 4, null, 5, 6, null, 7]",
     "[1, -1, null, null, -2, 2, null, null, 3, -3]",
@@ -234,7 +238,7 @@ const std::vector<std::string> SplitterTest::input_data_1 = {
     R"(["alice", "bob", null, null, "Alice", "Bob", null, "alicE", null, "boB"])",
     R"(["-1.01", "2.01", "-3.01", null, "0.11", "3.14", "2.27", null, "-3.14", null])"};
 
-const std::vector<std::string> SplitterTest::input_data_2 = {
+const std::vector<std::string> VeloxSplitterTest::input_data_2 = {
     "[null, null]",
     "[null, null]",
     "[1, -1]",
@@ -246,13 +250,14 @@ const std::vector<std::string> SplitterTest::input_data_2 = {
     R"([null, null])",
     R"([null, null])"};
 
-const std::vector<std::string> SplitterTest::hash_key_1 = {"[1, 2, 2, 2, 2, 1, 1, 1, 2, 1]"};
-const std::vector<std::string> SplitterTest::hash_key_2 = {"[2, 2]"};
+const std::vector<std::string> VeloxSplitterTest::hash_key_1 = {"[1, 2, 2, 2, 2, 1, 1, 1, 2, 1]"};
+const std::vector<std::string> VeloxSplitterTest::hash_key_2 = {"[2, 2]"};
 
-TEST_F(SplitterTest, TestSingleSplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestSingleSplitter) {
   split_options_.buffer_size = 10;
 
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, 1, split_options_))
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", 1, split_options_))
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_));
@@ -286,17 +291,18 @@ TEST_F(SplitterTest, TestSingleSplitter) {
       //      std::cout << " result " << rb->column(j)->ToString() << std::endl;
       //      std::cout << " expected " << expected[i]->column(j)->ToString() <<
       //      std::endl;
-      ASSERT_TRUE(
-          rb->column(j)->Equals(*expected[i]->column(j), arrow::EqualOptions::Defaults().diff_sink(&std::cout)));
+      ASSERT_TRUE(rb->column(j)->Equals(*expected[i]->column(j), EqualOptions::Defaults().diff_sink(&std::cout)));
     }
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinSplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinSplitter) {
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_));
@@ -356,8 +362,10 @@ TEST_F(SplitterTest, TestRoundRobinSplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestSplitterMemoryLeak) {
+#if 0
+TEST_F(VeloxSplitterTest, TestSplitterMemoryLeak) {
   std::shared_ptr<arrow::MemoryPool> pool = std::make_shared<MyMemoryPool>(17 * 1024 * 1024);
 
   int32_t num_partitions = 2;
@@ -365,7 +373,7 @@ TEST_F(SplitterTest, TestSplitterMemoryLeak) {
   split_options_.memory_pool = pool;
   split_options_.write_schema = false;
 
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_));
@@ -377,17 +385,20 @@ TEST_F(SplitterTest, TestSplitterMemoryLeak) {
   splitter_.reset();
   ASSERT_TRUE(pool->bytes_allocated() == 0);
 }
+#endif
 
-TEST_F(SplitterTest, TestHashSplitter) {
-  int32_t num_partitions = 2;
+#if 1
+TEST_F(VeloxSplitterTest, TestHashSplitter) {
+  uint32_t num_partitions = 2;
   split_options_.buffer_size = 4;
 
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("hash", hash_schema_, num_partitions, split_options_))
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("hash", num_partitions, split_options_))
 
-  ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_1_));
-  ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_2_));
-  ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_1_));
+  // ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_1_));
+  // ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_2_));
+  // ASSERT_NOT_OK(splitter_->Split(*hash_input_batch_1_));
 
+#if 0
   ASSERT_NOT_OK(splitter_->Stop());
 
   const auto& lengths = splitter_->PartitionLengths();
@@ -411,9 +422,12 @@ TEST_F(SplitterTest, TestHashSplitter) {
       ASSERT_EQ(rb->column(i)->length(), rb->num_rows());
     }
   }
+#endif
 }
+#endif
 
-TEST_F(SplitterTest, TestFallbackRangeSplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestFallbackRangeSplitter) {
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
 
@@ -430,7 +444,7 @@ TEST_F(SplitterTest, TestFallbackRangeSplitter) {
   ARROW_ASSIGN_OR_THROW(input_batch_1_w_pid, input_batch_1_->AddColumn(0, "pid", pid_arr_0));
   ARROW_ASSIGN_OR_THROW(input_batch_2_w_pid, input_batch_2_->AddColumn(0, "pid", pid_arr_1));
 
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("range", std::move(schema_w_pid), num_partitions, split_options_))
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("range", std::move(schema_w_pid), num_partitions, split_options_))
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_1_w_pid));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_2_w_pid));
@@ -490,22 +504,26 @@ TEST_F(SplitterTest, TestFallbackRangeSplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestSpillFailWithOutOfMemory) {
+#if 0
+TEST_F(VeloxSplitterTest, TestSpillFailWithOutOfMemory) {
   auto pool = std::make_shared<MyMemoryPool>(0);
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
   split_options_.memory_pool = pool;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   auto status = splitter_->Split(*input_batch_1_);
   // should return OOM status because there's no partition buffer to spill
   ASSERT_TRUE(status.IsOutOfMemory());
   ASSERT_NOT_OK(splitter_->Stop());
 }
+#endif
 
-TEST_F(SplitterTest, TestSpillLargestPartition) {
+#if 0
+TEST_F(VeloxSplitterTest, TestSpillLargestPartition) {
   std::shared_ptr<arrow::MemoryPool> pool = std::make_shared<MyMemoryPool>(9 * 1024 * 1024);
   //  pool = std::make_shared<arrow::LoggingMemoryPool>(pool.get());
 
@@ -513,7 +531,7 @@ TEST_F(SplitterTest, TestSpillLargestPartition) {
   split_options_.buffer_size = 4;
   // split_options_.memory_pool = pool.get();
   split_options_.compression_type = arrow::Compression::UNCOMPRESSED;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", schema_, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   for (int i = 0; i < 100; ++i) {
     ASSERT_NOT_OK(splitter_->Split(*input_batch_1_));
@@ -523,7 +541,7 @@ TEST_F(SplitterTest, TestSpillLargestPartition) {
   ASSERT_NOT_OK(splitter_->Stop());
 }
 
-TEST_F(SplitterTest, TestRoundRobinListArraySplitter) {
+TEST_F(VeloxSplitterTest, TestRoundRobinListArraySplitter) {
   auto f_arr_str = arrow::field("f_arr", arrow::list(arrow::utf8()));
   auto f_arr_bool = arrow::field("f_bool", arrow::list(arrow::boolean()));
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::int32()));
@@ -544,7 +562,7 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -599,8 +617,10 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinNestListArraySplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinNestListArraySplitter) {
   auto f_arr_str = arrow::field("f_str", arrow::list(arrow::list(arrow::utf8())));
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::list(arrow::int32())));
 
@@ -615,7 +635,7 @@ TEST_F(SplitterTest, TestRoundRobinNestListArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -669,8 +689,10 @@ TEST_F(SplitterTest, TestRoundRobinNestListArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinNestLargeListArraySplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinNestLargeListArraySplitter) {
   auto f_arr_str = arrow::field("f_str", arrow::large_list(arrow::list(arrow::utf8())));
   auto f_arr_int32 = arrow::field("f_int32", arrow::large_list(arrow::list(arrow::int32())));
 
@@ -685,7 +707,7 @@ TEST_F(SplitterTest, TestRoundRobinNestLargeListArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -739,12 +761,12 @@ TEST_F(SplitterTest, TestRoundRobinNestLargeListArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinListStructArraySplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinListStructArraySplitter) {
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::list(arrow::int32())));
-  auto f_arr_list_struct = arrow::field(
-      "f_list_struct",
-      arrow::list(arrow::struct_({arrow::field("a", arrow::int32()), arrow::field("b", arrow::utf8())})));
+  auto f_arr_list_struct = arrow::field("f_list_struct", arrow::list(struct_({arrow::field("a", int32()), arrow::field("b", arrow::utf8())})));
 
   auto rb_schema = arrow::schema({f_arr_int32, f_arr_list_struct});
 
@@ -757,7 +779,7 @@ TEST_F(SplitterTest, TestRoundRobinListStructArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -811,8 +833,10 @@ TEST_F(SplitterTest, TestRoundRobinListStructArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinListMapArraySplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinListMapArraySplitter) {
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::list(arrow::int32())));
   auto f_arr_list_map = arrow::field("f_list_map", arrow::list(arrow::map(arrow::utf8(), arrow::utf8())));
 
@@ -827,7 +851,7 @@ TEST_F(SplitterTest, TestRoundRobinListMapArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -881,12 +905,12 @@ TEST_F(SplitterTest, TestRoundRobinListMapArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinStructArraySplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinStructArraySplitter) {
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::list(arrow::int32())));
-  auto f_arr_struct_list = arrow::field(
-      "f_struct_list",
-      arrow::struct_({arrow::field("a", arrow::list(arrow::int32())), arrow::field("b", arrow::utf8())}));
+  auto f_arr_struct_list = arrow::field("f_struct_list", struct_({arrow::field("a", arrow::list(int32())), arrow::field("b", arrow::utf8())}));
 
   auto rb_schema = arrow::schema({f_arr_int32, f_arr_struct_list});
 
@@ -899,7 +923,7 @@ TEST_F(SplitterTest, TestRoundRobinStructArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -953,8 +977,10 @@ TEST_F(SplitterTest, TestRoundRobinStructArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinMapArraySplitter) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinMapArraySplitter) {
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::list(arrow::int32())));
   auto f_arr_map = arrow::field("f_map", arrow::map(arrow::utf8(), arrow::utf8()));
 
@@ -969,7 +995,7 @@ TEST_F(SplitterTest, TestRoundRobinMapArraySplitter) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
   ASSERT_NOT_OK(splitter_->Stop());
@@ -1023,8 +1049,10 @@ TEST_F(SplitterTest, TestRoundRobinMapArraySplitter) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestHashListArraySplitterWithMorePartitions) {
+#if 0
+TEST_F(VeloxSplitterTest, TestHashListArraySplitterWithMorePartitions) {
   int32_t num_partitions = 5;
   split_options_.buffer_size = 4;
 
@@ -1038,7 +1066,7 @@ TEST_F(SplitterTest, TestHashListArraySplitterWithMorePartitions) {
   std::shared_ptr<arrow::RecordBatch> input_batch_arr;
   MakeInputBatch(input_batch_1_data, rb_schema, &input_batch_arr);
 
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("hash", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("hash", num_partitions, split_options_));
 
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
 
@@ -1064,8 +1092,10 @@ TEST_F(SplitterTest, TestHashListArraySplitterWithMorePartitions) {
     }
   }
 }
+#endif
 
-TEST_F(SplitterTest, TestRoundRobinListArraySplitterwithCompression) {
+#if 0
+TEST_F(VeloxSplitterTest, TestRoundRobinListArraySplitterwithCompression) {
   auto f_arr_str = arrow::field("f_arr", arrow::list(arrow::utf8()));
   auto f_arr_bool = arrow::field("f_bool", arrow::list(arrow::boolean()));
   auto f_arr_int32 = arrow::field("f_int32", arrow::list(arrow::int32()));
@@ -1086,7 +1116,7 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitterwithCompression) {
 
   int32_t num_partitions = 2;
   split_options_.buffer_size = 4;
-  ARROW_ASSIGN_OR_THROW(splitter_, Splitter::Make("rr", rb_schema, num_partitions, split_options_));
+  ARROW_ASSIGN_OR_THROW(splitter_, VeloxSplitter::Make("rr", num_partitions, split_options_));
   auto compression_type = arrow::util::Codec::GetCompressionType("lz4");
   ASSERT_NOT_OK(splitter_->SetCompressType(compression_type.MoveValueUnsafe()));
   ASSERT_NOT_OK(splitter_->Split(*input_batch_arr));
@@ -1142,6 +1172,6 @@ TEST_F(SplitterTest, TestRoundRobinListArraySplitterwithCompression) {
     ASSERT_TRUE(rb->Equals(*expected[i]));
   }
 }
+#endif
 
-} // namespace shuffle
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. add VeloxSplitter to support splitting with `velox::RowVector`. when the backend is `Velox`, splitting with `RowVector` can avoid transferring from `velox::RowVector` to `arrow::RowBatch`, it's more efficient.
2. we should avoid writing `using namespace arrow` or `using namespace facebook::velox` in header files, this usage brings mess and conflict.
3. I will add `Unit test` soon, so file `cpp/velox/tests/VeloxSplitterTest.cc` is not ready now, but it will not affect others.
4. I will also add the `JNI call functions` in file `velox/jni/JniWrapper` soon.

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

