### PR TITLE
[VL] Remove Decimal failed SPARK-35955 ut exclude in GlutenDataFrameSuite

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/liujiayi771/velox.git
+VELOX_BRANCH=avg-overflow
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/liujiayi771/velox.git
-VELOX_BRANCH=avg-overflow
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -115,7 +115,6 @@ class VeloxTestSettings extends BackendTestSettings {
       "describe",
       // decimal failed ut.
       "SPARK-22271: mean overflows and returns null for some decimal variables",
-      "SPARK-35955: Aggregate avg should not return wrong results for decimal overflow",
       "SPARK-28067: Aggregate sum should not return wrong results for decimal overflow",
       "SPARK-28067: sum of null decimal values",
       "SPARK-28224: Aggregate sum big decimal overflow"


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove decimal failed ut


## How was this patch tested?

test in ci

