### PR TITLE
[GLUTEN-1296][VL][CI]fix: Speed up on running Spark unit tests

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -131,23 +131,23 @@ jobs:
         run: |
           docker stop velox-backend-ubuntu2004-test-$GITHUB_RUN_ID || true
 
-  velox-backend-ubuntu2004-test-slow-tests:
+  velox-backend-ubuntu2004-test-slow:
     runs-on: velox-self-hosted
     steps:
       - uses: actions/checkout@v2
       - name: Setup docker container
         run: |
-          EXTRA_DOCKER_OPTIONS="--name velox-backend-ubuntu2004-test-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" \
+          EXTRA_DOCKER_OPTIONS="--name velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" \
           NON_INTERACTIVE=ON \
           MOUNT_MAVEN_CACHE=OFF \
           OS_IMAGE=ubuntu:20.04 \
           tools/gluten-te/ubuntu/cbash.sh sleep 14400
       - name: Setup maven cache
         run: |
-          docker cp ~/.m2/repository velox-backend-ubuntu2004-test-$GITHUB_RUN_ID:/root/.m2/
+          docker cp ~/.m2/repository velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID:/root/.m2/
       - name: Build Gluten Velox-backend third party
         run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/ep/build-arrow/src && \
           ./get_arrow.sh  && \
           ./build_arrow.sh --build_tests=ON --build_benchmarks=ON && \
@@ -156,68 +156,28 @@ jobs:
           ./build_velox.sh'
       - name: Build Gluten CPP library
         run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           mkdir build && cd build && cmake -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON .. && make -j'
       - name: Build for Spark 3.2.0
         run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.0'
       - name: Build for Spark 3.2.1
         run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.1'
       - name: Build and run unit test for Spark 3.2.2(slow tests)
         run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
-      - name: Run CPP unit test
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
-          ctest -V'
-      # Cpp micro benchmarks will use generated files from unit test in backends-velox module.
-      - name: Run micro benchmarks
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build/velox/benchmarks && \
-          ./generic_benchmark --threads 1 --iterations 1'
-      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.2
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean package -Pspark-3.2 \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=h --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=ds --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1'
-      - name: Build for Spark 3.3.0
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -DskipTests -Dspark33.version=3.3.0'
-      - name: Build and Run unit test for Spark 3.3.1
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Pspark-ut'
-      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.3
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean package -Pspark-3.3 \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=h --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 --skip-data-gen \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=ds --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1 --skip-data-gen'
-      - name: Run HBM CPP unit test
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
-          cmake -DBUILD_TESTS=ON -DENABLE_HBM=ON .. && \
-          cmake --build . --target hbw_allocator_test -- -j && \
-          ctest -V -R TestHbw'
       - name: Exit docker container
         if: ${{ always() }}
         run: |
-          docker stop velox-backend-ubuntu2004-test-$GITHUB_RUN_ID || true
+          docker stop velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID || true
 
 
   velox-backend-ubuntu2204-test:

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -81,11 +81,11 @@ jobs:
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.1'
-      - name: Build and run unit test for Spark 3.2.2
+      - name: Build and run unit test for Spark 3.2.2(other tests)
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322"'
+          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest'
       - name: Run CPP unit test
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
@@ -130,6 +130,95 @@ jobs:
         if: ${{ always() }}
         run: |
           docker stop velox-backend-ubuntu2004-test-$GITHUB_RUN_ID || true
+
+  velox-backend-ubuntu2004-test-slow-tests:
+    runs-on: velox-self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup docker container
+        run: |
+          EXTRA_DOCKER_OPTIONS="--name velox-backend-ubuntu2004-test-$GITHUB_RUN_ID -e NUM_THREADS=30 --detach" \
+          NON_INTERACTIVE=ON \
+          MOUNT_MAVEN_CACHE=OFF \
+          OS_IMAGE=ubuntu:20.04 \
+          tools/gluten-te/ubuntu/cbash.sh sleep 14400
+      - name: Setup maven cache
+        run: |
+          docker cp ~/.m2/repository velox-backend-ubuntu2004-test-$GITHUB_RUN_ID:/root/.m2/
+      - name: Build Gluten Velox-backend third party
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten/ep/build-arrow/src && \
+          ./get_arrow.sh  && \
+          ./build_arrow.sh --build_tests=ON --build_benchmarks=ON && \
+          cd /opt/gluten/ep/build-velox/src && \
+          ./get_velox.sh && \
+          ./build_velox.sh'
+      - name: Build Gluten CPP library
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten/cpp && \
+          mkdir build && cd build && cmake -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON .. && make -j'
+      - name: Build for Spark 3.2.0
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten && \
+          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.0'
+      - name: Build for Spark 3.2.1
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten && \
+          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.1'
+      - name: Build and run unit test for Spark 3.2.2(slow tests)
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten && \
+          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
+      - name: Run CPP unit test
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
+          ctest -V'
+      # Cpp micro benchmarks will use generated files from unit test in backends-velox module.
+      - name: Run micro benchmarks
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build/velox/benchmarks && \
+          ./generic_benchmark --threads 1 --iterations 1'
+      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.2
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean package -Pspark-3.2 \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=h --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=ds --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1'
+      - name: Build for Spark 3.3.0
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten && \
+          mvn clean install -Pspark-3.3 -Pbackends-velox -DskipTests -Dspark33.version=3.3.0'
+      - name: Build and Run unit test for Spark 3.3.1
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Pspark-ut'
+      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.3
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean package -Pspark-3.3 \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=h --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 --skip-data-gen \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=ds --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1 --skip-data-gen'
+      - name: Run HBM CPP unit test
+        run: |
+          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
+          cmake -DBUILD_TESTS=ON -DENABLE_HBM=ON .. && \
+          cmake --build . --target hbw_allocator_test -- -j && \
+          ctest -V -R TestHbw'
+      - name: Exit docker container
+        if: ${{ always() }}
+        run: |
+          docker stop velox-backend-ubuntu2004-test-$GITHUB_RUN_ID || true
+
 
   velox-backend-ubuntu2204-test:
     runs-on: velox-self-hosted

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -84,10 +84,8 @@ jobs:
       - name: Build and run unit test for Spark 3.2.2
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
-          wget https://downloads.apache.org/maven/mvnd/1.0-m6/maven-mvnd-1.0-m6-m39-linux-amd64.tar.gz && \
-          tar xvf maven-mvnd-1.0-m6-m39-linux-amd64.tar.gz -C /tmp/ && \
           cd /opt/gluten && \
-          /tmp/maven-mvnd-1.0-m6-m39-linux-amd64/bin/mvnd clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322"'
+          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322"'
       - name: Run CPP unit test
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -95,14 +95,6 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build/velox/benchmarks && \
           ./generic_benchmark --threads 1 --iterations 1'
-      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.2
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean package -Pspark-3.2 \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1'
       - name: Build for Spark 3.3.0
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
@@ -112,14 +104,6 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
           mvn clean install -Pspark-3.3 -Pbackends-velox -Pspark-ut'
-      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.3
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean package -Pspark-3.3 \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 --skip-data-gen \
-          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
-            --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1 --skip-data-gen'
       - name: Run HBM CPP unit test
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
@@ -174,6 +158,22 @@ jobs:
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
+      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.2
+        run: |
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean package -Pspark-3.2 \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1'
+      - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.3
+        run: |
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean package -Pspark-3.3 \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 --skip-data-gen \
+          && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
+            --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1 --skip-data-gen'
       - name: Exit docker container
         if: ${{ always() }}
         run: |

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -84,8 +84,10 @@ jobs:
       - name: Build and run unit test for Spark 3.2.2
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
+          wget https://downloads.apache.org/maven/mvnd/1.0-m6/maven-mvnd-1.0-m6-m39-linux-amd64.tar.gz && \
+          tar xvf maven-mvnd-1.0-m6-m39-linux-amd64.tar.gz -C /tmp/ && \
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322"'
+          /tmp/maven-mvnd-1.0-m6-m39-linux-amd64/bin/mvnd clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322"'
       - name: Run CPP unit test
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
-          mkdir build && cd build && cmake -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON .. && make -j'
+          mkdir build && cd build && cmake .. && make -j'
       - name: Build for Spark 3.2.0
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -95,15 +95,6 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build/velox/benchmarks && \
           ./generic_benchmark --threads 1 --iterations 1'
-      - name: Build for Spark 3.3.0
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -DskipTests -Dspark33.version=3.3.0'
-      - name: Build and Run unit test for Spark 3.3.1
-        run: |
-          docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Pspark-ut'
       - name: Run HBM CPP unit test
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
@@ -166,6 +157,15 @@ jobs:
             --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --cpus=16 --iterations=1 \
           && java -Xmx5G -XX:ErrorFile=/var/log/java/hs_err_pid%p.log -cp target/gluten-it-1.0-SNAPSHOT-jar-with-dependencies.jar io.glutenproject.integration.tpc.Tpc \
             --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=8g -s=0.1 --cpus=16 --iterations=1'
+      - name: Build for Spark 3.3.0
+        run: |
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
+          cd /opt/gluten && \
+          mvn clean install -Pspark-3.3 -Pbackends-velox -DskipTests -Dspark33.version=3.3.0'
+      - name: Build and Run unit test for Spark 3.3.1
+        run: |
+          docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Pspark-ut'
       - name: TPC-H SF1.0 && TPC-DS SF0.1 Parquet local spark3.3
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \

--- a/gluten-ut/common/src/test/java/org/apache/spark/tags/ExtendedSQLTest.java
+++ b/gluten-ut/common/src/test/java/org/apache/spark/tags/ExtendedSQLTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.tags;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExtendedSQLTest { }
+

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.TimestampTypes
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.Utils
 import scala.sys.process.{Process, ProcessLogger}
 import scala.util.Try
@@ -124,6 +125,7 @@ import scala.util.Try
  * Therefore, UDF test cases should have single input and output files but executed by three
  * different types of UDFs. See 'udf/udf-inner-join.sql' as an example.
  */
+@ExtendedSQLTest
 class GlutenSQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
     with SQLQueryTestHelper {
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV1SchemaPruningSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV1SchemaPruningSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.execution.datasources.orc
 
 import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.tags.ExtendedSQLTest
 
+@ExtendedSQLTest
 class GlutenOrcV1SchemaPruningSuite extends OrcV1SchemaPruningSuite with GlutenSQLTestsBaseTrait {
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV2SchemaPruningSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcV2SchemaPruningSuite.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.execution.datasources.orc
 
 import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.tags.ExtendedSQLTest
 
+@ExtendedSQLTest
 class GlutenOrcV2SchemaPruningSuite extends OrcV2SchemaPruningSuite with GlutenSQLTestsBaseTrait {
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.Utils
 
 import java.sql.Date
@@ -301,6 +302,7 @@ abstract class GltuenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
   }
 }
 
+@ExtendedSQLTest
 class GlutenParquetV1FilterSuite extends GltuenParquetFilterSuite with GlutenSQLTestsBaseTrait {
   // TODO: enable Parquet V2 write path after file source V2 writers are workable.
   override def sparkConf: SparkConf =
@@ -379,6 +381,7 @@ class GlutenParquetV1FilterSuite extends GltuenParquetFilterSuite with GlutenSQL
   }
 }
 
+@ExtendedSQLTest
 class GlutenParquetV2FilterSuite extends GltuenParquetFilterSuite with GlutenSQLTestsBaseTrait {
   // TODO: enable Parquet V2 write path after file source V2 writers are workable.
   override def sparkConf: SparkConf =

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetSchemaPruningSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetSchemaPruningSuite.scala
@@ -18,11 +18,14 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.tags.ExtendedSQLTest
 
+@ExtendedSQLTest
 class GlutenParquetV1SchemaPruningSuite extends ParquetV1SchemaPruningSuite
   with GlutenSQLTestsBaseTrait {
 }
 
+@ExtendedSQLTest
 class GlutenParquetV2SchemaPruningSuite extends ParquetV2SchemaPruningSuite
   with GlutenSQLTestsBaseTrait {
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch picked up those slow tests from Spark unit tests and run them in a parallel job to speed up the CI.

- GlutenSQLQueryTestSuite
- GlutenOrcV1SchemaPruningSuite
- GlutenOrcV2SchemaPruningSuite
- GlutenParquetV1FilterSuite
- GlutenParquetV2FilterSuite
- GlutenParquetV1SchemaPruningSuite
- GlutenParquetV2SchemaPruningSuite

related: #1296 

## How was this patch tested?

pass GHA

