### PR TITLE
[Gluten-1072] [CH] Fix NPE when executing BatchScanExecTransformer.getInputFilePaths with MergeTree DS V2

### DIFF
--- a/backends-clickhouse/src/main/delta-20/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
+++ b/backends-clickhouse/src/main/delta-20/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.actions.Metadata
+
+class DeltaMergeTreeFileFormat(metadata: Metadata)
+  extends DeltaParquetFileFormat(metadata.columnMappingMode, metadata.schema) {
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case ff: DeltaMergeTreeFileFormat =>
+        ff.columnMappingMode == columnMappingMode && ff.referenceSchema == referenceSchema
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = getClass.getCanonicalName.hashCode()
+}

--- a/backends-clickhouse/src/main/delta-22/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
+++ b/backends-clickhouse/src/main/delta-22/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
+
+import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.actions.Metadata
+
+class DeltaMergeTreeFileFormat(metadata: Metadata) extends DeltaParquetFileFormat(metadata) {
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case ff: DeltaMergeTreeFileFormat =>
+        ff.columnMappingMode == columnMappingMode && ff.referenceSchema == referenceSchema
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = getClass.getCanonicalName.hashCode()
+}

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/table/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/table/ClickHouseTableV2.scala
@@ -31,11 +31,11 @@ import org.apache.spark.sql.delta.actions.{AddFile, Metadata, SingleAction}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSQLConf}
-import org.apache.spark.sql.execution.datasources.HadoopFsRelation
+import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation}
 import org.apache.spark.sql.execution.datasources.v1.ClickHouseFileIndex
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.{ClickHouseConfig, ClickHouseLog}
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.metadata.{AddFileTags, AddMergeTreeParts}
-import org.apache.spark.sql.execution.datasources.v2.clickhouse.source.{ClickHouseScanBuilder, ClickHouseWriteBuilder}
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.source.{ClickHouseScanBuilder, ClickHouseWriteBuilder, DeltaMergeTreeFileFormat}
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -268,6 +268,10 @@ case class ClickHouseTableV2(
     // TODO: Refresh cache after writing data.
     val allParts = ClickHouseTableV2.fileStatusCache.get(this.rootPath)
     allParts
+  }
+
+  override def fileFormat(metadata: Metadata): FileFormat = {
+    new DeltaMergeTreeFileFormat(metadata)
   }
 }
 

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -34,6 +34,7 @@ public class LocalFilesNode implements Serializable {
     ArrowReadFormat(),
     OrcReadFormat(),
     DwrfReadFormat(),
+    MergeTreeReadFormat(),
     UnknownFormat()
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -360,6 +360,7 @@ object ConverterUtils extends Logging {
           case "OrcScan" => ReadFileFormat.OrcReadFormat
           case "ParquetScan" => ReadFileFormat.ParquetReadFormat
           case "DwrfScan" => ReadFileFormat.DwrfReadFormat
+          case "ClickHouseScan" => ReadFileFormat.MergeTreeReadFormat
           case _ => ReadFileFormat.UnknownFormat
         }
       case f: FileSourceScanExecTransformer =>
@@ -367,6 +368,7 @@ object ConverterUtils extends Logging {
           case "OrcFileFormat" => ReadFileFormat.OrcReadFormat
           case "ParquetFileFormat" => ReadFileFormat.ParquetReadFormat
           case "DwrfFileFormat" => ReadFileFormat.DwrfReadFormat
+          case "DeltaMergeTreeFileFormat" => ReadFileFormat.MergeTreeReadFormat
           case _ => ReadFileFormat.UnknownFormat
         }
       case _ => ReadFileFormat.UnknownFormat

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -22,7 +22,6 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.{GlutenColumnarToRowExecBase, WholeStageTransformerExec}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
 import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
@@ -249,7 +248,7 @@ object ExpressionConverter extends Logging {
             getStructField)
       case md5: Md5 =>
         Md5Transformer(substraitExprName,
-          replaceWithExpressionTransformer(md5.child, attributeSeq), md5) 
+          replaceWithExpressionTransformer(md5.child, attributeSeq), md5)
       case t: StringTranslate =>
         StringTranslateTransformer(substraitExprName,
           replaceWithExpressionTransformer(t.srcExpr, attributeSeq),


### PR DESCRIPTION
## What changes were proposed in this pull request?
The override method fileIndex in MergeTree DS V2 ClickHouseScan returns null, when calling BatchScanExecTransformer.getInputFilePaths it will return null and lead to NPE.

Close #1072 .

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

