### PR TITLE
[VL] Add some config options for Velox spill

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHInitializerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHInitializerApi.scala
@@ -24,6 +24,8 @@ import org.apache.spark.SparkConf
 
 import org.apache.commons.lang3.StringUtils
 
+import java.util.TimeZone
+
 class CHInitializerApi extends InitializerApi {
 
   override def initialize(conf: SparkConf): Unit = {
@@ -34,6 +36,11 @@ class CHInitializerApi extends InitializerApi {
     }
     // Path based load. Ignore all other loadees.
     JniLibLoader.loadFromPath(libPath, true)
+
+    // Add configs
+    conf.set(
+      "spark.gluten.timezone",
+      conf.get("spark.sql.session.timeZone", TimeZone.getDefault.getID))
     val initKernel = new CHNativeExpressionEvaluator()
     initKernel.initNative(conf)
   }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -47,6 +47,7 @@ class CHColumnarShuffleWriter[K, V](
     .map(_.getAbsolutePath)
     .mkString(",")
   private val subDirsPerLocalDir = blockManager.diskBlockManager.subDirsPerLocalDir
+  // FIXME GlutenConfig.getConf.offHeapMemorySize is per executor
   private val offheapPerTask = GlutenConfig.getConf.offHeapMemorySize
   private val splitSize = GlutenConfig.getConf.shuffleSplitDefaultSize
   private val customizedCompressCodec =

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -25,7 +25,9 @@ const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
-const std::string kVeloxMemoryCap = "spark.gluten.sql.columnar.backend.velox.memoryCap";
+const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
+
+const std::string kSparkBatchSize = "spark.sql.execution.arrow.maxRecordsPerBatch";
 
 std::unordered_map<std::string, std::string> getConfMap(JNIEnv* env, jbyteArray planArray);
 } // namespace gluten

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -21,6 +21,7 @@
 
 #include "compute/VeloxBackend.h"
 #include "compute/VeloxInitializer.h"
+#include "config/GlutenConfig.h"
 
 using namespace facebook;
 namespace fs = std::filesystem;

--- a/cpp/velox/compute/VeloxInitializer.h
+++ b/cpp/velox/compute/VeloxInitializer.h
@@ -35,6 +35,7 @@ class VeloxInitializer {
   explicit VeloxInitializer(std::unordered_map<std::string, std::string>& conf) {
     Init(conf);
   }
+
   ~VeloxInitializer() {
     if (dynamic_cast<facebook::velox::cache::AsyncDataCache*>(asyncDataCache_.get())) {
       LOG(INFO) << asyncDataCache_->toString();

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -10,7 +10,6 @@
 namespace gluten {
 
 static const std::string kHiveConnectorId = "test-hive";
-static const std::string kSparkBatchSize = "spark.sql.execution.arrow.maxRecordsPerBatch";
 
 class WholeStageResultIterator {
  public:

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -50,8 +50,8 @@ class WholeStageResultIterator {
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;
 
  protected:
-  /// A map of custom configs.
-  std::unordered_map<std::string, std::string> confMap_;
+  /// Get config value by key.
+  std::string getConfigValue(const std::string& key, const std::optional<std::string>& fallbackValue = std::nullopt);
 
   std::shared_ptr<facebook::velox::core::QueryCtx> createNewVeloxQueryCtx();
 
@@ -72,6 +72,9 @@ class WholeStageResultIterator {
       const std::string& metricType,
       const std::unordered_map<std::string, facebook::velox::RuntimeMetric>& runtimeStats,
       const std::string& metricId) const;
+
+  /// A map of custom configs.
+  std::unordered_map<std::string, std::string> confMap_;
 
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
 

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -84,7 +84,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedSize);
     void* buffer;
     if (!gluten_alloc_->Allocate(alignedSize, &buffer)) {
-      VELOX_FAIL("VeloxMemoryAllocatorVariant: Failed to allocate " + std::to_string(alignedSize) + " bytes")
+      VELOX_FAIL("WrappedVeloxMemoryPool: Failed to allocate " + std::to_string(alignedSize) + " bytes")
     }
     if (FOLLY_UNLIKELY(buffer == nullptr)) {
       release(alignedSize);
@@ -101,8 +101,8 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     void* buffer;
     if (!gluten_alloc_->AllocateZeroFilled(alignedSize, 1, &buffer)) {
       VELOX_FAIL(
-          "VeloxMemoryAllocatorVariant: Failed to allocate (zero filled) " + std::to_string(alignedSize) +
-          " members, " + std::to_string(1) + " bytes for each")
+          "WrappedVeloxMemoryPool: Failed to allocate (zero filled) " + std::to_string(alignedSize) + " members, " +
+          std::to_string(1) + " bytes for each")
     }
     if (FOLLY_UNLIKELY(buffer == nullptr)) {
       release(alignedSize);
@@ -125,7 +125,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
       free(p, alignedSize);
       release(alignedNewSize);
       VELOX_MEM_ALLOC_ERROR(fmt::format(
-          "VeloxMemoryAllocatorVariant {} failed with {} new bytes and {} old bytes from {}",
+          "WrappedVeloxMemoryPool {} failed with {} new bytes and {} old bytes from {}",
           __FUNCTION__,
           newSize,
           size,
@@ -145,7 +145,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
 
     auto alignedSize = sizeAlign(size);
     if (!gluten_alloc_->Free(p, alignedSize)) {
-      VELOX_FAIL("VeloxMemoryAllocatorVariant: Failed to free " + std::to_string(alignedSize) + " bytes")
+      VELOX_FAIL("WrappedVeloxMemoryPool: Failed to free " + std::to_string(alignedSize) + " bytes")
     }
     release(alignedSize);
   }
@@ -154,7 +154,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
   void allocateNonContiguous(
       velox::memory::MachinePageCount numPages,
       velox::memory::Allocation& out,
-      velox::memory::MachinePageCount minSizeClass) {
+      velox::memory::MachinePageCount minSizeClass) override {
     checkMemoryAllocation();
     VELOX_CHECK_GT(numPages, 0);
 
@@ -197,7 +197,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     return velox_alloc_->sizeClasses();
   }
 
-  void allocateContiguous(velox::memory::MachinePageCount numPages, velox::memory::ContiguousAllocation& out) {
+  void allocateContiguous(velox::memory::MachinePageCount numPages, velox::memory::ContiguousAllocation& out) override {
     checkMemoryAllocation();
     VELOX_CHECK_GT(numPages, 0);
 
@@ -218,7 +218,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     out.setPool(this);
   }
 
-  void freeContiguous(velox::memory::ContiguousAllocation& allocation) {
+  void freeContiguous(velox::memory::ContiguousAllocation& allocation) override {
     checkMemoryAllocation();
 
     const int64_t bytesToFree = allocation.size();
@@ -322,7 +322,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     }
   }
 
-  void release(int64_t size) {
+  void release(int64_t size) override {
     checkMemoryAllocation();
 
     memoryManager_->release(size);

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/NativeExpressionEvaluator.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/NativeExpressionEvaluator.java
@@ -94,7 +94,10 @@ public abstract class NativeExpressionEvaluator implements AutoCloseable {
                 .namespace("velox-spill")
                 .mkChildDirRoundRobin(UUID.randomUUID().toString())
                 .getAbsolutePath(),
-            buildNativeConfNode(GlutenConfig.getNativeSessionConf()).toProtobuf().toByteArray());
+            buildNativeConfNode(
+                GlutenConfig.getNativeSessionConf(
+                    BackendsApiManager.getSettings().getBackendConfigPrefix()
+                )).toProtobuf().toByteArray());
     return createOutIterator(handle, outAttrs);
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -17,17 +17,18 @@
 
 package io.glutenproject
 
-import java.util
-import java.util.{Collections, Objects}
-import scala.language.implicitConversions
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.{ColumnarOverrides, ColumnarQueryStagePrepOverrides, OthersExtensionOverrides, StrategyOverrides}
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.{SparkConf, SparkContext}
+
+import java.util
+import java.util.{Collections, Objects}
+import scala.language.implicitConversions
 
 class GlutenPlugin extends SparkPlugin {
   override def driverPlugin(): DriverPlugin = {
@@ -41,9 +42,6 @@ class GlutenPlugin extends SparkPlugin {
 
 private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
-    // Set the system properties.
-    // Use appending policy for children with the same name in a arrow struct vector.
-    System.setProperty("arrow.struct.conflict.policy", "CONFLICT_APPEND")
     val conf = pluginContext.conf()
     setPredefinedConfigs(sc, conf)
     // Initialize Backends API
@@ -86,9 +84,6 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
    * Initialize the executor plugin.
    */
   override def init(ctx: PluginContext, extraConf: util.Map[String, String]): Unit = {
-    // Set the system properties.
-    // Use appending policy for children with the same name in a arrow struct vector.
-    System.setProperty("arrow.struct.conflict.policy", "CONFLICT_APPEND")
     val conf = ctx.conf()
     // Must set the 'spark.memory.offHeap.size' value to native memory malloc
     if (!conf.getBoolean("spark.memory.offHeap.enabled", false) ||

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/GlutenColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/GlutenColumnarShuffleWriter.scala
@@ -57,6 +57,7 @@ class GlutenColumnarShuffleWriter[K, V](shuffleBlockResolver: IndexShuffleBlockR
     .map(_.getAbsolutePath)
     .mkString(",")
 
+  // FIXME GlutenConfig.getConf.offHeapMemorySize is per executor
   private val offheapPerTask = GlutenConfig.getConf.offHeapMemorySize
 
   private val nativeBufferSize = GlutenConfig.getConf.shuffleSplitDefaultSize

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -65,6 +65,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createSourcesJar>true</createSourcesJar>
               <relocations>
                 <relocation>
                   <pattern>com.google.protobuf</pattern>

--- a/tools/gluten-it/src/main/scala/io/glutenproject/integration/tpc/TpcSuite.scala
+++ b/tools/gluten-it/src/main/scala/io/glutenproject/integration/tpc/TpcSuite.scala
@@ -38,6 +38,7 @@ abstract class TpcSuite(
   sessionSwitcher.defaultConf().set("spark.sql.shuffle.partitions", s"$shufflePartitions")
   sessionSwitcher.defaultConf().set("spark.storage.blockManagerSlaveTimeoutMs", "3600000")
   sessionSwitcher.defaultConf().set("spark.executor.heartbeatInterval", "3600000")
+  sessionSwitcher.defaultConf().set("spark.executor.metrics.pollingInterval", "1")
   sessionSwitcher.defaultConf().set("spark.network.timeout", "3601s")
   sessionSwitcher.defaultConf().set("spark.sql.broadcastTimeout", "1800")
   sessionSwitcher.defaultConf().set("spark.network.io.preferDirectBufs", "false")


### PR DESCRIPTION
Add following new config options:

```
// key -> default value
spark.gluten.sql.columnar.backend.velox.spillEnabled -> true
spark.gluten.sql.columnar.backend.velox.memoryCapRatio -> 0.75
spark.gluten.sql.columnar.backend.velox.kAggregationSpillEnabled -> true
spark.gluten.sql.columnar.backend.velox.kJoinSpillEnabled -> true
spark.gluten.sql.columnar.backend.velox.kOrderBySpillEnabled -> true
spark.gluten.sql.columnar.backend.velox.kAggregationSpillMemoryThreshold -> 0
spark.gluten.sql.columnar.backend.velox.kJoinSpillMemoryThreshold -> 0 // this one doesn't work for now
spark.gluten.sql.columnar.backend.velox.kOrderBySpillMemoryThreshold -> 0
```

Values for `xxxThreshold` are of unit byte.

`spark.gluten.sql.columnar.backend.velox.kJoinSpillMemoryThreshold` doesn't currently take effect - requires Velox community to support it.
