### PR TITLE
[VL] make the VeloxBackend's data & functions more readable

### DIFF
--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -59,11 +59,7 @@ class Backend : public std::enable_shared_from_this<Backend> {
       std::cout << "Error parsing substrait plan to json: " << maybe_plan_json.status().ToString() << std::endl;
     }
 #endif
-    return ParseProtobuf(data, size, &plan_);
-  }
-
-  const ::substrait::Plan& GetPlan() const {
-    return plan_;
+    return ParseProtobuf(data, size, &substraitPlan_);
   }
 
   /// This function is used to create certain converter from the format used by
@@ -100,7 +96,7 @@ class Backend : public std::enable_shared_from_this<Backend> {
   }
 
  protected:
-  ::substrait::Plan plan_;
+  ::substrait::Plan substraitPlan_;
   // static conf map
   std::unordered_map<std::string, std::string> confMap_;
 };

--- a/cpp/core/tests/ColumnarToRowTest.cc
+++ b/cpp/core/tests/ColumnarToRowTest.cc
@@ -77,8 +77,6 @@ TEST_F(ColumnarToRowTest, Int_64) {
 
   uint8_t* address = columnarToRowConverter->GetBufferAddress();
 
-  uint8_t a[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0};
-
   auto length_vec = columnarToRowConverter->GetLengths();
 
   long arr[length_vec.size()];

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -49,7 +49,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string&
   return maybePlan;
 }
 
-std::shared_ptr<velox::substrait::SplitInfo> getFileInfos(
+std::shared_ptr<velox::substrait::SplitInfo> getSplitInfos(
     const std::string& datasetPath,
     const std::string& fileFormat) {
   auto scanInfo = std::make_shared<velox::substrait::SplitInfo>();

--- a/cpp/velox/benchmarks/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/BenchmarkUtils.h
@@ -79,7 +79,7 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> getPlanFromFile(const std::string&
 /// Get the file paths, starts, lengths from a directory.
 /// Use fileFormat to specify the format to read, eg., orc, parquet.
 /// Return a split info.
-std::shared_ptr<facebook::velox::substrait::SplitInfo> getFileInfos(
+std::shared_ptr<facebook::velox::substrait::SplitInfo> getSplitInfos(
     const std::string& datasetPath,
     const std::string& fileFormat);
 

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -104,7 +104,7 @@ auto BM_Generic = [](::benchmark::State& state,
 
     auto* rawIter = static_cast<gluten::WholeStageResultIterator*>(resultIter->GetRaw());
     const auto& task = rawIter->task_;
-    const auto& planNode = rawIter->planNode_;
+    const auto& planNode = rawIter->veloxPlan_;
     auto statsStr = facebook::velox::exec::printPlanWithStats(*planNode, task->taskStats(), true);
     std::cout << statsStr << std::endl;
   }

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -37,7 +37,7 @@ auto BM = [](::benchmark::State& state,
   std::vector<std::shared_ptr<velox::substrait::SplitInfo>> scanInfos;
   scanInfos.reserve(datasetPaths.size());
   for (const auto& datasetPath : datasetPaths) {
-    scanInfos.emplace_back(getFileInfos(datasetPath, fileFormat));
+    scanInfos.emplace_back(getSplitInfos(datasetPath, fileFormat));
   }
 
   for (auto _ : state) {

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -239,7 +239,7 @@ std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
   if (inputs.size() > 0) {
     arrowInputIters_ = std::move(inputs);
   }
-  
+
   toVeloxPlan();
 
   // Scan node can be required.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -55,15 +55,6 @@ class VeloxBackend final : public Backend {
       SplitOptions options,
       const std::string& batchType) override;
 
-  /// Separate the scan ids and stream ids, and get the scan infos.
-  void getInfoAndIds(
-      std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<facebook::velox::substrait::SplitInfo>>
-          splitInfoMap,
-      std::unordered_set<facebook::velox::core::PlanNodeId> leafPlanNodeIds,
-      std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos,
-      std::vector<facebook::velox::core::PlanNodeId>& scanIds,
-      std::vector<facebook::velox::core::PlanNodeId>& streamIds);
-
   std::shared_ptr<Metrics> GetMetrics(void* raw_iter, int64_t exportNanos) override {
     auto iter = static_cast<WholeStageResultIterator*>(raw_iter);
     return iter->GetMetrics(exportNanos);
@@ -94,7 +85,7 @@ class VeloxBackend final : public Backend {
 
   void setInputPlanNode(const ::substrait::RelRoot& sroot);
 
-  std::shared_ptr<const facebook::velox::core::PlanNode> getVeloxPlanNode(const ::substrait::Plan& splan);
+  void toVeloxPlan();
 
   std::string nextPlanNodeId();
 
@@ -111,8 +102,8 @@ class VeloxBackend final : public Backend {
       std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(GetDefaultWrappedVeloxMemoryPool());
 
   // Cache for tests/benchmark purpose.
-  std::shared_ptr<const facebook::velox::core::PlanNode> planNode_;
-  std::shared_ptr<arrow::Schema> output_schema_;
+  std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;
+  std::shared_ptr<arrow::Schema> outputSchema_;
 };
 
 } // namespace gluten

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -94,7 +94,7 @@ void WholeStageResultIterator::collectMetrics() {
       if (omittedNodeIds_.find(nodeId) == omittedNodeIds_.end()) {
 #ifdef GLUTEN_PRINT_DEBUG
         std::cout << "Not found node id: " << nodeId << std::endl;
-        std::cout << "Plan Node: " << std::endl << planNode_->toString(true, true) << std::endl;
+        std::cout << "Plan Node: " << std::endl << veloxPlan_->toString(true, true) << std::endl;
 #endif
         throw std::runtime_error("Node id cannot be found in plan status.");
       }

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -15,10 +15,10 @@ class WholeStageResultIterator {
  public:
   WholeStageResultIterator(
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
-      std::shared_ptr<const facebook::velox::core::PlanNode> planNode,
+      const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::unordered_map<std::string, std::string>& confMap)
-      : planNode_(planNode), confMap_(confMap), pool_(pool) {
-    getOrderedNodeIds(planNode_, orderedNodeIds_);
+      : veloxPlan_(planNode), confMap_(confMap), pool_(pool) {
+    getOrderedNodeIds(veloxPlan_, orderedNodeIds_);
   }
 
   virtual ~WholeStageResultIterator() {
@@ -49,7 +49,7 @@ class WholeStageResultIterator {
 
   std::function<void(facebook::velox::exec::Task*)> addSplits_;
 
-  std::shared_ptr<const facebook::velox::core::PlanNode> planNode_;
+  std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;
 
  protected:
   /// A map of custom configs.


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. change `getVeloxPlanNode` to `toVeloxPlan`
2. change `getFileInfos` to `getSplitInfos`
3. rename several data members to express more explicit intentation 

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

