### PR TITLE
[Gluten-core] Reuse ByteString in ExpressionNode.toProtobuf to avoid OOM

### DIFF
--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/BinaryLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/BinaryLiteralNode.java
@@ -24,17 +24,17 @@ import java.io.Serializable;
 import com.google.protobuf.ByteString;
 
 public class BinaryLiteralNode implements ExpressionNode, Serializable {
-  private final byte[] value;
+  private final ByteString value;
 
   public BinaryLiteralNode(byte[] value) {
-    this.value = value;
+    this.value = ByteString.copyFrom(value);
   }
 
   @Override
   public Expression toProtobuf() {
     Expression.Literal.Builder binaryBuilder =
         Expression.Literal.newBuilder();
-    binaryBuilder.setBinary(ByteString.copyFrom(value));
+    binaryBuilder.setBinary(value);
 
     Expression.Builder builder = Expression.newBuilder();
     builder.setLiteral(binaryBuilder.build());

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/BinaryStructNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/BinaryStructNode.java
@@ -27,10 +27,15 @@ public class BinaryStructNode implements ExpressionNode, Serializable {
   // first is index, second is value
   private final byte[][] values;
   private final StructType type;
+  private final ByteString[] byteStrings;
 
   public BinaryStructNode(byte[][] values, StructType type) {
     this.values = values;
     this.type = type;
+    this.byteStrings = new ByteString[values.length];
+    for (int i = 0; i < values.length; i++) {
+      byteStrings[i] = ByteString.copyFrom(values[i]);
+    }
   }
 
   public ExpressionNode getFieldLiteral(int index) {
@@ -42,10 +47,10 @@ public class BinaryStructNode implements ExpressionNode, Serializable {
   public Expression toProtobuf() {
     Expression.Literal.Struct.Builder structBuilder = Expression.Literal.Struct.newBuilder();
     Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
-    for (byte[] value : values) {
+    for (ByteString byteString : byteStrings) {
       // TODO, here we copy the binary literal, if it is long such as BloomFilter binary,
       //  it will cost much time
-      literalBuilder.setBinary(ByteString.copyFrom(value));
+      literalBuilder.setBinary(byteString);
       structBuilder.addFields(literalBuilder);
     }
     literalBuilder.setStruct(structBuilder.build());

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/DecimalLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/DecimalLiteralNode.java
@@ -26,10 +26,13 @@ import java.math.BigDecimal;
 
 public class DecimalLiteralNode implements ExpressionNode, Serializable {
     private final Decimal value;
+    private final ByteString valueBytes;
 
     public DecimalLiteralNode(Decimal value) {
         ExpressionBuilder.checkDecimalScale(value.scale());
         this.value = value;
+        this.valueBytes = ByteString.copyFrom(
+                encodeDecimalIntoBytes(value.toJavaBigDecimal(), value.scale(), 16));
     }
 
     private static final long[] POWER_OF_10 = {
@@ -73,9 +76,7 @@ public class DecimalLiteralNode implements ExpressionNode, Serializable {
         decimalBuilder.setPrecision(value.precision());
         decimalBuilder.setScale(value.scale());
 
-        byte[] twosComplement =
-                encodeDecimalIntoBytes(value.toJavaBigDecimal(), value.scale(), 16);
-        decimalBuilder.setValue(ByteString.copyFrom(twosComplement));
+        decimalBuilder.setValue(valueBytes);
 
         Expression.Literal.Builder literalBuilder = Expression.Literal.newBuilder();
         literalBuilder.setDecimal(decimalBuilder.build());


### PR DESCRIPTION
## What changes were proposed in this pull request?
We meet the OOM problem when we were tring to perf TPCDS Q4 with native bloom filter enabled. Since memcp is called every time `toProtobuf` is called, most of the driver memory was occupied by ByteString, and finally coused `java.lang.OutOfMemoryError: Java heap space`.

## How was this patch tested?
unit tests

