### PR TITLE
[VL] fix ut failure by groupings size validation fix

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -10,8 +10,8 @@ BUILD_PROTOBUF=ON
 BUILD_TYPE=release
 VELOX_HOME=
 #for ep cache
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/zhli1142015/velox.git
+VELOX_BRANCH=fix-groupings-size-validation
 TARGET_BUILD_COMMIT=""
 
 LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/zhli1142015/velox.git
+VELOX_BRANCH=fix-groupings-size-validation
 ENABLE_EP_CACHE=OFF
 
 for arg in "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix ut failure SPARK-30279 Support 32 or more grouping attributes for GROUPING_ID().
After velox fix for https://github.com/oap-project/velox/pull/163, expand ops in this ut is offloaded to velox. But the result is not correct, this is because group id col in velox is always bigint type which doesn't align with spark behavior. Add convert in project after expend to fix this ut failure.

## How was this patch tested?

unit tests.


