### PR TITLE
[VL][bugfix] fix the bug of Splitter::CalculateSplitBatchSize() processing column bool

### DIFF
--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -771,11 +771,14 @@ Splitter::row_offset_type Splitter::CalculateSplitBatchSize(const arrow::RecordB
       }
     }
   }
+
   size_per_row = std::accumulate(binary_array_empirical_size_.begin(), binary_array_empirical_size_.end(), 0);
 
   for (size_t col = 0; col < array_idx_.size(); ++col) {
     auto col_idx = array_idx_[col];
-    size_per_row += arrow::bit_width(column_type_id_[col_idx]->id()) >> 3;
+    auto type_id = column_type_id_[col_idx]->id();
+    // why +7? to fit column bool
+    size_per_row += ((arrow::bit_width(type_id) + 7) >> 3);
   }
 
   int64_t prealloc_row_cnt = options_.offheap_per_task > 0 && size_per_row > 0


### PR DESCRIPTION
## What changes were proposed in this pull request?

`arrow::bit_width(bool) >> 3 ` will get 0, it's wrong.

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

