### PR TITLE
[VL] Add xsimd search path

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -191,6 +191,7 @@ target_include_directories(velox PUBLIC
     ${root_directory}/src
     ${VELOX_HOME}
     ${VELOX_BUILD_PATH}
+    ${VELOX_BUILD_PATH}/_deps/xsimd-src/include/
     ${VELOX_HOME}/velox/vector
     ${VELOX_HOME}/third_party/xsimd/include/)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox is going to use CMake modules replace gitmodules, this PR add CMake xsimd search path to pass compile.


## How was this patch tested?

manual test.