### PR TITLE
[GLUTEN-1270][VL][Feat] Support multiple HDFS endpoints

### DIFF
--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -105,8 +105,7 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
       velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
           ->createReader(
               std::make_unique<velox::dwio::common::BufferedInput>(
-                  std::make_shared<velox::dwio::common::ReadFileInputStream>(readFile),
-                  *pool_),
+                  std::make_shared<velox::dwio::common::ReadFileInputStream>(readFile), *pool_),
               reader_options);
   return toArrowSchema(reader->rowType());
 }

--- a/cpp/velox/compute/DwrfDatasource.cc
+++ b/cpp/velox/compute/DwrfDatasource.cc
@@ -23,7 +23,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <regex>
 #include <string>
 
 #include "ArrowTypeUtils.h"
@@ -98,37 +97,18 @@ std::shared_ptr<arrow::Schema> DwrfDatasource::InspectSchema() {
   auto format = velox::dwio::common::FileFormat::DWRF; // DWRF
   reader_options.setFileFormat(format);
 
-  if (strncmp(file_path_.c_str(), "file:", 5) == 0) {
-    auto input = std::make_unique<velox::dwio::common::BufferedInput>(
-        std::make_shared<velox::LocalReadFile>(file_path_.substr(5)), *pool_);
-    std::unique_ptr<velox::dwio::common::Reader> reader =
-        velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
-            ->createReader(std::move(input), reader_options);
-    return toArrowSchema(reader->rowType());
-  }
-#ifdef VELOX_ENABLE_HDFS
-  else if (strncmp(file_path_.c_str(), "hdfs:", 5) == 0) {
-    struct hdfsBuilder* builder = hdfsNewBuilder();
-    // read hdfs client conf from hdfs-client.xml from LIBHDFS3_CONF
-    hdfsBuilderSetNameNode(builder, "default");
-    hdfsFS hdfs = hdfsBuilderConnect(builder);
-    hdfsFreeBuilder(builder);
-    std::regex hdfsPrefixExp("hdfs://(\\w+)/");
-    std::string hdfsFilePath = regex_replace(file_path_.c_str(), hdfsPrefixExp, "/");
-    std::unique_ptr<velox::dwio::common::Reader> reader =
-        velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
-            ->createReader(
-                std::make_unique<velox::dwio::common::BufferedInput>(
-                    std::make_shared<velox::dwio::common::ReadFileInputStream>(
-                        std::make_shared<velox::HdfsReadFile>(hdfs, hdfsFilePath)),
-                    *pool_),
-                reader_options);
-    return toArrowSchema(reader->rowType());
-  }
-#endif
-  else {
-    throw std::runtime_error("The path is not local file path when inspect shcema with DWRF format!");
-  }
+  // Creates a file system: local, hdfs or s3.
+  auto fs = velox::filesystems::getFileSystem(file_path_, nullptr);
+  std::shared_ptr<velox::ReadFile> readFile{std::move(fs->openFileForRead(file_path_))};
+
+  std::unique_ptr<velox::dwio::common::Reader> reader =
+      velox::dwio::common::getReaderFactory(reader_options.getFileFormat())
+          ->createReader(
+              std::make_unique<velox::dwio::common::BufferedInput>(
+                  std::make_shared<velox::dwio::common::ReadFileInputStream>(readFile),
+                  *pool_),
+              reader_options);
+  return toArrowSchema(reader->rowType());
 }
 
 void DwrfDatasource::Close() {

--- a/cpp/velox/compute/DwrfDatasource.h
+++ b/cpp/velox/compute/DwrfDatasource.h
@@ -27,9 +27,6 @@
 #include "operators/c2r/ColumnarToRow.h"
 
 #include "velox/common/file/FileSystems.h"
-#ifdef VELOX_ENABLE_HDFS
-#include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
-#endif
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"

--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -51,27 +51,6 @@ void VeloxInitializer::Init(std::unordered_map<std::string, std::string>& conf) 
 
 #ifdef VELOX_ENABLE_HDFS
   velox::filesystems::registerHdfsFileSystem();
-  std::unordered_map<std::string, std::string> hdfsConfig({});
-
-  std::string hdfsUri = conf["spark.hadoop.fs.defaultFS"];
-  const char* envHdfsUri = std::getenv("VELOX_HDFS");
-  if (envHdfsUri != nullptr) {
-    hdfsUri = std::string(envHdfsUri);
-  }
-
-  auto hdfsHostWithPort = hdfsUri.substr(hdfsUri.find(':') + 3);
-  std::size_t pos = hdfsHostWithPort.find(':');
-  if (pos != std::string::npos) {
-    auto hdfsPort = hdfsHostWithPort.substr(pos + 1);
-    auto hdfsHost = hdfsHostWithPort.substr(0, pos);
-    hdfsConfig.insert({{"hive.hdfs.host", hdfsHost}, {"hive.hdfs.port", hdfsPort}});
-  } else {
-    // For HDFS HA mode. In this case, hive.hdfs.host should be the nameservice, we can
-    // get it from HDFS uri, and hive.hdfs.port should be an empty string, and the HDFS HA
-    // configurations should be taken from the LIBHDFS3_CONF file.
-    hdfsConfig.insert({{"hive.hdfs.host", hdfsHostWithPort}, {"hive.hdfs.port", ""}});
-  }
-  configurationValues.merge(hdfsConfig);
 #endif
 
 #ifdef VELOX_ENABLE_S3

--- a/docs/Velox.md
+++ b/docs/Velox.md
@@ -173,33 +173,10 @@ make -j
 cd /path_to_gluten
 mvn clean package -Pbackends-velox -Pspark-3.2 -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip
 ```
-Gluten HDFS support requires Hdfs URI, you can define this config in three ways:
+It is supported to access data on different HDFS endpoints.
+The endpoint info (hdfs://host:port) contained in a given hdfs file path will be used to initialize an hdfs client.
 
-1. spark-defaults.conf
-
-```
-spark.hadoop.fs.defaultFS hdfs://hdfshost:9000
-```
-
-2. envrionment variable `VELOX_HDFS`
-```
-// Spark local mode
-export VELOX_HDFS="hdfs://hdfshost:9000"
-
-// Spark Yarn cluster mode
---conf spark.executorEnv.VELOX_HDFS="hdfs://hdfshost:9000"
-```
-
-3. Hadoop's `core-site.xml` (recomended)
-```
-<property>
-   <name>fs.defaultFS</name>
-   <value>hdfs://hdfshost:9000</value>
-</property>
-```
-If Gluten is used in a fully-prepared Hadoop cluster, we recommend to use Hadoop's config.
-
-If your HDFS is in HA mode, you need to set the LIBHDFS3_CONF environment variable to specify the hdfs client configuration file.
+If your HDFS is in HA mode, you need to set the `LIBHDFS3_CONF` environment variable to specify hdfs client configuration file.
 
 ```
 // Spark local mode

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=multi-hdfs
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/PHILO-HE/velox.git
-VELOX_BRANCH=multi-hdfs
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -87,10 +87,6 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
       conf.set("spark.sql.orc.enableVectorizedReader", "false")
       conf.set("spark.sql.inMemoryColumnarStorage.enableVectorizedReader", "false")
     }
-    val hdfsUri = sc.hadoopConfiguration.get("fs.defaultFS", "hdfs://localhost:9000")
-    if (!conf.contains(GlutenConfig.SPARK_HDFS_URI)) {
-      conf.set(GlutenConfig.SPARK_HDFS_URI, hdfsUri)
-    }
   }
 }
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -305,8 +305,6 @@ object GlutenConfig {
 
   // Hadoop config
   val HADOOP_PREFIX = "spark.hadoop."
-  val HDFS_URI = "fs.defaultFS"
-  val SPARK_HDFS_URI: String = HADOOP_PREFIX + HDFS_URI
 
   // S3 config
   val S3_ACCESS_KEY = "fs.s3a.access.key"
@@ -431,7 +429,6 @@ object GlutenConfig {
       })
 
     val keyWithDefault = ImmutableList.of(
-      (SPARK_HDFS_URI, "hdfs://localhost:9000"),
       (SPARK_S3_ACCESS_KEY, "minio"),
       (SPARK_S3_SECRET_KEY, "miniopass"),
       (SPARK_S3_ENDPOINT, "localhost:9000"),


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some use cases, data is stored in multiple HDFS endpoints. In https://github.com/oap-project/velox/pull/174, we made some code changes in velox to initialize an hdfs client by need, i.e., getting endpoint info from full hdfs file path when read operation comes and do the initialization if the corresponding client is not created. Thus, there is no need to configure a single hdfs endpoint. 


## How was this patch tested?
Tests with multiple hdfs endpoints used.

