### PR TITLE
[VL] Clean up EP build scripts

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -62,7 +62,7 @@ jobs:
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh  && \
-          ./build_arrow_for_velox.sh --build_tests=ON --build_benchmarks=ON && \
+          ./build_arrow.sh --build_tests=ON --build_benchmarks=ON && \
           cd /opt/gluten/ep/build-velox/src && \
           ./get_velox.sh && \
           ./build_velox.sh'
@@ -150,7 +150,7 @@ jobs:
           docker exec velox-backend-ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh  && \
-          ./build_arrow_for_velox.sh && \
+          ./build_arrow.sh && \
           cd /opt/gluten/ep/build-velox/src && \
           ./get_velox.sh && \
           ./build_velox.sh --enable_hdfs=ON --enable_s3=ON'
@@ -197,7 +197,7 @@ jobs:
           source /opt/rh/gcc-toolset-9/enable && \
           cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh  && \
-          ./build_arrow_for_velox.sh && \
+          ./build_arrow.sh && \
           cd /opt/gluten/ep/build-velox/src && \
           ./get_velox.sh && \
           ./build_velox.sh'

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -152,7 +152,7 @@ jobs:
           ./get_arrow.sh  && \
           ./build_arrow.sh && \
           cd /opt/gluten/ep/build-velox/src && \
-          ./get_velox.sh && \
+          ./get_velox.sh --enable_hdfs=ON --enable_s3=ON && \
           ./build_velox.sh --enable_hdfs=ON --enable_s3=ON'
       - name: Build Gluten CPP library
         run: |

--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -16,65 +16,67 @@ NPROC=$(nproc --ignore=2)
 ARROW_ROOT=
 VELOX_HOME=
 
-for arg in "$@"
-do
-    case $arg in
-        --arrow_root=*)
-        ARROW_ROOT=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --velox_home=*)
-        VELOX_HOME=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_type=*)
-        BUILD_TYPE=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_velox_backend=*)
-        BUILD_VELOX_BACKEND=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_tests=*)
-        BUILD_TESTS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_benchmarks=*)
-        BUILD_BENCHMARKS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_jemalloc=*)
-        BUILD_JEMALLOC=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_qat=*)
-        ENABLE_QAT=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_hbm=*)
-        ENABLE_HBM=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_protobuf=*)
-        BUILD_PROTOBUF=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_s3=*)
-        ENABLE_S3=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_hdfs=*)
-        ENABLE_HDFS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        *)
-        OTHER_ARGUMENTS+=("$1")
-        shift # Remove generic argument from processing
-        ;;
-    esac
+for arg in "$@"; do
+  case $arg in
+  --arrow_root=*)
+    ARROW_ROOT=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --velox_home=*)
+    VELOX_HOME=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_type=*)
+    BUILD_TYPE=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_velox_backend=*)
+    BUILD_VELOX_BACKEND=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_tests=*)
+    BUILD_TESTS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_benchmarks=*)
+    BUILD_BENCHMARKS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_jemalloc=*)
+    BUILD_JEMALLOC=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_qat=*)
+    ENABLE_QAT=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_hbm=*)
+    ENABLE_HBM=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_protobuf=*)
+    BUILD_PROTOBUF=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_s3=*)
+    ENABLE_S3=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_hdfs=*)
+    ENABLE_HDFS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  *)
+    OTHER_ARGUMENTS+=("$1")
+    shift # Remove generic argument from processing
+    ;;
+  esac
 done
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(
+  cd "$(dirname "$BASH_SOURCE")"
+  pwd
+)
 #gluten cpp will find arrow lib from ARROW_ROOT
 if [ "$ARROW_ROOT" == "" ]; then
   ARROW_ROOT="$CURRENT_DIR/../ep/build-arrow/build/arrow_install"

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -70,22 +70,15 @@ done
 
 ##install arrow
 cd $GLUTEN_DIR/ep/build-arrow/src
-./get_arrow.sh --enable_ep_cache=$ENABLE_EP_CACHE
-
-if [ $ENABLE_EP_CACHE == 'OFF' ] || [ ! -f $GLUTEN_DIR/ep/build-arrow/build/arrow-commit.cache ]; then
-  ./build_arrow_for_velox.sh --build_type=$BUILD_TYPE --build_tests=$BUILD_TESTS --build_benchmarks=$BUILD_BENCHMARKS \
-                           --enable_qat=$ENABLE_QAT --enable_ep_cache=$ENABLE_EP_CACHE
-fi
+./get_arrow.sh --enable_qat=$ENABLE_QAT
+./build_arrow.sh --build_type=$BUILD_TYPE --build_tests=$BUILD_TESTS --build_benchmarks=$BUILD_BENCHMARKS \
+                         --enable_ep_cache=$ENABLE_EP_CACHE
 
 ##install velox
 cd $GLUTEN_DIR/ep/build-velox/src
-./get_velox.sh --enable_ep_cache=$ENABLE_EP_CACHE
-
-if [ $ENABLE_EP_CACHE == 'OFF' ] || [ ! -f $GLUTEN_DIR/ep/build-velox/build/velox-commit.cache ]; then
-  ./build_velox.sh --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3 \
-                 --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                 --enable_ep_cache=$ENABLE_EP_CACHE
-fi
+./get_velox.sh --enable_hdfs=$ENABLE_HDFS --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3
+./build_velox.sh --enable_s3=$ENABLE_S3 --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
+               --enable_ep_cache=$ENABLE_EP_CACHE
 
 ## compile gluten cpp
 cd $GLUTEN_DIR/cpp

--- a/docs/GlutenUsage.md
+++ b/docs/GlutenUsage.md
@@ -16,7 +16,7 @@ Please set them via `--`, e.g. `--build_type=Release`.
 | enable_hdfs | build with hdfs lib      | OFF|
 | enable_ep_cache | enable caching for external project build (Arrow and Velox) | OFF |
 
-#### Parameters for build_arrow_for_velox.sh
+#### Parameters for build_arrow.sh
 Please set them via `--`, e.g., `--arrow_home=/YOUR/PATH`.
 
 | Parameters | Description | Default value |

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -161,6 +161,7 @@ sudo apt install -y libiberty-dev libxml2-dev libkrb5-dev libgsasl7-dev libuuid1
 To build Gluten with HDFS support, below command is provided:
 ```
 cd /path_to_gluten/ep/build-velox/src
+./get_velox.sh --enable_hdfs=ON
 ./build_velox.sh --enable_hdfs=ON
 
 cd /path_to_gluten/cpp
@@ -268,6 +269,7 @@ Velox supports S3 with the open source [AWS C++ SDK](https://github.com/aws/aws-
 A new build option for S3(velox_enable_s3) is added. Below command is used to enable this feature
 ```
 cd /path_to_gluten/ep/build-velox/src/
+./get_velox.sh --enable_s3=ON
 ./build_velox.sh --enable_s3=ON
 
 cd /path_to_gluten/cpp

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -69,7 +69,7 @@ cd /path_to_gluten
 ## fetch arrow and compile
 cd /path_to_gluten/ep/build-arrow/src/
 ./get_arrow.sh
-./build_arrow_for_velox.sh
+./build_arrow.sh
 
 ## fetch velox
 cd /path_to_gluten/ep/build-velox/src/
@@ -131,9 +131,9 @@ Arrow home can be set as the same of Velox. We will soon switch to upstream Arro
 You can also clone the Arrow source from [OAP/Arrow](https://github.com/oap-project/arrow) to some other folder then specify it as below.
 
 ```shell script
-step 1: set ARROW_SOURCE_DIR in build_arrow_for_velox.sh and compile
+step 1: set ARROW_SOURCE_DIR in build_arrow.sh and compile
 cd /path_to_gluten/ep/build-arrow/src/
-./build_arrow_for_velox.sh
+./build_arrow.sh
 
 step 2: set ARROW_ROOT
 cd /path_to_gluten/cpp

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -39,7 +39,7 @@ You can generate the example files by the following steps:
 ```
 cd gluten_home/ep/build-arrow/src
 ./get_arrow.sh
-./build_arrow_for_velox.sh --build_tests=ON --build_benchmarks=ON
+./build_arrow.sh --build_tests=ON --build_benchmarks=ON
 ```
 
 2. get and build Velox

--- a/docs/developers/MicroBenchmarks.md
+++ b/docs/developers/MicroBenchmarks.md
@@ -18,7 +18,7 @@ The commands below help to generate example input files:
 ```shell
 cd /path_to_gluten/ep/build-arrow/src
 ./get_arrow.sh
-./build_arrow_for_velox.sh --build_tests=ON --build_benchmarks=ON
+./build_arrow.sh --build_tests=ON --build_benchmarks=ON
 
 cd /path_to_gluten/ep/build-velox/src
 # get velox and compile

--- a/docs/developers/NewToGluten.md
+++ b/docs/developers/NewToGluten.md
@@ -54,7 +54,7 @@ If you need to debug cpp code, please compile the backend code and gluten cpp co
 ## compile velox
 ./build_velox.sh --build_type=Debug
 ## compile arrow with tests required library
-./build_arrow_for_velox.sh --build_tests=ON
+./build_arrow.sh --build_tests=ON
 ## compile gluten cpp with benchmark and tests to debug
 cmake -DBUILD_VELOX_BACKEND=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Debug ..
 ```

--- a/ep/build-arrow/src/build_arrow.sh
+++ b/ep/build-arrow/src/build_arrow.sh
@@ -9,33 +9,35 @@ TARGET_BUILD_COMMIT=""
 ARROW_HOME=""
 ENABLE_EP_CACHE=OFF
 
-for arg in "$@"
-do
-    case $arg in
-        --build_tests=*)
-        BUILD_TESTS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_type=*)
-        BUILD_TYPE=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --arrow_home=*)
-        ARROW_HOME=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_ep_cache=*)
-        ENABLE_EP_CACHE=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        *)
-        OTHER_ARGUMENTS+=("$1")
-        shift # Remove generic argument from processing
-        ;;
-    esac
+for arg in "$@"; do
+  case $arg in
+  --build_tests=*)
+    BUILD_TESTS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_type=*)
+    BUILD_TYPE=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --arrow_home=*)
+    ARROW_HOME=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_ep_cache=*)
+    ENABLE_EP_CACHE=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  *)
+    OTHER_ARGUMENTS+=("$1")
+    shift # Remove generic argument from processing
+    ;;
+  esac
 done
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(
+  cd "$(dirname "$BASH_SOURCE")"
+  pwd
+)
 if [ "$ARROW_HOME" == "" ]; then
   ARROW_HOME="$CURRENT_DIR/../build/"
 fi
@@ -67,12 +69,12 @@ if [ $ENABLE_EP_CACHE == "ON" ]; then
     CACHED_BUILT_COMMIT="$(cat ${ARROW_HOME}/arrow-commit.cache)"
     if [ -n "$CACHED_BUILT_COMMIT" ]; then
       if [ "$TARGET_BUILD_COMMIT" = "$CACHED_BUILT_COMMIT" ]; then
-          echo "Arrow build of commit $TARGET_BUILD_COMMIT was cached."
-          exit 0
+        echo "Arrow build of commit $TARGET_BUILD_COMMIT was cached."
+        exit 0
       else
-          echo "Found cached commit $CACHED_BUILT_COMMIT for Arrow which is different with target commit $TARGET_BUILD_COMMIT."
+        echo "Found cached commit $CACHED_BUILT_COMMIT for Arrow which is different with target commit $TARGET_BUILD_COMMIT."
       fi
-      fi
+    fi
   fi
 else
   git clean -dfx :/
@@ -81,36 +83,36 @@ else
 fi
 
 if [ -f ${ARROW_HOME}/arrow-commit.cache ]; then
-    rm -f ${ARROW_HOME}/arrow-commit.cache
+  rm -f ${ARROW_HOME}/arrow-commit.cache
 fi
 
 # Arrow CPP libraries
 mkdir -p cpp/build
 pushd cpp/build
 cmake -G Ninja \
-        -DARROW_BUILD_STATIC=OFF \
-        -DARROW_COMPUTE=ON \
-        -DARROW_WITH_RE2=ON \
-        -DARROW_FILESYSTEM=ON \
-        -DARROW_WITH_LZ4=ON \
-        -DARROW_WITH_SNAPPY=ON \
-        -DARROW_WITH_ZLIB=ON \
-        -DARROW_JSON=$WITH_JSON \
-        -DARROW_PARQUET=ON \
-        -DARROW_ORC=ON \
-        -DARROW_WITH_ZSTD=ON \
-        -DARROW_BUILD_SHARED=ON \
-        -DARROW_BOOST_USE_SHARED=OFF \
-        -DARROW_JAVA_JNI_ENABLE_DEFAULT=OFF \
-        -DARROW_JEMALLOC=ON \
-        -DARROW_SIMD_LEVEL=AVX2 \
-        -DARROW_RUNTIME_SIMD_LEVEL=MAX \
-        -DARROW_DEPENDENCY_SOURCE=BUNDLED \
-        -Dre2_SOURCE=AUTO \
-        -DCMAKE_INSTALL_PREFIX=$ARROW_INSTALL_DIR \
-        -DCMAKE_INSTALL_LIBDIR=lib \
-        -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-        ..
+  -DARROW_BUILD_STATIC=OFF \
+  -DARROW_COMPUTE=ON \
+  -DARROW_WITH_RE2=ON \
+  -DARROW_FILESYSTEM=ON \
+  -DARROW_WITH_LZ4=ON \
+  -DARROW_WITH_SNAPPY=ON \
+  -DARROW_WITH_ZLIB=ON \
+  -DARROW_JSON=$WITH_JSON \
+  -DARROW_PARQUET=ON \
+  -DARROW_ORC=ON \
+  -DARROW_WITH_ZSTD=ON \
+  -DARROW_BUILD_SHARED=ON \
+  -DARROW_BOOST_USE_SHARED=OFF \
+  -DARROW_JAVA_JNI_ENABLE_DEFAULT=OFF \
+  -DARROW_JEMALLOC=ON \
+  -DARROW_SIMD_LEVEL=AVX2 \
+  -DARROW_RUNTIME_SIMD_LEVEL=MAX \
+  -DARROW_DEPENDENCY_SOURCE=BUNDLED \
+  -Dre2_SOURCE=AUTO \
+  -DCMAKE_INSTALL_PREFIX=$ARROW_INSTALL_DIR \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  ..
 cmake --build . --target install
 popd
 
@@ -122,8 +124,8 @@ popd
 # Arrow Java libraries
 pushd java
 mvn clean install -P arrow-c-data -pl c -am -DskipTests -Dcheckstyle.skip \
-    -Darrow.c.jni.dist.dir=$ARROW_INSTALL_DIR/lib -Dmaven.gitcommitid.skip=true
+  -Darrow.c.jni.dist.dir=$ARROW_INSTALL_DIR/lib -Dmaven.gitcommitid.skip=true
 popd
 
 echo "Successfully built Arrow from Source."
-echo $TARGET_BUILD_COMMIT > "${ARROW_HOME}/arrow-commit.cache"
+echo $TARGET_BUILD_COMMIT >"${ARROW_HOME}/arrow-commit.cache"

--- a/ep/build-arrow/src/build_arrow.sh
+++ b/ep/build-arrow/src/build_arrow.sh
@@ -75,7 +75,7 @@ if [ $ENABLE_EP_CACHE == "ON" ]; then
       fi
   fi
 else
-  git clean -dfx
+  git clean -dfx :/
   rm -rf $ARROW_INSTALL_DIR
   mkdir -p $ARROW_INSTALL_DIR
 fi

--- a/ep/build-arrow/src/get_arrow.sh
+++ b/ep/build-arrow/src/get_arrow.sh
@@ -7,26 +7,25 @@ ARROW_REPO=https://github.com/oap-project/arrow.git
 ARROW_BRANCH=arrow-11.0.0-gluten
 ENABLE_QAT=OFF
 
-for arg in "$@"
-do
-    case $arg in
-        --arrow_repo=*)
-        ARROW_REPO=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --arrow_branch=*)
-        ARROW_BRANCH=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_qat=*)
-        ENABLE_QAT=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-	      *)
-	      OTHER_ARGUMENTS+=("$1")
-        shift # Remove generic argument from processing
-        ;;
-    esac
+for arg in "$@"; do
+  case $arg in
+  --arrow_repo=*)
+    ARROW_REPO=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --arrow_branch=*)
+    ARROW_BRANCH=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_qat=*)
+    ENABLE_QAT=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  *)
+    OTHER_ARGUMENTS+=("$1")
+    shift # Remove generic argument from processing
+    ;;
+  esac
 done
 
 function checkout_code {
@@ -36,7 +35,7 @@ function checkout_code {
     cd $ARROW_SOURCE_DIR
     git init .
     TARGET_BUILD_COMMIT="$(git ls-remote $ARROW_REPO $ARROW_BRANCH | awk '{print $1;}')"
-    EXISTS=`git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true`
+    EXISTS=$(git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true)
     if [ -z "$EXISTS" ]; then
       git fetch $ARROW_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT
     fi
@@ -52,15 +51,18 @@ function checkout_code {
 echo "Preparing Arrow source code..."
 echo "ENABLE_QAT=${ENABLE_QAT}"
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(
+  cd "$(dirname "$BASH_SOURCE")"
+  pwd
+)
 
 checkout_code
 
 # apply patches
-git apply --reverse --check $CURRENT_DIR/memorypool.patch > /dev/null 2>&1 || git apply $CURRENT_DIR/memorypool.patch
+git apply --reverse --check $CURRENT_DIR/memorypool.patch >/dev/null 2>&1 || git apply $CURRENT_DIR/memorypool.patch
 # apply patch for custom codec
 if [ $ENABLE_QAT == ON ]; then
-  git apply --reverse --check $CURRENT_DIR/custom-codec.patch > /dev/null 2>&1 || git apply $CURRENT_DIR/custom-codec.patch
+  git apply --reverse --check $CURRENT_DIR/custom-codec.patch >/dev/null 2>&1 || git apply $CURRENT_DIR/custom-codec.patch
 fi
 
 echo "Arrow-get finished."

--- a/ep/build-arrow/src/get_arrow.sh
+++ b/ep/build-arrow/src/get_arrow.sh
@@ -29,6 +29,7 @@ for arg in "$@"; do
 done
 
 function checkout_code {
+  TARGET_BUILD_COMMIT=""
   ARROW_SOURCE_DIR="$CURRENT_DIR/../build/arrow_ep"
   if [ -d $ARROW_SOURCE_DIR ]; then
     echo "Arrow source folder $ARROW_SOURCE_DIR already exists..."

--- a/ep/build-arrow/src/get_arrow.sh
+++ b/ep/build-arrow/src/get_arrow.sh
@@ -29,13 +29,12 @@ for arg in "$@"; do
 done
 
 function checkout_code {
-  TARGET_BUILD_COMMIT=""
+  TARGET_BUILD_COMMIT="$(git ls-remote $ARROW_REPO $ARROW_BRANCH | awk '{print $1;}')"
   ARROW_SOURCE_DIR="$CURRENT_DIR/../build/arrow_ep"
   if [ -d $ARROW_SOURCE_DIR ]; then
     echo "Arrow source folder $ARROW_SOURCE_DIR already exists..."
     cd $ARROW_SOURCE_DIR
     git init .
-    TARGET_BUILD_COMMIT="$(git ls-remote $ARROW_REPO $ARROW_BRANCH | awk '{print $1;}')"
     EXISTS=$(git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true)
     if [ -z "$EXISTS" ]; then
       git fetch $ARROW_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -5,14 +5,9 @@ set -exu
 ENABLE_S3=OFF
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF
-#It can be set to OFF when compiling velox again
-BUILD_PROTOBUF=ON
 BUILD_TYPE=release
-VELOX_HOME=
-#for ep cache
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
-TARGET_BUILD_COMMIT=""
+VELOX_HOME=""
+ENABLE_EP_CACHE=OFF
 
 LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
 
@@ -31,12 +26,12 @@ do
         ENABLE_HDFS=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
-        --build_protobuf=*)
-        BUILD_PROTOBUF=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
         --build_type=*)
         BUILD_TYPE=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --enable_ep_cache=*)
+        ENABLE_EP_CACHE=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         *)
@@ -45,90 +40,6 @@ do
         ;;
     esac
 done
-function process_setup_ubuntu {
-      # make this function Reentrantly
-      git checkout scripts/setup-ubuntu.sh
-      sed -i '/libprotobuf-dev/d' scripts/setup-ubuntu.sh
-      sed -i '/protobuf-compiler/d' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  *thrift* \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libxml2-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libkrb5-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libgsasl7-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libuuid1 \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  uuid-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
-      sed -i 's/^  liblzo2-dev.*/  liblzo2-dev \\/g' scripts/setup-ubuntu.sh
-      if [ $ENABLE_HDFS == "ON" ]; then
-        sed -i '/^function install_fmt.*/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-ubuntu.sh
-        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
-      fi
-      if [ $BUILD_PROTOBUF == "ON" ]; then
-        sed -i '/^function install_fmt.*/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  sudo make install\n  sudo ldconfig\n}\n' scripts/setup-ubuntu.sh
-        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_protobuf' scripts/setup-ubuntu.sh
-      fi
-      if [ $ENABLE_S3 == "ON" ]; then
-        sed -i '/^function install_fmt.*/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-ubuntu.sh
-        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_awssdk' scripts/setup-ubuntu.sh
-      fi
-      sed -i 's/run_and_time install_conda/#run_and_time install_conda/' scripts/setup-ubuntu.sh
-      
-}
-
-function process_setup_centos8 {
-      # make this function Reentrantly
-      git checkout scripts/setup-centos8.sh
-      sed -i '/^function dnf_install/i\DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}' scripts/setup-centos8.sh
-      sed -i '/^dnf_install autoconf/a\dnf_install libxml2-devel libgsasl-devel libuuid-devel' scripts/setup-centos8.sh
-
-      # install gtest
-      sed -i '/^cmake_install_deps gflags/i function install_gtest {\n  wget https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz\n  tar -xzf release-1.12.1.tar.gz\n  cd googletest-release-1.12.1\n  mkdir -p build && cd build && cmake -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DINSTALL_GTEST=ON -DINSTALL_GMOCK=ON -DBUILD_SHARED_LIBS=ON ..\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
-      sed -i '/^cmake_install_deps gflags/i FB_OS_VERSION=v2022.11.14.00\nfunction install_folly {\n  github_checkout facebook/folly "${FB_OS_VERSION}"\n  cmake_install -DBUILD_TESTS=OFF\n}\n'  scripts/setup-centos8.sh
-      sed -i '/^cmake_install_deps fmt/a \ \ install_gtest' scripts/setup-centos8.sh
-      sed -i '/^cmake_install_deps fmt/a \install_folly' scripts/setup-centos8.sh
-
-      if [ $ENABLE_HDFS == "ON" ]; then
-        sed -i '/^cmake_install_deps gflags/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-centos8.sh
-        sed -i '/^cmake_install_deps fmt/a \ \ install_libhdfs3' scripts/setup-centos8.sh
-      fi
-      if [[ $BUILD_PROTOBUF == "ON" ]] || [[ $ENABLE_HDFS == "ON" ]]; then
-        sed -i '/^cmake_install_deps gflags/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
-        sed -i '/^cmake_install_deps fmt/a \ \ install_protobuf' scripts/setup-centos8.sh
-      fi
-      if [ $ENABLE_S3 == "ON" ]; then
-        sed -i '/^cmake_install_deps gflags/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-centos8.sh
-        sed -i '/^cmake_install_deps fmt/a \ \ install_awssdk' scripts/setup-centos8.sh
-      fi
-}
-
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
-if [ "$VELOX_HOME" == "" ]; then
-  VELOX_HOME="$CURRENT_DIR/../build/velox_ep"
-fi
-
-BUILD_DIR="$CURRENT_DIR/../build"
-echo "Start building Velox..."
-echo "CMAKE Arguments:"
-echo "VELOX_HOME=${VELOX_HOME}"
-echo "ENABLE_S3=${ENABLE_S3}"
-echo "ENABLE_HDFS=${ENABLE_HDFS}"
-echo "BUILD_PROTOBUF=${BUILD_PROTOBUF}"
-echo "BUILD_TYPE=${BUILD_TYPE}"
-
-if [ ! -d $VELOX_HOME ]; then
-  echo "$VELOX_HOME is not exist!!!"
-  exit 1
-fi
-
-function process_script {
-    sed -i 's/^  ninja -C "${BINARY_DIR}" install/  sudo ninja -C "${BINARY_DIR}" install/g' scripts/setup-helper-functions.sh
-    sed -i 's/-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17/-march=native -std=c++17 -mno-avx512f/g' scripts/setup-helper-functions.sh
-    if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then
-      process_setup_ubuntu
-    else # Assume CentOS
-      process_setup_centos8
-    fi
-}
 
 function compile {
     TARGET_BUILD_COMMIT=$(git rev-parse --verify HEAD)
@@ -148,24 +59,59 @@ function compile {
     COMPILE_TYPE=$(if [[ "$BUILD_TYPE" == "debug" ]] || [[ "$BUILD_TYPE" == "Debug" ]]; then echo 'debug'; else echo 'release'; fi)
     echo "COMPILE_OPTION: "$COMPILE_OPTION
     make $COMPILE_TYPE EXTRA_CMAKE_FLAGS="${COMPILE_OPTION}"
-    echo $TARGET_BUILD_COMMIT > "${BUILD_DIR}/velox-commit.cache"
 }
 
 function check_commit {
-    COMMIT_ID="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
-    if $(git merge-base --is-ancestor $COMMIT_ID HEAD);
-    then
-      echo "Current branch contain lastest commit: $COMMIT_ID "
-    else
-      echo "Current branch do not contain lastest commit: $COMMIT_ID !"
-      exit 1
+  if [ $ENABLE_EP_CACHE == "ON" ]; then
+    if [ -f ${BUILD_DIR}/velox-commit.cache ]; then
+      CACHED_BUILT_COMMIT="$(cat ${BUILD_DIR}/velox-commit.cache)"
+      if [ -n "$CACHED_BUILT_COMMIT" ]; then
+        if [ "$TARGET_BUILD_COMMIT" = "$CACHED_BUILT_COMMIT" ]; then
+            echo "Velox build of commit $TARGET_BUILD_COMMIT was cached."
+            exit 0
+        else
+            echo "Found cached commit $CACHED_BUILT_COMMIT for Velox which is different with target commit $TARGET_BUILD_COMMIT."
+        fi
+      fi
     fi
+  else
+    git clean -dfx
+  fi
+
+  if [ -f ${BUILD_DIR}/velox-commit.cache ]; then
+    rm -f ${BUILD_DIR}/velox-commit.cache
+  fi
 }
 
+CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+if [ "$VELOX_HOME" == "" ]; then
+  VELOX_HOME="$CURRENT_DIR/../build/velox_ep"
+fi
+
+BUILD_DIR="$CURRENT_DIR/../build"
+echo "Start building Velox..."
+echo "CMAKE Arguments:"
+echo "VELOX_HOME=${VELOX_HOME}"
+echo "ENABLE_S3=${ENABLE_S3}"
+echo "ENABLE_HDFS=${ENABLE_HDFS}"
+echo "BUILD_TYPE=${BUILD_TYPE}"
+
+if [ ! -d $VELOX_HOME ]; then
+  echo "$VELOX_HOME is not exist!!!"
+  exit 1
+fi
+
 cd $VELOX_HOME
+TARGET_BUILD_COMMIT="$(git rev-parse --verify HEAD)"
+if [ -z "$TARGET_BUILD_COMMIT" ]
+  then
+    echo "Unable to parse Velox commit: $TARGET_BUILD_COMMIT."
+    exit 0
+fi
+echo "Target Velox commit: $TARGET_BUILD_COMMIT"
+
 check_commit
-process_script
 compile
 
-echo "Velox Installation finished."
-
+echo "Successfully built Velox from Source."
+echo $TARGET_BUILD_COMMIT > "${BUILD_DIR}/velox-commit.cache"

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -11,54 +11,53 @@ ENABLE_EP_CACHE=OFF
 
 LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
 
-for arg in "$@"
-do
-    case $arg in
-        --velox_home=*)
-        VELOX_HOME=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_s3=*)
-        ENABLE_S3=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_hdfs=*)
-        ENABLE_HDFS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_type=*)
-        BUILD_TYPE=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_ep_cache=*)
-        ENABLE_EP_CACHE=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        *)
-        OTHER_ARGUMENTS+=("$1")
-        shift # Remove generic argument from processing
-        ;;
-    esac
+for arg in "$@"; do
+  case $arg in
+  --velox_home=*)
+    VELOX_HOME=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_s3=*)
+    ENABLE_S3=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_hdfs=*)
+    ENABLE_HDFS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_type=*)
+    BUILD_TYPE=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_ep_cache=*)
+    ENABLE_EP_CACHE=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  *)
+    OTHER_ARGUMENTS+=("$1")
+    shift # Remove generic argument from processing
+    ;;
+  esac
 done
 
 function compile {
-    TARGET_BUILD_COMMIT=$(git rev-parse --verify HEAD)
-    if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then
-      scripts/setup-ubuntu.sh
-    else # Assume CentOS
-      scripts/setup-centos8.sh
-    fi
-    COMPILE_OPTION="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF -DVELOX_ENABLE_DUCKDB=OFF -DVELOX_BUILD_TEST_UTILS=ON"
-    if [ $ENABLE_HDFS == "ON" ]; then
-      COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_HDFS=ON"
-    fi
-    if [ $ENABLE_S3 == "ON" ]; then
-      COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_S3=ON"
-    fi
-    COMPILE_OPTION="$COMPILE_OPTION -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
-    COMPILE_TYPE=$(if [[ "$BUILD_TYPE" == "debug" ]] || [[ "$BUILD_TYPE" == "Debug" ]]; then echo 'debug'; else echo 'release'; fi)
-    echo "COMPILE_OPTION: "$COMPILE_OPTION
-    make $COMPILE_TYPE EXTRA_CMAKE_FLAGS="${COMPILE_OPTION}"
+  TARGET_BUILD_COMMIT=$(git rev-parse --verify HEAD)
+  if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then
+    scripts/setup-ubuntu.sh
+  else # Assume CentOS
+    scripts/setup-centos8.sh
+  fi
+  COMPILE_OPTION="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF -DVELOX_ENABLE_DUCKDB=OFF -DVELOX_BUILD_TEST_UTILS=ON"
+  if [ $ENABLE_HDFS == "ON" ]; then
+    COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_HDFS=ON"
+  fi
+  if [ $ENABLE_S3 == "ON" ]; then
+    COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_S3=ON"
+  fi
+  COMPILE_OPTION="$COMPILE_OPTION -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
+  COMPILE_TYPE=$(if [[ "$BUILD_TYPE" == "debug" ]] || [[ "$BUILD_TYPE" == "Debug" ]]; then echo 'debug'; else echo 'release'; fi)
+  echo "COMPILE_OPTION: "$COMPILE_OPTION
+  make $COMPILE_TYPE EXTRA_CMAKE_FLAGS="${COMPILE_OPTION}"
 }
 
 function check_commit {
@@ -67,10 +66,10 @@ function check_commit {
       CACHED_BUILT_COMMIT="$(cat ${BUILD_DIR}/velox-commit.cache)"
       if [ -n "$CACHED_BUILT_COMMIT" ]; then
         if [ "$TARGET_BUILD_COMMIT" = "$CACHED_BUILT_COMMIT" ]; then
-            echo "Velox build of commit $TARGET_BUILD_COMMIT was cached."
-            exit 0
+          echo "Velox build of commit $TARGET_BUILD_COMMIT was cached."
+          exit 0
         else
-            echo "Found cached commit $CACHED_BUILT_COMMIT for Velox which is different with target commit $TARGET_BUILD_COMMIT."
+          echo "Found cached commit $CACHED_BUILT_COMMIT for Velox which is different with target commit $TARGET_BUILD_COMMIT."
         fi
       fi
     fi
@@ -83,7 +82,10 @@ function check_commit {
   fi
 }
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(
+  cd "$(dirname "$BASH_SOURCE")"
+  pwd
+)
 if [ "$VELOX_HOME" == "" ]; then
   VELOX_HOME="$CURRENT_DIR/../build/velox_ep"
 fi
@@ -103,10 +105,9 @@ fi
 
 cd $VELOX_HOME
 TARGET_BUILD_COMMIT="$(git rev-parse --verify HEAD)"
-if [ -z "$TARGET_BUILD_COMMIT" ]
-  then
-    echo "Unable to parse Velox commit: $TARGET_BUILD_COMMIT."
-    exit 0
+if [ -z "$TARGET_BUILD_COMMIT" ]; then
+  echo "Unable to parse Velox commit: $TARGET_BUILD_COMMIT."
+  exit 0
 fi
 echo "Target Velox commit: $TARGET_BUILD_COMMIT"
 
@@ -114,4 +115,4 @@ check_commit
 compile
 
 echo "Successfully built Velox from Source."
-echo $TARGET_BUILD_COMMIT > "${BUILD_DIR}/velox-commit.cache"
+echo $TARGET_BUILD_COMMIT >"${BUILD_DIR}/velox-commit.cache"

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -75,7 +75,7 @@ function check_commit {
       fi
     fi
   else
-    git clean -dfx
+    git clean -dfx :/
   fi
 
   if [ -f ${BUILD_DIR}/velox-commit.cache ]; then

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -14,97 +14,99 @@ ENABLE_S3=OFF
 
 LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
 
-for arg in "$@"
-do
-    case $arg in
-        --velox_repo=*)
-        VELOX_REPO=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --velox_branch=*)
-        VELOX_BRANCH=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_protobuf=*)
-        BUILD_PROTOBUF=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_hdfs=*)
-        ENABLE_HDFS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --enable_s3=*)
-        ENABLE_S3=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        *)
-        OTHER_ARGUMENTS+=("$1")
-        shift # Remove generic argument from processing
-        ;;
-    esac
+for arg in "$@"; do
+  case $arg in
+  --velox_repo=*)
+    VELOX_REPO=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --velox_branch=*)
+    VELOX_BRANCH=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_protobuf=*)
+    BUILD_PROTOBUF=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_hdfs=*)
+    ENABLE_HDFS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_s3=*)
+    ENABLE_S3=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  *)
+    OTHER_ARGUMENTS+=("$1")
+    shift # Remove generic argument from processing
+    ;;
+  esac
 done
 
 function process_setup_ubuntu {
-      # make this function Reentrantly
-      git checkout scripts/setup-ubuntu.sh
-      sed -i '/libprotobuf-dev/d' scripts/setup-ubuntu.sh
-      sed -i '/protobuf-compiler/d' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  *thrift* \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libxml2-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libkrb5-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libgsasl7-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libuuid1 \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  uuid-dev \\' scripts/setup-ubuntu.sh
-      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
-      sed -i 's/^  liblzo2-dev.*/  liblzo2-dev \\/g' scripts/setup-ubuntu.sh
-      if [ $ENABLE_HDFS == "ON" ]; then
-        sed -i '/^function install_fmt.*/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-ubuntu.sh
-        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
-      fi
-      if [ $BUILD_PROTOBUF == "ON" ]; then
-        sed -i '/^function install_fmt.*/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  sudo make install\n  sudo ldconfig\n}\n' scripts/setup-ubuntu.sh
-        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_protobuf' scripts/setup-ubuntu.sh
-      fi
-      if [ $ENABLE_S3 == "ON" ]; then
-        sed -i '/^function install_fmt.*/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-ubuntu.sh
-        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_awssdk' scripts/setup-ubuntu.sh
-      fi
-      sed -i 's/run_and_time install_conda/#run_and_time install_conda/' scripts/setup-ubuntu.sh
+  # make this function Reentrantly
+  git checkout scripts/setup-ubuntu.sh
+  sed -i '/libprotobuf-dev/d' scripts/setup-ubuntu.sh
+  sed -i '/protobuf-compiler/d' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  *thrift* \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libxml2-dev \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libkrb5-dev \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libgsasl7-dev \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libuuid1 \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  uuid-dev \\' scripts/setup-ubuntu.sh
+  sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
+  sed -i 's/^  liblzo2-dev.*/  liblzo2-dev \\/g' scripts/setup-ubuntu.sh
+  if [ $ENABLE_HDFS == "ON" ]; then
+    sed -i '/^function install_fmt.*/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-ubuntu.sh
+    sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
+  fi
+  if [ $BUILD_PROTOBUF == "ON" ]; then
+    sed -i '/^function install_fmt.*/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  sudo make install\n  sudo ldconfig\n}\n' scripts/setup-ubuntu.sh
+    sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_protobuf' scripts/setup-ubuntu.sh
+  fi
+  if [ $ENABLE_S3 == "ON" ]; then
+    sed -i '/^function install_fmt.*/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-ubuntu.sh
+    sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_awssdk' scripts/setup-ubuntu.sh
+  fi
+  sed -i 's/run_and_time install_conda/#run_and_time install_conda/' scripts/setup-ubuntu.sh
 
 }
 
 function process_setup_centos8 {
-      # make this function Reentrantly
-      git checkout scripts/setup-centos8.sh
-      sed -i '/^function dnf_install/i\DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}' scripts/setup-centos8.sh
-      sed -i '/^dnf_install autoconf/a\dnf_install libxml2-devel libgsasl-devel libuuid-devel' scripts/setup-centos8.sh
+  # make this function Reentrantly
+  git checkout scripts/setup-centos8.sh
+  sed -i '/^function dnf_install/i\DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}' scripts/setup-centos8.sh
+  sed -i '/^dnf_install autoconf/a\dnf_install libxml2-devel libgsasl-devel libuuid-devel' scripts/setup-centos8.sh
 
-      # install gtest
-      sed -i '/^cmake_install_deps gflags/i function install_gtest {\n  wget https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz\n  tar -xzf release-1.12.1.tar.gz\n  cd googletest-release-1.12.1\n  mkdir -p build && cd build && cmake -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DINSTALL_GTEST=ON -DINSTALL_GMOCK=ON -DBUILD_SHARED_LIBS=ON ..\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
-      sed -i '/^cmake_install_deps gflags/i FB_OS_VERSION=v2022.11.14.00\nfunction install_folly {\n  github_checkout facebook/folly "${FB_OS_VERSION}"\n  cmake_install -DBUILD_TESTS=OFF\n}\n'  scripts/setup-centos8.sh
-      sed -i '/^cmake_install_deps fmt/a \ \ install_gtest' scripts/setup-centos8.sh
-      sed -i '/^cmake_install_deps fmt/a \install_folly' scripts/setup-centos8.sh
+  # install gtest
+  sed -i '/^cmake_install_deps gflags/i function install_gtest {\n  wget https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz\n  tar -xzf release-1.12.1.tar.gz\n  cd googletest-release-1.12.1\n  mkdir -p build && cd build && cmake -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DINSTALL_GTEST=ON -DINSTALL_GMOCK=ON -DBUILD_SHARED_LIBS=ON ..\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
+  sed -i '/^cmake_install_deps gflags/i FB_OS_VERSION=v2022.11.14.00\nfunction install_folly {\n  github_checkout facebook/folly "${FB_OS_VERSION}"\n  cmake_install -DBUILD_TESTS=OFF\n}\n' scripts/setup-centos8.sh
+  sed -i '/^cmake_install_deps fmt/a \ \ install_gtest' scripts/setup-centos8.sh
+  sed -i '/^cmake_install_deps fmt/a \install_folly' scripts/setup-centos8.sh
 
-      if [ $ENABLE_HDFS == "ON" ]; then
-        sed -i '/^cmake_install_deps gflags/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-centos8.sh
-        sed -i '/^cmake_install_deps fmt/a \ \ install_libhdfs3' scripts/setup-centos8.sh
-      fi
-      if [[ $BUILD_PROTOBUF == "ON" ]] || [[ $ENABLE_HDFS == "ON" ]]; then
-        sed -i '/^cmake_install_deps gflags/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
-        sed -i '/^cmake_install_deps fmt/a \ \ install_protobuf' scripts/setup-centos8.sh
-      fi
-      if [ $ENABLE_S3 == "ON" ]; then
-        sed -i '/^cmake_install_deps gflags/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-centos8.sh
-        sed -i '/^cmake_install_deps fmt/a \ \ install_awssdk' scripts/setup-centos8.sh
-      fi
+  if [ $ENABLE_HDFS == "ON" ]; then
+    sed -i '/^cmake_install_deps gflags/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-centos8.sh
+    sed -i '/^cmake_install_deps fmt/a \ \ install_libhdfs3' scripts/setup-centos8.sh
+  fi
+  if [[ $BUILD_PROTOBUF == "ON" ]] || [[ $ENABLE_HDFS == "ON" ]]; then
+    sed -i '/^cmake_install_deps gflags/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
+    sed -i '/^cmake_install_deps fmt/a \ \ install_protobuf' scripts/setup-centos8.sh
+  fi
+  if [ $ENABLE_S3 == "ON" ]; then
+    sed -i '/^cmake_install_deps gflags/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-centos8.sh
+    sed -i '/^cmake_install_deps fmt/a \ \ install_awssdk' scripts/setup-centos8.sh
+  fi
 }
 
 echo "Preparing Velox source code..."
 echo "ENABLE_HDFS=${ENABLE_HDFS}"
 echo "BUILD_PROTOBUF=${BUILD_PROTOBUF}"
 
-CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+CURRENT_DIR=$(
+  cd "$(dirname "$BASH_SOURCE")"
+  pwd
+)
 
 # checkout code
 VELOX_SOURCE_DIR="$CURRENT_DIR/../build/velox_ep"
@@ -113,7 +115,7 @@ if [ -d $VELOX_SOURCE_DIR ]; then
   cd $VELOX_SOURCE_DIR
   git init .
   TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
-  EXISTS=`git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true`
+  EXISTS=$(git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true)
   if [ -z "$EXISTS" ]; then
     git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT
   fi

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -110,11 +110,11 @@ CURRENT_DIR=$(
 
 # checkout code
 VELOX_SOURCE_DIR="$CURRENT_DIR/../build/velox_ep"
+TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
 if [ -d $VELOX_SOURCE_DIR ]; then
   echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
   cd $VELOX_SOURCE_DIR
   git init .
-  TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
   EXISTS=$(git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true)
   if [ -z "$EXISTS" ]; then
     git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -4,7 +4,15 @@ set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
 VELOX_BRANCH=main
-ENABLE_EP_CACHE=OFF
+
+#Set on run gluten on HDFS
+ENABLE_HDFS=OFF
+#It can be set to OFF when compiling velox again
+BUILD_PROTOBUF=ON
+#Set on run gluten on S3
+ENABLE_S3=OFF
+
+LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
 
 for arg in "$@"
 do
@@ -17,8 +25,16 @@ do
         VELOX_BRANCH=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
-        --enable_ep_cache=*)
-        ENABLE_EP_CACHE=("${arg#*=}")
+        --build_protobuf=*)
+        BUILD_PROTOBUF=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --enable_hdfs=*)
+        ENABLE_HDFS=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --enable_s3=*)
+        ENABLE_S3=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         *)
@@ -28,66 +44,97 @@ do
     esac
 done
 
-function check_ep_cache {
-  TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
-  echo "Target Velox commit: $TARGET_BUILD_COMMIT"
-  if [ -f ${BUILD_DIR}/velox-commit.cache ]; then
-    LAST_BUILT_COMMIT="$(cat ${BUILD_DIR}/velox-commit.cache)"
-    if [ -n $LAST_BUILT_COMMIT ]; then
-      if [ -z "$TARGET_BUILD_COMMIT" ]
-        then
-          echo "Unable to parse Velox commit: $TARGET_BUILD_COMMIT."
-          exit 1
-          fi
-          if [ "$TARGET_BUILD_COMMIT" = "$LAST_BUILT_COMMIT" ]; then
-              echo "Velox build of commit $TARGET_BUILD_COMMIT was cached."
-              exit 0
-          else
-              echo "Found cached commit $LAST_BUILT_COMMIT for Velox which is different with target commit $TARGET_BUILD_COMMIT."
-          fi
+function process_setup_ubuntu {
+      # make this function Reentrantly
+      git checkout scripts/setup-ubuntu.sh
+      sed -i '/libprotobuf-dev/d' scripts/setup-ubuntu.sh
+      sed -i '/protobuf-compiler/d' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  *thrift* \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libxml2-dev \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libkrb5-dev \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libgsasl7-dev \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libuuid1 \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  uuid-dev \\' scripts/setup-ubuntu.sh
+      sed -i '/^sudo --preserve-env apt update && sudo apt install -y/a\  libiberty-dev \\' scripts/setup-ubuntu.sh
+      sed -i 's/^  liblzo2-dev.*/  liblzo2-dev \\/g' scripts/setup-ubuntu.sh
+      if [ $ENABLE_HDFS == "ON" ]; then
+        sed -i '/^function install_fmt.*/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-ubuntu.sh
+        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
       fi
-  fi
+      if [ $BUILD_PROTOBUF == "ON" ]; then
+        sed -i '/^function install_fmt.*/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  sudo make install\n  sudo ldconfig\n}\n' scripts/setup-ubuntu.sh
+        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_protobuf' scripts/setup-ubuntu.sh
+      fi
+      if [ $ENABLE_S3 == "ON" ]; then
+        sed -i '/^function install_fmt.*/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-ubuntu.sh
+        sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_awssdk' scripts/setup-ubuntu.sh
+      fi
+      sed -i 's/run_and_time install_conda/#run_and_time install_conda/' scripts/setup-ubuntu.sh
+
 }
 
-function checkout_code {
-  if [ -d $VELOX_SOURCE_DIR ]; then
-    echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
-    cd $VELOX_SOURCE_DIR
-    git init .
-    EXISTS=`git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true`
-    if [ -z "$EXISTS" ]; then
-      git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT
-    fi
-    git reset --hard HEAD
-    git checkout build_$TARGET_BUILD_COMMIT
-  else
-    git clone $VELOX_REPO -b $VELOX_BRANCH $VELOX_SOURCE_DIR
-    cd $VELOX_SOURCE_DIR
-    git checkout $TARGET_BUILD_COMMIT
-  fi
-  #sync submodules
-  git submodule sync --recursive
-  git submodule update --init --recursive
+function process_setup_centos8 {
+      # make this function Reentrantly
+      git checkout scripts/setup-centos8.sh
+      sed -i '/^function dnf_install/i\DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}' scripts/setup-centos8.sh
+      sed -i '/^dnf_install autoconf/a\dnf_install libxml2-devel libgsasl-devel libuuid-devel' scripts/setup-centos8.sh
 
-  if [ $ENABLE_EP_CACHE == "OFF" ]; then
-    git clean -dfx
-  fi
+      # install gtest
+      sed -i '/^cmake_install_deps gflags/i function install_gtest {\n  wget https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz\n  tar -xzf release-1.12.1.tar.gz\n  cd googletest-release-1.12.1\n  mkdir -p build && cd build && cmake -DBUILD_GTEST=ON -DBUILD_GMOCK=ON -DINSTALL_GTEST=ON -DINSTALL_GMOCK=ON -DBUILD_SHARED_LIBS=ON ..\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
+      sed -i '/^cmake_install_deps gflags/i FB_OS_VERSION=v2022.11.14.00\nfunction install_folly {\n  github_checkout facebook/folly "${FB_OS_VERSION}"\n  cmake_install -DBUILD_TESTS=OFF\n}\n'  scripts/setup-centos8.sh
+      sed -i '/^cmake_install_deps fmt/a \ \ install_gtest' scripts/setup-centos8.sh
+      sed -i '/^cmake_install_deps fmt/a \install_folly' scripts/setup-centos8.sh
+
+      if [ $ENABLE_HDFS == "ON" ]; then
+        sed -i '/^cmake_install_deps gflags/i function install_libhdfs3 {\n  github_checkout apache/hawq master\n  cd depends/libhdfs3\n sed -i "/FIND_PACKAGE(GoogleTest REQUIRED)/d" ./CMakeLists.txt\n  sed -i "s/dumpversion/dumpfullversion/" ./CMake/Platform.cmake\n sed -i "s/dfs.domain.socket.path\\", \\"\\"/dfs.domain.socket.path\\", \\"\\/var\\/lib\\/hadoop-hdfs\\/dn_socket\\"/g" src/common/SessionConfig.cpp\n sed -i "s/pos < endOfCurBlock/pos \\< endOfCurBlock \\&\\& pos \\- cursor \\<\\= 128 \\* 1024/g" src/client/InputStreamImpl.cpp\n cmake_install\n}\n' scripts/setup-centos8.sh
+        sed -i '/^cmake_install_deps fmt/a \ \ install_libhdfs3' scripts/setup-centos8.sh
+      fi
+      if [[ $BUILD_PROTOBUF == "ON" ]] || [[ $ENABLE_HDFS == "ON" ]]; then
+        sed -i '/^cmake_install_deps gflags/i function install_protobuf {\n  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz\n  tar -xzf protobuf-all-21.4.tar.gz\n  cd protobuf-21.4\n  ./configure  CXXFLAGS="-fPIC"  --prefix=/usr/local\n  make "-j$(nproc)"\n  make install\n  cd ../../ && ldconfig\n}\n' scripts/setup-centos8.sh
+        sed -i '/^cmake_install_deps fmt/a \ \ install_protobuf' scripts/setup-centos8.sh
+      fi
+      if [ $ENABLE_S3 == "ON" ]; then
+        sed -i '/^cmake_install_deps gflags/i function install_awssdk {\n  github_checkout aws/aws-sdk-cpp 1.9.379 --depth 1 --recurse-submodules\n  cmake_install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" \n} \n' scripts/setup-centos8.sh
+        sed -i '/^cmake_install_deps fmt/a \ \ install_awssdk' scripts/setup-centos8.sh
+      fi
 }
 
-echo "Velox-get start..."
+echo "Preparing Velox source code..."
+echo "ENABLE_HDFS=${ENABLE_HDFS}"
+echo "BUILD_PROTOBUF=${BUILD_PROTOBUF}"
+
 CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
-mkdir -p "$CURRENT_DIR/../build"
 
-BUILD_DIR="$CURRENT_DIR/../build"
+# checkout code
 VELOX_SOURCE_DIR="$CURRENT_DIR/../build/velox_ep"
+if [ -d $VELOX_SOURCE_DIR ]; then
+  echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
+  cd $VELOX_SOURCE_DIR
+  git init .
+  TARGET_BUILD_COMMIT="$(git ls-remote $VELOX_REPO $VELOX_BRANCH | awk '{print $1;}')"
+  EXISTS=`git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true`
+  if [ -z "$EXISTS" ]; then
+    git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT
+  fi
+  git reset --hard HEAD
+  git checkout build_$TARGET_BUILD_COMMIT
+else
+  git clone $VELOX_REPO -b $VELOX_BRANCH $VELOX_SOURCE_DIR
+  cd $VELOX_SOURCE_DIR
+  git checkout $TARGET_BUILD_COMMIT
+fi
+#sync submodules
+git submodule sync --recursive
+git submodule update --init --recursive
 
-check_ep_cache
-
-if [ -f ${BUILD_DIR}/velox-commit.cache ]; then
-    rm -f ${BUILD_DIR}/velox-commit.cache
+# apply patches
+sed -i 's/^  ninja -C "${BINARY_DIR}" install/  sudo ninja -C "${BINARY_DIR}" install/g' scripts/setup-helper-functions.sh
+sed -i 's/-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17/-march=native -std=c++17 -mno-avx512f/g' scripts/setup-helper-functions.sh
+if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then
+  process_setup_ubuntu
+else # Assume CentOS
+  process_setup_centos8
 fi
 
-checkout_code
-
 echo "Velox-get finished."
-


### PR DESCRIPTION
1. To provide better encapsulation between `get_xxx.sh`  and `build_xxx.sh`
    1. Move ep-caching code from `get` to `build`
    2. Move after-patching code from `build` to `get`
2. Reformat the bash codes