### PR TITLE
[Gluten-core] Get adaptive execution context known through checking thread stack trace

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.utils.AdaptiveSparkPlanUtil
+import io.glutenproject.utils.ColumnarShuffleUtil
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression, SortOrder}
@@ -87,7 +87,7 @@ case class TakeOrderedAndProjectExecTransformer (
         val sortStagePlan = WholeStageTransformerExec(limitExecPlan)(
           codegenStageCounter.incrementAndGet())
         val shuffleExec = ShuffleExchangeExec(SinglePartition, sortStagePlan)
-        val transformedShuffleExec = AdaptiveSparkPlanUtil.genColumnarShuffleExchange(shuffleExec,
+        val transformedShuffleExec = ColumnarShuffleUtil.genColumnarShuffleExchange(shuffleExec,
           sortStagePlan, false, isAdaptiveContextOrLeafPlanExchange)
 
         val globalSortExecPlan = SortExecTransformer(sortOrder, false,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.extension.TransformPreOverrides
 import io.glutenproject.utils.AdaptiveSparkPlanUtil
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -34,8 +33,8 @@ case class TakeOrderedAndProjectExecTransformer (
                                                 sortOrder: Seq[SortOrder],
                                                 projectList: Seq[NamedExpression],
                                                 child: SparkPlan,
-                                                supportAdaptive: Boolean) extends
-  UnaryExecNode{
+                                                isAdaptiveContextOrLeafPlanExchange: Boolean)
+    extends UnaryExecNode{
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
   override def supportsColumnar: Boolean = true
@@ -89,7 +88,7 @@ case class TakeOrderedAndProjectExecTransformer (
           codegenStageCounter.incrementAndGet())
         val shuffleExec = ShuffleExchangeExec(SinglePartition, sortStagePlan)
         val transformedShuffleExec = AdaptiveSparkPlanUtil.genColumnarShuffleExchange(shuffleExec,
-          sortStagePlan, supportAdaptive = supportAdaptive)
+          sortStagePlan, false, isAdaptiveContextOrLeafPlanExchange)
 
         val globalSortExecPlan = SortExecTransformer(sortOrder, false,
           new ColumnarInputAdapter(transformedShuffleExec))

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -494,7 +494,8 @@ case class ColumnarOverrideRules(session: SparkSession)
         case _ => false
       }
       val traceElements = Thread.currentThread.getStackTrace
-      assert(traceElements.length > 13, "More than 13 stack trace elements are expected!")
+      assert(traceElements.length > aqeStackTraceIndex,
+        s"The number of stack trace elements is expected to be more than $aqeStackTraceIndex")
       // ApplyColumnarRulesAndInsertTransitions is called by either QueryExecution or
       // AdaptiveSparkPlanExec. So by checking the stack trace, we can know whether
       // columnar rule will be applied in adaptive execution context. This part of code

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -491,14 +491,15 @@ case class ColumnarOverrideRules(session: SparkSession)
         case _: Exchange => true
         case _ => false
       }
-      val traces = Thread.currentThread.getStackTrace()
+      val traceElements = Thread.currentThread.getStackTrace
+      assert(traceElements.length > 13, "More than 13 stack trace elements are expected!")
       // ApplyColumnarRulesAndInsertTransitions is called by either QueryExecution or
       // AdaptiveSparkPlanExec. So by checking the stack trace, we can know whether
       // columnar rule will be applied in adaptive execution context. This part of code
       // needs to be carefully checked when supporting higher versions of spark to make
       // sure the calling stack has not been changed.
       this.isAdaptiveContext =
-        traces(13).getClassName.equals(AdaptiveSparkPlanExec.getClass.getName)
+        traceElements(13).getClassName.equals(AdaptiveSparkPlanExec.getClass.getName)
       logOnLevel(
         transformPlanLogLevel,
         s"preColumnarTransitions preOverriden plan:\n${plan.toString}")

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -458,6 +458,8 @@ case class ColumnarOverrideRules(session: SparkSession)
   private var isLeafPlanExchange: Boolean = false
   // Tracks whether the columnar rule is called through AQE.
   private var isAdaptiveContext: Boolean = false
+  // This is an empirical value, may need to be changed for supporting other versions of spark.
+  private val aqeStackTraceIndex = 13
   // Do not create rules in class initialization as we should access SQLConf
   // while creating the rules. At this time SQLConf may not be there yet.
 
@@ -498,8 +500,8 @@ case class ColumnarOverrideRules(session: SparkSession)
       // columnar rule will be applied in adaptive execution context. This part of code
       // needs to be carefully checked when supporting higher versions of spark to make
       // sure the calling stack has not been changed.
-      this.isAdaptiveContext =
-        traceElements(13).getClassName.equals(AdaptiveSparkPlanExec.getClass.getName)
+      this.isAdaptiveContext = traceElements(aqeStackTraceIndex).getClassName.equals(
+        AdaptiveSparkPlanExec.getClass.getName)
       logOnLevel(
         transformPlanLogLevel,
         s"preColumnarTransitions preOverriden plan:\n${plan.toString}")

--- a/gluten-core/src/main/scala/io/glutenproject/utils/AdaptiveSparkPlanUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/AdaptiveSparkPlanUtil.scala
@@ -59,8 +59,8 @@ object AdaptiveSparkPlanUtil {
   def genColumnarShuffleExchange(plan: ShuffleExchangeExec,
                                  child: SparkPlan,
                                  removeHashColumn: Boolean = false,
-                                 supportAdaptive: Boolean): SparkPlan = {
-    if (supportAdaptive) {
+                                 isAdaptiveContextOrLeafPlanExchange: Boolean): SparkPlan = {
+    if (isAdaptiveContextOrLeafPlanExchange) {
       ColumnarShuffleExchangeExec(
         plan.outputPartitioning, child, plan.shuffleOrigin, removeHashColumn)
     } else {

--- a/gluten-core/src/main/scala/io/glutenproject/utils/ColumnarShuffleUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/ColumnarShuffleUtil.scala
@@ -19,34 +19,9 @@ package io.glutenproject.utils
 
 import io.glutenproject.execution.CoalesceBatchesExec
 import org.apache.spark.sql.execution.{ColumnarShuffleExchangeExec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.{Exchange, ShuffleExchangeExec}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec}
 
-/**
- * Mostly ported from spark source code for checking whether a plan supports adaptive.
- * See InsertAdaptiveSparkPlan#supportAdaptive in vanilla spark.
- * Since spark-3.2, AQE can work for DPP, so no need to exclude DPP plan in the check.
- * This part of code may need update for supporting higher versions of spark.
- */
-object AdaptiveSparkPlanUtil {
-
-  def sanityCheck(plan: SparkPlan): Boolean = plan.logicalLink.isDefined
-
-  def supportAdaptive(plan: SparkPlan): Boolean = {
-    SQLConf.get.adaptiveExecutionEnabled &&
-        (sanityCheck(plan) &&
-            !plan.logicalLink.exists(_.isStreaming) &&
-            plan.children.forall(supportAdaptive))
-  }
-
-  def supportAdaptiveWithExchangeConsidered(plan: SparkPlan): Boolean = {
-    // Only QueryStage will have Exchange as Leaf Plan
-    val isLeafPlanExchange = plan match {
-      case _: Exchange => true
-      case _ => false
-    }
-    isLeafPlanExchange || supportAdaptive(plan)
-  }
+object ColumnarShuffleUtil {
 
   /**
    * Generate a columnar plan for shuffle exchange.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, there are some differences in applying columnar rule, depending on whether adaptive execution is taking effect. So it is important to check whether the current execution goes into AQE context. Previously, we achieved the check by porting a piece of spark's source code, which is not a good approach. As that code logic needs our careful maintenance, especially in supporting multiple versions of spark. On the other hand, it breaks the principle of encapsulation, as Hongze pointed out.
Here, we are proposing to get AQE context known through checking thread stack trace, assuming the stack trace is stable. This approach may be tricky, but is more reliable and easier to maintain than the current approach.
