### PR TITLE
[VL] Upgrade velox to 2023.3.29

### DIFF
--- a/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
+++ b/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
@@ -94,7 +94,7 @@ class GoogleBenchmarkColumnarToRow {
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool());
+    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
   }
 
  protected:
@@ -153,10 +153,11 @@ class GoogleBenchmarkColumnarToRow_CacheScan_Benchmark : public GoogleBenchmarkC
 
     auto arrowPool = GetDefaultWrappedArrowMemoryPool();
     auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
+    auto ctxPool = veloxPool->addChild("cache_scan", velox::memory::MemoryPool::Kind::kLeaf);
     for (auto _ : state) {
       for (const auto& vector : vectors) {
         auto columnarToRowConverter = std::make_shared<gluten::VeloxColumnarToRowConverter>(
-            std::dynamic_pointer_cast<velox::RowVector>(vector), arrowPool, veloxPool);
+            std::dynamic_pointer_cast<velox::RowVector>(vector), arrowPool, ctxPool);
         TIME_NANO_OR_THROW(init_time, columnarToRowConverter->Init());
         TIME_NANO_OR_THROW(write_time, columnarToRowConverter->Write());
       }
@@ -203,6 +204,7 @@ class GoogleBenchmarkColumnarToRow_IterateScan_Benchmark : public GoogleBenchmar
 
     auto arrowPool = GetDefaultWrappedArrowMemoryPool();
     auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
+    auto ctxPool = veloxPool->addChild("iterate_scan", velox::memory::MemoryPool::Kind::kLeaf);
     for (auto _ : state) {
       ASSERT_NOT_OK(parquet_reader->GetRecordBatchReader(row_group_indices, column_indices, &record_batch_reader));
       TIME_NANO_OR_THROW(elapse_read, record_batch_reader->ReadNext(&record_batch));
@@ -211,7 +213,7 @@ class GoogleBenchmarkColumnarToRow_IterateScan_Benchmark : public GoogleBenchmar
         num_rows += record_batch->num_rows();
         auto vector = recordBatch2RowVector(*record_batch);
         auto columnarToRowConverter = std::make_shared<gluten::VeloxColumnarToRowConverter>(
-            std::dynamic_pointer_cast<velox::RowVector>(vector), arrowPool, veloxPool);
+            std::dynamic_pointer_cast<velox::RowVector>(vector), arrowPool, ctxPool);
         TIME_NANO_OR_THROW(init_time, columnarToRowConverter->Init());
         TIME_NANO_OR_THROW(write_time, columnarToRowConverter->Write());
         TIME_NANO_OR_THROW(elapse_read, record_batch_reader->ReadNext(&record_batch));

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <filesystem>
 
 #include "VeloxBackend.h"
+#include <filesystem>
 
 #include "ArrowTypeUtils.h"
 #include "VeloxBridge.h"
@@ -269,8 +269,7 @@ std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
   getInfoAndIds(subVeloxPlanConverter_->splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
   auto veloxPool = AsWrappedVeloxMemoryPool(allocator);
-  auto ctxPool = veloxPool->addChild("ctx_root");
-  ctxPool->setMemoryUsageTracker(memUsageTracker_->addChild());
+  auto ctxPool = veloxPool->addChild("result_iterator_spill", velox::memory::MemoryPool::Kind::kAggregate);
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter =
@@ -298,8 +297,7 @@ std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
   getInfoAndIds(subVeloxPlanConverter_->splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
   auto veloxPool = AsWrappedVeloxMemoryPool(allocator);
-  auto ctxPool = veloxPool->addChild("ctx_root");
-  ctxPool->setMemoryUsageTracker(memUsageTracker_->addChild());
+  auto ctxPool = veloxPool->addChild("result_iterator", velox::memory::MemoryPool::Kind::kLeaf);
   auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
       ctxPool, veloxPlan_, scanIds, setScanInfos, streamIds, "/tmp/test-spill", confMap_);
   return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
@@ -312,7 +310,8 @@ arrow::Result<std::shared_ptr<ColumnarToRowConverter>> VeloxBackend::getColumnar
   if (veloxBatch != nullptr) {
     auto arrowPool = AsWrappedArrowMemoryPool(allocator);
     auto veloxPool = AsWrappedVeloxMemoryPool(allocator);
-    return std::make_shared<VeloxColumnarToRowConverter>(veloxBatch->getFlattenedRowVector(), arrowPool, veloxPool);
+    auto ctxVeloxPool = veloxPool->addChild("columnar_to_row_velox", velox::memory::MemoryPool::Kind::kLeaf);
+    return std::make_shared<VeloxColumnarToRowConverter>(veloxBatch->getFlattenedRowVector(), arrowPool, ctxVeloxPool);
   } else {
     return Backend::getColumnar2RowConverter(allocator, cb);
   }
@@ -349,7 +348,8 @@ std::shared_ptr<facebook::velox::memory::MemoryUsageTracker> VeloxBackend::getMe
 
 void VeloxBackend::cacheOutputSchema(const std::shared_ptr<const velox::core::PlanNode>& planNode) {
   ArrowSchema arrowSchema{};
-  exportToArrow(velox::BaseVector::create(planNode->outputType(), 0, GetDefaultWrappedVeloxMemoryPool()), arrowSchema);
+  exportToArrow(
+      velox::BaseVector::create(planNode->outputType(), 0, GetDefaultWrappedVeloxMemoryPool().get()), arrowSchema);
   GLUTEN_ASSIGN_OR_THROW(outputSchema_, arrow::ImportSchema(&arrowSchema));
 }
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -103,7 +103,8 @@ class VeloxBackend final : public Backend {
       std::make_shared<facebook::velox::substrait::SubstraitParser>();
 
   std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter> subVeloxPlanConverter_ =
-      std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(GetDefaultWrappedVeloxMemoryPool());
+      std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(
+          GetDefaultWrappedVeloxMemoryPool().get());
 
   // Cache for tests/benchmark purpose.
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -254,7 +254,8 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
   }
 
   // Set task parameters.
-  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1};
+  std::unordered_set<velox::core::PlanNodeId> emptySet;
+  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = std::make_shared<velox::exec::Task>(
@@ -328,7 +329,8 @@ WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
     const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap)
     : WholeStageResultIterator(pool, planNode, confMap), streamIds_(streamIds) {
-  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1};
+  std::unordered_set<velox::core::PlanNodeId> emptySet;
+  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = std::make_shared<velox::exec::Task>(

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -22,7 +22,7 @@ class WholeStageResultIterator {
   }
 
   virtual ~WholeStageResultIterator() {
-    if (task_->isRunning()) {
+    if (task_ != nullptr && task_->isRunning()) {
       // calling .wait() may take no effect in single thread execution mode
       task_->requestCancel().wait();
     }

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -86,9 +86,7 @@ JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJ
 
   // A query context used for function validation.
   velox::core::QueryCtx queryCtx;
-
-  auto pool = gluten::GetDefaultWrappedVeloxMemoryPool();
-
+  auto pool = gluten::GetDefaultWrappedVeloxMemoryPool().get();
   // An execution context used for function validation.
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 
@@ -108,12 +106,12 @@ Java_io_glutenproject_spark_sql_execution_datasources_velox_DwrfDatasourceJniWra
     jobject obj,
     jstring file_path,
     jlong c_schema) {
-  auto pool = gluten::GetDefaultWrappedVeloxMemoryPool();
+  auto pool = gluten::GetDefaultWrappedVeloxMemoryPool().get();
   gluten::DwrfDatasource* dwrfDatasource = nullptr;
   if (c_schema == -1) {
     // Only inspect the schema and not write
     dwrfDatasource = new gluten::DwrfDatasource(JStringToCString(env, file_path), nullptr, pool);
-    // dwrfDatasource->Init( );
+    // dwrfDatasource->Init();
   } else {
     auto schema = gluten::JniGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(c_schema)));
     dwrfDatasource = new gluten::DwrfDatasource(JStringToCString(env, file_path), schema, pool);

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -34,7 +34,7 @@ std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
 std::shared_ptr<ArrowArray> VeloxColumnarBatch::exportArrowArray() {
   auto out = std::make_shared<ArrowArray>();
   EnsureFlattened();
-  velox::exportToArrow(flattened_, *out, GetDefaultWrappedVeloxMemoryPool());
+  velox::exportToArrow(flattened_, *out, GetDefaultWrappedVeloxMemoryPool().get());
   return out;
 }
 

--- a/cpp/velox/memory/VeloxMemoryPool.h
+++ b/cpp/velox/memory/VeloxMemoryPool.h
@@ -24,6 +24,6 @@ namespace gluten {
 
 std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(MemoryAllocator* allocator);
 
-facebook::velox::memory::MemoryPool* GetDefaultWrappedVeloxMemoryPool();
+std::shared_ptr<facebook::velox::memory::MemoryPool> GetDefaultWrappedVeloxMemoryPool();
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxSplitter.cc
+++ b/cpp/velox/shuffle/VeloxSplitter.cc
@@ -707,7 +707,7 @@ arrow::Status VeloxSplitter::SplitListArray(const velox::RowVector& rv) {
 
     // TODO: rethink the cost of `exportToArrow+ImportArray`
     ArrowArray arrowArray;
-    velox::exportToArrow(column, arrowArray);
+    velox::exportToArrow(column, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
 
     auto result = arrow::ImportArray(&arrowArray, arrow_column_types_[col_idx]);
     RETURN_NOT_OK(result);
@@ -743,7 +743,7 @@ arrow::Status VeloxSplitter::SplitBinaryArray(const velox::RowVector& rv) {
 
 arrow::Status VeloxSplitter::VeloxType2ArrowSchema(const velox::TypePtr& type) {
   auto out = std::make_shared<ArrowSchema>();
-  auto rvp = velox::RowVector::createEmpty(type, GetDefaultWrappedVeloxMemoryPool());
+  auto rvp = velox::RowVector::createEmpty(type, GetDefaultWrappedVeloxMemoryPool().get());
 
   // get ArrowSchema from velox::RowVector
   velox::exportToArrow(rvp, *out);
@@ -1300,7 +1300,7 @@ arrow::Status VeloxSinglePartSplitter::Split(ColumnarBatch* cb) {
   RETURN_NOT_OK(InitFromRowVector(*vp));
   // 1. convert RowVector to RecordBatch
   ArrowArray arrowArray;
-  velox::exportToArrow(vp, arrowArray, GetDefaultWrappedVeloxMemoryPool());
+  velox::exportToArrow(vp, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
 
   auto result = arrow::ImportRecordBatch(&arrowArray, schema_);
   RETURN_NOT_OK(result);

--- a/cpp/velox/tests/ArrowToVeloxTest.cc
+++ b/cpp/velox/tests/ArrowToVeloxTest.cc
@@ -38,14 +38,14 @@ velox::VectorPtr RecordBatch2RowVector(const RecordBatch& rb) {
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
   ASSERT_NOT_OK(ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-  return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool());
+  return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
 }
 
 void checkBatchEqual(std::shared_ptr<RecordBatch> input_batch, bool checkMetadata = true) {
   velox::VectorPtr vp = RecordBatch2RowVector(*input_batch);
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  velox::exportToArrow(vp, arrowArray);
+  velox::exportToArrow(vp, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
   velox::exportToArrow(vp, arrowSchema);
   auto in = gluten::JniGetOrThrow(ImportRecordBatch(&arrowArray, &arrowSchema));
   ASSERT_TRUE(in->Equals(*input_batch, checkMetadata)) << in->ToString() << input_batch->ToString();
@@ -111,7 +111,7 @@ TEST_F(ArrowToVeloxTest, decimalV2A) {
     auto shortDecimalFlatVector = makeShortDecimalFlatVector({1000265, -35610, 0}, DECIMAL(10, 3));
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
-    velox::exportToArrow(shortDecimalFlatVector, arrowArray);
+    velox::exportToArrow(shortDecimalFlatVector, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
     velox::exportToArrow(shortDecimalFlatVector, arrowSchema);
   }
 
@@ -129,7 +129,7 @@ TEST_F(ArrowToVeloxTest, decimalV2A) {
 
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
-    velox::exportToArrow(row, arrowArray);
+    velox::exportToArrow(row, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
     velox::exportToArrow(row, arrowSchema);
     //     c0:   [
     //     1000.265,
@@ -156,7 +156,7 @@ TEST_F(ArrowToVeloxTest, timestampV2A) {
   });
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  EXPECT_ANY_THROW(velox::exportToArrow(row, arrowArray));
+  EXPECT_ANY_THROW(velox::exportToArrow(row, arrowArray, GetDefaultWrappedVeloxMemoryPool().get()));
   velox::exportToArrow(row, arrowSchema);
 }
 

--- a/cpp/velox/tests/VeloxColumnarToRowTest.cc
+++ b/cpp/velox/tests/VeloxColumnarToRowTest.cc
@@ -39,7 +39,7 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool());
+    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
     return std::dynamic_pointer_cast<velox::RowVector>(vp);
   }
 };
@@ -53,6 +53,7 @@ TEST_F(VeloxColumnarToRowTest, timestamp) {
   });
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
+  auto ctxPool = veloxPool->addChild("columnar_to_row_timestamp", velox::memory::MemoryPool::Kind::kLeaf);
   auto converter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
 
   JniAssertOkOrThrow(
@@ -73,7 +74,8 @@ TEST_F(VeloxColumnarToRowTest, Int_64) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_i64", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -122,7 +124,8 @@ TEST_F(VeloxColumnarToRowTest, basic) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_basic", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -161,6 +164,7 @@ TEST_F(VeloxColumnarToRowTest, Int_64_twoColumn) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
+  auto ctxPool = veloxPool->addChild("columnar_to_row_int64_2col", velox::memory::MemoryPool::Kind::kLeaf);
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
 
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
@@ -202,7 +206,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int8_int16) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_i8_i16", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -236,7 +241,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int32_int64) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_i32_i64", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -270,7 +276,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_float_double) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_float_double", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -302,7 +309,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool_binary) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_bool_binary", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -332,7 +340,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_decimal_string) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_decimal_string", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -363,7 +372,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int64_int64_with_null) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_i64_i64", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -394,7 +404,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_string) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_string", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -428,7 +439,8 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_bool", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
 
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -467,7 +479,8 @@ TEST_F(VeloxColumnarToRowTest, _allTypes) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_alltype", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -526,7 +539,8 @@ TEST_F(VeloxColumnarToRowTest, _allTypes_18rows) {
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
   auto veloxPool = AsWrappedVeloxMemoryPool(DefaultMemoryAllocator().get());
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto ctxPool = veloxPool->addChild("columnar_to_row_alltype_18row", velox::memory::MemoryPool::Kind::kLeaf);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, ctxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 

--- a/cpp/velox/tests/VeloxSplitterTest.cc
+++ b/cpp/velox/tests/VeloxSplitterTest.cc
@@ -218,7 +218,7 @@ std::shared_ptr<ColumnarBatch> RecordBatch2VeloxColumnarBatch(const arrow::Recor
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
   ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-  auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool());
+  auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<velox::RowVector>(vp));
 }
 

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -58,6 +58,10 @@ function compile {
   COMPILE_TYPE=$(if [[ "$BUILD_TYPE" == "debug" ]] || [[ "$BUILD_TYPE" == "Debug" ]]; then echo 'debug'; else echo 'release'; fi)
   echo "COMPILE_OPTION: "$COMPILE_OPTION
   make $COMPILE_TYPE EXTRA_CMAKE_FLAGS="${COMPILE_OPTION}"
+  echo "INSTALL xsimd gtest."
+  cd _build/$COMPILE_TYPE/_deps
+  sudo cmake --install xsimd-build/
+  sudo cmake --install gtest-build/
 }
 
 function check_commit {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. velox change memory pool API. we need call addChild to create memory pool to allocate.
2. planFragment constructor  change a little bit.
3. setMemoryUsageTracker was removed by velox.
corresponding velox branch is https://github.com/zhejiangxiaomai/velox/tree/main_rebase_329
4. add "  cmake --install xsimd-build/  cmake --install gtest-build/" in build_velox.sh.  because velox move xsimd/gtest into resolve_dependency module.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

