### PR TITLE
[GLUTEN-1141][VL]fix: building hashmap with new key equality check

### DIFF
--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/GlutenBuildSideRelation.scala
@@ -83,13 +83,18 @@ case class GlutenBuildSideRelation(mode: BroadcastMode,
           throw new IllegalArgumentException(s"Key column not found in expression: $key")
         }
         if (columnNames.size != 1) {
-          throw new IllegalArgumentException(s"Multiple key column not found in expression: $key")
+          throw new IllegalArgumentException(s"Multiple key columns found in expression: $key")
         }
         val columnExpr = columnNames.head
 
         val columnInOutput = output.zipWithIndex.filter {
           p: (Attribute, Int) =>
-            p._1.name == columnExpr.name
+            if (output.size == 1) {
+              p._1.name == columnExpr.name
+            } else {
+              // A case where output has multiple columns with same name
+              p._1.name == columnExpr.name && p._1.exprId == columnExpr.exprId
+            }
         }
         if (columnInOutput.isEmpty) {
           throw new IllegalStateException(


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch modifies the equality check with both name and exprId if there are at least 2 columns in the output, so that two or more keys with same name(but different exprId) are allowed in hashmap building process.

- on Q72 the issue is due to the output of build relation has two columns with same name but different exprId
- on Q5 the issue is due to a reused broadcast xchg, although there's only output column, the expr name and Id are not matching from the original plan

Fixes: #1141 

## How was this patch tested?
pass GHA
manually verified with TPCDS Q72 + CBO enabled

