### PR TITLE
[Gluten-core] Unify/Correct the check for whether a spark plan supports adaptive

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -22,9 +22,8 @@ import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar._
 import io.glutenproject.sql.shims.SparkShimLoader
-import io.glutenproject.utils.{LogLevelUtil, PhysicalPlanSelector}
+import io.glutenproject.utils.{AdaptiveSparkPlanUtil, LogLevelUtil, PhysicalPlanSelector}
 import io.glutenproject.{GlutenConfig, GlutenSparkExtensionsInjector}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, Murmur3Hash, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
@@ -81,7 +80,7 @@ case class TransformPreOverrides() extends Rule[SparkPlan] {
   def genColumnarShuffleExchange(plan: ShuffleExchangeExec,
                                  child: SparkPlan,
                                  removeHashColumn: Boolean = false): SparkPlan = {
-    if (SparkShimLoader.getSparkShims.supportAdaptiveWithExchangeConsidered(plan)) {
+    if (AdaptiveSparkPlanUtil.supportAdaptiveWithExchangeConsidered(plan)) {
       ColumnarShuffleExchangeAdaptor(
         plan.outputPartitioning, child, plan.shuffleOrigin, removeHashColumn)
     } else {

--- a/gluten-core/src/main/scala/io/glutenproject/utils/AdaptiveSparkPlanUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/AdaptiveSparkPlanUtil.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.utils
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Mostly ported from spark source code for checking whether a plan supports adaptive.
+ * Since spark-3.2, AQE can work for DPP, so no need to exclude DPP plan in the check.
+ * This part of code may need update for supporting higher versions of spark.
+ */
+object AdaptiveSparkPlanUtil {
+
+  def sanityCheck(plan: SparkPlan): Boolean = plan.logicalLink.isDefined
+
+  def supportAdaptiveWithExchangeConsidered(plan: SparkPlan): Boolean = {
+    // Only QueryStage will have Exchange as Leaf Plan
+    val isLeafPlanExchange = plan match {
+      case _: Exchange => true
+      case _ => false
+    }
+    isLeafPlanExchange || (SQLConf.get.adaptiveExecutionEnabled &&
+        (sanityCheck(plan) &&
+            !plan.logicalLink.exists(_.isStreaming) &&
+            plan.children.forall(supportAdaptiveWithExchangeConsidered)))
+  }
+
+}

--- a/gluten-core/src/main/scala/io/glutenproject/utils/AdaptiveSparkPlanUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/AdaptiveSparkPlanUtil.scala
@@ -41,5 +41,4 @@ object AdaptiveSparkPlanUtil {
             !plan.logicalLink.exists(_.isStreaming) &&
             plan.children.forall(supportAdaptiveWithExchangeConsidered)))
   }
-
 }

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -42,10 +42,6 @@ trait SparkShims {
   // https://github.com/apache/spark/pull/32875
   def getDistribution(leftKeys: Seq[Expression], rightKeys: Seq[Expression]): Seq[Distribution]
 
-  protected def sanityCheck(plan: SparkPlan): Boolean = plan.logicalLink.isDefined
-
-  def supportAdaptiveWithExchangeConsidered(plan: SparkPlan): Boolean
-
   def expressionMappings: Seq[Sig]
 
   def convertPartitionTransforms(partitions: Seq[Transform]): (Seq[String], Option[BucketSpec])

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.Distribution
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
 
 sealed abstract class ShimDescriptor

--- a/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
@@ -40,18 +40,6 @@ class Spark32Shims extends SparkShims {
     HashClusteredDistribution(leftKeys) :: HashClusteredDistribution(rightKeys) :: Nil
   }
 
-  override def supportAdaptiveWithExchangeConsidered(plan: SparkPlan): Boolean = {
-    // Only QueryStage will have Exchange as Leaf Plan
-    val isLeafPlanExchange = plan match {
-      case _: Exchange => true
-      case _ => false
-    }
-    isLeafPlanExchange || (SQLConf.get.adaptiveExecutionEnabled &&
-      (sanityCheck(plan) &&
-        !plan.logicalLink.exists(_.isStreaming) &&
-        plan.children.forall(supportAdaptiveWithExchangeConsidered)))
-  }
-
   override def expressionMappings: Seq[Sig] = Seq.empty
 
   override def convertPartitionTransforms(

--- a/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
@@ -25,11 +25,9 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClusteredDistribution}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
-import org.apache.spark.sql.execution.exchange.Exchange
-import org.apache.spark.sql.internal.SQLConf
 
 class Spark32Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR

--- a/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
@@ -22,14 +22,12 @@ import io.glutenproject.sql.shims.{ShimDescriptor, SparkShims}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{DynamicPruningSubquery, Expression, SplitPart}
+import org.apache.spark.sql.catalyst.expressions.{Expression, SplitPart}
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
-import org.apache.spark.sql.execution.exchange.Exchange
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
 class Spark33Shims extends SparkShims {

--- a/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
@@ -41,20 +41,6 @@ class Spark33Shims extends SparkShims {
     ClusteredDistribution(leftKeys) :: ClusteredDistribution(rightKeys) :: Nil
   }
 
-  override def supportAdaptiveWithExchangeConsidered(plan: SparkPlan): Boolean = {
-    // TODO migrate dynamic-partition-pruning onto adaptive execution.
-    // Only QueryStage will have Exchange as Leaf Plan
-    val isLeafPlanExchange = plan match {
-      case _: Exchange => true
-      case _ => false
-    }
-    isLeafPlanExchange || (SQLConf.get.adaptiveExecutionEnabled &&
-      (sanityCheck(plan) &&
-        !plan.logicalLink.exists(_.isStreaming) &&
-        !plan.expressions.exists(_.find(_.isInstanceOf[DynamicPruningSubquery]).isDefined) &&
-        plan.children.forall(supportAdaptiveWithExchangeConsidered)))
-  }
-
   override def expressionMappings: Seq[Sig] = Seq(
     Sig[SplitPart]("split_part")
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since spark-3.2, AQE can work for DPP. So it's not correct to exclude DPP in the check for spark-3.3. And there is no need to separate the implementation in shim layers. Some code refactor is also done here.