### PR TITLE
[VL] avoid clean package/target/*.jar when call mvn clean

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -110,6 +110,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+      <artifactId>maven-clean-plugin</artifactId>
+      <version>3.2.0</version>
+      <configuration>
+        <excludeDefaultDirectories>true</excludeDefaultDirectories>
+        <filesets>
+          <fileset>
+            <directory>target</directory>
+            <excludes>
+              <exclude>*3.2*</exclude>
+              <exclude>*3.3*</exclude>
+            </excludes>
+            <followSymlinks>false</followSymlinks>
+          </fileset>
+        </filesets>
+      </configuration>
+    </plugin>
 
     </plugins>
   </build>


### PR DESCRIPTION
## What changes were proposed in this pull request?
maven clean package will automatically clean up package/target folder.
We want to keep all gluten jar for both 3.2 and 3.3.

## How was this patch tested?
cd $GLUTEN_DIR
mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests

The maven clean command will not delete gluten jar.
![image](https://user-images.githubusercontent.com/14065538/226786042-39b3cd76-e773-4612-b357-359ebb0a1da8.png)

when we change some codes, and compile again.
mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests

Old jar will be overwrited by new jar.

