### PR TITLE
[VL] Add config to limit the max memory

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -25,5 +25,7 @@ const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
+const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
+
 std::unordered_map<std::string, std::string> getConfMap(JNIEnv* env, jbyteArray planArray);
 } // namespace gluten

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -25,7 +25,7 @@ const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
-const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
+const std::string kVeloxMemoryCap = "spark.gluten.sql.columnar.backend.velox.memoryCap";
 
 std::unordered_map<std::string, std::string> getConfMap(JNIEnv* env, jbyteArray planArray);
 } // namespace gluten

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -36,7 +36,7 @@ namespace gluten {
 VeloxBackend::VeloxBackend(const std::unordered_map<std::string, std::string>& confMap) : Backend(confMap) {
   // mem tracker
   int64_t maxMemory;
-  auto got = confMap_.find(kSparkOffHeapMemory);
+  auto got = confMap_.find(kVeloxMemoryCap);
   if (got == confMap_.end()) {
     // not found
     maxMemory = facebook::velox::memory::kMaxMemory;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -33,10 +33,6 @@ using namespace facebook;
 
 namespace gluten {
 
-namespace {
-const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
-}
-
 VeloxBackend::VeloxBackend(const std::unordered_map<std::string, std::string>& confMap) : Backend(confMap) {
   // mem tracker
   int64_t maxMemory;
@@ -45,7 +41,7 @@ VeloxBackend::VeloxBackend(const std::unordered_map<std::string, std::string>& c
     // not found
     maxMemory = facebook::velox::memory::kMaxMemory;
   } else {
-    maxMemory = (long)(0.75 * std::stol(got->second));
+    maxMemory = (long)(std::stol(got->second));
   }
   try {
     // 1/2 of offheap size.

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -176,7 +176,7 @@ void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox
   }
   // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.
   // FIXME this uses process-wise off-heap memory which is not for task
-  got = confMap_.find(kSparkOffHeapMemory);
+  got = confMap_.find(kVeloxMemoryCap);
   if (got != confMap_.end()) {
     try {
       auto maxMemory = (long)(std::stol(got->second));

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -14,7 +14,6 @@ namespace gluten {
 
 namespace {
 const std::string kSparkBatchSize = "spark.sql.execution.arrow.maxRecordsPerBatch";
-const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
 const std::string kDynamicFiltersProduced = "dynamicFiltersProduced";
 const std::string kDynamicFiltersAccepted = "dynamicFiltersAccepted";
 const std::string kReplacedWithDynamicFilterRows = "replacedWithDynamicFilterRows";
@@ -180,8 +179,7 @@ void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox
   got = confMap_.find(kSparkOffHeapMemory);
   if (got != confMap_.end()) {
     try {
-      // Set the max memory of partial aggregation as 3/4 of offheap size.
-      auto maxMemory = (long)(0.75 * std::stol(got->second));
+      auto maxMemory = (long)(std::stol(got->second));
       configs[velox::core::QueryConfig::kMaxPartialAggregationMemory] = std::to_string(maxMemory);
     } catch (const std::invalid_argument&) {
       throw std::runtime_error("Invalid off-heap memory size.");

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -222,7 +222,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   }
 
   def offHeapMemorySize: Long =
-    conf.getConfString(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY, "0").toLong
+    conf.getConfString(GlutenConfig.GLUTEN_MEMORY_CAP_KEY, "0").toLong
 
   // velox caching options
   // enable Velox cache, default off
@@ -328,9 +328,9 @@ object GlutenConfig {
 
   // Added back to Spark Conf during driver / executor initialization
   val GLUTEN_TIMEZONE = "spark.gluten.timezone"
-  val GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY = "spark.gluten.memory.offHeap.size.in.bytes"
-  val GLUTEN_DEFAULT_OFFHEAP_PERCENT: Double = 0.75
-  val GLUTEN_OFFHEAP_PERCENT_KEY = "spark.gluten.memory.offHeap.percent"
+  val GLUTEN_MEMORY_CAP_KEY = "spark.gluten.sql.columnar.backend.velox.memoryCap"
+  val GLUTEN_DEFAULT_MEMORY_CAP_RETIO: Double = 0.75
+  val GLUTEN_MEMORY_CAP_RETIO_KEY = "spark.gluten.sql.columnar.backend.velox.memoryCapRatio"
 
   // Whether load DLL from jars
   val GLUTEN_LOAD_LIB_FROM_JAR = "spark.gluten.loadLibFromJar"
@@ -368,10 +368,10 @@ object GlutenConfig {
     }
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)
     val glutenOffheapPercent = conf.getDouble(
-      GlutenConfig.GLUTEN_OFFHEAP_PERCENT_KEY,
-      GlutenConfig.GLUTEN_DEFAULT_OFFHEAP_PERCENT)
+      GlutenConfig.GLUTEN_MEMORY_CAP_RETIO_KEY,
+      GlutenConfig.GLUTEN_DEFAULT_MEMORY_CAP_RETIO)
     generatedMap.put(
-      GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY,
+      GlutenConfig.GLUTEN_MEMORY_CAP_KEY,
       (offHeapSize * glutenOffheapPercent).toLong.toString)
 
     // return
@@ -383,7 +383,7 @@ object GlutenConfig {
     val conf = SQLConf.get
     val keys = ImmutableList.of(
       GLUTEN_SAVE_DIR,
-      GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY
+      GLUTEN_MEMORY_CAP_KEY
     )
     keys.forEach(
       k => {
@@ -413,7 +413,7 @@ object GlutenConfig {
       SPARK_HIVE_EXEC_ORC_COMPRESS,
       // DWRF datasource config end
       GLUTEN_TIMEZONE,
-      GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY
+      GLUTEN_MEMORY_CAP_KEY
     )
     keys.forEach(
       k => {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -368,8 +368,10 @@ object GlutenConfig {
     }
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)
     val glutenOffheapPercent = conf.getDouble(
-      GlutenConfig.GLUTEN_OFFHEAP_PERCENT_KEY, GlutenConfig.GLUTEN_DEFAULT_OFFHEAP_PERCENT)
-    generatedMap.put(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY,
+      GlutenConfig.GLUTEN_OFFHEAP_PERCENT_KEY,
+      GlutenConfig.GLUTEN_DEFAULT_OFFHEAP_PERCENT)
+    generatedMap.put(
+      GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY,
       (offHeapSize * glutenOffheapPercent).toLong.toString)
 
     // return

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -329,6 +329,8 @@ object GlutenConfig {
   // Added back to Spark Conf during driver / executor initialization
   val GLUTEN_TIMEZONE = "spark.gluten.timezone"
   val GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY = "spark.gluten.memory.offHeap.size.in.bytes"
+  val GLUTEN_DEFAULT_OFFHEAP_PERCENT: Double = 0.75
+  val GLUTEN_OFFHEAP_PERCENT_KEY = "spark.gluten.memory.offHeap.percent"
 
   // Whether load DLL from jars
   val GLUTEN_LOAD_LIB_FROM_JAR = "spark.gluten.loadLibFromJar"
@@ -365,7 +367,10 @@ object GlutenConfig {
       throw new UnsupportedOperationException(s"${GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY} is not set")
     }
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)
-    generatedMap.put(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY, offHeapSize.toString)
+    val glutenOffheapPercent = conf.getDouble(
+      GlutenConfig.GLUTEN_OFFHEAP_PERCENT_KEY, GlutenConfig.GLUTEN_DEFAULT_OFFHEAP_PERCENT)
+    generatedMap.put(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY,
+      (offHeapSize * glutenOffheapPercent).toLong.toString)
 
     // return
     generatedMap


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a configuration `spark.gluten.memory.offHeap.percent` to limit the max memory used by native engine.


## How was this patch tested?
unit tests

