### PR TITLE
[VL] All unit test for velox splitter passed

### DIFF
--- a/cpp/core/tests/TestUtils.h
+++ b/cpp/core/tests/TestUtils.h
@@ -88,7 +88,7 @@ void MakeInputBatch(
   std::vector<std::shared_ptr<arrow::Array>> array_list;
   int length = -1;
   int i = 0;
-  for (auto data : input_data) {
+  for (auto& data : input_data) {
     std::shared_ptr<arrow::Array> a0;
     ARROW_ASSIGN_OR_THROW(a0, arrow::ipc::internal::json::ArrayFromJSON(sch->field(i++)->type(), data.c_str()));
     if (length == -1) {
@@ -99,5 +99,4 @@ void MakeInputBatch(
   }
 
   *input_batch = arrow::RecordBatch::Make(sch, length, array_list);
-  return;
 }

--- a/cpp/core/utils/Print.h
+++ b/cpp/core/utils/Print.h
@@ -10,11 +10,6 @@ namespace gluten {
 // the token `ToString` means the method of `ToString()`
 // the token `2String` means the method of `toString()`
 
-// just for test, will be deleted in the future
-#ifndef GLUTEN_PRINT_DEBUG
-// #define GLUTEN_PRINT_DEBUG
-#endif
-
 #ifdef GLUTEN_PRINT_DEBUG
 
 template <typename T>

--- a/cpp/velox/shuffle/VeloxSplitter.h
+++ b/cpp/velox/shuffle/VeloxSplitter.h
@@ -31,6 +31,47 @@
 
 namespace gluten {
 
+// set 1 to open print
+#define VELOX_SPLITTER_PRINT 0
+
+#if VELOX_SPLITTER_PRINT
+
+#define VsPrint Print
+#define VsPrintLF PrintLF
+#define VsPrintSplit PrintSplit
+#define VsPrintSplitLF PrintSplitLF
+#define VsPrintVectorRange PrintVectorRange
+#define VS_PRINT PRINT
+#define VS_PRINTLF PRINTLF
+#define VS_PRINT_FUNCTION_NAME PRINT_FUNCTION_NAME
+#define VS_PRINT_FUNCTION_SPLIT_LINE PRINT_FUNCTION_SPLIT_LINE
+#define VS_PRINT_CONTAINER PRINT_CONTAINER
+#define VS_PRINT_CONTAINER_TO_STRING PRINT_CONTAINER_TO_STRING
+#define VS_PRINT_CONTAINER_2_STRING PRINT_CONTAINER_2_STRING
+#define VS_PRINT_VECTOR_TO_STRING PRINT_VECTOR_TO_STRING
+#define VS_PRINT_VECTOR_2_STRING PRINT_VECTOR_2_STRING
+#define VS_PRINT_VECTOR_MAPPING PRINT_VECTOR_MAPPING
+
+#else // VELOX_SPLITTER_PRINT
+
+#define VsPrint(...)
+#define VsPrintLF(...)
+#define VsPrintSplit(...)
+#define VsPrintSplitLF(...)
+#define VsPrintVectorRange(...)
+#define VS_PRINT(a)
+#define VS_PRINTLF(a)
+#define VS_PRINT_FUNCTION_NAME()
+#define VS_PRINT_FUNCTION_SPLIT_LINE()
+#define VS_PRINT_CONTAINER(c)
+#define VS_PRINT_CONTAINER_TO_STRING(c)
+#define VS_PRINT_CONTAINER_2_STRING(c)
+#define VS_PRINT_VECTOR_TO_STRING(v)
+#define VS_PRINT_VECTOR_2_STRING(v)
+#define VS_PRINT_VECTOR_MAPPING(v)
+
+#endif // end of VELOX_SPLITTER_PRINT
+
 class VeloxSplitter {
   enum { VALIDITY_BUFFER_INDEX = 0, OFFSET_BUFFER_INDEX = 1, VALUE_BUFFER_INEDX = 2 };
 
@@ -105,47 +146,49 @@ class VeloxSplitter {
 
   // for debugging
   void PrintColumnsInfo() const {
-    PRINT_FUNCTION_SPLIT_LINE();
-    PRINTLF(fixed_width_column_count_);
+    VS_PRINT_FUNCTION_SPLIT_LINE();
+    VS_PRINTLF(fixed_width_column_count_);
 
-    PRINT_CONTAINER(simple_column_indices_);
-    PRINT_CONTAINER(binary_column_indices_);
-    PRINT_CONTAINER(complex_column_indices_);
+    VS_PRINT_CONTAINER(simple_column_indices_);
+    VS_PRINT_CONTAINER(binary_column_indices_);
+    VS_PRINT_CONTAINER(complex_column_indices_);
 
-    PRINT_VECTOR_2_STRING(velox_column_types_);
-    PRINT_VECTOR_TO_STRING(arrow_column_types_);
+    VS_PRINT_VECTOR_2_STRING(velox_column_types_);
+    VS_PRINT_VECTOR_TO_STRING(arrow_column_types_);
   }
 
   void PrintPartition() const {
-    PRINT_FUNCTION_SPLIT_LINE();
+    VS_PRINT_FUNCTION_SPLIT_LINE();
     // row ID -> partition ID
-    PRINT_VECTOR_MAPPING(row_2_partition_);
+    VS_PRINT_VECTOR_MAPPING(row_2_partition_);
 
     // partition -> row count
-    PRINT_VECTOR_MAPPING(partition_2_row_count_);
+    VS_PRINT_VECTOR_MAPPING(partition_2_row_count_);
   }
 
   void PrintPartitionBuffer() const {
-    PRINT_FUNCTION_SPLIT_LINE();
-    PRINT_VECTOR_MAPPING(partition_2_buffer_size_);
-    PRINT_VECTOR_MAPPING(partition_buffer_idx_base_);
+    VS_PRINT_FUNCTION_SPLIT_LINE();
+    VS_PRINT_VECTOR_MAPPING(partition_2_buffer_size_);
+    VS_PRINT_VECTOR_MAPPING(partition_buffer_idx_base_);
   }
 
   void PrintPartition2Row() const {
-    PRINT_FUNCTION_SPLIT_LINE();
-    PRINT_VECTOR_MAPPING(partition_2_row_offset_);
+    VS_PRINT_FUNCTION_SPLIT_LINE();
+    VS_PRINT_VECTOR_MAPPING(partition_2_row_offset_);
 
+#if VELOX_SPLITTER_PRINT
     for (auto pid = 0; pid < num_partitions_; ++pid) {
       auto begin = partition_2_row_offset_[pid];
       auto end = partition_2_row_offset_[pid + 1];
-      Print("partition", pid);
-      PrintVectorRange(row_offset_2_row_id_, begin, end);
+      VsPrint("partition", pid);
+      VsPrintVectorRange(row_offset_2_row_id_, begin, end);
     }
+#endif
   }
 
   void PrintInputHasNull() const {
-    PRINT_FUNCTION_SPLIT_LINE();
-    PRINT_CONTAINER(input_has_null_);
+    VS_PRINT_FUNCTION_SPLIT_LINE();
+    VS_PRINT_CONTAINER(input_has_null_);
   }
 
  protected:


### PR DESCRIPTION
## What changes were proposed in this pull request?

add unit test for VeloxSplitter according to SplitterTest.

all UT passed except `TestRoundRobinNestLargeListArraySplitter` because `importFromArrow` does not support large list

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

