### PR TITLE
[CH] Make bufferSize of IteratorOptions configurable

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -183,7 +183,7 @@ object CHExecUtil {
       } else {
         val options = new IteratorOptions
         options.setExpr("")
-        options.setBufferSize(8192)
+        options.setBufferSize(GlutenConfig.getConf.shuffleSplitDefaultSize)
         newPartitioning match {
           case HashPartitioning(exprs, n) =>
             rdd.mapPartitionsWithIndexInternal(


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current implementation of IteratorOptions sets the `bufferSize` as a hard-coded number, which happens to be the same value as `shuffleSplitDefaultSize`. 

However, both variables represent the same concept and have the same intended use.
