### PR TITLE
[VL] Include Velox non-contiguous allocations into Spark memory manager's accountation

### DIFF
--- a/cpp/core/memory/HbwAllocator.cc
+++ b/cpp/core/memory/HbwAllocator.cc
@@ -81,6 +81,16 @@ bool HbwMemoryAllocator::Free(void* p, int64_t size) {
   return true;
 }
 
+bool HbwMemoryAllocator::ReserveBytes(int64_t size) {
+  bytes_ += size;
+  return true;
+}
+
+bool HbwMemoryAllocator::UnreserveBytes(int64_t size) {
+  bytes_ -= size;
+  return true;
+}
+
 int64_t HbwMemoryAllocator::GetBytes() const {
   return bytes_;
 }

--- a/cpp/core/memory/HbwAllocator.h
+++ b/cpp/core/memory/HbwAllocator.h
@@ -37,6 +37,10 @@ class HbwMemoryAllocator final : public MemoryAllocator {
 
   bool Free(void* p, int64_t size) override;
 
+  bool ReserveBytes(int64_t size) override;
+
+  bool UnreserveBytes(int64_t size) override;
+
   int64_t GetBytes() const override;
 
  private:

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -99,6 +99,16 @@ bool ListenableMemoryAllocator::Free(void* p, int64_t size) {
   return succeed;
 }
 
+bool ListenableMemoryAllocator::ReserveBytes(int64_t size) {
+  listener_->AllocationChanged(size);
+  return true;
+}
+
+bool ListenableMemoryAllocator::UnreserveBytes(int64_t size) {
+  listener_->AllocationChanged(-size);
+  return true;
+}
+
 int64_t ListenableMemoryAllocator::GetBytes() const {
   return bytes_;
 }
@@ -144,6 +154,16 @@ bool StdMemoryAllocator::ReallocateAligned(void* p, uint16_t alignment, int64_t 
 
 bool StdMemoryAllocator::Free(void* p, int64_t size) {
   std::free(p);
+  bytes_ -= size;
+  return true;
+}
+
+bool StdMemoryAllocator::ReserveBytes(int64_t size) {
+  bytes_ += size;
+  return true;
+}
+
+bool StdMemoryAllocator::UnreserveBytes(int64_t size) {
   bytes_ -= size;
   return true;
 }

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -40,6 +40,9 @@ class MemoryAllocator {
 
   virtual bool Free(void* p, int64_t size) = 0;
 
+  virtual bool ReserveBytes(int64_t size) = 0;
+  virtual bool UnreserveBytes(int64_t size) = 0;
+
   virtual int64_t GetBytes() const = 0;
 };
 
@@ -72,6 +75,10 @@ class ListenableMemoryAllocator final : public MemoryAllocator {
 
   bool Free(void* p, int64_t size) override;
 
+  bool ReserveBytes(int64_t size) override;
+
+  bool UnreserveBytes(int64_t size) override;
+
   int64_t GetBytes() const override;
 
  private:
@@ -93,6 +100,10 @@ class StdMemoryAllocator final : public MemoryAllocator {
   bool ReallocateAligned(void* p, uint16_t alignment, int64_t size, int64_t new_size, void** out) override;
 
   bool Free(void* p, int64_t size) override;
+
+  bool ReserveBytes(int64_t size) override;
+
+  bool UnreserveBytes(int64_t size) override;
 
   int64_t GetBytes() const override;
 


### PR DESCRIPTION
Relate to #1194