### PR TITLE
[VL] Include Velox non-contiguous allocations into Spark memory manager's accountation (patch 2)

### DIFF
--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -138,6 +138,8 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
             numPages,
             out,
             [this](int64_t allocBytes, bool preAllocate) {
+              bool succeed = preAllocate ? gluten_alloc_->ReserveBytes(allocBytes) : gluten_alloc_->UnreserveBytes(allocBytes);
+              VELOX_CHECK(succeed)
               if (memoryUsageTracker_ != nullptr) {
                 memoryUsageTracker_->update(preAllocate ? allocBytes : -allocBytes);
               }
@@ -157,6 +159,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     if (memoryUsageTracker_ != nullptr) {
       memoryUsageTracker_->update(-freedBytes);
     }
+    VELOX_CHECK(gluten_alloc_->UnreserveBytes(freedBytes))
   }
 
   velox::memory::MachinePageCount largestSizeClass() const override {

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -138,7 +138,8 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
             numPages,
             out,
             [this](int64_t allocBytes, bool preAllocate) {
-              bool succeed = preAllocate ? gluten_alloc_->ReserveBytes(allocBytes) : gluten_alloc_->UnreserveBytes(allocBytes);
+              bool succeed =
+                  preAllocate ? gluten_alloc_->ReserveBytes(allocBytes) : gluten_alloc_->UnreserveBytes(allocBytes);
               VELOX_CHECK(succeed)
               if (memoryUsageTracker_ != nullptr) {
                 memoryUsageTracker_->update(preAllocate ? allocBytes : -allocBytes);


### PR DESCRIPTION
Made a mistake: The previous PR https://github.com/oap-project/gluten/pull/1228 just operated on **contiguous** allocations.

This would include **non-contiguous** allocations into the routine too.