### PR TITLE
[Gluten-core] Remove std::cout in cpp code

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -19,7 +19,6 @@
 #include <malloc.h>
 #include <filesystem>
 
-#include <glog/logging.h>
 #include "compute/Backend.h"
 #include "compute/ProtobufUtils.h"
 #include "config/GlutenConfig.h"
@@ -749,7 +748,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
   jmethodID mid = env->GetStaticMethodID(cls, "currentThread", "()Ljava/lang/Thread;");
   jobject thread = env->CallStaticObjectMethod(cls, mid);
   if (thread == NULL) {
-    LOG(INFO) << "Thread.currentThread() return NULL" << std::endl;
+    std::cerr << "Thread.currentThread() return NULL" << std::endl;
   } else {
     jmethodID mid_getid = GetMethodIDOrError(env, cls, "getId", "()J");
     jlong sid = env->CallLongMethod(thread, mid_getid);
@@ -760,7 +759,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
   jmethodID get_tc_mid = env->GetStaticMethodID(tc_cls, "get", "()Lorg/apache/spark/TaskContext;");
   jobject tc_obj = env->CallStaticObjectMethod(tc_cls, get_tc_mid);
   if (tc_obj == NULL) {
-    LOG(INFO) << "TaskContext.get() return NULL" << std::endl;
+    std::cerr << "TaskContext.get() return NULL" << std::endl;
   } else {
     jmethodID get_tsk_attmpt_mid = GetMethodIDOrError(env, tc_cls, "taskAttemptId", "()J");
     jlong attmpt_id = env->CallLongMethod(tc_obj, get_tsk_attmpt_mid);

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -19,6 +19,7 @@
 #include <malloc.h>
 #include <filesystem>
 
+#include <glog/logging.h>
 #include "compute/Backend.h"
 #include "compute/ProtobufUtils.h"
 #include "config/GlutenConfig.h"
@@ -748,7 +749,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
   jmethodID mid = env->GetStaticMethodID(cls, "currentThread", "()Ljava/lang/Thread;");
   jobject thread = env->CallStaticObjectMethod(cls, mid);
   if (thread == NULL) {
-    std::cout << "Thread.currentThread() return NULL" << std::endl;
+    LOG(INFO) << "Thread.currentThread() return NULL" << std::endl;
   } else {
     jmethodID mid_getid = GetMethodIDOrError(env, cls, "getId", "()J");
     jlong sid = env->CallLongMethod(thread, mid_getid);
@@ -759,7 +760,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleSplitterJniWrapp
   jmethodID get_tc_mid = env->GetStaticMethodID(tc_cls, "get", "()Lorg/apache/spark/TaskContext;");
   jobject tc_obj = env->CallStaticObjectMethod(tc_cls, get_tc_mid);
   if (tc_obj == NULL) {
-    std::cout << "TaskContext.get() return NULL" << std::endl;
+    LOG(INFO) << "TaskContext.get() return NULL" << std::endl;
   } else {
     jmethodID get_tsk_attmpt_mid = GetMethodIDOrError(env, tc_cls, "taskAttemptId", "()J");
     jlong attmpt_id = env->CallLongMethod(tc_obj, get_tsk_attmpt_mid);

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -29,7 +29,6 @@
 #include <arm_neon.h>
 #endif
 
-#include <glog/logging.h>
 #include "compute/ProtobufUtils.h"
 #include "utils/compression.h"
 #include "utils/macros.h"
@@ -662,20 +661,20 @@ arrow::Status Splitter::AllocateNew(int32_t partition_id, int32_t new_size) {
   int32_t retry = 0;
   while (status.IsOutOfMemory() && retry < 3) {
     // retry allocate
-    LOG(INFO) << status.ToString() << std::endl
+    std::cerr << status.ToString() << std::endl
               << std::to_string(++retry) << " retry to allocate new buffer for partition "
               << std::to_string(partition_id) << std::endl;
     int64_t spilled_size;
     ARROW_ASSIGN_OR_RAISE(auto partition_to_spill, SpillLargestPartition(&spilled_size));
     if (partition_to_spill == -1) {
-      LOG(INFO) << "Failed to allocate new buffer for partition " << std::to_string(partition_id)
+      std::cerr << "Failed to allocate new buffer for partition " << std::to_string(partition_id)
                 << ". No partition buffer to spill." << std::endl;
       return status;
     }
     status = AllocatePartitionBuffers(partition_id, new_size);
   }
   if (status.IsOutOfMemory()) {
-    LOG(INFO) << "Failed to allocate new buffer for partition " << std::to_string(partition_id) << ". Out of memory."
+    std::cerr << "Failed to allocate new buffer for partition " << std::to_string(partition_id) << ". Out of memory."
               << std::endl;
   }
   return status;
@@ -1174,7 +1173,7 @@ arrow::Status Splitter::SplitBinaryType(
         dst_addrs[pid].valueptr = value_buffer->mutable_data();
         dst_addrs[pid].value_capacity = capacity;
         dst_value_base = dst_addrs[pid].valueptr + value_offset - strlength;
-        LOG(INFO) << "Split value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[x]
+        std::cerr << "Split value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[x]
                   << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity
                   << " new size = " << capacity << " row = " << partition_buffer_idx_base_[pid]
                   << " strlen = " << strlength << std::endl;

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -29,6 +29,7 @@
 #include <arm_neon.h>
 #endif
 
+#include <glog/logging.h>
 #include "compute/ProtobufUtils.h"
 #include "utils/compression.h"
 #include "utils/macros.h"
@@ -1173,7 +1174,7 @@ arrow::Status Splitter::SplitBinaryType(
         dst_addrs[pid].valueptr = value_buffer->mutable_data();
         dst_addrs[pid].value_capacity = capacity;
         dst_value_base = dst_addrs[pid].valueptr + value_offset - strlength;
-        std::cout << "Split value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[x]
+        LOG(INFO) << "Split value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[x]
                   << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity
                   << " new size = " << capacity << " row = " << partition_buffer_idx_base_[pid]
                   << " strlen = " << strlength << std::endl;

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -1175,8 +1175,9 @@ arrow::Status Splitter::SplitBinaryType(
         dst_addrs[pid].value_capacity = capacity;
         dst_value_base = dst_addrs[pid].valueptr + value_offset - strlength;
         LOG(INFO) << "Split value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[x]
-              << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity << " new size = " << capacity
-              << " row = " << partition_buffer_idx_base_[pid] << " strlen = " << strlength << std::endl;
+                  << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity
+                  << " new size = " << capacity << " row = " << partition_buffer_idx_base_[pid]
+                  << " strlen = " << strlength << std::endl;
       }
       auto value_src_ptr = src_addr + src_offset_addr[src_offset];
 #ifdef __AVX512BW__

--- a/cpp/core/operators/shuffle/splitter.cc
+++ b/cpp/core/operators/shuffle/splitter.cc
@@ -662,20 +662,20 @@ arrow::Status Splitter::AllocateNew(int32_t partition_id, int32_t new_size) {
   int32_t retry = 0;
   while (status.IsOutOfMemory() && retry < 3) {
     // retry allocate
-    std::cout << status.ToString() << std::endl
+    LOG(INFO) << status.ToString() << std::endl
               << std::to_string(++retry) << " retry to allocate new buffer for partition "
               << std::to_string(partition_id) << std::endl;
     int64_t spilled_size;
     ARROW_ASSIGN_OR_RAISE(auto partition_to_spill, SpillLargestPartition(&spilled_size));
     if (partition_to_spill == -1) {
-      std::cout << "Failed to allocate new buffer for partition " << std::to_string(partition_id)
+      LOG(INFO) << "Failed to allocate new buffer for partition " << std::to_string(partition_id)
                 << ". No partition buffer to spill." << std::endl;
       return status;
     }
     status = AllocatePartitionBuffers(partition_id, new_size);
   }
   if (status.IsOutOfMemory()) {
-    std::cout << "Failed to allocate new buffer for partition " << std::to_string(partition_id) << ". Out of memory."
+    LOG(INFO) << "Failed to allocate new buffer for partition " << std::to_string(partition_id) << ". Out of memory."
               << std::endl;
   }
   return status;
@@ -1175,9 +1175,8 @@ arrow::Status Splitter::SplitBinaryType(
         dst_addrs[pid].value_capacity = capacity;
         dst_value_base = dst_addrs[pid].valueptr + value_offset - strlength;
         LOG(INFO) << "Split value buffer resized colid = " << binary_idx << " dst_start " << dst_offset_base[x]
-                  << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity
-                  << " new size = " << capacity << " row = " << partition_buffer_idx_base_[pid]
-                  << " strlen = " << strlength << std::endl;
+              << " dst_end " << dst_offset_base[x + 1] << " old size = " << old_capacity << " new size = " << capacity
+              << " row = " << partition_buffer_idx_base_[pid] << " strlen = " << strlength << std::endl;
       }
       auto value_src_ptr = src_addr + src_offset_addr[src_offset];
 #ifdef __AVX512BW__


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark print result in stdout, print log in stderr, we should not use std::cout explicitly.