### PR TITLE
[CK] support locate

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -33,7 +33,6 @@ object CHExpressionUtil {
   final val CH_EXPR_BLACKLIST: Map[String, Set[String]] = Map(
     REGEXP_EXTRACT -> Set(EMPTY_TYPE),
     REGEXP_EXTRACT_ALL -> Set(EMPTY_TYPE),
-    LOCATE -> Set(EMPTY_TYPE),
     LPAD -> Set(EMPTY_TYPE),
     RPAD -> Set(EMPTY_TYPE),
     REVERSE -> Set(EMPTY_TYPE),


### PR DESCRIPTION
## What changes were proposed in this pull request?
support locate function in gluten by clickhouse backend
1. remove the locate from CH_EXPR_BLACKLIST
2. convert locate function expression locate(s1,s2,n) to if(n<=0, 0, locate(s1,s2,n)), to make sure the result will be 0 while the third parameter is 0

the related issue is: https://github.com/oap-project/gluten/issues/1008
the related clickhouse pr is: https://github.com/Kyligence/ClickHouse/pull/311

## How was this patch tested?
test by manual

