### PR TITLE
[Gluten-core] Add a general trait for gluten plan to extend

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -95,8 +95,6 @@ abstract class FilterExecBaseTransformer(val cond: Expression,
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genFilterTransformerMetricsUpdater(metrics)
 
-  override def getChild: SparkPlan = child
-
   def doTransform(context: SubstraitContext): TransformContext
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
@@ -294,8 +292,6 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genProjectTransformerMetricsUpdater(metrics)
 
-  override def getChild: SparkPlan = child
-
   override def doTransform(context: SubstraitContext): TransformContext = {
     val childCtx = child match {
       case c: TransformSupport =>
@@ -385,7 +381,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
 }
 
 // An alternatives for UnionExec.
-case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan {
+case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with TransformSupport {
   override def supportsColumnar: Boolean = true
 
   override def output: Seq[Attribute] = {
@@ -427,7 +423,7 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan {
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = columnarInputRDD
 
-  def doValidate(): Boolean = {
+  override def doValidate(): Boolean = {
     BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -22,6 +22,7 @@ import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter, ExpressionTransformer}
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.SubstraitContext
@@ -46,6 +47,7 @@ import scala.collection.JavaConverters._
 abstract class FilterExecBaseTransformer(val cond: Expression,
                                          val input: SparkPlan) extends UnaryExecNode
   with TransformSupport
+  with GlutenPlan
   with PredicateHelper
   with AliasAwareOutputPartitioning
   with Logging {
@@ -231,6 +233,7 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
 case class ProjectExecTransformer(projectList: Seq[NamedExpression],
                                   child: SparkPlan) extends UnaryExecNode
   with TransformSupport
+  with GlutenPlan
   with PredicateHelper
   with AliasAwareOutputPartitioning
   with Logging {
@@ -381,7 +384,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
 }
 
 // An alternatives for UnionExec.
-case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan {
+case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with GlutenPlan {
   override def supportsColumnar: Boolean = true
 
   override def output: Seq[Attribute] = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -381,7 +381,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
 }
 
 // An alternatives for UnionExec.
-case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with TransformSupport {
+case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan {
   override def supportsColumnar: Boolean = true
 
   override def output: Seq[Attribute] = {
@@ -423,7 +423,7 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = columnarInputRDD
 
-  override def doValidate(): Boolean = {
+  def doValidate(): Boolean = {
     BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -21,11 +21,11 @@ import com.google.common.collect.Lists
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter}
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.`type`.ColumnTypeNode
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.RelBuilder
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.InputPartition
@@ -34,7 +34,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-trait BasicScanExecTransformer extends TransformSupport {
+trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
 
   def filterExprs(): Seq[Expression]
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -91,10 +91,6 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     this
   }
 
-  override def getChild: SparkPlan = {
-    null
-  }
-
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genBatchScanTransformerMetricsUpdater(metrics)
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceBatchesExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceBatchesExec.scala
@@ -18,7 +18,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-
+import io.glutenproject.extension.GlutenPlan
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode {
+case class CoalesceBatchesExec(child: SparkPlan) extends UnaryExecNode with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genCoalesceBatchesMetrics(sparkContext)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -54,10 +54,6 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
       this
   }
 
-  override def getChild: SparkPlan = {
-    throw new UnsupportedOperationException(s"This operator doesn't support getChild.")
-  }
-
   override def doValidate(): Boolean = false
 
   override def doTransform(context: SubstraitContext): TransformContext = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -17,9 +17,9 @@
 
 package io.glutenproject.execution
 
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
 import io.glutenproject.substrait.SubstraitContext
-
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -29,7 +29,7 @@ import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
-  extends UnaryExecNode with TransformSupport {
+  extends UnaryExecNode with TransformSupport with GlutenPlan {
 
   override def supportsColumnar: Boolean = true
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ColumnarInMemoryTableScanExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ColumnarInMemoryTableScanExec.scala
@@ -18,7 +18,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-
+import io.glutenproject.extension.GlutenPlan
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -33,7 +33,7 @@ case class ColumnarInMemoryTableScanExec(
                                           attributes: Seq[Attribute],
                                           predicates: Seq[Expression],
                                           @transient relation: InMemoryRelation)
-  extends LeafExecNode {
+  extends LeafExecNode with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genColumnarInMemoryTableMetrics(sparkContext)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -19,10 +19,10 @@ package io.glutenproject.execution
 
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{AttributeReferenceTransformer, ConverterUtils, ExpressionConverter}
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
@@ -31,7 +31,6 @@ import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.BindReferencesUtil
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -46,7 +45,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
                                  groupExpression: Seq[NamedExpression],
                                  output: Seq[Attribute],
                                  child: SparkPlan)
-  extends UnaryExecNode with TransformSupport {
+  extends UnaryExecNode with TransformSupport with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genExpandTransformerMetrics(sparkContext)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -80,8 +80,6 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
       this
   }
 
-  override def getChild: SparkPlan = child
-
   def getRelNode(context: SubstraitContext,
                  projections: Seq[Seq[Expression]],
                  groupExpression: Seq[NamedExpression],

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -114,10 +114,6 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     this
   }
 
-  override def getChild: SparkPlan = {
-    null
-  }
-
   override def doValidate(): Boolean = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
     if (!bucketedScan) {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.rdd.RDD
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
@@ -42,6 +41,7 @@ import io.glutenproject.substrait.plan.PlanBuilder
 import java.util.ArrayList
 import com.google.protobuf.Any
 import com.google.common.collect.Lists
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
 
 // Transformer for GeneratorExec, which Applies a [[Generator]] to a stream of input rows.
@@ -53,7 +53,7 @@ case class GenerateExecTransformer(
   generatorOutput: Seq[Attribute],
   child: SparkPlan)
   extends UnaryExecNode
-  with TransformSupport {
+  with TransformSupport with GlutenPlan {
 
   override def output: Seq[Attribute] = requiredChildOutput ++ generatorOutput
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -86,8 +86,6 @@ case class GenerateExecTransformer(
       this
   }
 
-  override def getChild: SparkPlan = child
-
   override def supportsColumnar: Boolean = true
 
   override def doValidate(): Boolean = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -22,6 +22,7 @@ import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
@@ -55,8 +56,7 @@ abstract class HashAggregateExecBaseTransformer(
                                      initialInputBufferOffset: Int,
                                      resultExpressions: Seq[NamedExpression],
                                      child: SparkPlan)
-  extends BaseAggregateExec
-    with TransformSupport {
+  extends BaseAggregateExec with TransformSupport with GlutenPlan {
 
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -108,8 +108,6 @@ abstract class HashAggregateExecBaseTransformer(
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genHashAggregateTransformerMetricsUpdater(metrics)
 
-  override def getChild: SparkPlan = child
-
   override def verboseString(maxFields: Int): String = toString(verbose = true, maxFields)
 
   private def toString(verbose: Boolean, maxFields: Int): String = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -216,8 +216,6 @@ trait HashJoinLikeExecTransformer
       this
   }
 
-  override def getChild: SparkPlan = streamedPlan
-
   override def doValidate(): Boolean = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -22,6 +22,7 @@ import com.google.protobuf.{Any, StringValue}
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.{JoinParams, SubstraitContext}
@@ -29,9 +30,7 @@ import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
-
 import io.substrait.proto.JoinRel
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -101,7 +100,7 @@ trait ColumnarShuffledJoin extends BaseJoinExec {
  * Performs a hash join of two child relations by first shuffling the data using the join keys.
  */
 trait HashJoinLikeExecTransformer
-  extends BaseJoinExec with TransformSupport with ColumnarShuffledJoin {
+  extends BaseJoinExec with TransformSupport with ColumnarShuffledJoin with GlutenPlan {
 
   def joinBuildSide: BuildSide
   def hashJoinType: JoinType

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -18,19 +18,18 @@
 package io.glutenproject.execution
 
 import java.util
-
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -39,7 +38,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class LimitTransformer(child: SparkPlan,
                             offset: Long,
-                            count: Long) extends UnaryExecNode with TransformSupport {
+                            count: Long)
+    extends UnaryExecNode with TransformSupport with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genLimitTransformerMetrics(sparkContext)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -48,8 +48,6 @@ case class LimitTransformer(child: SparkPlan,
 
   override def output: Seq[Attribute] = child.output
 
-  override def getChild: SparkPlan = child
-
   override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = child match {
     case c: TransformSupport =>
       c.columnarInputRDDs

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -19,7 +19,6 @@ package io.glutenproject.execution
 
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter}
 import io.glutenproject.metrics.MetricsUpdater
@@ -27,13 +26,12 @@ import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.utils.BindReferencesUtil
-
 import io.substrait.proto.SortField
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -49,7 +47,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
                                global: Boolean,
                                child: SparkPlan,
                                testSpillFrequency: Int = 0)
-  extends UnaryExecNode with TransformSupport {
+  extends UnaryExecNode with TransformSupport with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genSortTransformerMetrics(sparkContext)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -70,8 +70,6 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
   override def requiredChildDistribution: Seq[Distribution] =
     if (global) OrderedDistribution(sortOrder) :: Nil else UnspecifiedDistribution :: Nil
 
-  override def getChild: SparkPlan = child
-
   override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = child match {
     case c: TransformSupport =>
       c.columnarInputRDDs

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -19,17 +19,15 @@ package io.glutenproject.execution
 
 import com.google.common.collect.Lists
 import com.google.protobuf.StringValue
-
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.{JoinParams, SubstraitContext}
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.GlutenConfig
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
-
 import io.substrait.proto.JoinRel
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -39,7 +37,6 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.collection.JavaConverters._
-
 import java.{lang, util}
 
 /**
@@ -54,8 +51,7 @@ case class SortMergeJoinExecTransformer(
                                          right: SparkPlan,
                                          isSkewJoin: Boolean = false,
                                          projectList: Seq[NamedExpression] = null)
-  extends BinaryExecNode
-    with TransformSupport {
+  extends BinaryExecNode with TransformSupport with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genSortMergeJoinTransformerMetrics(sparkContext)
@@ -274,7 +270,8 @@ case class SortMergeJoinExecTransformer(
         bufferedPlan.output, substraitContext, substraitContext.nextOperatorId, validation = true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        logValidateFailure(s"Validation failed for ${this.getClass.toString}" +
+            s" due to ${e.getMessage}", e)
         return false
     }
     // Then, validate the generated plan in native engine.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -215,8 +215,6 @@ case class SortMergeJoinExecTransformer(
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genSortMergeJoinTransformerMetricsUpdater(metrics)
 
-  override def getChild: SparkPlan = streamedPlan
-
   def genJoinParametersBuilder(): com.google.protobuf.Any.Builder = {
     val (isSMJ, isNullAwareAntiJoin) = (0, 0)
     // Start with "JoinParameters:"

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -34,7 +34,7 @@ case class TakeOrderedAndProjectExecTransformer (
                                                 projectList: Seq[NamedExpression],
                                                 child: SparkPlan,
                                                 isAdaptiveContextOrLeafPlanExchange: Boolean)
-    extends UnaryExecNode{
+    extends UnaryExecNode with TransformSupport {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
   override def supportsColumnar: Boolean = true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -34,7 +34,7 @@ case class TakeOrderedAndProjectExecTransformer (
                                                 projectList: Seq[NamedExpression],
                                                 child: SparkPlan,
                                                 isAdaptiveContextOrLeafPlanExchange: Boolean)
-    extends UnaryExecNode with TransformSupport {
+    extends UnaryExecNode {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
   override def supportsColumnar: Boolean = true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.utils.ColumnarShuffleUtil
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -34,7 +35,7 @@ case class TakeOrderedAndProjectExecTransformer (
                                                 projectList: Seq[NamedExpression],
                                                 child: SparkPlan,
                                                 isAdaptiveContextOrLeafPlanExchange: Boolean)
-    extends UnaryExecNode {
+    extends UnaryExecNode with GlutenPlan {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
   override def supportsColumnar: Boolean = true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -21,13 +21,13 @@ import com.google.common.collect.Lists
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
 import io.glutenproject.substrait.rel.RelNode
 import io.glutenproject.test.TestStats
 import io.glutenproject.utils.{LogLevelUtil, SubstraitPlanPrinterUtil}
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
@@ -99,7 +99,7 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
 }
 
 case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int)
-  extends UnaryExecNode with TransformSupport with LogLevelUtil {
+  extends UnaryExecNode with TransformSupport with GlutenPlan with LogLevelUtil {
 
   // For WholeStageCodegen-like operator, only pipeline time will be handled in graph plotting.
   // See SparkPlanGraph.scala:205 for reference.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -86,7 +86,7 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
       s"This operator doesn't support doTransform with SubstraitContext.")
   }
 
-  def metricsUpdater(): MetricsUpdater =
+  def metricsUpdater(): MetricsUpdater
 
   def getColumnarInputRDDs(plan: SparkPlan): Seq[RDD[ColumnarBatch]] = {
     plan match {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -50,9 +50,6 @@ case class WholestageTransformContext(
     root: PlanNode,
     substraitContext: SubstraitContext = null)
 
-/**
- * Every gluten OP should extend this trait.
- */
 trait TransformSupport extends SparkPlan with LogLevelUtil {
 
   lazy val validateFailureLogLevel = GlutenConfig.getConf.validateFailureLogLevel
@@ -78,18 +75,18 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
    * @note
    *   Right now we support up to two RDDs
    */
-  def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = throw new UnsupportedOperationException()
+  def columnarInputRDDs: Seq[RDD[ColumnarBatch]]
 
-  def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = throw new UnsupportedOperationException()
+  def getBuildPlans: Seq[(SparkPlan, SparkPlan)]
 
-  def getStreamedLeafPlan: SparkPlan = throw new UnsupportedOperationException()
+  def getStreamedLeafPlan: SparkPlan
 
   def doTransform(context: SubstraitContext): TransformContext = {
     throw new UnsupportedOperationException(
       s"This operator doesn't support doTransform with SubstraitContext.")
   }
 
-  def metricsUpdater(): MetricsUpdater = throw new UnsupportedOperationException()
+  def metricsUpdater(): MetricsUpdater =
 
   def getColumnarInputRDDs(plan: SparkPlan): Seq[RDD[ColumnarBatch]] = {
     plan match {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -19,11 +19,11 @@ package io.glutenproject.execution
 
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
-
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
@@ -31,9 +31,7 @@ import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.BindReferencesUtil
-
 import io.substrait.proto.SortField
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -48,7 +46,8 @@ import java.util
 case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
                                  partitionSpec: Seq[Expression],
                                  orderSpec: Seq[SortOrder],
-                                 child: SparkPlan) extends WindowExecBase with TransformSupport {
+                                 child: SparkPlan)
+    extends WindowExecBase with TransformSupport with GlutenPlan {
 
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genWindowTransformerMetrics(sparkContext)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -118,8 +118,6 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
       this
   }
 
-  override def getChild: SparkPlan = child
-
   def getRelNode(context: SubstraitContext,
                  windowExpression: Seq[NamedExpression],
                  partitionSpec: Seq[Expression],

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.extension
+
+/**
+ * Every Gluten OP should extend this trait.
+ */
+trait GlutenPlan {
+}

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.TransformSupport
 import org.apache.spark.{SparkException, broadcast}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
@@ -33,12 +32,13 @@ import org.apache.spark.util.SparkFatalException
 
 import java.util.UUID
 import java.util.concurrent.{TimeUnit, TimeoutException}
+
 import scala.concurrent.Promise
 import scala.concurrent.duration.NANOSECONDS
 import scala.util.control.NonFatal
 
 case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
-  extends BroadcastExchangeLike with TransformSupport {
+  extends BroadcastExchangeLike {
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genColumnarBroadcastExchangeMetrics(sparkContext)
 
@@ -125,7 +125,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     ColumnarBroadcastExchangeExec(mode.canonicalized, child.canonicalized)
   }
 
-  override def doValidate(): Boolean = mode match {
+  def doValidate(): Boolean = mode match {
     case _: HashedRelationBroadcastMode =>
       true
     case _ =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.GlutenPlan
 import org.apache.spark.{SparkException, broadcast}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
@@ -32,13 +33,12 @@ import org.apache.spark.util.SparkFatalException
 
 import java.util.UUID
 import java.util.concurrent.{TimeUnit, TimeoutException}
-
 import scala.concurrent.Promise
 import scala.concurrent.duration.NANOSECONDS
 import scala.util.control.NonFatal
 
 case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
-  extends BroadcastExchangeLike {
+  extends BroadcastExchangeLike with GlutenPlan {
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genColumnarBroadcastExchangeMetrics(sparkContext)
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,8 +17,8 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-
-import org.apache.spark.{broadcast, SparkException}
+import io.glutenproject.execution.TransformSupport
+import org.apache.spark.{SparkException, broadcast}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -32,14 +32,13 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.SparkFatalException
 
 import java.util.UUID
-import java.util.concurrent.{TimeoutException, TimeUnit}
-
+import java.util.concurrent.{TimeUnit, TimeoutException}
 import scala.concurrent.Promise
 import scala.concurrent.duration.NANOSECONDS
 import scala.util.control.NonFatal
 
 case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
-  extends BroadcastExchangeLike {
+  extends BroadcastExchangeLike with TransformSupport {
   override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genColumnarBroadcastExchangeMetrics(sparkContext)
 
@@ -126,7 +125,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     ColumnarBroadcastExchangeExec(mode.canonicalized, child.canonicalized)
   }
 
-  def doValidate(): Boolean = mode match {
+  override def doValidate(): Boolean = mode match {
     case _: HashedRelationBroadcastMode =>
       true
     case _ =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.TransformSupport
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -39,7 +38,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
                                        child: SparkPlan,
                                        shuffleOrigin: ShuffleOrigin = ENSURE_REQUIREMENTS,
                                        removeHashColumn: Boolean = false)
-  extends ShuffleExchangeLike with TransformSupport {
+  extends ShuffleExchangeLike {
 
   private[sql] lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
@@ -102,7 +101,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
 
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 
-  override def doValidate(): Boolean = {
+  def doValidate(): Boolean = {
     BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child.output)
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.execution.TransformSupport
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -38,7 +39,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
                                        child: SparkPlan,
                                        shuffleOrigin: ShuffleOrigin = ENSURE_REQUIREMENTS,
                                        removeHashColumn: Boolean = false)
-  extends ShuffleExchangeLike {
+  extends ShuffleExchangeLike with TransformSupport {
 
   private[sql] lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
@@ -101,7 +102,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
 
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 
-  def doValidate(): Boolean = {
+  override def doValidate(): Boolean = {
     BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child.output)
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.GlutenPlan
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -38,7 +39,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
                                        child: SparkPlan,
                                        shuffleOrigin: ShuffleOrigin = ENSURE_REQUIREMENTS,
                                        removeHashColumn: Boolean = false)
-  extends ShuffleExchangeLike {
+  extends ShuffleExchangeLike with GlutenPlan {
 
   private[sql] lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarSubqueryBroadcastExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarSubqueryBroadcastExec.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.GlutenPlan
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -25,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
-import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashedRelation, HashJoin, LongHashedRelation}
+import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashJoin, HashedRelation, LongHashedRelation}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.util.ThreadUtils
 
@@ -36,7 +37,8 @@ case class ColumnarSubqueryBroadcastExec(name: String,
                                          index: Int,
                                          buildKeys: Seq[Expression],
                                          child: SparkPlan
-                                        ) extends BaseSubqueryExec with UnaryExecNode {
+                                        )
+    extends BaseSubqueryExec with UnaryExecNode with GlutenPlan {
 
   // `ColumnarSubqueryBroadcastExec` is only used with `InSubqueryExec`.
   // No one would reference this output,

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExecTransformer.scala
@@ -66,10 +66,6 @@ case class ArrowEvalPythonExecTransformer(udfs: Seq[PythonUDF], resultAttrs: Seq
       this
   }
 
-  override def getChild: SparkPlan = {
-    throw new UnsupportedOperationException(s"This operator doesn't support getChild.")
-  }
-
   override def doValidate(): Boolean = false
 
   override def doTransform(context: SubstraitContext): TransformContext = {


### PR DESCRIPTION
We need to have a easy check to see whether a plan is a gluten plan or not. Considering the `TransformSupport` trait cannot be extended by all gluten plan, e.g, union, etc. for some reasons, I am proposing to add a new trait for gluten plan to extend.