### PR TITLE
[VL] Fix test issues in GlutenCoalesceShufflePartitionsSuite

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -245,7 +245,10 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
     .excludeByPrefix("SPARK-35675")
-  // enableSuite[GlutenCoalesceShufflePartitionsSuite]
+  enableSuite[GlutenCoalesceShufflePartitionsSuite]
+    // Rewrite with columnar operators
+    .excludeByPrefix("SPARK-24705")
+    .excludeByPrefix("SPARK-34790")
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
   enableSuite[GlutenDSV2CharVarcharTestSuite]
   enableSuite[GlutenFileScanSuite]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -249,6 +249,7 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite with columnar operators
     .excludeByPrefix("SPARK-24705")
     .excludeByPrefix("SPARK-34790")
+    .excludeByPrefix("determining the number of reducers")
   enableSuite[GlutenFileSourceCharVarcharTestSuite]
   enableSuite[GlutenDSV2CharVarcharTestSuite]
   enableSuite[GlutenFileScanSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -64,7 +64,7 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
           .set("spark.plugins", "io.glutenproject.GlutenPlugin")
           .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
           .set("spark.memory.offHeap.enabled", "true")
-          .set("spark.memory.offHeap.size", "1024MB")
+          .set("spark.memory.offHeap.size", "2048MB")
     minNumPostShufflePartitions match {
       case Some(numPartitions) =>
         sparkConf.set(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key, numPartitions.toString)

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -265,7 +265,62 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
       // See ShufflePartitionsUtil.coalescePartitions & GlutenColumnarShuffleWriter's mapStatus.
       withSparkSession(test, 40000, minNumPostShufflePartitions)
     }
-    
+
+    test(GLUTEN_TEST + s"determining the number of reducers: complex query 1$testNameNote") {
+      val test: (SparkSession) => Unit = { spark: SparkSession =>
+        val df1 =
+          spark
+              .range(0, 1000, 1, numInputPartitions)
+              .selectExpr("id % 500 as key1", "id as value1")
+              .groupBy("key1")
+              .count()
+              .toDF("key1", "cnt1")
+        val df2 =
+          spark
+              .range(0, 1000, 1, numInputPartitions)
+              .selectExpr("id % 500 as key2", "id as value2")
+              .groupBy("key2")
+              .count()
+              .toDF("key2", "cnt2")
+
+        val join = df1.join(df2, col("key1") === col("key2")).select(col("key1"), col("cnt2"))
+
+        // Check the answer first.
+        val expectedAnswer =
+          spark
+              .range(0, 500)
+              .selectExpr("id", "2 as cnt")
+        QueryTest.checkAnswer(
+          join,
+          expectedAnswer.collect())
+
+        // Then, let's look at the number of post-shuffle partitions estimated
+        // by the ExchangeCoordinator.
+        val finalPlan = join.queryExecution.executedPlan
+            .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+        val shuffleReads = finalPlan.collect {
+          case r@CoalescedShuffleRead() => r
+          // Added for gluten.
+          case r@ColumnarCoalescedShuffleRead() => r
+        }
+
+        minNumPostShufflePartitions match {
+          case Some(numPartitions) =>
+            assert(shuffleReads.isEmpty)
+
+          case None =>
+            assert(shuffleReads.length === 2)
+            shuffleReads.foreach { read =>
+              assert(read.outputPartitioning.numPartitions === 2)
+            }
+        }
+      }
+
+      // Change the original value 16384 to 40000 for gluten. The test depends on the calculation
+      // for bytesByPartitionId in MapOutputStatistics. Gluten has a different statistic result.
+      // See ShufflePartitionsUtil.coalescePartitions & GlutenColumnarShuffleWriter's mapStatus.
+      withSparkSession(test, 40000, minNumPostShufflePartitions)
+    }
 
   }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ColumnarA
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.functions.{col, max}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.{GlutenSQLTestsBaseTrait, GlutenTestsCommonTrait, QueryTest, Row, SparkSession}
+import org.apache.spark.sql.{GlutenTestsCommonTrait, QueryTest, Row, SparkSession}
 
 class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuite
    with GlutenTestsCommonTrait {

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -174,6 +174,7 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
       case None => ""
     }
 
+    // Ported from vanilla spark with targetPostShuffleInputSize changed.
     test(GLUTEN_TEST + s"determining the number of reducers: aggregate operator$testNameNote") {
       val test: SparkSession => Unit = { spark: SparkSession =>
         val df =
@@ -208,6 +209,7 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
       }
       // Change the original value 400 to 6000 in gluten. The test depends on the calculation for
       // bytesByPartitionId in MapOutputStatistics. Gluten has a different statistic result.
+      // See ShufflePartitionsUtil.coalescePartitions.
       withSparkSession(test, 6000, minNumPostShufflePartitions)
     }
   }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -207,7 +207,7 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
             }
         }
       }
-      // Change the original value 400 to 6000 in gluten. The test depends on the calculation for
+      // Change the original value 2000 to 6000 in gluten. The test depends on the calculation for
       // bytesByPartitionId in MapOutputStatistics. Gluten has a different statistic result.
       // See ShufflePartitionsUtil.coalescePartitions.
       withSparkSession(test, 6000, minNumPostShufflePartitions)

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -194,7 +194,8 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
             .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
         val shuffleReads = finalPlan.collect {
            case r@CoalescedShuffleRead() => r
-          case r@ColumnarCoalescedShuffleRead() => r
+           // Added for gluten.
+           case r@ColumnarCoalescedShuffleRead() => r
         }
 
         minNumPostShufflePartitions match {
@@ -207,11 +208,64 @@ class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuit
             }
         }
       }
-      // Change the original value 2000 to 6000 in gluten. The test depends on the calculation for
+      // Change the original value 2000 to 6000 for gluten. The test depends on the calculation for
       // bytesByPartitionId in MapOutputStatistics. Gluten has a different statistic result.
-      // See ShufflePartitionsUtil.coalescePartitions.
+      // See ShufflePartitionsUtil.coalescePartitions & GlutenColumnarShuffleWriter's mapStatus.
       withSparkSession(test, 6000, minNumPostShufflePartitions)
     }
-  }
 
+    test(GLUTEN_TEST + s"determining the number of reducers: join operator$testNameNote") {
+      val test: SparkSession => Unit = { spark: SparkSession =>
+        val df1 =
+          spark
+              .range(0, 1000, 1, numInputPartitions)
+              .selectExpr("id % 500 as key1", "id as value1")
+        val df2 =
+          spark
+              .range(0, 1000, 1, numInputPartitions)
+              .selectExpr("id % 500 as key2", "id as value2")
+
+        val join = df1.join(df2, col("key1") === col("key2")).select(col("key1"), col("value2"))
+
+        // Check the answer first.
+        val expectedAnswer =
+          spark
+              .range(0, 1000)
+              .selectExpr("id % 500 as key", "id as value")
+              .union(spark.range(0, 1000).selectExpr("id % 500 as key", "id as value"))
+        QueryTest.checkAnswer(
+          join,
+          expectedAnswer.collect())
+
+        // Then, let's look at the number of post-shuffle partitions estimated
+        // by the ExchangeCoordinator.
+        val finalPlan = join.queryExecution.executedPlan
+            .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+        print("$$$$$$")
+        print(join.queryExecution.executedPlan)
+        val shuffleReads = finalPlan.collect {
+          case r@CoalescedShuffleRead() => r
+          // Added for gluten.
+          case r@ColumnarCoalescedShuffleRead() => r
+        }
+
+        minNumPostShufflePartitions match {
+          case Some(numPartitions) =>
+            assert(shuffleReads.isEmpty)
+
+          case None =>
+            assert(shuffleReads.length === 2)
+            shuffleReads.foreach { read =>
+              assert(read.outputPartitioning.numPartitions === 2)
+            }
+        }
+      }
+      // Change the original value 16384 to 40000 for gluten. The test depends on the calculation
+      // for bytesByPartitionId in MapOutputStatistics. Gluten has a different statistic result.
+      // See ShufflePartitionsUtil.coalescePartitions & GlutenColumnarShuffleWriter's mapStatus.
+      withSparkSession(test, 40000, minNumPostShufflePartitions)
+    }
+    
+
+  }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -17,8 +17,107 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ColumnarAQEShuffleReadExec, QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.functions.{col, max}
+import org.apache.spark.sql.{GlutenSQLTestsBaseTrait, QueryTest, Row, SparkSession}
 
 class GlutenCoalesceShufflePartitionsSuite extends CoalesceShufflePartitionsSuite
   with GlutenSQLTestsBaseTrait {
+
+  object ColumnarCoalescedShuffleRead {
+    def unapply(read: ColumnarAQEShuffleReadExec): Boolean = {
+      !read.isLocalRead && !read.hasSkewedPartition && read.hasCoalescedPartition
+    }
+  }
+
+  test(GLUTEN_TEST +
+      "SPARK-24705 adaptive query execution works correctly when exchange reuse enabled") {
+    val test: SparkSession => Unit = { spark: SparkSession =>
+      spark.sql("SET spark.sql.exchange.reuse=true")
+      val df = spark.range(0, 6, 1).selectExpr("id AS key", "id AS value")
+
+      // test case 1: a query stage has 3 child stages but they are the same stage.
+      // Final Stage 1
+      //   ShuffleQueryStage 0
+      //   ReusedQueryStage 0
+      //   ReusedQueryStage 0
+      val resultDf = df.join(df, "key").join(df, "key")
+      QueryTest.checkAnswer(resultDf, (0 to 5).map(i => Row(i, i, i, i)))
+      val finalPlan = resultDf.queryExecution.executedPlan
+        .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+      assert(finalPlan.collect {
+        case ShuffleQueryStageExec(_, r: ReusedExchangeExec, _) => r
+      }.length == 2)
+      assert(
+        finalPlan.collect {
+          case r @ CoalescedShuffleRead() => r
+          case c @ ColumnarCoalescedShuffleRead() => c
+        }.length == 3)
+
+      // test case 2: a query stage has 2 parent stages.
+      // Final Stage 3
+      //   ShuffleQueryStage 1
+      //     ShuffleQueryStage 0
+      //   ShuffleQueryStage 2
+      //     ReusedQueryStage 0
+      val grouped = df.groupBy("key").agg(max("value").as("value"))
+      val resultDf2 = grouped.groupBy(col("key") + 1).max("value")
+        .union(grouped.groupBy(col("key") + 2).max("value"))
+      QueryTest.checkAnswer(resultDf2, Row(1, 0) :: Row(2, 0) :: Row(2, 1) :: Row(3, 1) ::
+        Row(3, 2) :: Row(4, 2) :: Row(4, 3) :: Row(5, 3) :: Row(5, 4) :: Row(6, 4) :: Row(6, 5) ::
+        Row(7, 5) :: Nil)
+
+      val finalPlan2 = resultDf2.queryExecution.executedPlan
+        .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+
+      // The result stage has 2 children
+      val level1Stages = finalPlan2.collect { case q: QueryStageExec => q }
+      assert(level1Stages.length == 2)
+      level1Stages.foreach(qs =>
+        assert(qs.plan.collect {
+          case r @ CoalescedShuffleRead() => r
+          case c @ ColumnarCoalescedShuffleRead() => c
+        }.length == 1,
+          "Wrong CoalescedShuffleRead below " + qs.simpleString(3)))
+
+      val leafStages = level1Stages.flatMap { stage =>
+        // All of the child stages of result stage have only one child stage.
+        val children = stage.plan.collect { case q: QueryStageExec => q }
+        assert(children.length == 1)
+        children
+      }
+      assert(leafStages.length == 2)
+
+      val reusedStages = level1Stages.flatMap { stage =>
+        stage.plan.collect {
+          case ShuffleQueryStageExec(_, r: ReusedExchangeExec, _) => r
+        }
+      }
+      assert(reusedStages.length == 1)
+    }
+    withSparkSession(test, 400, None)
+  }
+
+  test(GLUTEN_TEST + "SPARK-34790: enable IO encryption in AQE partition coalescing") {
+    val test: SparkSession => Unit = { spark: SparkSession =>
+      val ds = spark.range(0, 100, 1, numInputPartitions)
+      val resultDf = ds.repartition(ds.col("id"))
+      resultDf.collect()
+
+      val finalPlan = resultDf.queryExecution.executedPlan
+        .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
+      assert(
+        finalPlan.collect {
+          case r @ CoalescedShuffleRead() => r
+          case c @ ColumnarCoalescedShuffleRead() => c
+        }.isDefinedAt(0))
+    }
+    Seq(true, false).foreach { enableIOEncryption =>
+      // Before SPARK-34790, it will throw an exception when io encryption enabled.
+      withSparkSession(test, Int.MaxValue, None, enableIOEncryption)
+    }
+  }
+
 }


### PR DESCRIPTION
We are enabling `GlutenCoalesceShufflePartitionsSuite` for velox backend. A few tests were modified to adapt to gluten based on the original vanilla tests.