### PR TITLE
[GLUTEN-1217][VL] UT: Enable UT when partitioned column is decimal type

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -407,14 +407,10 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-7847: Dynamic partition directory path escaping and unescaping")
     .exclude(
       "SPARK-22109: Resolve type conflicts between strings and timestamps in partition column")
-    // decimal failed ut
-    .exclude("Resolve type conflicts - decimals, dates and timestamps in partition column")
   enableSuite[GlutenParquetV2PartitionDiscoverySuite]
     .exclude("SPARK-7847: Dynamic partition directory path escaping and unescaping")
     .exclude(
       "SPARK-22109: Resolve type conflicts between strings and timestamps in partition column")
-    // decimal failed ut
-    .exclude("Resolve type conflicts - decimals, dates and timestamps in partition column")
   enableSuite[GlutenParquetProtobufCompatibilitySuite]
   enableSuite[GlutenParquetV1QuerySuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable  `Resolve type conflicts - decimals, dates and timestamps in partition column`.
https://github.com/oap-project/velox/pull/167
https://github.com/oap-project/gluten/issues/1217

## How was this patch tested?

Testing on CI.

