### PR TITLE
[VL] package.sh support centos7 and centos8

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,19 @@ There are several key component in Gluten:
 
 # 3 Usage
 
-Gluten is still under active development now. There isn't a released binary yet. The only way to use Gluten is to build from source, copy the jar to your spark jars, then enable Gluten plugin when you start your spark context. Here is the simple example. Refer to Velox or Clickhouse backend below for more details
+Gluten is still under active development now. There are two ways to use Gluten. 
+One Way is use released binary jar. Here is the simple example.
+
+```
+spark-shell --name run_gluten \
+ --master yarn --deploy-mode client \
+ --conf spark.plugins=io.glutenproject.GlutenPlugin \
+ --conf spark.gluten.sql.columnar.backend.lib=velox \
+ --conf spark.gluten.loadLibFromJar=true \
+ --jars https://github.com/oap-project/gluten/releases/download/0.5.0/gluten-velox-bundle-spark3.2_2.12-ubuntu_20.04-0.5.0-SNAPSHOT.jar,https://github.com/oap-project/gluten/releases/download/0.5.0/gluten-thirdparty-lib-ubuntu-20.04.jar 
+```
+
+Another way is build from source, copy the jar to your spark jars, then enable Gluten plugin when you start your spark context. Here is the simple example. Refer to Velox or Clickhouse backend below for more details.
 
 ```
 export gluten_jvm_jar = /PATH/TO/GLUTEN/backends-velox/target/<gluten-jar>
@@ -69,7 +81,7 @@ spark-shell
   --conf spark.executor.extraClassPath=${gluten_jvm_jar} \
   --conf spark.shuffle.manager=org.apache.spark.shuffle.sort.ColumnarShuffleManager \
   ...
-  ```
+```
 
 ## 3.1 Build and Install Gluten with Velox backend
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,21 @@ There are several key component in Gluten:
 # 3 Usage
 
 Gluten is still under active development now. There are two ways to use Gluten. 
-One Way is use released binary jar. Here is the simple example.
+
+# 3.1 Use Prebuilt jar
+
+One Way is use released binary jar. Here is the simple example. we support centos7/8 and ubuntu20.04/22.04 now.
 
 ```
-spark-shell --name run_gluten \
+spark-shell \
  --master yarn --deploy-mode client \
  --conf spark.plugins=io.glutenproject.GlutenPlugin \
  --conf spark.gluten.sql.columnar.backend.lib=velox \
  --conf spark.gluten.loadLibFromJar=true \
  --jars https://github.com/oap-project/gluten/releases/download/0.5.0/gluten-velox-bundle-spark3.2_2.12-ubuntu_20.04-0.5.0-SNAPSHOT.jar,https://github.com/oap-project/gluten/releases/download/0.5.0/gluten-thirdparty-lib-ubuntu-20.04.jar 
 ```
+
+# 3.2 Custom Build
 
 Another way is build from source, copy the jar to your spark jars, then enable Gluten plugin when you start your spark context. Here is the simple example. Refer to Velox or Clickhouse backend below for more details.
 

--- a/README.md
+++ b/README.md
@@ -88,23 +88,23 @@ spark-shell
   ...
 ```
 
-## 3.1 Build and Install Gluten with Velox backend
+### 3.2.1 Build and Install Gluten with Velox backend
 
 <img src="https://github.com/facebookincubator/velox/raw/main/static/logo.svg" width="200">
 
 If you would like to build and try Gluten with **Velox** backend, please follow the steps in [Build with Velox](./docs/Velox.md) to build and install the necessary libraries, compile Velox and try out the TPC-H workload.
 
-## 3.2 Build and Install Gluten with ClickHouse backend
+### 3.2.2 Build and Install Gluten with ClickHouse backend
 
 ![logo](./docs/image/ClickHouse/logo.png)
 
 If you would like to build and try  Gluten with **ClickHouse** backend, please follow the steps in [Build with ClickHouse Backend](./docs/ClickHouse.md). ClickHouse backend is developed by [Kyligence](https://kyligence.io/), please visit https://github.com/Kyligence/ClickHouse for more infomation.
 
-## 3.4 Build script parameters
+### 3.2.3 Build script parameters
 
 [Gluten Usage](./docs/GlutenUsage.md) listed the parameters and their default value of build command for your reference
 
-## 3.5 Jar conflicts
+### 3.2.4 Jar conflicts
 
 With the latest version of Gluten, there should not be any jar conflict anymore. If you still get hit with such issues, please following the below instructions.
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
@@ -18,7 +18,7 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.InitializerApi
-import io.glutenproject.utils.{VeloxDllLoaderUbuntu2004, VeloxDllLoaderUbuntu2204}
+import io.glutenproject.utils.{VeloxSharedlibraryLoaderUbuntu2004, VeloxSharedlibraryLoaderUbuntu2204, VeloxSharedlibraryLoaderCentos8, VeloxSharedlibraryLoaderCentos7}
 import io.glutenproject.vectorized.{GlutenNativeExpressionEvaluator, JniLibLoader, JniWorkspace}
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkConf
@@ -29,10 +29,16 @@ class VeloxInitializerApi extends InitializerApi {
   def loadLibFromJar(load: JniLibLoader): Unit = {
       val system = "cat /etc/os-release".!!
       if (system.contains("Ubuntu") && system.contains("20.04")) {
-        val loader = new VeloxDllLoaderUbuntu2004
+        val loader = new VeloxSharedlibraryLoaderUbuntu2004
         loader.loadLib(load)
       } else if (system.contains("Ubuntu") && system.contains("22.04")) {
-        val loader = new VeloxDllLoaderUbuntu2204
+        val loader = new VeloxSharedlibraryLoaderUbuntu2204
+        loader.loadLib(load)
+      } else if (system.contains("CentOS") && system.contains("8")){
+        val loader = new VeloxSharedlibraryLoaderCentos8
+        loader.loadLib(load)
+      } else if (system.contains("CentOS") && system.contains("7")){
+        val loader = new VeloxSharedlibraryLoaderCentos7
         loader.loadLib(load)
       }
   }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxInitializerApi.scala
@@ -18,7 +18,7 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.InitializerApi
-import io.glutenproject.utils.{VeloxSharedlibraryLoaderUbuntu2004, VeloxSharedlibraryLoaderUbuntu2204, VeloxSharedlibraryLoaderCentos8, VeloxSharedlibraryLoaderCentos7}
+import io.glutenproject.utils.{VeloxSharedlibraryLoaderUbuntu2004, VeloxSharedlibraryLoaderUbuntu2204, VeloxSharedlibraryLoaderCentos8, VeloxSharedlibraryLoaderCentos7, VeloxSharedlibraryLoader}
 import io.glutenproject.vectorized.{GlutenNativeExpressionEvaluator, JniLibLoader, JniWorkspace}
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkConf
@@ -28,19 +28,16 @@ import scala.sys.process._
 class VeloxInitializerApi extends InitializerApi {
   def loadLibFromJar(load: JniLibLoader): Unit = {
       val system = "cat /etc/os-release".!!
-      if (system.contains("Ubuntu") && system.contains("20.04")) {
-        val loader = new VeloxSharedlibraryLoaderUbuntu2004
-        loader.loadLib(load)
+      val loader = if (system.contains("Ubuntu") && system.contains("20.04")) {
+        new VeloxSharedlibraryLoaderUbuntu2004
       } else if (system.contains("Ubuntu") && system.contains("22.04")) {
-        val loader = new VeloxSharedlibraryLoaderUbuntu2204
-        loader.loadLib(load)
+        new VeloxSharedlibraryLoaderUbuntu2204
       } else if (system.contains("CentOS") && system.contains("8")){
-        val loader = new VeloxSharedlibraryLoaderCentos8
-        loader.loadLib(load)
+        new VeloxSharedlibraryLoaderCentos8
       } else if (system.contains("CentOS") && system.contains("7")){
-        val loader = new VeloxSharedlibraryLoaderCentos7
-        loader.loadLib(load)
+        new VeloxSharedlibraryLoaderCentos7
       }
+      loader.asInstanceOf[VeloxSharedlibraryLoader].loadLib(load)
   }
 
   override def initialize(conf: SparkConf): Unit = {

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoader.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoader.scala
@@ -2,7 +2,7 @@ package io.glutenproject.utils
 
 import io.glutenproject.vectorized.JniLibLoader
 
-trait VeloxDllLoader{
+trait VeloxSharedlibraryLoader{
     def loadLib(loader: JniLibLoader) : Unit = {}
 }
 

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderCentos7.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderCentos7.scala
@@ -1,0 +1,27 @@
+package io.glutenproject.utils
+
+import io.glutenproject.vectorized.JniLibLoader
+
+class VeloxSharedlibraryLoaderCentos7 extends VeloxSharedlibraryLoader {
+  override def loadLib(loader: JniLibLoader) : Unit = {
+    loader.newTransaction()
+      .loadAndCreateLink("libboost_thread.so.1.72.0", "libboost_thread.so", false)
+      .loadAndCreateLink("libboost_system.so.1.72.0", "libboost_system.so", false)
+      .loadAndCreateLink("libboost_regex.so.1.72.0", "libboost_regex.so", false)
+      .loadAndCreateLink("libboost_program_options.so.1.72.0", "libboost_program_options.so", false)
+      .loadAndCreateLink("libboost_filesystem.so.1.72.0", "libboost_filesystem.so", false)
+      .loadAndCreateLink("libboost_context.so.1.72.0", "libboost_context.so", false)
+      .loadAndCreateLink("libdouble-conversion.so.1", "libdouble-conversion.so", false)
+      .loadAndCreateLink("libevent-2.0.so.5", "libevent-2.0.so", false)
+      .loadAndCreateLink("libgflags.so.2.2", "libgflags.so", false)
+      .loadAndCreateLink("libglog.so.0", "libglog.so", false)
+      .loadAndCreateLink("libntlm.so.0", "libntlm.so", false)
+      .loadAndCreateLink("libgsasl.so.7", "libgsasl.so", false)
+      .loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so", false)
+      .loadAndCreateLink("libhdfs3.so.1", "libhdfs3.so", false)
+      .loadAndCreateLink("libre2.so.10", "libre2.so", false)
+      .loadAndCreateLink("libzstd.so.1", "libzstd.so", false)
+      .commit()
+  }
+}
+

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderCentos8.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderCentos8.scala
@@ -1,0 +1,31 @@
+package io.glutenproject.utils
+
+import io.glutenproject.vectorized.JniLibLoader
+
+class VeloxSharedlibraryLoaderCentos8 extends VeloxSharedlibraryLoader {
+  override def loadLib(loader: JniLibLoader) : Unit = {
+    loader.newTransaction()
+      .loadAndCreateLink("libboost_thread.so.1.72.0", "libboost_thread.so", false)
+      .loadAndCreateLink("libboost_system.so.1.72.0", "libboost_system.so", false)
+      .loadAndCreateLink("libicudata.so.60", "libicudata.so", false)
+      .loadAndCreateLink("libicuuc.so.60", "libicuuc.so", false)
+      .loadAndCreateLink("libicui18n.so.60", "libicui18n.so", false)
+      .loadAndCreateLink("libboost_regex.so.1.72.0", "libboost_regex.so", false)
+      .loadAndCreateLink("libboost_program_options.so.1.72.0", "libboost_program_options.so", false)
+      .loadAndCreateLink("libboost_filesystem.so.1.72.0", "libboost_filesystem.so", false)
+      .loadAndCreateLink("libboost_context.so.1.72.0", "libboost_context.so", false)
+      .loadAndCreateLink("libdouble-conversion.so.3", "libdouble-conversion.so", false)
+      .loadAndCreateLink("libevent-2.1.so.6", "libevent-2.1.so", false)
+      .loadAndCreateLink("libgflags.so.2.2", "libgflags.so", false)
+      .loadAndCreateLink("libglog.so.0", "libglog.so", false)
+      .loadAndCreateLink("libdwarf.so.1", "libdwarf.so", false)
+      .loadAndCreateLink("libidn.so.11", "libidn.so", false)
+      .loadAndCreateLink("libntlm.so.0", "libntlm.so", false)
+      .loadAndCreateLink("libgsasl.so.7", "libgsasl.so", false)
+      .loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so", false)
+      .loadAndCreateLink("libhdfs3.so.1", "libhdfs3.so", false)
+      .loadAndCreateLink("libre2.so.0", "libre2.so", false)
+      .commit()
+  }
+}
+

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2004.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2004.scala
@@ -2,7 +2,7 @@ package io.glutenproject.utils
 
 import io.glutenproject.vectorized.JniLibLoader
 
-class VeloxDllLoaderUbuntu2004 extends VeloxDllLoader {
+class VeloxSharedlibraryLoaderUbuntu2004 extends VeloxSharedlibraryLoader {
   override def loadLib(loader: JniLibLoader) : Unit = {
     loader.newTransaction()
       .loadAndCreateLink("libroken.so.18", "libroken.so", false)

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2204.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2204.scala
@@ -2,7 +2,7 @@ package io.glutenproject.utils
 
 import io.glutenproject.vectorized.JniLibLoader
 
-class VeloxDllLoaderUbuntu2204 extends VeloxDllLoader {
+class VeloxSharedlibraryLoaderUbuntu2204 extends VeloxSharedlibraryLoader {
   override def loadLib(loader: JniLibLoader) : Unit = {
     loader.newTransaction()
       .loadAndCreateLink("libboost_context.so.1.74.0", "libboost_context.so", false)

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -6,7 +6,7 @@ LINUX_OS=$(. /etc/os-release && echo ${ID})
 VERSION=$(. /etc/os-release && echo ${VERSION_ID})
 
 # compile gluten jar
-$GLUTEN_DIR/dev//builddeps-veloxbe.sh --build_test=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON
+$GLUTEN_DIR/dev/builddeps-veloxbe.sh --build_test=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON
 mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
 mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests
 
@@ -21,6 +21,17 @@ function process_setup_ubuntu_2204 {
   cp /usr/local/lib/{libhdfs3.so.1,libprotobuf.so.32} $THIRDPARTY_LIB/
 }
 
+function process_setup_centos_8 {
+  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libgflags.so.2.2,libglog.so.0,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0} $THIRDPARTY_LIB/
+  cp /usr/local/lib/{libhdfs3.so.1,libboost_context.so.1.72.0,libboost_filesystem.so.1.72.0,libboost_program_options.so.1.72.0,libboost_regex.so.1.72.0,libboost_system.so.1.72.0,libboost_thread.so.1.72.0,libprotobuf.so.32} $THIRDPARTY_LIB/
+}
+
+function process_setup_centos_7 {
+  cp /usr/local/lib64/{libgflags.so.2.2,libglog.so.0} $THIRDPARTY_LIB/
+  cp /usr/lib64/{libdouble-conversion.so.1,libevent-2.0.so.5,libzstd.so.1,libntlm.so.0,libgsasl.so.7} $THIRDPARTY_LIB/
+  cp /usr/local/lib/{libre2.so.10,libhdfs3.so.1,libboost_context.so.1.72.0,libboost_filesystem.so.1.72.0,libboost_program_options.so.1.72.0,libboost_system.so.1.72.0,libboost_thread.so.1.72.0,libboost_regex.so.1.72.0,libprotobuf.so.32} $THIRDPARTY_LIB/
+}
+
 if [ "$LINUX_OS" == "ubuntu" ]; then
   if [ "$VERSION" == "20.04" ]; then
     process_setup_ubuntu_2004
@@ -28,7 +39,11 @@ if [ "$LINUX_OS" == "ubuntu" ]; then
     process_setup_ubuntu_2204
   fi
 elif [ "$LINUX_OS" == "centos" ]; then
-  echo $LINUX_OS-$VERSION
+  if [ "$VERSION" == "8" ]; then
+    process_setup_centos_8
+  elif [ "$VERSION" == "7" ]; then
+    process_setup_centos_7
+  fi
 fi
 cd $THIRDPARTY_LIB/
 jar cvf gluten-thirdparty-lib-$LINUX_OS-$VERSION.jar ./

--- a/docs/developers/NewToGluten.md
+++ b/docs/developers/NewToGluten.md
@@ -352,8 +352,9 @@ spark-shell --name run_gluten \
  --master yarn --deploy-mode client \
  --conf spark.plugins=io.glutenproject.GlutenPlugin \
  --conf spark.gluten.sql.columnar.backend.lib=velox \
- --jars https://github.com/oap/gluten/releases/tag/gluten-velox-bundle-spark3.3_2.12-ubuntu_22.04-0.5.0-SNAPSHOT.jar,https://github.com/oap/gluten/releases/tag/gluten-thirdparty-lib-ubuntu-22.04.jar
  --conf spark.memory.offHeap.enabled=true \
  --conf spark.memory.offHeap.size=20g \
- --conf spark.gluten.loadLibFromJar=true
+ --conf spark.gluten.loadLibFromJar=true \
+ --jars https://github.com/oap-project/gluten/releases/download/0.5.0/gluten-velox-bundle-spark3.2_2.12-ubuntu_20.04-0.5.0-SNAPSHOT.jar,https://github.com/oap-project/gluten/releases/download/0.5.0/gluten-thirdparty-lib-ubuntu-20.04.jar 
+
 ```

--- a/docs/developers/docker_ubuntu22.04.md
+++ b/docs/developers/docker_ubuntu22.04.md
@@ -1,4 +1,4 @@
-Here is a docker script we verified to build Gluten+Velox backend on Ubuntu22.04:
+Here is a docker script we verified to build Gluten+Velox backend on Ubuntu22.04/20.04:
 
 Run on host as root user:
 ```


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. support package thirdparty libs for centos7 and centos8.
2. use can run on centos7/centos8 with one command.
3. package.sh is just run on clean docker. user can change the path of lib for themselves. And package.sh is only work for velox now.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

