### PR TITLE
(refactor) make the code conform to `the Gluten cpp guidelines`

### DIFF
--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -35,6 +35,7 @@ DEFINE_int32(cpu, -1, "Run benchmark on specific CPU");
 DEFINE_int32(threads, 0, "The number of threads to run this benchmark");
 DEFINE_int32(iterations, 0, "The number of iterations to run this benchmark");
 
+using namespace facebook;
 using namespace boost::filesystem;
 namespace fs = std::filesystem;
 
@@ -45,7 +46,7 @@ std::string getExampleFilePath(const std::string& fileName) {
   if (path.is_absolute()) {
     return fileName;
   }
-  return ::facebook::velox::test::getDataFilePath("cpp/velox/benchmarks", "data/" + fileName);
+  return velox::test::getDataFilePath("cpp/velox/benchmarks", "data/" + fileName);
 }
 
 arrow::Result<std::string> getGeneratedFilePath(const std::string& fileName) {
@@ -85,17 +86,17 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string&
   return maybePlan;
 }
 
-std::shared_ptr<facebook::velox::substrait::SplitInfo> getFileInfos(
+std::shared_ptr<velox::substrait::SplitInfo> getFileInfos(
     const std::string& datasetPath,
     const std::string& fileFormat) {
-  auto scanInfo = std::make_shared<facebook::velox::substrait::SplitInfo>();
+  auto scanInfo = std::make_shared<velox::substrait::SplitInfo>();
 
   // Set format to scan info.
-  auto format = facebook::velox::dwio::common::FileFormat::UNKNOWN;
+  auto format = velox::dwio::common::FileFormat::UNKNOWN;
   if (fileFormat.compare("orc") == 0) {
-    format = facebook::velox::dwio::common::FileFormat::ORC;
+    format = velox::dwio::common::FileFormat::ORC;
   } else if (fileFormat.compare("parquet") == 0) {
-    format = facebook::velox::dwio::common::FileFormat::PARQUET;
+    format = velox::dwio::common::FileFormat::PARQUET;
   }
   scanInfo->format = format;
 

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -20,6 +20,8 @@
 #include "BenchmarkUtils.h"
 #include "compute/VeloxBackend.h"
 
+using namespace facebook;
+
 auto BM = [](::benchmark::State& state,
              const std::vector<std::string>& datasetPaths,
              const std::string& jsonFile,
@@ -32,7 +34,7 @@ auto BM = [](::benchmark::State& state,
   }
   auto plan = std::move(maybePlan).ValueOrDie();
 
-  std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>> scanInfos;
+  std::vector<std::shared_ptr<velox::substrait::SplitInfo>> scanInfos;
   scanInfos.reserve(datasetPaths.size());
   for (const auto& datasetPath : datasetPaths) {
     scanInfos.emplace_back(getFileInfos(datasetPath, fileFormat));

--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -17,7 +17,7 @@
 
 #include "ArrowTypeUtils.h"
 
-using namespace facebook::velox;
+using namespace facebook;
 
 namespace gluten {
 
@@ -160,21 +160,21 @@ std::shared_ptr<arrow::DataType> toArrowTypeFromName(const std::string& typeName
   throw std::runtime_error("Type name is not supported: " + typeName + ".");
 }
 
-std::shared_ptr<arrow::DataType> toArrowType(const TypePtr& type) {
+std::shared_ptr<arrow::DataType> toArrowType(const velox::TypePtr& type) {
   switch (type->kind()) {
-    case TypeKind::INTEGER:
+    case velox::TypeKind::INTEGER:
       return arrow::int32();
-    case TypeKind::BIGINT:
+    case velox::TypeKind::BIGINT:
       return arrow::int64();
-    case TypeKind::REAL:
+    case velox::TypeKind::REAL:
       return arrow::float32();
-    case TypeKind::DOUBLE:
+    case velox::TypeKind::DOUBLE:
       return arrow::float64();
-    case TypeKind::VARCHAR:
+    case velox::TypeKind::VARCHAR:
       return arrow::utf8();
-    case TypeKind::VARBINARY:
+    case velox::TypeKind::VARBINARY:
       return arrow::utf8();
-    case TypeKind::TIMESTAMP:
+    case velox::TypeKind::TIMESTAMP:
       return arrow::timestamp(arrow::TimeUnit::MICRO);
     default:
       throw std::runtime_error("Type conversion is not supported.");
@@ -201,7 +201,7 @@ const char* arrowTypeIdToFormatStr(arrow::Type::type typeId) {
 }
 */
 
-std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const RowType>& rowType) {
+std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const velox::RowType>& rowType) {
   std::vector<std::shared_ptr<arrow::Field>> fields;
   auto size = rowType->size();
   fields.reserve(size);

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -99,10 +99,11 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
   reader_options.setFileFormat(format);
 
   if (strncmp(file_path_.c_str(), "file:", 5) == 0) {
-    auto input =
-        std::make_unique<velox::dwio::common::BufferedInput>(std::make_shared<velox::LocalReadFile>(file_path_.substr(5)), *pool_);
+    auto input = std::make_unique<velox::dwio::common::BufferedInput>(
+        std::make_shared<velox::LocalReadFile>(file_path_.substr(5)), *pool_);
     std::unique_ptr<velox::dwio::common::Reader> reader =
-        velox::dwio::common::getReaderFactory(reader_options.getFileFormat())->createReader(std::move(input), reader_options);
+        velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
+            ->createReader(std::move(input), reader_options);
     return toArrowSchema(reader->rowType());
   }
 #ifdef VELOX_ENABLE_HDFS
@@ -114,13 +115,14 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
     hdfsFreeBuilder(builder);
     std::regex hdfsPrefixExp("hdfs://(\\w+)/");
     std::string hdfsFilePath = regex_replace(file_path_.c_str(), hdfsPrefixExp, "/");
-    std::unique_ptr<velox::dwio::common::Reader> reader = velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
-                                                       ->createReader(
-                                                           std::make_unique<velox::dwio::common::BufferedInput>(
-                                                               std::make_shared<velox::dwio::common::ReadFileInputStream>(
-                                                                   std::make_shared<velox::HdfsReadFile>(hdfs, hdfsFilePath)),
-                                                               *pool_),
-                                                           reader_options);
+    std::unique_ptr<velox::dwio::common::Reader> reader =
+        velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
+            ->createReader(
+                std::make_unique<velox::dwio::common::BufferedInput>(
+                    std::make_shared<velox::dwio::common::ReadFileInputStream>(
+                        std::make_shared<velox::HdfsReadFile>(hdfs, hdfsFilePath)),
+                    *pool_),
+                reader_options);
     return toArrowSchema(reader->rowType());
   }
 #endif

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -33,7 +33,7 @@
 #include "velox/row/UnsafeRowSerializer.h"
 #include "velox/vector/arrow/Bridge.h"
 
-using namespace facebook::velox;
+using namespace facebook;
 
 namespace gluten {
 
@@ -62,47 +62,47 @@ void DwrfDatasource::Init(const std::unordered_map<std::string, std::string>& sp
     throw std::runtime_error("Failed to export from Arrow record batch");
   }
 
-  type_ = importFromArrow(c_schema);
-  auto sink = std::make_unique<dwio::common::LocalFileSink>(final_path_);
-  auto config = std::make_shared<dwrf::Config>();
+  type_ = velox::importFromArrow(c_schema);
+  auto sink = std::make_unique<velox::dwio::common::LocalFileSink>(final_path_);
+  auto config = std::make_shared<velox::dwrf::Config>();
 
   for (auto iter = sparkConfs.begin(); iter != sparkConfs.end(); iter++) {
     auto key = iter->first;
     if (strcmp(key.c_str(), "hive.exec.orc.stripe.size") == 0) {
-      config->set(dwrf::Config::STRIPE_SIZE, static_cast<uint64_t>(stoi(iter->second)));
+      config->set(velox::dwrf::Config::STRIPE_SIZE, static_cast<uint64_t>(stoi(iter->second)));
     } else if (strcmp(key.c_str(), "hive.exec.orc.row.index.stride") == 0) {
-      config->set(dwrf::Config::ROW_INDEX_STRIDE, static_cast<uint32_t>(stoi(iter->second)));
+      config->set(velox::dwrf::Config::ROW_INDEX_STRIDE, static_cast<uint32_t>(stoi(iter->second)));
     } else if (strcmp(key.c_str(), "hive.exec.orc.compress") == 0) {
       // Currently velox only support ZLIB and ZSTD and the default is ZSTD.
       if (strcasecmp(iter->second.c_str(), "ZLIB") == 0) {
-        config->set(dwrf::Config::COMPRESSION, dwio::common::CompressionKind::CompressionKind_ZLIB);
+        config->set(velox::dwrf::Config::COMPRESSION, velox::dwio::common::CompressionKind::CompressionKind_ZLIB);
       } else {
-        config->set(dwrf::Config::COMPRESSION, dwio::common::CompressionKind::CompressionKind_ZSTD);
+        config->set(velox::dwrf::Config::COMPRESSION, velox::dwio::common::CompressionKind::CompressionKind_ZSTD);
       }
     }
   }
   const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max();
 
-  dwrf::WriterOptions options;
+  velox::dwrf::WriterOptions options;
   options.config = config;
   options.schema = type_;
   options.memoryBudget = writerMemoryCap;
   options.flushPolicyFactory = nullptr;
   options.layoutPlannerFactory = nullptr;
 
-  writer_ = std::make_unique<dwrf::Writer>(options, std::move(sink), *pool_);
+  writer_ = std::make_unique<velox::dwrf::Writer>(options, std::move(sink), *pool_);
 }
 
 std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
-  dwio::common::ReaderOptions reader_options{pool_};
-  auto format = dwio::common::FileFormat::DWRF; // DWRF
+  velox::dwio::common::ReaderOptions reader_options{pool_};
+  auto format = velox::dwio::common::FileFormat::DWRF; // DWRF
   reader_options.setFileFormat(format);
 
   if (strncmp(file_path_.c_str(), "file:", 5) == 0) {
     auto input =
-        std::make_unique<dwio::common::BufferedInput>(std::make_shared<LocalReadFile>(file_path_.substr(5)), *pool_);
-    std::unique_ptr<dwio::common::Reader> reader =
-        dwio::common::getReaderFactory(reader_options.getFileFormat())->createReader(std::move(input), reader_options);
+        std::make_unique<velox::dwio::common::BufferedInput>(std::make_shared<velox::LocalReadFile>(file_path_.substr(5)), *pool_);
+    std::unique_ptr<velox::dwio::common::Reader> reader =
+        velox::dwio::common::getReaderFactory(reader_options.getFileFormat())->createReader(std::move(input), reader_options);
     return toArrowSchema(reader->rowType());
   }
 #ifdef VELOX_ENABLE_HDFS
@@ -114,11 +114,11 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
     hdfsFreeBuilder(builder);
     std::regex hdfsPrefixExp("hdfs://(\\w+)/");
     std::string hdfsFilePath = regex_replace(file_path_.c_str(), hdfsPrefixExp, "/");
-    std::unique_ptr<dwio::common::Reader> reader = dwio::common::getReaderFactory(reader_options.getFileFormat())
+    std::unique_ptr<velox::dwio::common::Reader> reader = velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
                                                        ->createReader(
-                                                           std::make_unique<dwio::common::BufferedInput>(
-                                                               std::make_shared<dwio::common::ReadFileInputStream>(
-                                                                   std::make_shared<HdfsReadFile>(hdfs, hdfsFilePath)),
+                                                           std::make_unique<velox::dwio::common::BufferedInput>(
+                                                               std::make_shared<velox::dwio::common::ReadFileInputStream>(
+                                                                   std::make_shared<velox::HdfsReadFile>(hdfs, hdfsFilePath)),
                                                                *pool_),
                                                            reader_options);
     return toArrowSchema(reader->rowType());
@@ -139,7 +139,7 @@ void DwrfDatasource::Write(const std::shared_ptr<arrow::RecordBatch>& rb) {
   auto num_cols = rb->num_columns();
   num_rbs_ += 1;
 
-  std::vector<VectorPtr> vecs;
+  std::vector<velox::VectorPtr> vecs;
 
   for (int col_idx = 0; col_idx < num_cols; col_idx++) {
     auto array = rb->column(col_idx);
@@ -150,11 +150,11 @@ void DwrfDatasource::Write(const std::shared_ptr<arrow::RecordBatch>& rb) {
       throw std::runtime_error("Failed to export from Arrow record batch");
     }
 
-    VectorPtr vec = importFromArrowAsOwner(c_schema, c_array, pool_);
+    velox::VectorPtr vec = velox::importFromArrowAsOwner(c_schema, c_array, pool_);
     vecs.push_back(vec);
   }
 
-  auto row_vec = std::make_shared<RowVector>(pool_, type_, nullptr, rb->num_rows(), vecs, 0);
+  auto row_vec = std::make_shared<velox::RowVector>(pool_, type_, nullptr, rb->num_rows(), vecs, 0);
   writer_->write(row_vec);
 }
 

--- a/cpp/velox/compute/RegistrationAllFunctions.cc
+++ b/cpp/velox/compute/RegistrationAllFunctions.cc
@@ -22,27 +22,25 @@
 #include "velox/functions/sparksql/Register.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::exec;
-using namespace facebook::velox::aggregate::prestosql;
+using namespace facebook;
 
 namespace gluten {
 
 void registerCustomFunctions() {
-  exec::registerVectorFunction(
-      "row_constructor", std::vector<std::shared_ptr<exec::FunctionSignature>>{}, std::make_unique<RowConstructor>());
+  velox::exec::registerVectorFunction(
+      "row_constructor", std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{}, std::make_unique<RowConstructor>());
 }
 
 void registerAllFunctions() {
   // The registration order matters. Spark sql functions are registered after
   // presto sql functions to overwrite the registration for same named
   // functions.
-  functions::prestosql::registerAllScalarFunctions();
-  functions::sparksql::registerFunctions("");
+  velox::functions::prestosql::registerAllScalarFunctions();
+  velox::functions::sparksql::registerFunctions("");
   registerCustomFunctions();
-  registerAllAggregateFunctions();
-  functions::sparksql::aggregates::registerAggregateFunctions("");
-  window::prestosql::registerAllWindowFunctions();
+  velox::aggregate::prestosql::registerAllAggregateFunctions();
+  velox::functions::sparksql::aggregates::registerAggregateFunctions("");
+  velox::window::prestosql::registerAllWindowFunctions();
 }
 
 } // namespace gluten

--- a/cpp/velox/compute/RegistrationAllFunctions.cc
+++ b/cpp/velox/compute/RegistrationAllFunctions.cc
@@ -28,7 +28,9 @@ namespace gluten {
 
 void registerCustomFunctions() {
   velox::exec::registerVectorFunction(
-      "row_constructor", std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{}, std::make_unique<RowConstructor>());
+      "row_constructor",
+      std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{},
+      std::make_unique<RowConstructor>());
 }
 
 void registerAllFunctions() {

--- a/cpp/velox/compute/RowConstructor.h
+++ b/cpp/velox/compute/RowConstructor.h
@@ -31,7 +31,8 @@ class RowConstructor final : public facebook::velox::exec::VectorFunction {
       facebook::velox::VectorPtr& result) const override {
     auto argsCopy = args;
 
-    facebook::velox::BufferPtr nulls = facebook::velox::AlignedBuffer::allocate<char>(facebook::velox::bits::nbytes(rows.size()), context.pool(), 1);
+    facebook::velox::BufferPtr nulls =
+        facebook::velox::AlignedBuffer::allocate<char>(facebook::velox::bits::nbytes(rows.size()), context.pool(), 1);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
     auto cntNull = 0;
     rows.applyToSelected([&](facebook::velox::vector_size_t i) {

--- a/cpp/velox/compute/RowConstructor.h
+++ b/cpp/velox/compute/RowConstructor.h
@@ -20,30 +20,27 @@
 #include "velox/expression/VectorFunction.h"
 #include "velox/type/Type.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::exec;
-
 namespace gluten {
 
-class RowConstructor final : public exec::VectorFunction {
+class RowConstructor final : public facebook::velox::exec::VectorFunction {
   void apply(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      const TypePtr& outputType,
-      exec::EvalCtx& context,
-      VectorPtr& result) const override {
+      const facebook::velox::SelectivityVector& rows,
+      std::vector<facebook::velox::VectorPtr>& args,
+      const facebook::velox::TypePtr& outputType,
+      facebook::velox::exec::EvalCtx& context,
+      facebook::velox::VectorPtr& result) const override {
     auto argsCopy = args;
 
-    BufferPtr nulls = AlignedBuffer::allocate<char>(bits::nbytes(rows.size()), context.pool(), 1);
+    facebook::velox::BufferPtr nulls = facebook::velox::AlignedBuffer::allocate<char>(facebook::velox::bits::nbytes(rows.size()), context.pool(), 1);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
     auto cntNull = 0;
-    rows.applyToSelected([&](vector_size_t i) {
-      bits::clearNull(nullsPtr, i);
-      if (!bits::isBitNull(nullsPtr, i)) {
+    rows.applyToSelected([&](facebook::velox::vector_size_t i) {
+      facebook::velox::bits::clearNull(nullsPtr, i);
+      if (!facebook::velox::bits::isBitNull(nullsPtr, i)) {
         for (size_t c = 0; c < argsCopy.size(); c++) {
           auto arg = argsCopy[c].get();
           if (arg->mayHaveNulls() && arg->isNullAt(i)) {
-            bits::setNull(nullsPtr, i, true);
+            facebook::velox::bits::setNull(nullsPtr, i, true);
             cntNull++;
             break;
           }
@@ -51,7 +48,7 @@ class RowConstructor final : public exec::VectorFunction {
       }
     });
 
-    RowVectorPtr localResult = std::make_shared<RowVector>(
+    facebook::velox::RowVectorPtr localResult = std::make_shared<facebook::velox::RowVector>(
         context.pool(), outputType, nulls, rows.size(), std::move(argsCopy), cntNull /*nullCount*/);
     context.moveOrCopyResult(localResult, rows, result);
   }

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -164,8 +164,9 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string> conf) {
 #endif
 
   auto properties = std::make_shared<const velox::core::MemConfig>(configurationValues);
-  auto hiveConnector = velox::connector::getConnectorFactory(velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)
-                           ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
+  auto hiveConnector =
+      velox::connector::getConnectorFactory(velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)
+          ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
 
   velox::connector::registerConnector(hiveConnector);
   velox::parquet::registerParquetReaderFactory(velox::parquet::ParquetReaderType::NATIVE);

--- a/cpp/velox/compute/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/compute/VeloxColumnarToRowConverter.cc
@@ -97,23 +97,23 @@ arrow::Status VeloxColumnarToRowConverter::Write() {
     int64_t field_offset = GetFieldOffset(nullBitsetWidthInBytes_, col_idx);
     auto field_address = (char*)(buffer_address_ + field_offset);
 
-#define SERIALIZE_COLUMN(DataType)                                                    \
-  do {                                                                                \
-    if (mayHaveNulls) {                                                               \
-      for (int row_idx = 0; row_idx < num_rows_; row_idx++) {                         \
-        if (vec->isNullAt(row_idx)) {                                                 \
-          SetNullAt(buffer_address_, offsets_[row_idx], field_offset, col_idx);       \
-        } else {                                                                      \
-          auto write_address = (char*)(field_address + offsets_[row_idx]);            \
+#define SERIALIZE_COLUMN(DataType)                                                                  \
+  do {                                                                                              \
+    if (mayHaveNulls) {                                                                             \
+      for (int row_idx = 0; row_idx < num_rows_; row_idx++) {                                       \
+        if (vec->isNullAt(row_idx)) {                                                               \
+          SetNullAt(buffer_address_, offsets_[row_idx], field_offset, col_idx);                     \
+        } else {                                                                                    \
+          auto write_address = (char*)(field_address + offsets_[row_idx]);                          \
           velox::row::UnsafeRowSerializer::serialize<velox::DataType>(vec, write_address, row_idx); \
-        }                                                                             \
-      }                                                                               \
-    } else {                                                                          \
-      for (int row_idx = 0; row_idx < num_rows_; row_idx++) {                         \
-        auto write_address = (char*)(field_address + offsets_[row_idx]);              \
+        }                                                                                           \
+      }                                                                                             \
+    } else {                                                                                        \
+      for (int row_idx = 0; row_idx < num_rows_; row_idx++) {                                       \
+        auto write_address = (char*)(field_address + offsets_[row_idx]);                            \
         velox::row::UnsafeRowSerializer::serialize<velox::DataType>(vec, write_address, row_idx);   \
-      }                                                                               \
-    }                                                                                 \
+      }                                                                                             \
+    }                                                                                               \
   } while (0)
 
     auto col_type_id = schema_->field(col_idx)->type()->id();

--- a/cpp/velox/compute/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/compute/VeloxColumnarToRowConverter.cc
@@ -28,7 +28,7 @@
 #include "velox/row/UnsafeRowSerializer.h"
 #include "velox/vector/arrow/Bridge.h"
 
-using namespace facebook::velox;
+using namespace facebook;
 
 namespace gluten {
 
@@ -37,7 +37,7 @@ arrow::Status VeloxColumnarToRowConverter::Init() {
   num_cols_ = rv_->childrenSize();
 
   ArrowSchema c_schema{};
-  facebook::velox::exportToArrow(rv_, c_schema);
+  velox::exportToArrow(rv_, c_schema);
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Schema> schema, arrow::ImportSchema(&c_schema));
   if (num_cols_ != schema->num_fields()) {
     return arrow::Status::Invalid("Mismatch: num_cols_ != schema->num_fields()");
@@ -60,7 +60,7 @@ arrow::Status VeloxColumnarToRowConverter::Init() {
   for (int64_t col_idx = 0; col_idx < num_cols_; col_idx++) {
     std::shared_ptr<arrow::Field> field = schema_->field(col_idx);
     if (arrow::is_binary_like(field->type()->id())) {
-      auto str_views = vecs_[col_idx]->asFlatVector<StringView>()->rawValues();
+      auto str_views = vecs_[col_idx]->asFlatVector<velox::StringView>()->rawValues();
       for (int row_idx = 0; row_idx < num_rows_; row_idx++) {
         auto length = str_views[row_idx].size();
         int64_t bytes = RoundNumberOfBytesToNearestWord(length);
@@ -105,13 +105,13 @@ arrow::Status VeloxColumnarToRowConverter::Write() {
           SetNullAt(buffer_address_, offsets_[row_idx], field_offset, col_idx);       \
         } else {                                                                      \
           auto write_address = (char*)(field_address + offsets_[row_idx]);            \
-          row::UnsafeRowSerializer::serialize<DataType>(vec, write_address, row_idx); \
+          velox::row::UnsafeRowSerializer::serialize<velox::DataType>(vec, write_address, row_idx); \
         }                                                                             \
       }                                                                               \
     } else {                                                                          \
       for (int row_idx = 0; row_idx < num_rows_; row_idx++) {                         \
         auto write_address = (char*)(field_address + offsets_[row_idx]);              \
-        row::UnsafeRowSerializer::serialize<DataType>(vec, write_address, row_idx);   \
+        velox::row::UnsafeRowSerializer::serialize<velox::DataType>(vec, write_address, row_idx);   \
       }                                                                               \
     }                                                                                 \
   } while (0)
@@ -153,7 +153,7 @@ arrow::Status VeloxColumnarToRowConverter::Write() {
       }
       case arrow::BinaryType::type_id:
       case arrow::StringType::type_id: {
-        auto str_views = vec->asFlatVector<StringView>()->rawValues();
+        auto str_views = vec->asFlatVector<velox::StringView>()->rawValues();
         for (int row_idx = 0; row_idx < num_rows_; row_idx++) {
           if (mayHaveNulls && vec->isNullAt(row_idx)) {
             SetNullAt(buffer_address_, offsets_[row_idx], field_offset, col_idx);

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -7,7 +7,6 @@
 #include "velox/exec/PlanNodeStats.h"
 
 using namespace facebook;
-using namespace facebook::velox;
 
 namespace gluten {
 
@@ -91,7 +90,7 @@ void WholeStageResultIterator::collectMetrics() {
     const auto& nodeId = orderedNodeIds_[idx];
     if (planStats.find(nodeId) == planStats.end()) {
       if (omittedNodeIds_.find(nodeId) == omittedNodeIds_.end()) {
-#ifdef DEBUG
+#ifdef GLUTEN_PRINT_DEBUG
         std::cout << "Not found node id: " << nodeId << std::endl;
         std::cout << "Plan Node: " << std::endl << planNode_->toString(true, true) << std::endl;
 #endif

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -32,7 +32,7 @@
 
 #include <iostream>
 
-using namespace facebook::velox;
+using namespace facebook;
 
 static std::unordered_map<std::string, std::string> sparkConfs_;
 
@@ -79,14 +79,14 @@ JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJ
   gluten::ParseProtobuf(planData, planSize, &subPlan);
 
   // A query context used for function validation.
-  core::QueryCtx queryCtx;
+  velox::core::QueryCtx queryCtx;
 
   auto pool = gluten::GetDefaultWrappedVeloxMemoryPool();
 
   // An execution context used for function validation.
-  core::ExecCtx execCtx(pool, &queryCtx);
+  velox::core::ExecCtx execCtx(pool, &queryCtx);
 
-  facebook::velox::substrait::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
+  velox::substrait::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
   try {
     return planValidator.validate(subPlan);
   } catch (std::invalid_argument& e) {

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -2,9 +2,7 @@
 
 namespace gluten {
 
-using facebook::velox::BaseVector;
-using facebook::velox::RowVector;
-using facebook::velox::RowVectorPtr;
+using namespace facebook;
 
 void VeloxColumnarBatch::EnsureFlattened() {
   if (flattened_ != nullptr) {
@@ -17,8 +15,8 @@ void VeloxColumnarBatch::EnsureFlattened() {
   }
 
   // Perform copy to flatten dictionary vectors.
-  RowVectorPtr copy = std::dynamic_pointer_cast<RowVector>(
-      BaseVector::create(rowVector_->type(), rowVector_->size(), rowVector_->pool()));
+  velox::RowVectorPtr copy = std::dynamic_pointer_cast<velox::RowVector>(
+      velox::BaseVector::create(rowVector_->type(), rowVector_->size(), rowVector_->pool()));
   copy->copy(rowVector_.get(), 0, 0, rowVector_->size());
   flattened_ = copy;
   auto endTime = std::chrono::steady_clock::now();
@@ -29,14 +27,14 @@ void VeloxColumnarBatch::EnsureFlattened() {
 std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
   auto out = std::make_shared<ArrowSchema>();
   EnsureFlattened();
-  facebook::velox::exportToArrow(flattened_, *out);
+  velox::exportToArrow(flattened_, *out);
   return out;
 }
 
 std::shared_ptr<ArrowArray> VeloxColumnarBatch::exportArrowArray() {
   auto out = std::make_shared<ArrowArray>();
   EnsureFlattened();
-  facebook::velox::exportToArrow(flattened_, *out, GetDefaultWrappedVeloxMemoryPool());
+  velox::exportToArrow(flattened_, *out, GetDefaultWrappedVeloxMemoryPool());
   return out;
 }
 
@@ -56,11 +54,11 @@ void VeloxColumnarBatch::saveToFile(std::shared_ptr<ArrowWriter> writer) {
   GLUTEN_THROW_NOT_OK(writer->writeInBatches(maybeBatch.ValueOrDie()));
 }
 
-RowVectorPtr VeloxColumnarBatch::getRowVector() const {
+velox::RowVectorPtr VeloxColumnarBatch::getRowVector() const {
   return rowVector_;
 }
 
-RowVectorPtr VeloxColumnarBatch::getFlattenedRowVector() {
+velox::RowVectorPtr VeloxColumnarBatch::getFlattenedRowVector() {
   EnsureFlattened();
   return flattened_;
 }

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -17,25 +17,22 @@
 
 #include "VeloxMemoryPool.h"
 
-using facebook::velox::memory::kMaxMemory;
-using facebook::velox::memory::MachinePageCount;
-using facebook::velox::memory::MemoryAllocator;
-using facebook::velox::memory::MemoryManager;
+using namespace facebook;
 
 namespace gluten {
 namespace {
-#define VELOX_MEM_MANUAL_CAP()                                      \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
+#define VELOX_MEM_MANUAL_CAP()                          \
+  _VELOX_THROW(                                         \
+      velox::VeloxRuntimeError,                         \
+      velox::error_source::kErrorSourceRuntime.c_str(), \
+      velox::error_code::kMemCapExceeded.c_str(),       \
+      /* isRetriable */ true,                           \
       "Memory allocation manually capped");
 } // namespace
 
 class VeloxMemoryAllocatorVariant {
  public:
-  VeloxMemoryAllocatorVariant(MemoryAllocator* gluten_alloc) : gluten_alloc_(gluten_alloc) {}
+  VeloxMemoryAllocatorVariant(gluten::MemoryAllocator* gluten_alloc) : gluten_alloc_(gluten_alloc) {}
 
   static std::shared_ptr<VeloxMemoryAllocatorVariant> createDefaultAllocator() {
     static std::shared_ptr<VeloxMemoryAllocatorVariant> velox_alloc =
@@ -92,22 +89,22 @@ class VeloxMemoryAllocatorVariant {
   }
 
  private:
-  MemoryAllocator* gluten_alloc_;
+  gluten::MemoryAllocator* gluten_alloc_;
 };
 
 //  The code is originated from /velox/common/memory/Memory.h
 //  Removed memory manager.
-class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool {
+class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
  public:
   // Should perhaps make this method private so that we only create node through
   // parent.
   WrappedVeloxMemoryPool(
-      facebook::velox::memory::MemoryManager& memoryManager,
+      velox::memory::MemoryManager& memoryManager,
       const std::string& name,
-      std::shared_ptr<MemoryPool> parent,
+      std::shared_ptr<velox::memory::MemoryPool> parent,
       std::shared_ptr<VeloxMemoryAllocatorVariant> glutenAllocator,
       const Options& options = Options{})
-      : MemoryPool{name, parent, options},
+      : velox::memory::MemoryPool{name, parent, options},
         cap_{options.capacity},
         memoryManager_{memoryManager},
         localMemoryUsage_{},
@@ -183,9 +180,9 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
 
   // FIXME: This function should call glutenAllocator_.
   void allocateNonContiguous(
-      MachinePageCount numPages,
-      facebook::velox::memory::Allocation& out,
-      MachinePageCount minSizeClass) {
+      velox::memory::MachinePageCount numPages,
+      velox::memory::Allocation& out,
+      velox::memory::MachinePageCount minSizeClass) {
     VELOX_CHECK_GT(numPages, 0);
 
     if (!allocator_.allocateNonContiguous(
@@ -205,7 +202,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     out.setPool(this);
   }
 
-  void freeNonContiguous(facebook::velox::memory::Allocation& allocation) {
+  void freeNonContiguous(velox::memory::Allocation& allocation) {
     const int64_t freedBytes = allocator_.freeNonContiguous(allocation);
     VELOX_CHECK(allocation.empty());
     if (memoryUsageTracker_ != nullptr) {
@@ -213,15 +210,15 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     }
   }
 
-  MachinePageCount largestSizeClass() const {
+  velox::memory::MachinePageCount largestSizeClass() const {
     return allocator_.largestSizeClass();
   }
 
-  const std::vector<MachinePageCount>& sizeClasses() const {
+  const std::vector<velox::memory::MachinePageCount>& sizeClasses() const {
     return allocator_.sizeClasses();
   }
 
-  void allocateContiguous(MachinePageCount numPages, facebook::velox::memory::ContiguousAllocation& out) {
+  void allocateContiguous(velox::memory::MachinePageCount numPages, velox::memory::ContiguousAllocation& out) {
     VELOX_CHECK_GT(numPages, 0);
 
     if (!allocator_.allocateContiguous(numPages, nullptr, out, [this](int64_t allocBytes, bool preAlloc) {
@@ -237,7 +234,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     out.setPool(this);
   }
 
-  void freeContiguous(facebook::velox::memory::ContiguousAllocation& allocation) {
+  void freeContiguous(velox::memory::ContiguousAllocation& allocation) {
     const int64_t bytesToFree = allocation.size();
     allocator_.freeContiguous(allocation);
     VELOX_CHECK(allocation.empty());
@@ -275,7 +272,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     return std::max(getSubtreeMaxBytes(), localMemoryUsage_.getMaxBytes());
   }
 
-  void setMemoryUsageTracker(const std::shared_ptr<facebook::velox::memory::MemoryUsageTracker>& tracker) {
+  void setMemoryUsageTracker(const std::shared_ptr<velox::memory::MemoryUsageTracker>& tracker) {
     const auto currentBytes = getCurrentBytes();
     if (memoryUsageTracker_) {
       memoryUsageTracker_->update(-currentBytes);
@@ -284,18 +281,18 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     memoryUsageTracker_->update(currentBytes);
   }
 
-  const std::shared_ptr<facebook::velox::memory::MemoryUsageTracker>& getMemoryUsageTracker() const {
+  const std::shared_ptr<velox::memory::MemoryUsageTracker>& getMemoryUsageTracker() const {
     return memoryUsageTracker_;
   }
 
   void setSubtreeMemoryUsage(int64_t size) {
     updateSubtreeMemoryUsage(
-        [size](facebook::velox::memory::MemoryUsage& subtreeUsage) { subtreeUsage.setCurrentBytes(size); });
+        [size](velox::memory::MemoryUsage& subtreeUsage) { subtreeUsage.setCurrentBytes(size); });
   }
 
   int64_t updateSubtreeMemoryUsage(int64_t size) {
     int64_t aggregateBytes;
-    updateSubtreeMemoryUsage([&aggregateBytes, size](facebook::velox::memory::MemoryUsage& subtreeUsage) {
+    updateSubtreeMemoryUsage([&aggregateBytes, size](velox::memory::MemoryUsage& subtreeUsage) {
       aggregateBytes = subtreeUsage.getCurrentBytes() + size;
       subtreeUsage.setCurrentBytes(aggregateBytes);
     });
@@ -315,7 +312,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     return capped_.load();
   }
 
-  std::shared_ptr<MemoryPool> genChild(std::shared_ptr<MemoryPool> parent, const std::string& name) {
+  std::shared_ptr<velox::memory::MemoryPool> genChild(std::shared_ptr<velox::memory::MemoryPool> parent, const std::string& name) {
     return std::make_shared<WrappedVeloxMemoryPool>(
         memoryManager_, name, parent, glutenAllocator_, Options{.alignment = alignment_});
   }
@@ -323,7 +320,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
   // Gets the memory allocation stats of the MemoryPoolImpl attached to the
   // current MemoryPoolImpl. Not to be confused with total memory usage of the
   // subtree.
-  const facebook::velox::memory::MemoryUsage& getLocalMemoryUsage() const {
+  const velox::memory::MemoryUsage& getLocalMemoryUsage() const {
     return localMemoryUsage_;
   }
 
@@ -331,7 +328,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
   // children.
   int64_t getAggregateBytes() const {
     int64_t aggregateBytes = localMemoryUsage_.getCurrentBytes();
-    accessSubtreeMemoryUsage([&aggregateBytes](const facebook::velox::memory::MemoryUsage& subtreeUsage) {
+    accessSubtreeMemoryUsage([&aggregateBytes](const velox::memory::MemoryUsage& subtreeUsage) {
       aggregateBytes += subtreeUsage.getCurrentBytes();
     });
     return aggregateBytes;
@@ -339,7 +336,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
 
   int64_t getSubtreeMaxBytes() const {
     int64_t maxBytes;
-    accessSubtreeMemoryUsage([&maxBytes](const facebook::velox::memory::MemoryUsage& subtreeUsage) {
+    accessSubtreeMemoryUsage([&maxBytes](const velox::memory::MemoryUsage& subtreeUsage) {
       maxBytes = subtreeUsage.getMaxBytes();
     });
     return maxBytes;
@@ -378,7 +375,7 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
 
   std::string toString() const {
     return fmt::format(
-        "Memory Pool[{} {}]", name_, facebook::velox::memory::MemoryAllocator::kindString(allocator_.kind()));
+        "Memory Pool[{} {}]", name_, velox::memory::MemoryAllocator::kindString(allocator_.kind()));
   }
 
  private:
@@ -393,37 +390,37 @@ class WrappedVeloxMemoryPool final : public facebook::velox::memory::MemoryPool 
     return glutenAllocator_->realloc(p, size, newSize);
   }
 
-  void accessSubtreeMemoryUsage(std::function<void(const facebook::velox::memory::MemoryUsage&)> visitor) const {
+  void accessSubtreeMemoryUsage(std::function<void(const velox::memory::MemoryUsage&)> visitor) const {
     folly::SharedMutex::ReadHolder readLock{subtreeUsageMutex_};
     visitor(subtreeMemoryUsage_);
   }
 
-  void updateSubtreeMemoryUsage(std::function<void(facebook::velox::memory::MemoryUsage&)> visitor) {
+  void updateSubtreeMemoryUsage(std::function<void(velox::memory::MemoryUsage&)> visitor) {
     folly::SharedMutex::WriteHolder writeLock{subtreeUsageMutex_};
     visitor(subtreeMemoryUsage_);
   }
 
   int64_t cap_;
-  MemoryManager& memoryManager_;
+  velox::memory::MemoryManager& memoryManager_;
 
   // Memory allocated attributed to the memory node.
-  facebook::velox::memory::MemoryUsage localMemoryUsage_;
-  std::shared_ptr<facebook::velox::memory::MemoryUsageTracker> memoryUsageTracker_;
+  velox::memory::MemoryUsage localMemoryUsage_;
+  std::shared_ptr<velox::memory::MemoryUsageTracker> memoryUsageTracker_;
   mutable folly::SharedMutex subtreeUsageMutex_;
-  facebook::velox::memory::MemoryUsage subtreeMemoryUsage_;
+  velox::memory::MemoryUsage subtreeMemoryUsage_;
   std::atomic_bool capped_{false};
-  facebook::velox::memory::MemoryAllocator& allocator_;
+  velox::memory::MemoryAllocator& allocator_;
   std::shared_ptr<VeloxMemoryAllocatorVariant> glutenAllocator_;
 };
 
-std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(MemoryAllocator* allocator) {
+std::shared_ptr<velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(gluten::MemoryAllocator* allocator) {
   return std::make_shared<WrappedVeloxMemoryPool>(
-      MemoryManager::getInstance(), "wrapped", nullptr, std::make_shared<VeloxMemoryAllocatorVariant>(allocator));
+      velox::memory::MemoryManager::getInstance(), "wrapped", nullptr, std::make_shared<VeloxMemoryAllocatorVariant>(allocator));
 }
 
-facebook::velox::memory::MemoryPool* GetDefaultWrappedVeloxMemoryPool() {
+velox::memory::MemoryPool* GetDefaultWrappedVeloxMemoryPool() {
   static WrappedVeloxMemoryPool default_pool(
-      MemoryManager::getInstance(), "root", nullptr, VeloxMemoryAllocatorVariant::createDefaultAllocator());
+      velox::memory::MemoryManager::getInstance(), "root", nullptr, VeloxMemoryAllocatorVariant::createDefaultAllocator());
   return &default_pool;
 }
 

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -286,8 +286,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
   }
 
   void setSubtreeMemoryUsage(int64_t size) {
-    updateSubtreeMemoryUsage(
-        [size](velox::memory::MemoryUsage& subtreeUsage) { subtreeUsage.setCurrentBytes(size); });
+    updateSubtreeMemoryUsage([size](velox::memory::MemoryUsage& subtreeUsage) { subtreeUsage.setCurrentBytes(size); });
   }
 
   int64_t updateSubtreeMemoryUsage(int64_t size) {
@@ -312,7 +311,9 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     return capped_.load();
   }
 
-  std::shared_ptr<velox::memory::MemoryPool> genChild(std::shared_ptr<velox::memory::MemoryPool> parent, const std::string& name) {
+  std::shared_ptr<velox::memory::MemoryPool> genChild(
+      std::shared_ptr<velox::memory::MemoryPool> parent,
+      const std::string& name) {
     return std::make_shared<WrappedVeloxMemoryPool>(
         memoryManager_, name, parent, glutenAllocator_, Options{.alignment = alignment_});
   }
@@ -336,9 +337,8 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
 
   int64_t getSubtreeMaxBytes() const {
     int64_t maxBytes;
-    accessSubtreeMemoryUsage([&maxBytes](const velox::memory::MemoryUsage& subtreeUsage) {
-      maxBytes = subtreeUsage.getMaxBytes();
-    });
+    accessSubtreeMemoryUsage(
+        [&maxBytes](const velox::memory::MemoryUsage& subtreeUsage) { maxBytes = subtreeUsage.getMaxBytes(); });
     return maxBytes;
   }
 
@@ -374,8 +374,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
   }
 
   std::string toString() const {
-    return fmt::format(
-        "Memory Pool[{} {}]", name_, velox::memory::MemoryAllocator::kindString(allocator_.kind()));
+    return fmt::format("Memory Pool[{} {}]", name_, velox::memory::MemoryAllocator::kindString(allocator_.kind()));
   }
 
  private:
@@ -415,12 +414,18 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
 
 std::shared_ptr<velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(gluten::MemoryAllocator* allocator) {
   return std::make_shared<WrappedVeloxMemoryPool>(
-      velox::memory::MemoryManager::getInstance(), "wrapped", nullptr, std::make_shared<VeloxMemoryAllocatorVariant>(allocator));
+      velox::memory::MemoryManager::getInstance(),
+      "wrapped",
+      nullptr,
+      std::make_shared<VeloxMemoryAllocatorVariant>(allocator));
 }
 
 velox::memory::MemoryPool* GetDefaultWrappedVeloxMemoryPool() {
   static WrappedVeloxMemoryPool default_pool(
-      velox::memory::MemoryManager::getInstance(), "root", nullptr, VeloxMemoryAllocatorVariant::createDefaultAllocator());
+      velox::memory::MemoryManager::getInstance(),
+      "root",
+      nullptr,
+      VeloxMemoryAllocatorVariant::createDefaultAllocator());
   return &default_pool;
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. avoid `using namespace xxx` in the header files.
2. I think using a fully qualified name is better than `using namespace` in most cases, but `using namespace facebook` in source files is no problem because `velox` is unique and we needn't use `facebook::velox` to guard.
3. let me explain why I proposed this PR:
- the Gluten project uses many third libraries, such as `arrow、velox、Substrait、protobuf`, so using a fully qualified name can express clear intention. don't let me guess.
- `using namespace xxx` will bring conflict and mess, I remind here again.

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

