### PR TITLE
[CH-364] Explicitly invoke JNI_ONUnload when spark driver or executor are shuting down

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -33,6 +33,7 @@ import scala.util.control.Breaks.{break, breakable}
 class CHBackend extends Backend {
   override def name(): String = GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND
   override def initializerApi(): InitializerApi = new CHInitializerApi
+  override def shutdownApi(): ShutdownApi = new CHShutdownApi
   override def iteratorApi(): IteratorApi = new CHIteratorApi
   override def sparkPlanExecApi(): SparkPlanExecApi = new CHSparkPlanExecApi
   override def transformerApi(): TransformerApi = new CHTransformerApi

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHShutdownApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHShutdownApi.scala
@@ -17,10 +17,11 @@
 package io.glutenproject.backendsapi.clickhouse
 
 import io.glutenproject.backendsapi.ShutdownApi
-import io.glutenproject.vectorized.JniLibLoader
+import io.glutenproject.vectorized.CHNativeExpressionEvaluator
 
 class CHShutdownApi extends ShutdownApi {
   override def shutdown(): Unit = {
-    JniLibLoader.forceUnloadAll()
+    val kernel = new CHNativeExpressionEvaluator()
+    kernel.finalizeNative()
   }
 }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHShutdownApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHShutdownApi.scala
@@ -14,25 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.glutenproject.backendsapi.clickhouse
 
-package io.glutenproject.backendsapi
+import io.glutenproject.backendsapi.ShutdownApi
+import io.glutenproject.vectorized.JniLibLoader
 
-trait Backend {
-  def name(): String
-
-  def initializerApi(): InitializerApi
-
-  def shutdownApi(): ShutdownApi
-
-  def iteratorApi(): IteratorApi
-
-  def sparkPlanExecApi(): SparkPlanExecApi
-
-  def transformerApi(): TransformerApi
-
-  def validatorApi(): ValidatorApi
-
-  def metricsApi(): MetricsApi
-
-  def settings(): BackendSettings
+class CHShutdownApi extends ShutdownApi {
+  override def shutdown(): Unit = {
+    JniLibLoader.forceUnloadAll()
+  }
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -33,6 +33,7 @@ import scala.util.control.Breaks.{break, breakable}
 class VeloxBackend extends Backend {
   override def name: String = GlutenConfig.GLUTEN_VELOX_BACKEND
   override def initializerApi(): InitializerApi = new VeloxInitializerApi
+  override def shutdownApi(): ShutdownApi = new VeloxShutdownApi
   override def iteratorApi(): IteratorApi = new VeloxIteratorApi
   override def sparkPlanExecApi(): SparkPlanExecApi = new VeloxSparkPlanExecApi
   override def transformerApi(): TransformerApi = new VeloxTransformerApi

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxShutdownApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxShutdownApi.scala
@@ -14,25 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.glutenproject.backendsapi.velox
 
-package io.glutenproject.backendsapi
+import io.glutenproject.backendsapi.ShutdownApi
 
-trait Backend {
-  def name(): String
+class VeloxShutdownApi extends ShutdownApi {
 
-  def initializerApi(): InitializerApi
-
-  def shutdownApi(): ShutdownApi
-
-  def iteratorApi(): IteratorApi
-
-  def sparkPlanExecApi(): SparkPlanExecApi
-
-  def transformerApi(): TransformerApi
-
-  def validatorApi(): ValidatorApi
-
-  def metricsApi(): MetricsApi
-
-  def settings(): BackendSettings
+  override def shutdown(): Unit = {
+    /// TODO shutdown implementation in velox to release resources
+  }
 }

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -69,12 +69,10 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWr
   JNI_METHOD_END()
 }
 
-JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeFinalizeNative(
-  JNIEnv* env) {
-  JNI_METHOD_START
-  // TODO Release resources allocated for single executor/driver
-  JNI_METHOD_END()
-}
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeFinalizeNative(JNIEnv* env){
+    JNI_METHOD_START
+        // TODO Release resources allocated for single executor/driver
+        JNI_METHOD_END()}
 
 JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
     JNIEnv* env,

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -69,6 +69,13 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWr
   JNI_METHOD_END()
 }
 
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeFinalizeNative(
+  JNIEnv* env) {
+  JNI_METHOD_START
+  // TODO Release resources allocated for single executor/driver
+  JNI_METHOD_END()
+}
+
 JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeDoValidate(
     JNIEnv* env,
     jobject obj,

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -35,6 +35,11 @@ public class ExpressionEvaluatorJniWrapper {
    */
   native void nativeInitNative(byte[] subPlan);
 
+	/**
+	 * Call finalizeNative to finalize native computing.
+	 */
+  native void nativeFinalizeNative();
+
   /**
    * Validate the Substrait plan in native compute engine.
    *

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -35,9 +35,9 @@ public class ExpressionEvaluatorJniWrapper {
    */
   native void nativeInitNative(byte[] subPlan);
 
-	/**
-	 * Call finalizeNative to finalize native computing.
-	 */
+  /**
+   * Call finalizeNative to finalize native computing.
+   */
   native void nativeFinalizeNative();
 
   /**

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
@@ -127,7 +127,7 @@ public class JniLibLoader {
 
   public static synchronized void unloadFromPath(String libPath) {
     if (!LOADED_LIBRARY_PATHS.remove(libPath)) {
-		  LOG.warn("Library {} was not loaded or alreay unloaded:", libPath);
+      LOG.warn("Library {} was not loaded or alreay unloaded:", libPath);
       return;
     }
 

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
@@ -127,6 +127,7 @@ public class JniLibLoader {
 
   public static synchronized void unloadFromPath(String libPath) {
     if (!LOADED_LIBRARY_PATHS.remove(libPath)) {
+		  LOG.warn("Library {} was not loaded or alreay unloaded:", libPath);
       return;
     }
 

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/NativeExpressionEvaluator.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/NativeExpressionEvaluator.java
@@ -62,6 +62,10 @@ public abstract class NativeExpressionEvaluator implements AutoCloseable {
     jniWrapper.nativeInitNative(buildNativeConfNode(nativeConfMap).toProtobuf().toByteArray());
   }
 
+  public void finalizeNative() {
+    jniWrapper.nativeFinalizeNative();
+  }
+
   // Used to validate the Substrait plan in native compute engine.
   public boolean doValidate(byte[] subPlan) {
     return jniWrapper.nativeDoValidate(subPlan);

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -52,6 +52,10 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
     Collections.emptyMap()
   }
 
+  override def shutdown() {
+    BackendsApiManager.getShutdownApiInstance.shutdown()
+  }
+
   def setPredefinedConfigs(sc: SparkContext, conf: SparkConf): Unit = {
     val extensions = if (conf.contains(SPARK_SESSION_EXTS_KEY)) {
       s"${conf.get(SPARK_SESSION_EXTS_KEY)},${GLUTEN_SESSION_EXTENSION_NAME}"
@@ -103,6 +107,7 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
    * For example: close the native engine.
    */
   override def shutdown(): Unit = {
+    BackendsApiManager.getShutdownApiInstance.shutdown()
     super.shutdown()
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -53,7 +53,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
   }
 
   override def shutdown() {
-    // BackendsApiManager.getShutdownApiInstance.shutdown()
+    BackendsApiManager.getShutdownApiInstance.shutdown()
   }
 
   def setPredefinedConfigs(sc: SparkContext, conf: SparkConf): Unit = {
@@ -107,7 +107,7 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
    * For example: close the native engine.
    */
   override def shutdown(): Unit = {
-    // BackendsApiManager.getShutdownApiInstance.shutdown()
+    BackendsApiManager.getShutdownApiInstance.shutdown()
     super.shutdown()
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -53,7 +53,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
   }
 
   override def shutdown() {
-    BackendsApiManager.getShutdownApiInstance.shutdown()
+    // BackendsApiManager.getShutdownApiInstance.shutdown()
   }
 
   def setPredefinedConfigs(sc: SparkContext, conf: SparkConf): Unit = {
@@ -107,7 +107,7 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
    * For example: close the native engine.
    */
   override def shutdown(): Unit = {
-    BackendsApiManager.getShutdownApiInstance.shutdown()
+    // BackendsApiManager.getShutdownApiInstance.shutdown()
     super.shutdown()
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
@@ -26,6 +26,7 @@ object BackendsApiManager {
   private case class Wrapper(
       glutenBackendName: String,
       initializerApiInstance: InitializerApi,
+      shutdownApiInstance: ShutdownApi,
       iteratorApiInstance: IteratorApi,
       sparkPlanExecApiInstance: SparkPlanExecApi,
       transformerApiInstance: TransformerApi,
@@ -51,6 +52,7 @@ object BackendsApiManager {
     Wrapper(
       backend.name(),
       backend.initializerApi(),
+      backend.shutdownApi(),
       backend.iteratorApi(),
       backend.sparkPlanExecApi(),
       backend.transformerApi(),
@@ -73,6 +75,10 @@ object BackendsApiManager {
 
   def getInitializerApiInstance: InitializerApi = {
     manager.initializerApiInstance
+  }
+
+  def getShutdownApiInstance: ShutdownApi = {
+    manager.shutdownApiInstance
   }
 
   def getIteratorApiInstance: IteratorApi = {

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ShutdownApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ShutdownApi.scala
@@ -1,0 +1,5 @@
+package io.glutenproject.backendsapi
+
+trait ShutdownApi {
+  def shutdown(): Unit = {}
+}

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ShutdownApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ShutdownApi.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.glutenproject.backendsapi
 
 trait ShutdownApi {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix coredump existed in libch.so: https://github.com/Kyligence/ClickHouse/issues/364

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

test by CH[[377]]