### PR TITLE
[Gluten-1147][Gluten-core] Make validate failure logLevel configuable

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHFilterExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHFilterExecTransformer.scala
@@ -57,7 +57,9 @@ case class CHFilterExecTransformer(condition: Expression, child: SparkPlan)
           validation = true)
       } catch {
         case e: Throwable =>
-          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          logValidateFailure(
+            s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}",
+            e)
           return false
       }
     val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -253,8 +253,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
         substraitContext, projectList, child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} " +
-          s"due to ${e.getMessage} stack:${e.printStackTrace()}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
     // Then, validate the generated plan in native engine.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -234,7 +234,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
         child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -117,7 +117,7 @@ case class GenerateExecTransformer(
       getRelNode(context, operatorId, child.output, null, generatorNode, childOutputNodes, true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -147,7 +147,7 @@ abstract class HashAggregateExecBaseTransformer(
         getAggRel(substraitContext, operatorId, aggParams, null, validation = true)
       } catch {
         case e: Throwable =>
-          logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
           return false
       }
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -237,7 +237,7 @@ trait HashJoinLikeExecTransformer
         buildPlan.output, substraitContext, substraitContext.nextOperatorId, validation = true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
     // Then, validate the generated plan in native engine.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -93,7 +93,7 @@ case class LimitTransformer(child: SparkPlan,
       getRelNode(context, operatorId, offset, count, child.output, null, true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -259,7 +259,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
         substraitContext, sortOrder, child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -276,7 +276,7 @@ case class SortMergeJoinExecTransformer(
         bufferedPlan.output, substraitContext, substraitContext.nextOperatorId, validation = true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
     // Then, validate the generated plan in native engine.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -50,12 +50,24 @@ case class WholestageTransformContext(
     root: PlanNode,
     substraitContext: SubstraitContext = null)
 
-trait TransformSupport extends SparkPlan {
+trait TransformSupport extends SparkPlan with LogLevelUtil {
+
+  lazy val validateFailureLogLevel = GlutenConfig.getConf.validateFailureLogLevel
+  lazy val printStackOnValidateFailure = GlutenConfig.getConf.printStackOnValidateFailure
 
   /**
    * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
    */
   def doValidate(): Boolean = false
+
+  def logValidateFailure(msg: => String, e: Throwable): Unit = {
+    if (printStackOnValidateFailure) {
+      logOnLevel(validateFailureLogLevel, msg, e)
+    } else {
+      logOnLevel(validateFailureLogLevel, msg)
+    }
+
+  }
 
   /**
    * Returns all the RDDs of ColumnarBatch which generates the input rows.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -279,7 +279,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
         orderSpec, child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logDebug(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/utils/LogLevelUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/LogLevelUtil.scala
@@ -29,4 +29,14 @@ trait LogLevelUtil { self: Logging =>
       case "ERROR" => logError(msg)
       case _ => logDebug(msg)
     }
+
+  protected def logOnLevel(level: String, msg: => String, e: Throwable): Unit =
+    level match {
+      case "TRACE" => logTrace(msg, e)
+      case "DEBUG" => logDebug(msg, e)
+      case "INFO" => logInfo(msg, e)
+      case "WARN" => logWarning(msg, e)
+      case "ERROR" => logError(msg, e)
+      case _ => logDebug(msg, e)
+    }
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -243,6 +243,12 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def substraitPlanLogLevel: String =
     conf.getConfString("spark.gluten.sql.substrait.plan.logLevel", "DEBUG")
 
+  def validateFailureLogLevel: String =
+    conf.getConfString("spark.gluten.sql.validate.failure.logLevel", "WARN")
+
+  def printStackOnValidateFailure: Boolean =
+    conf.getConfString("spark.gluten.sql.validate.failure.printStack", "false").toBoolean
+
   def debug: Boolean = conf.getConfString("spark.gluten.sql.debug", "false").toBoolean
   def taskStageId: Int = conf.getConfString("spark.gluten.sql.benchmark_task.stageId", "1").toInt
   def taskPartitionId: Int =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validation failure log level now is debug, which makes finding reasons of fallback difficult.

This PR try to make it configuable, just like the way to control plan log: spark.gluten.sql.transform.logLevel and spark.gluten.sql.substrait.plan.logLevel

I propose add two new flags:
spark.gluten.sql.validate.failure.logLevel
spark.gluten.sql.validate.failure.printStack


## How was this patch tested?

test manually by ”explain select sum(i_current_price) from item;“
Table item is a tpcds table in parquet format.
Column i_current_price data type is decimal

