### PR TITLE
[Gluten-999] Gluten shuffle service supports Celeborn hash based columnar Shuffle

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -98,7 +98,8 @@ object VeloxBackendSettings extends BackendSettings {
     allSupported
   }
   override def supportColumnarShuffleExec(): Boolean = {
-    GlutenConfig.getConf.isUseColumnarShuffleManager
+    GlutenConfig.getConf.isUseColumnarShuffleManager ||
+      GlutenConfig.getConf.isUseCelebornShuffleManager
   }
   override def supportHashBuildJoinTypeOnLeft: JoinType => Boolean = {
     t =>

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -178,6 +178,7 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
         operators/r2c/RowToArrowColumnarConverter.cc
         operators/shuffle/reader.cc
         operators/shuffle/splitter.cc
+        operators/shuffle/CelebornSplitter.cc
         operators/writer/ArrowWriter.cc
         )
 

--- a/cpp/core/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/core/benchmarks/ShuffleSplitBenchmark.cc
@@ -269,24 +269,24 @@ class BenchmarkShuffleSplit {
         benchmark::Counter(split_buffer_size, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
 
     state.counters["bytes_spilled"] = benchmark::Counter(
-        splitter->TotalBytesSpilled(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
+        splitter->TotalBytesEvicted(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
     state.counters["bytes_written"] = benchmark::Counter(
         splitter->TotalBytesWritten(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
     state.counters["bytes_raw"] = benchmark::Counter(
         splitter->RawPartitionBytes(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
     state.counters["bytes_spilled"] = benchmark::Counter(
-        splitter->TotalBytesSpilled(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
+        splitter->TotalBytesEvicted(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1024);
 
     state.counters["parquet_parse"] =
         benchmark::Counter(elapse_read, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
     state.counters["write_time"] = benchmark::Counter(
         splitter->TotalWriteTime(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
     state.counters["spill_time"] = benchmark::Counter(
-        splitter->TotalSpillTime(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
+        splitter->TotalEvictTime(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
     state.counters["compress_time"] = benchmark::Counter(
         splitter->TotalCompressTime(), benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
 
-    split_time = split_time - splitter->TotalSpillTime() - splitter->TotalCompressTime() - splitter->TotalWriteTime();
+    split_time = split_time - splitter->TotalEvictTime() - splitter->TotalCompressTime() - splitter->TotalWriteTime();
 
     state.counters["split_time"] =
         benchmark::Counter(split_time, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -63,6 +63,9 @@ static jmethodID serialized_arrow_array_iterator_next;
 static jclass native_columnar_to_row_info_class;
 static jmethodID native_columnar_to_row_info_constructor;
 
+jclass celeborn_partition_pusher_class;
+jmethodID celeborn_push_partition_data_method;
+
 jlong default_memory_allocator_id = -1L;
 
 static ConcurrentMap<std::shared_ptr<ColumnarToRowConverter>> columnar_to_row_converter_holder_;
@@ -284,6 +287,11 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   unreserve_memory_method = GetMethodIDOrError(env, java_reservation_listener_class, "unreserve", "(J)J");
 
   default_memory_allocator_id = reinterpret_cast<jlong>(DefaultMemoryAllocator().get());
+
+  celeborn_partition_pusher_class =
+      CreateGlobalClassReferenceOrError(env, "Lorg/apache/spark/shuffle/utils/CelebornPartitionPusher;");
+  celeborn_push_partition_data_method =
+      GetMethodIDOrError(env, celeborn_partition_pusher_class, "pushPartitionData", "(I[B)I");
 
   return JNI_VERSION;
 }
@@ -770,6 +778,80 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
   JNI_METHOD_END(-1L)
 }
 
+JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_nativeMakeForCeleborn(
+    JNIEnv* env,
+    jobject,
+    jstring partitioning_name_jstr,
+    jint num_partitions,
+    jlong offheap_per_task,
+    jint buffer_size,
+    jstring compression_type_jstr,
+    jint batch_compress_threshold,
+    jint push_buffer_max_size,
+    jobject celeborn_partition_pusher,
+    jlong allocator_id,
+    jlong firstBatchHandle,
+    jlong taskAttemptId) {
+  JNI_METHOD_START
+  if (partitioning_name_jstr == NULL) {
+    gluten::JniThrow(std::string("Short partitioning name can't be null"));
+    return 0;
+  }
+  auto partitioning_name_c = env->GetStringUTFChars(partitioning_name_jstr, JNI_FALSE);
+  auto partitioning_name = std::string(partitioning_name_c);
+  env->ReleaseStringUTFChars(partitioning_name_jstr, partitioning_name_c);
+  auto splitOptions = SplitOptions::Defaults();
+  splitOptions.buffered_write = true;
+  splitOptions.is_celeborn = true;
+  if (buffer_size > 0) {
+    splitOptions.buffer_size = buffer_size;
+  }
+  if (push_buffer_max_size > 0) {
+    splitOptions.push_buffer_max_size = push_buffer_max_size;
+  }
+  splitOptions.offheap_per_task = offheap_per_task;
+  if (compression_type_jstr != NULL) {
+    auto compression_type_result = GetCompressionType(env, compression_type_jstr);
+    if (compression_type_result.status().ok()) {
+      splitOptions.compression_type = compression_type_result.MoveValueUnsafe();
+    }
+  }
+
+  auto* allocator = reinterpret_cast<MemoryAllocator*>(allocator_id);
+  if (allocator == nullptr) {
+    gluten::JniThrow("Memory pool does not exist or has been closed");
+  }
+  splitOptions.memory_pool = AsWrappedArrowMemoryPool(allocator);
+  jclass cls = env->FindClass("java/lang/Thread");
+  jmethodID mid = env->GetStaticMethodID(cls, "currentThread", "()Ljava/lang/Thread;");
+  jobject thread = env->CallStaticObjectMethod(cls, mid);
+  if (thread == NULL) {
+    std::cout << "Thread.currentThread() return NULL" << std::endl;
+  } else {
+    jmethodID mid_getid = GetMethodIDOrError(env, cls, "getId", "()J");
+    jlong sid = env->CallLongMethod(thread, mid_getid);
+    splitOptions.thread_id = (int64_t)sid;
+  }
+
+  splitOptions.task_attempt_id = (int64_t)taskAttemptId;
+  splitOptions.batch_compress_threshold = batch_compress_threshold;
+  JavaVM* vm;
+  if (env->GetJavaVM(&vm) != JNI_OK) {
+    gluten::JniThrow("Unable to get JavaVM instance");
+  }
+  std::shared_ptr<CelebornClient> celeborn_client =
+      std::make_shared<CelebornClient>(vm, celeborn_partition_pusher, celeborn_push_partition_data_method);
+
+  splitOptions.celeborn_client = std::move(celeborn_client);
+
+  auto backend = gluten::CreateBackend();
+  auto batch = gluten_columnarbatch_holder_.Lookup(firstBatchHandle);
+  auto splitter = backend->makeSplitter(partitioning_name, num_partitions, std::move(splitOptions), batch->GetType());
+
+  return shuffle_splitter_holder_.Insert(splitter);
+  JNI_METHOD_END(-1L)
+}
+
 JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_nativeSpill(
     JNIEnv* env,
     jobject,
@@ -783,8 +865,26 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
     gluten::JniThrow(error_message);
   }
   jlong spilled_size;
-  gluten::JniAssertOkOrThrow(splitter->SpillFixedSize(size, &spilled_size), "(shuffle) nativeSpill: spill failed");
+  gluten::JniAssertOkOrThrow(splitter->EvictFixedSize(size, &spilled_size), "(shuffle) nativeSpill: spill failed");
   return spilled_size;
+  JNI_METHOD_END(-1L)
+}
+
+JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_nativePush(
+    JNIEnv* env,
+    jobject,
+    jlong splitter_id,
+    jlong size,
+    jboolean callBySelf) {
+  JNI_METHOD_START
+  auto splitter = shuffle_splitter_holder_.Lookup(splitter_id);
+  if (!splitter) {
+    std::string error_message = "Invalid splitter id " + std::to_string(splitter_id);
+    gluten::JniThrow(error_message);
+  }
+  jlong pushed_size;
+  gluten::JniAssertOkOrThrow(splitter->EvictFixedSize(size, &pushed_size), "(shuffle) nativePush: push failed");
+  return pushed_size;
   JNI_METHOD_END(-1L)
 }
 
@@ -835,10 +935,10 @@ Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapper_stop(JNIEnv* env, job
       split_result_constructor,
       0L,
       splitter->TotalWriteTime(),
-      splitter->TotalSpillTime(),
+      splitter->TotalEvictTime(),
       splitter->TotalCompressTime(),
       splitter->TotalBytesWritten(),
-      splitter->TotalBytesSpilled(),
+      splitter->TotalBytesEvicted(),
       partition_length_arr,
       raw_partition_length_arr);
 

--- a/cpp/core/operators/shuffle/CelebornSplitter.cc
+++ b/cpp/core/operators/shuffle/CelebornSplitter.cc
@@ -1,0 +1,476 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "operators/shuffle/CelebornSplitter.h"
+
+#if defined(__x86_64__)
+#include <immintrin.h>
+#include <x86intrin.h>
+#elif defined(__aarch64__)
+#include <arm_neon.h>
+#endif
+
+#include "utils/macros.h"
+
+namespace gluten {
+
+#ifndef SPLIT_BUFFER_SIZE
+// by default, allocate 8M block, 2M page size
+#define SPLIT_BUFFER_SIZE 16 * 1024 * 1024
+#endif
+
+// macro to rotate left an 8-bit value 'x' given the shift 's' is a 32-bit integer
+// (x is left shifted by 's' modulo 8) OR (x right shifted by (8 - 's' modulo 8))
+#if !defined(__x86_64__)
+#define rotateLeft(x, s) (x << (s - ((s >> 3) << 3)) | x >> (8 - (s - ((s >> 3) << 3))))
+#endif
+
+// on x86 machines, _MM_HINT_T0,T1,T2 are defined as 1, 2, 3
+// equivalent mapping to __builtin_prefetch hints is 3, 2, 1
+#if defined(__x86_64__)
+#define PREFETCHT0(ptr) _mm_prefetch(ptr, _MM_HINT_T0)
+#define PREFETCHT1(ptr) _mm_prefetch(ptr, _MM_HINT_T1)
+#define PREFETCHT2(ptr) _mm_prefetch(ptr, _MM_HINT_T2)
+#else
+#define PREFETCHT0(ptr) __builtin_prefetch(ptr, 0, 3)
+#define PREFETCHT1(ptr) __builtin_prefetch(ptr, 0, 2)
+#define PREFETCHT2(ptr) __builtin_prefetch(ptr, 0, 1)
+#endif
+// #define SKIPWRITE
+
+#if defined(__x86_64__)
+template <typename T>
+std::string __m128i_toString(const __m128i var) {
+  std::stringstream sstr;
+  T values[16 / sizeof(T)];
+  std::memcpy(values, &var, sizeof(values)); // See discussion below
+  if (sizeof(T) == 1) {
+    for (unsigned int i = 0; i < sizeof(__m128i); i++) { // C++11: Range for also possible
+      sstr << std::hex << (int)values[i] << " " << std::dec;
+    }
+  } else {
+    for (unsigned int i = 0; i < sizeof(__m128i) / sizeof(T); i++) {
+      sstr << std::hex << values[i] << " " << std::dec;
+    }
+  }
+  return sstr.str();
+}
+#endif
+
+// ----------------------------------------------------------------------
+// CelebornSplitter
+arrow::Result<std::shared_ptr<CelebornSplitter>>
+CelebornSplitter::Make(const std::string& short_name, int num_partitions, SplitOptions options) {
+  if (short_name == "hash") {
+    return CelebornHashSplitter::Create(num_partitions, std::move(options));
+  } else if (short_name == "rr") {
+    return CelebornRoundRobinSplitter::Create(num_partitions, std::move(options));
+  } else if (short_name == "range") {
+    return CelebornFallbackRangeSplitter::Create(num_partitions, std::move(options));
+  } else if (short_name == "single") {
+    return CelebornSinglePartSplitter::Create(1, std::move(options));
+  }
+  return arrow::Status::NotImplemented("Partitioning " + short_name + " not supported yet.");
+}
+
+arrow::Status CelebornSplitter::Stop() {
+  EVAL_START("push", options_.thread_id)
+
+  // push data and collect metrics
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, true));
+    if (partition_cached_recordbatch_size_[pid] > 0) {
+      RETURN_NOT_OK(PushPartition(pid));
+    }
+    total_bytes_written_ += partition_lengths_[pid];
+  }
+  this->combine_buffer_.reset();
+  partition_buffers_.clear();
+
+  EVAL_END("push", options_.thread_id, options_.task_attempt_id)
+
+  return arrow::Status::OK();
+}
+
+// call from memory management
+arrow::Status CelebornSplitter::EvictFixedSize(int64_t size, int64_t* actual) {
+  int64_t current_pushed = 0L;
+  int32_t try_count = 0;
+  while (current_pushed < size && try_count < 5) {
+    try_count++;
+    int64_t single_call_spilled;
+    ARROW_ASSIGN_OR_RAISE(int32_t pushed_partition_id, PushLargestPartition(&single_call_spilled))
+    if (pushed_partition_id == -1) {
+      break;
+    }
+    current_pushed += single_call_spilled;
+  }
+  *actual = current_pushed;
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornSplitter::PushPartition(int32_t partition_id) {
+  int64_t temp_total_write_time = 0;
+  int64_t temp_total_push_time = 0;
+  TIME_NANO_OR_RAISE(temp_total_push_time, WriteArrowToOutputStream(partition_id));
+  total_write_time_ += temp_total_write_time;
+  TIME_NANO_OR_RAISE(temp_total_push_time, Push(partition_id));
+  total_evict_time_ += temp_total_push_time;
+  // reset validity buffer after push
+  std::for_each(
+      partition_buffers_.begin(), partition_buffers_.end(), [partition_id](std::vector<arrow::BufferVector>& bufs) {
+        if (bufs[partition_id].size() != 0 && bufs[partition_id][0] != nullptr) {
+          // initialize all true once allocated
+          auto addr = bufs[partition_id][0]->mutable_data();
+          memset(addr, 0xff, bufs[partition_id][0]->capacity());
+        }
+      });
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornSplitter::WriteArrowToOutputStream(int32_t partition_id) {
+  ARROW_ASSIGN_OR_RAISE(
+      celeborn_buffer_os_, arrow::io::BufferOutputStream::Create(options_.buffer_size, options_.memory_pool.get()));
+  int32_t metadata_length = 0; // unused
+#ifndef SKIPWRITE
+  for (auto& payload : partition_cached_recordbatch_[partition_id]) {
+    RETURN_NOT_OK(
+        arrow::ipc::WriteIpcPayload(*payload, options_.ipc_write_options, celeborn_buffer_os_.get(), &metadata_length));
+    payload = nullptr;
+  }
+#endif
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornSplitter::Push(int32_t partition_id) {
+  auto buffer = celeborn_buffer_os_->Finish();
+  int32_t size = buffer->get()->size();
+  char* dst = reinterpret_cast<char*>(buffer->get()->mutable_data());
+  celeborn_client_->PushPartitonData(partition_id, dst, size);
+  partition_cached_recordbatch_[partition_id].clear();
+  partition_cached_recordbatch_size_[partition_id] = 0;
+  partition_lengths_[partition_id] += size;
+  return arrow::Status::OK();
+}
+
+arrow::Result<int32_t> CelebornSplitter::PushLargestPartition(int64_t* size) {
+  // push the largest partition
+  auto max_size = 0;
+  int32_t partition_to_push = -1;
+  for (auto i = 0; i < num_partitions_; ++i) {
+    if (partition_cached_recordbatch_size_[i] > max_size) {
+      max_size = partition_cached_recordbatch_size_[i];
+      partition_to_push = i;
+    }
+  }
+  if (partition_to_push != -1) {
+    RETURN_NOT_OK(PushPartition(partition_to_push));
+#ifdef GLUTEN_PRINT_DEBUG
+    std::cout << "Pushed partition " << std::to_string(partition_to_push) << ", " << std::to_string(max_size)
+              << " bytes released" << std::endl;
+#endif
+    *size = max_size;
+  } else {
+    *size = 0;
+  }
+  return partition_to_push;
+}
+
+arrow::Status CelebornSplitter::DoSplit(const arrow::RecordBatch& rb) {
+  // buffer is allocated less than 64K
+  // ARROW_CHECK_LE(rb.num_rows(),64*1024);
+
+  reducer_offsets_.resize(rb.num_rows());
+
+  reducer_offset_offset_[0] = 0;
+  for (auto pid = 1; pid <= num_partitions_; pid++) {
+    reducer_offset_offset_[pid] = reducer_offset_offset_[pid - 1] + partition_id_cnt_[pid - 1];
+  }
+  for (auto row = 0; row < rb.num_rows(); row++) {
+    auto pid = partition_id_[row];
+    reducer_offsets_[reducer_offset_offset_[pid]] = row;
+    PREFETCHT0((reducer_offsets_.data() + reducer_offset_offset_[pid] + 32));
+    reducer_offset_offset_[pid]++;
+  }
+  std::transform(
+      reducer_offset_offset_.begin(),
+      std::prev(reducer_offset_offset_.end()),
+      partition_id_cnt_.begin(),
+      reducer_offset_offset_.begin(),
+      [](row_offset_type x, row_offset_type y) { return x - y; });
+  // for the first input record batch, scan binary arrays and large binary
+  // arrays to get their empirical sizes
+
+  for (size_t col = 0; col < array_idx_.size(); ++col) {
+    auto col_idx = array_idx_[col];
+    // check input_has_null_[col] is cheaper than GetNullCount()
+    // once input_has_null_ is set to true, we didn't reset it after spill
+    if (!input_has_null_[col] && rb.column_data(col_idx)->GetNullCount() != 0) {
+      input_has_null_[col] = true;
+    }
+  }
+
+  // prepare partition buffers and spill if necessary
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    if (partition_id_cnt_[pid] > 0) {
+      // make sure the size to be allocated is larger than the size to be filled
+      if (partition_buffer_size_[pid] == 0) {
+        // allocate buffer if it's not yet allocated
+        auto new_size = std::max(CalculateSplitBatchSize(rb), partition_id_cnt_[pid]);
+        RETURN_NOT_OK(AllocatePartitionBuffers(pid, new_size));
+      } else if (partition_buffer_idx_base_[pid] + partition_id_cnt_[pid] > (unsigned)partition_buffer_size_[pid]) {
+        auto new_size = std::max(CalculateSplitBatchSize(rb), partition_id_cnt_[pid]);
+        // if the size to be filled + allready filled > the buffer size, need to
+        // allocate new buffer
+        if (new_size > (unsigned)partition_buffer_size_[pid]) {
+          RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, /*reset_buffers = */ true));
+          RETURN_NOT_OK(PushPartition(pid));
+          RETURN_NOT_OK(AllocatePartitionBuffers(pid, new_size));
+        } else {
+          RETURN_NOT_OK(CreateRecordBatchFromBuffer(pid, /*reset_buffers = */ false));
+          RETURN_NOT_OK(PushPartition(pid));
+        }
+      }
+    }
+  }
+  // now start to split the record batch
+  RETURN_NOT_OK(SplitFixedWidthValueBuffer(rb));
+  RETURN_NOT_OK(SplitValidityBuffer(rb));
+  RETURN_NOT_OK(SplitBinaryArray(rb));
+  RETURN_NOT_OK(SplitListArray(rb));
+
+  // update partition buffer base after split
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    partition_buffer_idx_base_[pid] += partition_id_cnt_[pid];
+  }
+
+  return arrow::Status::OK();
+}
+
+// ----------------------------------------------------------------------
+// CelebornRoundRobinSplitter
+
+arrow::Result<std::shared_ptr<CelebornRoundRobinSplitter>> CelebornRoundRobinSplitter::Create(
+    int32_t num_partitions,
+    SplitOptions options) {
+  std::shared_ptr<CelebornRoundRobinSplitter> res(new CelebornRoundRobinSplitter(num_partitions, std::move(options)));
+  RETURN_NOT_OK(res->Init());
+  return res;
+}
+
+arrow::Status CelebornRoundRobinSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch& rb) {
+  std::fill(std::begin(partition_id_cnt_), std::end(partition_id_cnt_), 0);
+  partition_id_.resize(rb.num_rows());
+  for (auto& pid : partition_id_) {
+    pid = pid_selection_;
+    partition_id_cnt_[pid_selection_]++;
+    pid_selection_ = (pid_selection_ + 1) == num_partitions_ ? 0 : (pid_selection_ + 1);
+  }
+  return arrow::Status::OK();
+}
+
+// ----------------------------------------------------------------------
+// CelebornSinglePartSplitter
+
+arrow::Result<std::shared_ptr<CelebornSinglePartSplitter>> CelebornSinglePartSplitter::Create(
+    int32_t num_partitions,
+    SplitOptions options) {
+  std::shared_ptr<CelebornSinglePartSplitter> res(new CelebornSinglePartSplitter(num_partitions, std::move(options)));
+  RETURN_NOT_OK(res->Init());
+  return res;
+}
+
+arrow::Status CelebornSinglePartSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch& rb) {
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornSinglePartSplitter::Init() {
+  partition_writer_.resize(num_partitions_);
+  partition_buffer_idx_base_.resize(num_partitions_);
+  partition_cached_recordbatch_.resize(num_partitions_);
+  partition_cached_recordbatch_size_.resize(num_partitions_);
+  partition_lengths_.resize(num_partitions_);
+  raw_partition_lengths_.resize(num_partitions_);
+
+  ARROW_ASSIGN_OR_RAISE(configured_dirs_, GetConfiguredLocalDirs());
+  sub_dir_selection_.assign(configured_dirs_.size(), 0);
+
+  // Both data_file and shuffle_index_file should be set through jni.
+  // For test purpose, Create a temporary subdirectory in the system temporary
+  // dir with prefix "columnar-shuffle"
+  if (options_.data_file.length() == 0) {
+    ARROW_ASSIGN_OR_RAISE(options_.data_file, CreateTempShuffleFile(configured_dirs_[0]));
+  }
+
+  RETURN_NOT_OK(SetCompressType(options_.compression_type));
+
+  auto& ipc_write_options = options_.ipc_write_options;
+  ipc_write_options.memory_pool = options_.memory_pool.get();
+  ipc_write_options.use_threads = false;
+
+  // initialize tiny batch write options
+  tiny_bach_write_options_ = ipc_write_options;
+  tiny_bach_write_options_.codec = nullptr;
+
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornSinglePartSplitter::Split(ColumnarBatch* batch) {
+  ARROW_ASSIGN_OR_RAISE(
+      auto rb, arrow::ImportRecordBatch(batch->exportArrowArray().get(), batch->exportArrowSchema().get()));
+  EVAL_START("split", options_.thread_id)
+  if (schema_ == nullptr) {
+    schema_ = rb->schema();
+    RETURN_NOT_OK(InitColumnType());
+  }
+  RETURN_NOT_OK(CacheRecordBatch(0, *rb));
+  if (partition_cached_recordbatch_size_[0] > options_.push_buffer_max_size) {
+    RETURN_NOT_OK(PushPartition(0));
+  }
+
+  EVAL_END("split", options_.thread_id, options_.task_attempt_id)
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornSinglePartSplitter::Stop() {
+  EVAL_START("push", options_.thread_id)
+
+  // push data and collect metrics
+  for (auto pid = 0; pid < num_partitions_; ++pid) {
+    if (partition_cached_recordbatch_size_[pid] > 0) {
+      RETURN_NOT_OK(PushPartition(pid));
+    }
+    total_bytes_written_ += partition_lengths_[pid];
+  }
+
+  EVAL_END("push", options_.thread_id, options_.task_attempt_id)
+
+  return arrow::Status::OK();
+}
+
+// ----------------------------------------------------------------------
+// CelebornHashSplitter
+
+arrow::Result<std::shared_ptr<CelebornHashSplitter>> CelebornHashSplitter::Create(
+    int32_t num_partitions,
+    SplitOptions options) {
+  std::shared_ptr<CelebornHashSplitter> res(new CelebornHashSplitter(num_partitions, std::move(options)));
+  RETURN_NOT_OK(res->Init());
+  return res;
+}
+
+arrow::Status CelebornHashSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch& rb) {
+  if (rb.num_columns() == 0) {
+    return arrow::Status::Invalid("Recordbatch missing partition id column.");
+  }
+  if (rb.column(0)->type_id() != arrow::Type::INT32) {
+    return arrow::Status::Invalid(
+        "RecordBatch field 0 should be ", arrow::int32()->ToString(), ", actual is ", rb.column(0)->type()->ToString());
+  }
+  auto num_rows = rb.num_rows();
+  partition_id_.resize(num_rows);
+  std::fill(std::begin(partition_id_cnt_), std::end(partition_id_cnt_), 0);
+  // first column is partition key hash value
+  auto pid_arr = std::dynamic_pointer_cast<arrow::Int32Array>(rb.column(0));
+  if (pid_arr == nullptr) {
+    return arrow::Status::Invalid("failed to cast rb.column(0), this column should be hash_partition_key");
+  }
+  for (auto i = 0; i < num_rows; ++i) {
+    // positive mod
+    auto pid = pid_arr->Value(i) % num_partitions_;
+#if defined(__x86_64__)
+    // force to generate ASM
+    __asm__(
+        "lea (%[num_partitions],%[pid],1),%[tmp]\n"
+        "test %[pid],%[pid]\n"
+        "cmovs %[tmp],%[pid]\n"
+        : [pid] "+r"(pid)
+        : [num_partitions] "r"(num_partitions_), [tmp] "r"(0));
+#else
+    if (pid < 0)
+      pid += num_partitions_;
+#endif
+    partition_id_[i] = pid;
+    partition_id_cnt_[pid]++;
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornHashSplitter::Split(ColumnarBatch* batch) {
+  EVAL_START("split", options_.thread_id)
+  ARROW_ASSIGN_OR_RAISE(
+      auto rb, arrow::ImportRecordBatch(batch->exportArrowArray().get(), batch->exportArrowSchema().get()));
+  RETURN_NOT_OK(ComputeAndCountPartitionId(*rb));
+  ARROW_ASSIGN_OR_RAISE(auto remove_pid, rb->RemoveColumn(0));
+  if (schema_ == nullptr) {
+    schema_ = remove_pid->schema();
+    RETURN_NOT_OK(InitColumnType());
+  }
+  RETURN_NOT_OK(DoSplit(*remove_pid));
+  EVAL_END("split", options_.thread_id, options_.task_attempt_id)
+  return arrow::Status::OK();
+}
+
+// ----------------------------------------------------------------------
+// CelebornFallbackRangeSplitter
+
+arrow::Result<std::shared_ptr<CelebornFallbackRangeSplitter>> CelebornFallbackRangeSplitter::Create(
+    int32_t num_partitions,
+    SplitOptions options) {
+  auto res = std::shared_ptr<CelebornFallbackRangeSplitter>(
+      new CelebornFallbackRangeSplitter(num_partitions, std::move(options)));
+  RETURN_NOT_OK(res->Init());
+  return res;
+}
+
+arrow::Status CelebornFallbackRangeSplitter::Split(ColumnarBatch* batch) {
+  EVAL_START("split", options_.thread_id)
+  ARROW_ASSIGN_OR_RAISE(
+      auto rb, arrow::ImportRecordBatch(batch->exportArrowArray().get(), batch->exportArrowSchema().get()));
+  RETURN_NOT_OK(ComputeAndCountPartitionId(*rb));
+  ARROW_ASSIGN_OR_RAISE(auto remove_pid, rb->RemoveColumn(0));
+  if (schema_ == nullptr) {
+    schema_ = remove_pid->schema();
+    RETURN_NOT_OK(InitColumnType());
+  }
+  RETURN_NOT_OK(DoSplit(*remove_pid));
+  EVAL_END("split", options_.thread_id, options_.task_attempt_id)
+  return arrow::Status::OK();
+}
+
+arrow::Status CelebornFallbackRangeSplitter::ComputeAndCountPartitionId(const arrow::RecordBatch& rb) {
+  if (rb.column(0)->type_id() != arrow::Type::INT32) {
+    return arrow::Status::Invalid(
+        "RecordBatch field 0 should be ", arrow::int32()->ToString(), ", actual is ", rb.column(0)->type()->ToString());
+  }
+
+  auto pid_arr = reinterpret_cast<const int32_t*>(rb.column_data(0)->buffers[1]->data());
+  auto num_rows = rb.num_rows();
+  partition_id_.resize(num_rows);
+  std::fill(std::begin(partition_id_cnt_), std::end(partition_id_cnt_), 0);
+  for (auto i = 0; i < num_rows; ++i) {
+    auto pid = pid_arr[i];
+    if (pid >= num_partitions_) {
+      return arrow::Status::Invalid(
+          "Partition id ", std::to_string(pid), " is equal or greater than ", std::to_string(num_partitions_));
+    }
+    partition_id_[i] = pid;
+    partition_id_cnt_[pid]++;
+  }
+  return arrow::Status::OK();
+}
+} // namespace gluten

--- a/cpp/core/operators/shuffle/CelebornSplitter.h
+++ b/cpp/core/operators/shuffle/CelebornSplitter.h
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "operators/shuffle/splitter.h"
+
+namespace gluten {
+class CelebornSplitter : public Splitter {
+ public:
+  static arrow::Result<std::shared_ptr<CelebornSplitter>>
+  Make(const std::string& short_name, int num_partitions, SplitOptions options = SplitOptions::Defaults());
+
+ protected:
+  CelebornSplitter(int32_t num_partitions, SplitOptions options) : Splitter(num_partitions, options) {
+    celeborn_client_ = std::move(options.celeborn_client);
+  }
+
+  arrow::Status Stop() override;
+
+  arrow::Status DoSplit(const arrow::RecordBatch& rb) override;
+
+  arrow::Status EvictFixedSize(int64_t size, int64_t* actual) override;
+  /**
+   * push specified partition
+   */
+  arrow::Status PushPartition(int32_t partition_id);
+
+  arrow::Status Push(int32_t partition_id);
+
+  arrow::Status WriteArrowToOutputStream(int32_t partition_id);
+
+  /**
+   * Push the largest partition buffer
+   * @return partition id. If no partition to push, return -1
+   */
+  arrow::Result<int32_t> PushLargestPartition(int64_t* size);
+
+  std::shared_ptr<arrow::io::BufferOutputStream> celeborn_buffer_os_;
+
+  std::shared_ptr<CelebornClient> celeborn_client_;
+};
+
+class CelebornRoundRobinSplitter final : public CelebornSplitter {
+ public:
+  static arrow::Result<std::shared_ptr<CelebornRoundRobinSplitter>> Create(
+      int32_t num_partitions,
+      SplitOptions options);
+
+ private:
+  CelebornRoundRobinSplitter(int32_t num_partitions, SplitOptions options)
+      : CelebornSplitter(num_partitions, std::move(options)) {}
+
+  arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) override;
+
+  int32_t pid_selection_ = 0;
+};
+
+class CelebornSinglePartSplitter final : public CelebornSplitter {
+ public:
+  static arrow::Result<std::shared_ptr<CelebornSinglePartSplitter>> Create(
+      int32_t num_partitions,
+      SplitOptions options);
+
+ private:
+  CelebornSinglePartSplitter(int32_t num_partitions, SplitOptions options)
+      : CelebornSplitter(num_partitions, std::move(options)) {}
+
+  arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) override;
+
+  arrow::Status Split(ColumnarBatch* cb) override;
+
+  arrow::Status Init() override;
+
+  arrow::Status Stop() override;
+};
+
+class CelebornHashSplitter final : public CelebornSplitter {
+ public:
+  static arrow::Result<std::shared_ptr<CelebornHashSplitter>> Create(int32_t num_partitions, SplitOptions options);
+
+ private:
+  CelebornHashSplitter(int32_t num_partitions, SplitOptions options)
+      : CelebornSplitter(num_partitions, std::move(options)) {}
+
+  arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) override;
+
+  arrow::Status Split(ColumnarBatch* cb) override;
+};
+
+class CelebornFallbackRangeSplitter final : public CelebornSplitter {
+ public:
+  static arrow::Result<std::shared_ptr<CelebornFallbackRangeSplitter>> Create(
+      int32_t num_partitions,
+      SplitOptions options);
+
+  arrow::Status Split(ColumnarBatch* cb) override;
+
+ private:
+  CelebornFallbackRangeSplitter(int32_t num_partitions, SplitOptions options)
+      : CelebornSplitter(num_partitions, std::move(options)) {}
+
+  arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) override;
+};
+
+} // namespace gluten

--- a/cpp/core/operators/shuffle/SplitterBase.h
+++ b/cpp/core/operators/shuffle/SplitterBase.h
@@ -24,9 +24,9 @@ namespace gluten {
 class SplitterBase {
  public:
   /**
-   * Spill for fixed size of partition data
+   * Evict fixed size of partition data from memory
    */
-  virtual arrow::Status SpillFixedSize(int64_t size, int64_t* actual) = 0;
+  virtual arrow::Status EvictFixedSize(int64_t size, int64_t* actual) = 0;
 
   virtual arrow::Status Split(ColumnarBatch* cb) = 0;
 
@@ -36,16 +36,16 @@ class SplitterBase {
     return total_bytes_written_;
   }
 
-  int64_t TotalBytesSpilled() const {
-    return total_bytes_spilled_;
+  int64_t TotalBytesEvicted() const {
+    return total_bytes_evicted_;
   }
 
   int64_t TotalWriteTime() const {
     return total_write_time_;
   }
 
-  int64_t TotalSpillTime() const {
-    return total_spill_time_;
+  int64_t TotalEvictTime() const {
+    return total_evict_time_;
   }
 
   int64_t TotalCompressTime() const {
@@ -70,9 +70,9 @@ class SplitterBase {
   SplitOptions options_;
 
   int64_t total_bytes_written_ = 0;
-  int64_t total_bytes_spilled_ = 0;
+  int64_t total_bytes_evicted_ = 0;
   int64_t total_write_time_ = 0;
-  int64_t total_spill_time_ = 0;
+  int64_t total_evict_time_ = 0;
   int64_t total_compress_time_ = 0;
   int64_t peak_memory_allocated_ = 0;
 

--- a/cpp/core/operators/shuffle/splitter.h
+++ b/cpp/core/operators/shuffle/splitter.h
@@ -25,6 +25,7 @@
 
 #include <random>
 
+#include "jni/JniCommon.h"
 #include "memory/ColumnarBatch.h"
 #include "operators/shuffle/SplitterBase.h"
 #include "operators/shuffle/type.h"
@@ -74,9 +75,9 @@ class Splitter : public SplitterBase {
   arrow::Status SetCompressType(arrow::Compression::type compressed_type);
 
   /**
-   * Spill for fixed size of partition data
+   * Evict for fixed size of partition data from memory
    */
-  arrow::Status SpillFixedSize(int64_t size, int64_t* actual);
+  arrow::Status EvictFixedSize(int64_t size, int64_t* actual);
 
   /**
    * Spill the largest partition buffer
@@ -102,7 +103,7 @@ class Splitter : public SplitterBase {
 
   virtual arrow::Status ComputeAndCountPartitionId(const arrow::RecordBatch& rb) = 0;
 
-  arrow::Status DoSplit(const arrow::RecordBatch& rb);
+  virtual arrow::Status DoSplit(const arrow::RecordBatch& rb);
 
   row_offset_type CalculateSplitBatchSize(const arrow::RecordBatch& rb);
 

--- a/cpp/core/operators/shuffle/type.h
+++ b/cpp/core/operators/shuffle/type.h
@@ -24,6 +24,8 @@
 
 #include <deque>
 
+#include "jni/JniCommon.h"
+
 #include "memory/ArrowMemoryPool.h"
 
 namespace gluten {
@@ -46,12 +48,15 @@ struct ReaderOptions {
 struct SplitOptions {
   int64_t offheap_per_task = 0;
   int32_t buffer_size = kDefaultSplitterBufferSize;
+  int32_t push_buffer_max_size = kDefaultSplitterBufferSize;
   int32_t num_sub_dirs = kDefaultNumSubDirs;
   int32_t batch_compress_threshold = kDefaultBatchCompressThreshold;
   arrow::Compression::type compression_type = arrow::Compression::UNCOMPRESSED;
+
   bool prefer_spill = true;
   bool write_schema = true;
   bool buffered_write = false;
+  bool is_celeborn = false;
 
   std::string data_file;
 
@@ -59,6 +64,8 @@ struct SplitOptions {
   int64_t task_attempt_id = -1;
 
   std::shared_ptr<arrow::MemoryPool> memory_pool = GetDefaultWrappedArrowMemoryPool();
+
+  std::shared_ptr<CelebornClient> celeborn_client;
 
   arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -24,6 +24,7 @@
 #include "compute/ResultIterator.h"
 #include "config/GlutenConfig.h"
 #include "include/arrow/c/bridge.h"
+#include "operators/shuffle/CelebornSplitter.h"
 #include "operators/shuffle/splitter.h"
 #include "shuffle/VeloxSplitter.h"
 #include "velox/common/file/FileSystems.h"
@@ -300,7 +301,11 @@ std::shared_ptr<SplitterBase> VeloxBackend::makeSplitter(
     int num_partitions,
     SplitOptions options,
     const std::string& batchType) {
-  if (batchType == "velox") {
+  if (options.is_celeborn) {
+    GLUTEN_ASSIGN_OR_THROW(
+        auto splitter, CelebornSplitter::Make(partitioning_name, num_partitions, std::move(options)));
+    return splitter;
+  } else if (batchType == "velox") {
     GLUTEN_ASSIGN_OR_THROW(auto splitter, VeloxSplitter::Make(partitioning_name, num_partitions, std::move(options)));
     return splitter;
   } else {

--- a/cpp/velox/shuffle/VeloxSplitter.h
+++ b/cpp/velox/shuffle/VeloxSplitter.h
@@ -105,7 +105,7 @@ class VeloxSplitter : public SplitterBase {
 
   virtual arrow::Status Stop();
 
-  arrow::Status SpillFixedSize(int64_t size, int64_t* actual);
+  arrow::Status EvictFixedSize(int64_t size, int64_t* actual);
 
   int64_t RawPartitionBytes() const {
     return std::accumulate(raw_partition_lengths_.begin(), raw_partition_lengths_.end(), 0LL);

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -52,6 +52,10 @@
   </profiles>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-spark-${spark.major.version}-shaded_${scala.binary.version}</artifactId>
+    </dependency>
     <!-- Prevent our dummy JAR from being included in Spark distributions or uploaded to YARN -->
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/SplitResult.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/SplitResult.java
@@ -23,28 +23,28 @@ package io.glutenproject.vectorized;
 public class SplitResult {
   private final long totalComputePidTime;
   private final long totalWriteTime;
-  private final long totalSpillTime;
-  private final long totalCompressTime; // overlaps with totalSpillTime and totalWriteTime
+  private final long totalEvictTime;
+  private final long totalCompressTime; // overlaps with totalEvictTime and totalWriteTime
   private final long totalBytesWritten;
-  private final long totalBytesSpilled;
+  private final long totalBytesEvicted;
   private final long[] partitionLengths;
   private final long[] rawPartitionLengths;
 
   public SplitResult(
       long totalComputePidTime,
       long totalWriteTime,
-      long totalSpillTime,
+      long totalEvictTime,
       long totalCompressTime,
       long totalBytesWritten,
-      long totalBytesSpilled,
+      long totalBytesEvicted,
       long[] partitionLengths,
       long[] rawPartitionLengths) {
     this.totalComputePidTime = totalComputePidTime;
     this.totalWriteTime = totalWriteTime;
-    this.totalSpillTime = totalSpillTime;
+    this.totalEvictTime = totalEvictTime;
     this.totalCompressTime = totalCompressTime;
     this.totalBytesWritten = totalBytesWritten;
-    this.totalBytesSpilled = totalBytesSpilled;
+    this.totalBytesEvicted = totalBytesEvicted;
     this.partitionLengths = partitionLengths;
     this.rawPartitionLengths = rawPartitionLengths;
   }
@@ -58,7 +58,7 @@ public class SplitResult {
   }
 
   public long getTotalSpillTime() {
-    return totalSpillTime;
+    return totalEvictTime;
   }
 
   public long getTotalCompressTime() {
@@ -70,7 +70,11 @@ public class SplitResult {
   }
 
   public long getTotalBytesSpilled() {
-    return totalBytesSpilled;
+    return totalBytesEvicted;
+  }
+
+  public long getTotalPushTime() {
+    return totalBytesEvicted;
   }
 
   public long[] getPartitionLengths() {

--- a/gluten-core/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleManager.java
+++ b/gluten-core/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleManager.java
@@ -1,0 +1,198 @@
+package org.apache.spark.shuffle.celeborn;
+
+import org.apache.celeborn.client.LifecycleManager;
+import org.apache.celeborn.client.ShuffleClient;
+import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.protocol.ShuffleMode;
+
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.TaskContext;
+import org.apache.spark.shuffle.*;
+import org.apache.spark.shuffle.sort.ColumnarShuffleManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CelebornShuffleManager implements ShuffleManager {
+
+  private static final Logger logger = LoggerFactory.getLogger(CelebornShuffleManager.class);
+
+  private static final String glutenShuffleManagerName =
+    "org.apache.spark.shuffle.sort.ColumnarShuffleManager";
+
+  private final SparkConf conf;
+  private final CelebornConf celebornConf;
+  private final ConcurrentHashMap.KeySetView<Integer, Boolean> columnarShuffleIds =
+    ConcurrentHashMap.newKeySet();
+  private final RssShuffleFallbackPolicyRunner fallbackPolicyRunner;
+  private String newAppId;
+  private LifecycleManager lifecycleManager;
+  private ShuffleClient rssShuffleClient;
+  private volatile ColumnarShuffleManager _columnarShuffleManager;
+
+  public CelebornShuffleManager(SparkConf conf) {
+    this.conf = conf;
+    this.celebornConf = SparkUtils.fromSparkConf(conf);
+    this.fallbackPolicyRunner = new RssShuffleFallbackPolicyRunner(celebornConf);
+  }
+
+  private boolean isDriver() {
+    return "driver".equals(SparkEnv.get().executorId());
+  }
+
+  private ColumnarShuffleManager columnarShuffleManager() {
+    if (_columnarShuffleManager == null) {
+      synchronized (this) {
+        if (_columnarShuffleManager == null) {
+          _columnarShuffleManager =
+            SparkUtils.instantiateClass(glutenShuffleManagerName, conf, isDriver());
+        }
+      }
+    }
+    return _columnarShuffleManager;
+  }
+
+  private void initializeLifecycleManager(String appId) {
+    // Only create LifecycleManager singleton in Driver.
+    // When register shuffle multiple times, we
+    // need to ensure that LifecycleManager will only be created once.
+    // Parallelism needs to be considered in this place,
+    // because if there is one RDD that depends on multiple RDDs
+    // at the same time, it may bring parallel `register shuffle`, such as Join in Sql.
+    if (isDriver() && lifecycleManager == null) {
+      synchronized (this) {
+        if (lifecycleManager == null) {
+          lifecycleManager = new LifecycleManager(appId, celebornConf);
+          rssShuffleClient =
+            ShuffleClient.get(
+              lifecycleManager.self(), celebornConf, lifecycleManager.getUserIdentifier());
+        }
+      }
+    }
+  }
+
+  @Override
+  public <K, V, C> ShuffleHandle registerShuffle(
+    int shuffleId, ShuffleDependency<K, V, C> dependency) {
+    // Note: generate newAppId at driver side, make sure dependency.rdd.context
+    // is the same SparkContext among different shuffleIds.
+    // This method may be called many times.
+    if (dependency instanceof ColumnarShuffleDependency) {
+      newAppId = SparkUtils.genNewAppId(dependency.rdd().context());
+      initializeLifecycleManager(newAppId);
+
+      if (fallbackPolicyRunner.applyAllFallbackPolicy(
+        lifecycleManager, dependency.partitioner().numPartitions())) {
+        logger.warn("Fallback to ColumnarShuffleManager!");
+        columnarShuffleIds.add(shuffleId);
+
+        return columnarShuffleManager().registerShuffle(shuffleId, dependency);
+      } else {
+        return new RssShuffleHandle<>(
+          newAppId,
+          lifecycleManager.getRssMetaServiceHost(),
+          lifecycleManager.getRssMetaServicePort(),
+          lifecycleManager.getUserIdentifier(),
+          shuffleId,
+          dependency.rdd().getNumPartitions(),
+          dependency);
+      }
+    }
+    return columnarShuffleManager().registerShuffle(shuffleId, dependency);
+  }
+
+  @Override
+  public boolean unregisterShuffle(int shuffleId) {
+    if (columnarShuffleIds.contains(shuffleId)) {
+      return columnarShuffleManager().unregisterShuffle(shuffleId);
+    }
+    if (newAppId == null) {
+      return true;
+    }
+    if (rssShuffleClient == null) {
+      return false;
+    }
+    return rssShuffleClient.unregisterShuffle(newAppId, shuffleId, isDriver());
+  }
+
+  @Override
+  public ShuffleBlockResolver shuffleBlockResolver() {
+    return columnarShuffleManager().shuffleBlockResolver();
+  }
+
+  @Override
+  public void stop() {
+    if (rssShuffleClient != null) {
+      rssShuffleClient.shutdown();
+    }
+    if (lifecycleManager != null) {
+      lifecycleManager.stop();
+    }
+    if (columnarShuffleManager() != null) {
+      columnarShuffleManager().stop();
+    }
+  }
+
+  @Override
+  public <K, V> ShuffleWriter<K, V> getWriter(
+    ShuffleHandle handle, long mapId, TaskContext context, ShuffleWriteMetricsReporter metrics) {
+    try {
+      if (handle instanceof RssShuffleHandle) {
+        @SuppressWarnings("unchecked")
+        RssShuffleHandle<K, V, V> h = ((RssShuffleHandle<K, V, V>) handle);
+        ShuffleClient client =
+          ShuffleClient.get(
+            h.rssMetaServiceHost(), h.rssMetaServicePort(), celebornConf, h.userIdentifier());
+        if (ShuffleMode.HASH.equals(celebornConf.shuffleWriterMode())) {
+          return CelebornShuffleWriterWrapper
+            .genCelebornColumnarShuffleWriter(ShuffleMode.HASH.toString(),
+            h, context, celebornConf, client, metrics);
+        } else {
+          throw new UnsupportedOperationException(
+            "Unrecognized shuffle write mode!" + celebornConf.shuffleWriterMode());
+        }
+      } else {
+        columnarShuffleIds.add(handle.shuffleId());
+        return columnarShuffleManager().getWriter(handle, mapId, context, metrics);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public <K, C> ShuffleReader<K, C> getReader(
+    ShuffleHandle handle,
+    int startMapIndex,
+    int endMapIndex,
+    int startPartition,
+    int endPartition,
+    TaskContext context,
+    ShuffleReadMetricsReporter metrics) {
+    if (handle instanceof RssShuffleHandle) {
+      @SuppressWarnings("unchecked")
+      RssShuffleHandle<K, ?, C> h = (RssShuffleHandle<K, ?, C>) handle;
+      return new RssShuffleReader<>(
+        h,
+        startPartition,
+        endPartition,
+        startMapIndex,
+        endMapIndex,
+        context,
+        celebornConf,
+        metrics);
+    }
+    return columnarShuffleManager().getReader(
+      handle,
+      startMapIndex,
+      endMapIndex,
+      startPartition,
+      endPartition,
+      context,
+      metrics);
+  }
+}
+

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -22,7 +22,7 @@ import io.glutenproject.expression.{AliasBaseTransformer, ExpressionTransformer,
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
-import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
+import org.apache.spark.shuffle.{CelebornShuffleWriterWrapper, GenCelebornShuffleWriterParameters, GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GetStructField, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
@@ -138,6 +138,16 @@ trait SparkPlanExecApi {
    */
   def genColumnarShuffleWriter[K, V](parameters: GenShuffleWriterParameters[K, V]
                                     ): GlutenShuffleWriterWrapper[K, V]
+
+  /**
+   * Generate CelebornColumnarShuffleWriter for ColumnarShuffleManager.
+   *
+   * @return
+   */
+  def genCelebornColumnarShuffleWriter[K, V](parameters: GenCelebornShuffleWriterParameters[K, V]
+                                    ): CelebornShuffleWriterWrapper[K, V] = {
+    throw new UnsupportedOperationException
+  }
 
   /**
    * Generate ColumnarBatchSerializer for ColumnarShuffleExchangeExec.

--- a/gluten-core/src/main/scala/org/apache/spark/shuffle/CelebornShuffleWriterWrapper.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/shuffle/CelebornShuffleWriterWrapper.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import io.glutenproject.backendsapi.BackendsApiManager
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.common.CelebornConf
+import org.apache.spark.TaskContext
+import org.apache.spark.shuffle.celeborn.RssShuffleHandle
+
+case class CelebornShuffleWriterWrapper[K, V](shuffleWriter: ShuffleWriter[K, V])
+
+case class GenCelebornShuffleWriterParameters[K, V](writerMode: String,
+                                                    shuffleHandle: RssShuffleHandle[K, V, V],
+                                                    context: TaskContext,
+                                                    conf: CelebornConf,
+                                                    client: ShuffleClient,
+                                                    metrics: ShuffleWriteMetricsReporter)
+
+object CelebornShuffleWriterWrapper {
+
+  def genCelebornColumnarShuffleWriter[K, V](
+      writerMode: String,
+      shuffleHandle: RssShuffleHandle[K, V, V],
+      context: TaskContext,
+      conf: CelebornConf,
+      client: ShuffleClient,
+      metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] =
+    BackendsApiManager.getSparkPlanExecApiInstance
+      .genCelebornColumnarShuffleWriter(GenCelebornShuffleWriterParameters(writerMode,
+        shuffleHandle, context, conf, client, metrics))
+      .shuffleWriter
+}

--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -42,6 +42,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.celeborn</groupId>
+      <artifactId>celeborn-client-spark-${spark.major.version}-shaded_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleSplitterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleSplitterJniWrapper.java
@@ -19,6 +19,8 @@ package io.glutenproject.vectorized;
 
 import java.io.IOException;
 
+import org.apache.spark.shuffle.utils.CelebornPartitionPusher;
+
 public class ShuffleSplitterJniWrapper {
 
   public ShuffleSplitterJniWrapper() throws IOException {
@@ -46,11 +48,35 @@ public class ShuffleSplitterJniWrapper {
           subDirsPerLocalDir, localDirs, preferSpill, memoryPoolId, writeSchema, handle);
   }
 
+  /**
+   * Construct celeborn native splitter for shuffled RecordBatch over
+   *
+   * @param part contains the partitioning parameter needed by native splitter
+   * @param bufferSize size of native buffers hold by each partition writer
+   * @param codec compression codec
+   * @param memoryPoolId
+   * @return native splitter instance id if created successfully.
+   */
+  public long makeForCeleborn(NativePartitioning part, long offheapPerTask,
+                              int bufferSize, String codec, int batchCompressThreshold,
+                              int pushBufferMaxSize, CelebornPartitionPusher pusher,
+                              long memoryPoolId, long handle, long taskAttemptId) {
+      return nativeMakeForCeleborn(part.getShortName(), part.getNumPartitions(),
+          offheapPerTask, bufferSize, codec, batchCompressThreshold,
+          pushBufferMaxSize, pusher, memoryPoolId, handle, taskAttemptId);
+  }
+
   public native long nativeMake(String shortName, int numPartitions,
                                 long offheapPerTask, int bufferSize,
                                 String codec, int batchCompressThreshold, String dataFile,
                                 int subDirsPerLocalDir, String localDirs, boolean preferSpill,
                                 long memoryPoolId, boolean writeSchema, long handle);
+
+  public native long nativeMakeForCeleborn(String shortName, int numPartitions,
+                                           long offheapPerTask, int bufferSize,
+                                           String codec, int batchCompressThreshold,
+                                           int pushBufferMaxSize, CelebornPartitionPusher pusher,
+                                           long memoryPoolId, long handle, long taskAttemptId);
 
   /**
    * Spill partition data to disk.
@@ -64,6 +90,19 @@ public class ShuffleSplitterJniWrapper {
    */
   public native long nativeSpill(
       long splitterId, long size, boolean callBySelf) throws RuntimeException;
+
+  /**
+   * Push partition data to celeborn server.
+   *
+   * @param splitterId splitter instance id
+   * @param size expected size to push (in bytes)
+   * @param callBySelf whether the caller is the shuffle splitter itself, true
+   * when running out of off-heap memory due to allocations from
+   * the evaluator itself
+   * @return actual pushed size
+   */
+  public native long nativePush(
+          long splitterId, long size, boolean callBySelf) throws RuntimeException;
 
   /**
    * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/CelebornColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/CelebornColumnarBatchSerializer.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.vectorized
+
+import io.glutenproject.columnarbatch.GlutenColumnarBatches
+import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
+import io.glutenproject.utils.GlutenArrowAbiUtil
+
+import org.apache.arrow.c.ArrowSchema
+import org.apache.arrow.memory.BufferAllocator
+
+import org.apache.celeborn.client.read.RssInputStream
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer, SerializerInstance}
+import org.apache.spark.sql.execution.datasources.v2.arrow.SparkSchemaUtil
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import java.io._
+import java.nio.ByteBuffer
+import scala.reflect.ClassTag
+
+class CelebornColumnarBatchSerializer(schema: StructType, readBatchNumRows: SQLMetric,
+  numOutputRows: SQLMetric)
+  extends Serializer with Serializable {
+
+  /** Creates a new [[SerializerInstance]]. */
+  override def newInstance(): SerializerInstance = {
+    new CelebornColumnarBatchSerializerInstance(schema, readBatchNumRows, numOutputRows)
+  }
+}
+
+private class CelebornColumnarBatchSerializerInstance(schema: StructType,
+  readBatchNumRows: SQLMetric,
+  numOutputRows: SQLMetric)
+  extends SerializerInstance
+    with Logging {
+
+  override def deserializeStream(in: InputStream): DeserializationStream = {
+    new DeserializationStream {
+
+      private val allocator: BufferAllocator = ArrowBufferAllocators
+        .contextInstance()
+        .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)
+
+      private lazy val shuffleReaderHandle = {
+        val cSchema = ArrowSchema.allocateNew(ArrowBufferAllocators.contextInstance())
+        val arrowSchema =
+          SparkSchemaUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)
+        GlutenArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
+        val handle = ShuffleReaderJniWrapper.make(
+          JniByteInputStreams.create(in), cSchema.memoryAddress())
+        cSchema.close()
+        handle
+      }
+
+      private var cb: ColumnarBatch = _
+
+      private var numBatchesTotal: Long = _
+      private var numRowsTotal: Long = _
+
+      private var isClosed: Boolean = false
+
+      private val isEmptyStream: Boolean = in.equals(RssInputStream.empty())
+
+      override def asKeyValueIterator: Iterator[(Any, Any)] = new Iterator[(Any, Any)] {
+        private var gotNext = false
+        private var nextValue: (Any, Any) = _
+        private var finished = false
+
+        def getNext: (Any, Any) = {
+          try {
+            (readKey[Any](), readValue[Any]())
+          } catch {
+            case eof: EOFException =>
+              finished = true
+              null
+          }
+        }
+
+        override def hasNext: Boolean = {
+          if (!isEmptyStream && !finished) {
+            if (!gotNext) {
+              nextValue = getNext
+              gotNext = true
+            }
+          }
+          !isEmptyStream && !finished
+        }
+
+        override def next(): (Any, Any) = {
+          if (!hasNext) {
+            throw new NoSuchElementException("End of stream")
+          }
+          gotNext = false
+          nextValue
+        }
+      }
+
+      override def asIterator: Iterator[Any] = {
+        // This method is never called by shuffle code.
+        throw new UnsupportedOperationException
+      }
+
+      override def readKey[T: ClassTag](): T = {
+        // We skipped serialization of the key in writeKey(), so just return a dummy value since
+        // this is going to be discarded anyways.
+        null.asInstanceOf[T]
+      }
+
+      @throws(classOf[EOFException])
+      override def readValue[T: ClassTag](): T = {
+        if (cb != null) {
+          cb.close()
+          cb = null
+        }
+        val batch = {
+          val batchHandle = try {
+            ShuffleReaderJniWrapper.next(shuffleReaderHandle)
+          } catch {
+            case ioe: IOException =>
+              this.close()
+              logError("Failed to load next RecordBatch", ioe)
+              throw ioe
+          }
+          if (batchHandle == -1L) {
+            // EOF reached
+            this.close()
+            throw new EOFException
+          }
+          GlutenColumnarBatches.create(batchHandle)
+        }
+        val numRows = batch.numRows()
+        logDebug(s"Read ColumnarBatch of ${numRows} rows")
+        numBatchesTotal += 1
+        numRowsTotal += numRows
+        cb = batch
+        cb.asInstanceOf[T]
+      }
+
+      override def readObject[T: ClassTag](): T = {
+        // This method is never called by shuffle code.
+        throw new UnsupportedOperationException
+      }
+
+      override def close(): Unit = {
+        if (!isClosed) {
+          if (numBatchesTotal > 0) {
+            readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
+          }
+          numOutputRows += numRowsTotal
+          if (cb != null) cb.close()
+          ShuffleReaderJniWrapper.close(shuffleReaderHandle)
+          allocator.close()
+          isClosed = true
+        }
+      }
+    }
+  }
+
+  // Columnar shuffle write process don't need this.
+  override def serializeStream(s: OutputStream): SerializationStream =
+    throw new UnsupportedOperationException
+
+  // These methods are never called by shuffle code.
+  override def serialize[T: ClassTag](t: T): ByteBuffer = throw new UnsupportedOperationException
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
+    throw new UnsupportedOperationException
+
+  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
+    throw new UnsupportedOperationException
+}

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedColumnarShuffleWriter.scala
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import io.glutenproject.columnarbatch.GlutenColumnarBatches
+import io.glutenproject.memory.alloc.{NativeMemoryAllocators, Spiller}
+import io.glutenproject.GlutenConfig
+import io.glutenproject.vectorized._
+
+import org.apache.spark._
+import org.apache.spark.internal.Logging
+import org.apache.spark.memory.MemoryConsumer
+import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.shuffle.celeborn.RssShuffleHandle
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.shuffle.utils.CelebornPartitionPusher
+
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.common.CelebornConf
+
+import java.io.IOException
+
+class CelebornHashBasedColumnarShuffleWriter[K, V](
+    handle: RssShuffleHandle[K, V, V],
+    context: TaskContext,
+    celebornConf: CelebornConf,
+    client: ShuffleClient,
+    writeMetrics: ShuffleWriteMetricsReporter)
+  extends ShuffleWriter[K, V]
+  with Logging {
+
+  private val appId: String = handle.newAppId
+
+  private val shuffleId = handle.dependency.shuffleId
+
+  private val numMappers = handle.numMappers
+
+  private val numPartitions = handle.dependency.partitioner.numPartitions
+
+  private val dep = handle.dependency.asInstanceOf[ColumnarShuffleDependency[K, V, V]]
+
+  private val conf = SparkEnv.get.conf
+
+  private val mapId = context.partitionId()
+
+  private val celebornPartitionPusher = new CelebornPartitionPusher(appId, shuffleId, numMappers,
+    numPartitions, context, mapId, client, celebornConf)
+
+  private val blockManager = SparkEnv.get.blockManager
+  private val offheapSize = conf.getSizeAsBytes("spark.memory.offHeap.size", 0)
+  private val executorNum = conf.getInt("spark.executor.cores", 1)
+  private val offheapPerTask = offheapSize / executorNum
+  private val nativeBufferSize = GlutenConfig.getConf.shuffleSplitDefaultSize
+  private val customizedCompressionCodec = {
+    val codec = GlutenConfig.getConf.columnarShuffleUseCustomizedCompressionCodec
+    val enableQat = conf.getBoolean(GlutenConfig.GLUTEN_ENABLE_QAT, false) &&
+      GlutenConfig.GLUTEN_QAT_SUPPORTED_CODEC.contains(codec)
+    if (enableQat) {
+      GlutenConfig.GLUTEN_QAT_CODEC_PREFIX + codec
+    } else {
+      codec
+    }
+  }
+  private val batchCompressThreshold =
+    GlutenConfig.getConf.columnarShuffleBatchCompressThreshold
+  private val jniWrapper = new ShuffleSplitterJniWrapper
+  // Are we in the process of stopping? Because map tasks can call stop() with success = true
+  // and then call stop() with success = false if they get an exception, we want to make sure
+  // we don't try deleting files, etc twice.
+  private var stopping = false
+  private var mapStatus: MapStatus = _
+  private var nativeSplitter: Long = 0
+
+  private var splitResult: SplitResult = _
+
+  private var partitionLengths: Array[Long] = _
+
+  @throws[IOException]
+  override def write(records: Iterator[Product2[K, V]]): Unit = {
+    internalWrite(records)
+  }
+
+  @throws[IOException]
+  def internalWrite(records: Iterator[Product2[K, V]]): Unit = {
+    if (!records.hasNext) {
+      partitionLengths = new Array[Long](dep.partitioner.numPartitions)
+      client.mapperEnd(appId, shuffleId, mapId, context.attemptNumber, numMappers)
+      mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
+      return
+    }
+
+    while (records.hasNext) {
+      val cb = records.next()._2.asInstanceOf[ColumnarBatch]
+      if (cb.numRows == 0 || cb.numCols == 0) {
+        logInfo(s"Skip ColumnarBatch of ${cb.numRows} rows, ${cb.numCols} cols")
+      } else {
+        val handle = GlutenColumnarBatches.getNativeHandle(cb)
+        if (nativeSplitter == 0) {
+          nativeSplitter = jniWrapper.makeForCeleborn(
+            dep.nativePartitioning,
+            offheapPerTask,
+            nativeBufferSize,
+            customizedCompressionCodec,
+            batchCompressThreshold,
+            celebornConf.pushBufferMaxSize,
+            celebornPartitionPusher,
+            NativeMemoryAllocators
+              .createSpillable(new Spiller() {
+                override def spill(size: Long, trigger: MemoryConsumer): Long = {
+                  if (nativeSplitter == 0) {
+                    throw new IllegalStateException(
+                      "Fatal: spill() called before a shuffle splitter " +
+                        "evaluator is created. This behavior should be" +
+                        "optimized by moving memory " +
+                        "allocations from make() to split()")
+                  }
+                  logInfo(s"Gluten shuffle writer: Trying to push $size bytes of data")
+                  // fixme pass true when being called by self
+                  val pushed = jniWrapper.nativePush(nativeSplitter, size, false)
+                  logInfo(s"Gluten shuffle writer: Spilled $pushed / $size bytes of data")
+                  pushed
+                }
+              })
+              .getNativeInstanceId,
+            handle,
+            context.taskAttemptId()
+          )
+        }
+        val startTime = System.nanoTime()
+        val bytes = jniWrapper.split(nativeSplitter, cb.numRows, handle)
+        dep.metrics("dataSize").add(bytes)
+        dep.metrics("splitTime").add(System.nanoTime() - startTime)
+        dep.metrics("numInputRows").add(cb.numRows)
+        dep.metrics("inputBatches").add(1)
+        // This metric is important, AQE use it to decide if EliminateLimit
+        writeMetrics.incRecordsWritten(cb.numRows())
+      }
+    }
+
+    val startTime = System.nanoTime()
+    if (nativeSplitter != 0) {
+      splitResult = jniWrapper.stop(nativeSplitter)
+    }
+
+    dep.metrics("splitTime").add(
+      System.nanoTime() - startTime - splitResult.getTotalPushTime -
+        splitResult.getTotalWriteTime -
+        splitResult.getTotalCompressTime)
+    writeMetrics.incBytesWritten(splitResult.getTotalBytesWritten)
+    writeMetrics.incWriteTime(splitResult.getTotalWriteTime + splitResult.getTotalPushTime)
+
+    partitionLengths = splitResult.getPartitionLengths
+
+    val pushMergedDataTime = System.nanoTime
+    client.prepareForMergeData(shuffleId, mapId, context.attemptNumber())
+    client.pushMergedData(appId, shuffleId, mapId, context.attemptNumber)
+    client.mapperEnd(appId, shuffleId, mapId, context.attemptNumber, numMappers)
+    writeMetrics.incWriteTime(System.nanoTime - pushMergedDataTime)
+    mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
+  }
+
+  override def stop(success: Boolean): Option[MapStatus] = {
+    try {
+      if (stopping) {
+        None
+      }
+      stopping = true
+      if (success) {
+        Option(mapStatus)
+      } else {
+        None
+      }
+    } finally {
+      if (nativeSplitter != 0) {
+        closeSplitter()
+        nativeSplitter = 0
+      }
+      client.cleanup(appId, shuffleId, mapId, context.attemptNumber)
+    }
+  }
+
+  def closeSplitter(): Unit = {
+    jniWrapper.close(nativeSplitter)
+  }
+
+  def getPartitionLengths: Array[Long] = partitionLengths
+}

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/utils/CelebornPartitionPusher.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/utils/CelebornPartitionPusher.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.utils
+
+import org.apache.spark._
+import org.apache.spark.internal.Logging
+
+import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.common.CelebornConf
+
+import java.io.IOException
+
+class CelebornPartitionPusher(
+    val appId: String,
+    val shuffleId: Int,
+    val numMappers: Int,
+    val numPartitions: Int,
+    val context: TaskContext,
+    val mapId: Int,
+    val client: ShuffleClient,
+    val celebornConf: CelebornConf)
+  extends Logging {
+
+  @throws[IOException]
+  def pushPartitionData(partitionId: Int, buffer: Array[Byte]): Int = {
+    logDebug(s"Push record, size ${buffer.length}.")
+    if (buffer.length > celebornConf.pushBufferMaxSize) {
+      client.pushData(
+        appId,
+        shuffleId,
+        mapId,
+        context.attemptNumber,
+        partitionId,
+        buffer,
+        0,
+        buffer.length,
+        numMappers,
+        numPartitions)
+    } else {
+      client.mergeData(
+        appId,
+        shuffleId,
+        mapId,
+        context.attemptNumber,
+        partitionId,
+        buffer,
+        0,
+        buffer.length,
+        numMappers,
+        numPartitions)
+    }
+  }
+}

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/utils/GlutenShuffleUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/utils/GlutenShuffleUtil.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.shuffle.utils
 
-import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper, GlutenColumnarShuffleWriter}
+import org.apache.spark.shuffle.{CelebornHashBasedColumnarShuffleWriter, CelebornShuffleWriterWrapper, GenCelebornShuffleWriterParameters, GenShuffleWriterParameters, GlutenColumnarShuffleWriter, GlutenShuffleWriterWrapper}
 
 object GlutenShuffleUtil {
 
@@ -27,6 +27,16 @@ object GlutenShuffleUtil {
       parameters.shuffleBlockResolver,
       parameters.columnarShuffleHandle,
       parameters.mapId,
+      parameters.metrics))
+  }
+
+  def genCelebornHashBasedColumnarShuffleWriter[K, V](
+    parameters: GenCelebornShuffleWriterParameters[K, V]): CelebornShuffleWriterWrapper[K, V] = {
+    CelebornShuffleWriterWrapper(new CelebornHashBasedColumnarShuffleWriter[K, V](
+      parameters.shuffleHandle,
+      parameters.context,
+      parameters.conf,
+      parameters.client,
       parameters.metrics))
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
     <scala.binary.version>2.12</scala.binary.version>
     <scala.version>${spark32.scala}</scala.version>
     <spark.version>${spark32.version}</spark.version>
+    <spark.major.version>3</spark.major.version>
+    <celeborn.version>0.2.1-SNAPSHOT</celeborn.version>
     <sparkbundle.version>${spark32bundle.version}</sparkbundle.version>
     <arrow.version>11.0.0-gluten</arrow.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
@@ -111,6 +113,7 @@
       </activation>
       <properties>
         <scala.version>${spark32.scala}</scala.version>
+        <spark.major.version>3</spark.major.version>
         <spark.version>${spark32.version}</spark.version>
         <delta.version>${delta20.version}</delta.version>
         <delta.binary.version>20</delta.binary.version>
@@ -121,6 +124,7 @@
       <id>spark-3.3</id>
       <properties>
         <scala.version>${spark33.scala}</scala.version>
+        <spark.major.version>3</spark.major.version>
         <spark.version>${spark33.version}</spark.version>
         <delta.version>${delta22.version}</delta.version>
         <delta.binary.version>22</delta.binary.version>
@@ -204,6 +208,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.celeborn</groupId>
+        <artifactId>celeborn-client-spark-${spark.major.version}-shaded_${scala.binary.version}</artifactId>
+        <version>${celeborn.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-sql_${scala.binary.version}</artifactId>
@@ -689,4 +698,11 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>apache</id>
+      <name>celeborn snapshots</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
 </project>

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -117,6 +117,12 @@ class GlutenConfig(conf: SQLConf) extends Logging {
       .getConfString("spark.shuffle.manager", "sort")
       .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")
 
+  // whether to use CelebornShuffleManager
+  def isUseCelebornShuffleManager: Boolean =
+    conf
+      .getConfString("spark.shuffle.manager", "sort")
+      .equals("org.apache.spark.shuffle.celeborn.CelebornShuffleManager")
+
   // enable or disable columnar exchange
   def enableColumnarShuffle: Boolean =
     conf


### PR DESCRIPTION
## What changes were proposed in this pull request?

Gluten shuffle service supports Celeborn hash based columnar Shuffle

## How was this patch tested?
First refer this URL(https://github.com/apache/incubator-celeborn) to create a celeborn cluster.

Then add the following configurations when starting the Spark Application.
* spark.shuffle.manager org.apache.spark.shuffle.celeborn.CelebornShuffleManager
* spark.serializer org.apache.spark.serializer.KryoSerializer
* spark.celeborn.master.endpoints clb-master:9097
* spark.celeborn.shuffle.writer hash
* spark.shuffle.service.enabled false
* spark.sql.adaptive.localShuffleReader.enabled false
* spark.dynamicAllocation.enabled false (If you want to use dynamic resource allocation, please refer to this URL (https://github.com/apache/incubator-celeborn/tree/main/assets/spark-patch) to apply the patch into your own Spark)