### PR TITLE
[GLUTEN-1354][CORE] Fix the wrong result when calling the df.describe

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -516,6 +516,12 @@ class TestOperator extends WholeStageTransformerSuite {
     }}
   }
 
+  test("test df.describe() method") {
+    val d = 3
+    val df = Seq(d, d, d, d, d, d, d, d, d, d).toDF("IntegerCol")
+    df.describe().show()
+  }
+
   test("bit_and and bit_or") {
     runQueryAndCompare(
       """

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -613,7 +613,7 @@ case class ColumnarOverrideRules(session: SparkSession)
     List(
       (_: SparkSession) => FallbackEmptySchemaRelation(),
       (_: SparkSession) => StoreExpandGroupExpression(),
-      (_: SparkSession) => AddTransformHintRule(),
+      (_: SparkSession) => AddTransformHintRule(isTopParentExchange),
       (_: SparkSession) => TransformPreOverrides(
         this.isTopParentExchange || this.isAdaptiveContext),
       (_: SparkSession) => RemoveTransformHintRule()) :::

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -238,7 +238,7 @@ case class FallbackEmptySchemaRelation() extends Rule[SparkPlan] {
 // The doValidate function will be called to check if the conversion is supported.
 // If false is returned or any unsupported exception is thrown, a row guard will
 // be added on the top of that plan to prevent actual conversion.
-case class AddTransformHintRule() extends Rule[SparkPlan] {
+case class AddTransformHintRule(isTopExchange: Boolean = true) extends Rule[SparkPlan] {
   val columnarConf: GlutenConfig = GlutenConfig.getConf
   val preferColumnar: Boolean = columnarConf.enablePreferColumnar
   val optimizeLevel: Integer = columnarConf.physicalJoinOptimizationThrottle
@@ -277,6 +277,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
    * Inserts a transformable tag on top of those that are not supported.
    */
   private def addTransformableTags(plan: SparkPlan): SparkPlan = {
+    if (!isTopExchange) {
+      TransformHints.tagNotTransformable(plan)
+    }
     addTransformableTag(plan)
     plan.withNewChildren(plan.children.map(addTransformableTags))
   }

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -88,9 +88,7 @@ class VeloxTestSettings extends BackendTestSettings {
       // Mismatch when max NaN and infinite value
       "NaN is greater than all other non-NaN numeric values",
       // Rewrite this test because the describe functions creates unmatched plan.
-      "describe",
-      // decimal failed ut.
-      "SPARK-22271: mean overflows and returns null for some decimal variables"
+      "describe"
   )
 
   enableSuite[GlutenDataFrameNaFunctionsSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?


When calling the `df.describe()` method, it will call the `rdd.collect()` method to cache the `RDD[UnsafeRow]`. If the last RDD is `GlutenColumnarToRowRDD`, the `UnsafeRow` will be released  when the batch is accessed. So `df.describe()` method will  access the released `RDD[UnsafeRow]` , which cause the wrong result. This PR will fallback ColumnarToRow if the ColumnarToRow  is the last operator.

Fix [ISSUE#1354](https://github.com/oap-project/gluten/issues/1354)
## How was this patch tested?
added unit test
