### PR TITLE
[VL] Fix exec_backend_test  compile problem introduced by gtest 1.13

### DIFF
--- a/cpp/core/memory/ColumnarBatch.h
+++ b/cpp/core/memory/ColumnarBatch.h
@@ -56,6 +56,11 @@ class ColumnarBatch {
     return exportNanos_;
   };
 
+  friend std::ostream& operator<<(std::ostream& os, const ColumnarBatch& columnarBatch) {
+    return os << "NumColumns: " << std::to_string(columnarBatch.GetNumColumns())
+              << "NumRows: " << std::to_string(columnarBatch.GetNumRows());
+  }
+
  private:
   int32_t numColumns_;
   int32_t numRows_;


### PR DESCRIPTION
## What changes were proposed in this pull request?

add `operator<<` for ColumnarBatch.
Fixes: Since gtest upgraded to 1.13, exec_backend_test will encounter  this problem.
```
undefined reference to `testing::internal::PrintBytesInObjectTo(unsigned char const*, unsigned long, std::ostream*)'
```
Follow this solution to fix it. https://github.com/google/googletest/issues/3816
## How was this patch tested?
GHA test
