### PR TITLE
[Gluten-1100] Making transformer plan log more obvious#1100

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -278,6 +278,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     selected
   }
 
+  override val nodeNamePrefix: String = "NativeFile"
 }
 
 object FileSourceScanExecTransformer {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -149,7 +149,7 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
       maxFields: Int,
       printNodeId: Boolean,
       indent: Int = 0): Unit = {
-    val prefix = if (printNodeId) "* " else s"*($transformStageId) "
+    val prefix = if (printNodeId) "^ " else s"^($transformStageId) "
     child.generateTreeString(
       depth,
       lastChildren,


### PR DESCRIPTION
**Is your feature request related to a problem or challenge? Please describe what you are trying to do.**
Making the transformer plan log more obvious. Plan for sql 
```sql
select count(*) from my_char where name = 'Nemon'
``` 
Now is 
```sql
CHNativeColumnarToRow
+- *(2) HashAggregateTransformer(keys=[], functions=[count(1)], output=[count(1)#7])
   +- ShuffleQueryStage 0
      +- ColumnarExchangeAdaptor SinglePartition, ENSURE_REQUIREMENTS, false, [plan_id=49], [id=#49], [OUTPUT] List(count:LongType), [OUTPUT] List(count:LongType)
         +- *(1) HashAggregateTransformer(keys=[], functions=[partial_count(1)], output=[count#10L])
            +- *(1) ProjectExecTransformer
               +- *(1) FilterExecTransformer (isnotnull(name#2) AND (name#2 = Nemon))
                  +- FileScan orc tpcds_parquet.my_char[name#2] Batched: true, DataFilters: [isnotnull(name#2), (name#2 = Nemon)], Format: ORC, ...
```  
A more obvious one will look like this 
```sql
CHNativeColumnarToRow
+- ^(2) HashAggregateTransformer(keys=[], functions=[count(1)], output=[count(1)#7])
   +- ShuffleQueryStage 0
      +- ColumnarExchangeAdaptor SinglePartition, ENSURE_REQUIREMENTS, false, [plan_id=49], [id=#49], [OUTPUT] List(count:LongType), [OUTPUT] List(count:LongType)
         +- ^(1) HashAggregateTransformer(keys=[], functions=[partial_count(1)], output=[count#10L])
            +- ^(1) ProjectExecTransformer
               +- ^(1) FilterExecTransformer (isnotnull(name#2) AND (name#2 = Nemon))
                  +- NativeFileScan orc tpcds_parquet.my_char[name#2] Batched: true, DataFilters: [isnotnull(name#2), (name#2 = Nemon)],...
``` 
