### PR TITLE
[Gluten-core] Avoid printing stack traces with excessive depth

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/utils/QueryPlanSelector.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/QueryPlanSelector.scala
@@ -44,7 +44,7 @@ abstract class QueryPlanSelector[T <: QueryPlan[_]] extends Logging {
   var ENABLE_BY_DEFAULT = true
   val CONF_KEY = "spark.gluten.enabled"
 
-  private[this] def stackTrace(max: Int = 1000): String = {
+  private[this] def stackTrace(max: Int = 5): String = {
     val trim: Int = 6
     new Throwable().getStackTrace().slice(trim, trim + max).mkString("\n")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid printing stack traces with excessive depth in QueryPlanSelector, as this will make the logs clearer.
