### PR TITLE
[VL] Support using Celeborn in the scenario of switching multiple SparkContexts in the same process of Velox CI

### DIFF
--- a/gluten-core/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleManager.java
+++ b/gluten-core/src/main/java/org/apache/spark/shuffle/celeborn/CelebornShuffleManager.java
@@ -128,12 +128,16 @@ public class CelebornShuffleManager implements ShuffleManager {
   public void stop() {
     if (rssShuffleClient != null) {
       rssShuffleClient.shutdown();
+      ShuffleClient.reset();
+      rssShuffleClient = null;
     }
     if (lifecycleManager != null) {
       lifecycleManager.stop();
+      lifecycleManager = null;
     }
     if (columnarShuffleManager() != null) {
       columnarShuffleManager().stop();
+      _columnarShuffleManager = null;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support using Celeborn in the scenario of switching multiple SparkContexts in the same process of Velox CI

## How was this patch tested?
If we switch the SparkSession in the Velxo CI, the following exception will occur.

```
 [Executor task launch worker for task 0.0 in stage 8.0 (TID 8)] WARN  org.apache.celeborn.shaded.io.netty.channel.AbstractChannel - Force-closing a channel whose registration task was not accepted by an event loop: [id: 0xca6cd07d]
java.util.concurrent.RejectedExecutionException: event executor terminated
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:932) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:351) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:344) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:834) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.execute0(SingleThreadEventExecutor.java:825) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:815) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.AbstractChannel$AbstractUnsafe.register(AbstractChannel.java:483) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.SingleThreadEventLoop.register(SingleThreadEventLoop.java:87) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.SingleThreadEventLoop.register(SingleThreadEventLoop.java:81) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.channel.MultithreadEventLoopGroup.register(MultithreadEventLoopGroup.java:86) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.bootstrap.AbstractBootstrap.initAndRegister(AbstractBootstrap.java:323) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.bootstrap.Bootstrap.doResolveAndConnect(Bootstrap.java:155) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.shaded.io.netty.bootstrap.Bootstrap.connect(Bootstrap.java:139) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.common.network.client.TransportClientFactory.internalCreateClient(TransportClientFactory.java:219) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.common.network.client.TransportClientFactory.createClient(TransportClientFactory.java:169) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.client.ShuffleClientImpl.pushOrMergeData(ShuffleClientImpl.java:719) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.celeborn.client.ShuffleClientImpl.pushData(ShuffleClientImpl.java:791) ~[celeborn-client-spark-3-shaded_2.12-0.2.0-incubating.jar:?]
	at org.apache.spark.shuffle.utils.CelebornPartitionPusher.pushPartitionData(CelebornPartitionPusher.scala:53) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at io.glutenproject.vectorized.ShuffleSplitterJniWrapper.split(Native Method) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.shuffle.CelebornHashBasedColumnarShuffleWriter.internalWrite(CelebornHashBasedColumnarShuffleWriter.scala:145) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.shuffle.CelebornHashBasedColumnarShuffleWriter.write(CelebornHashBasedColumnarShuffleWriter.scala:95) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.scheduler.Task.run(Task.scala:136) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551) ~[gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_352]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_352]
```
