### PR TITLE
[Gluten-core] Change some variables' name

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -34,7 +34,7 @@ case class TakeOrderedAndProjectExecTransformer (
                                                 sortOrder: Seq[SortOrder],
                                                 projectList: Seq[NamedExpression],
                                                 child: SparkPlan,
-                                                isAdaptiveContextOrLeafPlanExchange: Boolean)
+                                                isAdaptiveContextOrTopParentExchange: Boolean)
     extends UnaryExecNode with GlutenPlan {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
@@ -89,7 +89,7 @@ case class TakeOrderedAndProjectExecTransformer (
           codegenStageCounter.incrementAndGet())
         val shuffleExec = ShuffleExchangeExec(SinglePartition, sortStagePlan)
         val transformedShuffleExec = ColumnarShuffleUtil.genColumnarShuffleExchange(shuffleExec,
-          sortStagePlan, false, isAdaptiveContextOrLeafPlanExchange)
+          sortStagePlan, false, isAdaptiveContextOrTopParentExchange)
 
         val globalSortExecPlan = SortExecTransformer(sortOrder, false,
           new ColumnarInputAdapter(transformedShuffleExec))

--- a/gluten-core/src/main/scala/io/glutenproject/utils/ColumnarShuffleUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/ColumnarShuffleUtil.scala
@@ -34,8 +34,8 @@ object ColumnarShuffleUtil {
   def genColumnarShuffleExchange(plan: ShuffleExchangeExec,
                                  child: SparkPlan,
                                  removeHashColumn: Boolean = false,
-                                 isAdaptiveContextOrLeafPlanExchange: Boolean): SparkPlan = {
-    if (isAdaptiveContextOrLeafPlanExchange) {
+                                 isAdaptiveContextOrTopParentExchange: Boolean): SparkPlan = {
+    if (isAdaptiveContextOrTopParentExchange) {
       ColumnarShuffleExchangeExec(
         plan.outputPartitioning, child, plan.shuffleOrigin, removeHashColumn)
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some variables' name is misleading. In somewhere, we are checking the top parent plan to see whether it is exchange. So we should not name the corresponding variable with leaf plan used.