### PR TITLE
[VL] Upgrade velox to 2023/4/20

### DIFF
--- a/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
+++ b/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
@@ -94,7 +94,7 @@ class GoogleBenchmarkColumnarToRow {
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
+    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultLeafWrappedVeloxMemoryPool().get());
   }
 
  protected:
@@ -150,10 +150,8 @@ class GoogleBenchmarkColumnarToRow_CacheScan_Benchmark : public GoogleBenchmarkC
     std::cout << " parquet parse done elapsed time = " << elapse_read / 1000000 << " rows = " << num_rows << std::endl;
 
     // reuse the columnarToRowConverter for batches caused system % increase a lot
-
     auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-    auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
-    auto ctxPool = veloxPool->addChild("cache_scan", velox::memory::MemoryPool::Kind::kLeaf);
+    auto ctxPool = GetDefaultLeafWrappedVeloxMemoryPool();
     for (auto _ : state) {
       for (const auto& vector : vectors) {
         auto columnarToRowConverter = std::make_shared<gluten::VeloxColumnarToRowConverter>(
@@ -203,8 +201,7 @@ class GoogleBenchmarkColumnarToRow_IterateScan_Benchmark : public GoogleBenchmar
         arrow::default_memory_pool(), ::parquet::ParquetFileReader::Open(file), properties, &parquet_reader));
 
     auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-    auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
-    auto ctxPool = veloxPool->addChild("iterate_scan", velox::memory::MemoryPool::Kind::kLeaf);
+    auto ctxPool = GetDefaultLeafWrappedVeloxMemoryPool();
     for (auto _ : state) {
       ASSERT_NOT_OK(parquet_reader->GetRecordBatchReader(row_group_indices, column_indices, &record_batch_reader));
       TIME_NANO_OR_THROW(elapse_read, record_batch_reader->ReadNext(&record_batch));

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -284,8 +284,8 @@ std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
   // Separate the scan ids and stream ids, and get the scan infos.
   getInfoAndIds(subVeloxPlanConverter_->splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
-  auto veloxPool = AsWrappedVeloxMemoryPool(allocator, memPoolOptions_);
-  auto ctxPool = veloxPool->addChild("result_iterator", velox::memory::MemoryPool::Kind::kAggregate);
+  auto veloxPool = AsWrappedVeloxAggregateMemoryPool(allocator, memPoolOptions_);
+  auto ctxPool = veloxPool->addAggregateChild("result_iterator");
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter =
@@ -312,8 +312,8 @@ std::shared_ptr<ResultIterator> VeloxBackend::GetResultIterator(
   // Separate the scan ids and stream ids, and get the scan infos.
   getInfoAndIds(subVeloxPlanConverter_->splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
-  auto veloxPool = AsWrappedVeloxMemoryPool(allocator, memPoolOptions_);
-  auto ctxPool = veloxPool->addChild("result_iterator", velox::memory::MemoryPool::Kind::kLeaf);
+  auto veloxPool = AsWrappedVeloxAggregateMemoryPool(allocator, memPoolOptions_);
+  auto ctxPool = veloxPool->addLeafChild("result_iterator");
   auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
       ctxPool, veloxPlan_, scanIds, setScanInfos, streamIds, "/tmp/test-spill", confMap_);
   return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
@@ -325,8 +325,8 @@ arrow::Result<std::shared_ptr<ColumnarToRowConverter>> VeloxBackend::getColumnar
   auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
   if (veloxBatch != nullptr) {
     auto arrowPool = AsWrappedArrowMemoryPool(allocator);
-    auto veloxPool = AsWrappedVeloxMemoryPool(allocator, memPoolOptions_);
-    auto ctxVeloxPool = veloxPool->addChild("columnar_to_row_velox", velox::memory::MemoryPool::Kind::kLeaf);
+    auto veloxPool = AsWrappedVeloxAggregateMemoryPool(allocator, memPoolOptions_);
+    auto ctxVeloxPool = veloxPool->addLeafChild("columnar_to_row_velox");
     return std::make_shared<VeloxColumnarToRowConverter>(veloxBatch->getFlattenedRowVector(), arrowPool, ctxVeloxPool);
   } else {
     return Backend::getColumnar2RowConverter(allocator, cb);
@@ -337,8 +337,8 @@ std::shared_ptr<RowToColumnarConverter> VeloxBackend::getRowToColumnarConverter(
     MemoryAllocator* allocator,
     struct ArrowSchema* cSchema) {
   // TODO: wait to fix task memory pool
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
-  // AsWrappedVeloxMemoryPool(allocator)->addChild("row_to_columnar", velox::memory::MemoryPool::Kind::kLeaf);
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
+  // AsWrappedVeloxAggregateMemoryPool(allocator)->addChild("row_to_columnar", velox::memory::MemoryPool::Kind::kLeaf);
   return std::make_shared<VeloxRowToColumnarConverter>(cSchema, veloxPool);
 }
 
@@ -372,7 +372,7 @@ std::shared_ptr<arrow::Schema> VeloxBackend::GetOutputSchema() {
 void VeloxBackend::cacheOutputSchema(const std::shared_ptr<const velox::core::PlanNode>& planNode) {
   ArrowSchema arrowSchema{};
   exportToArrow(
-      velox::BaseVector::create(planNode->outputType(), 0, GetDefaultWrappedVeloxMemoryPool().get()), arrowSchema);
+      velox::BaseVector::create(planNode->outputType(), 0, GetDefaultLeafWrappedVeloxMemoryPool().get()), arrowSchema);
   GLUTEN_ASSIGN_OR_THROW(outputSchema_, arrow::ImportSchema(&arrowSchema));
 }
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -118,7 +118,7 @@ class VeloxBackend final : public Backend {
 
   std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter> subVeloxPlanConverter_ =
       std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(
-          GetDefaultWrappedVeloxMemoryPool().get());
+          GetDefaultLeafWrappedVeloxMemoryPool().get());
 
   // Cache for tests/benchmark purpose.
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;

--- a/cpp/velox/compute/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/compute/VeloxColumnarToRowConverter.cc
@@ -25,8 +25,8 @@
 #include "ArrowTypeUtils.h"
 #include "arrow/c/helpers.h"
 #include "include/arrow/c/bridge.h"
-#include "velox/row/UnsafeRowDynamicSerializer.h"
-#include "velox/row/UnsafeRowSerializer.h"
+#include "velox/row/UnsafeRowDeserializers.h"
+#include "velox/row/UnsafeRowSerializers.h"
 #include "velox/vector/arrow/Bridge.h"
 
 using namespace facebook;

--- a/cpp/velox/compute/VeloxParquetDatasource.cc
+++ b/cpp/velox/compute/VeloxParquetDatasource.cc
@@ -33,8 +33,6 @@
 #include "memory/MemoryAllocator.h"
 #include "memory/VeloxMemoryPool.h"
 #include "velox/dwio/common/Options.h"
-#include "velox/row/UnsafeRowDynamicSerializer.h"
-#include "velox/row/UnsafeRowSerializer.h"
 #include "velox/vector/arrow/Bridge.h"
 
 using namespace facebook;
@@ -44,8 +42,9 @@ namespace gluten {
 void VeloxParquetDatasource::Init(const std::unordered_map<std::string, std::string>& sparkConfs) {
   auto backend = std::dynamic_pointer_cast<gluten::VeloxBackend>(gluten::CreateBackend());
 
-  auto veloxPool = AsWrappedVeloxMemoryPool(gluten::DefaultMemoryAllocator().get(), backend->GetMemoryPoolOptions());
-  pool_ = veloxPool->addChild("velox_parquet_write");
+  auto veloxPool =
+      AsWrappedVeloxAggregateMemoryPool(gluten::DefaultMemoryAllocator().get(), backend->GetMemoryPoolOptions());
+  pool_ = veloxPool->addLeafChild("velox_parquet_write");
 
   // Construct the file path and writer
   std::string local_path = "";

--- a/cpp/velox/compute/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/compute/VeloxRowToColumnarConverter.cc
@@ -17,7 +17,7 @@
 
 #include "VeloxRowToColumnarConverter.h"
 #include "memory/VeloxColumnarBatch.h"
-#include "velox/row/UnsafeRowBatchDeserializer.h"
+#include "velox/row/UnsafeRowDeserializers.h"
 #include "velox/vector/arrow/Bridge.h"
 
 using namespace facebook::velox;
@@ -38,7 +38,7 @@ VeloxRowToColumnarConverter::convert(int64_t numRows, int64_t* rowLength, uint8_
     data.emplace_back(std::string_view(reinterpret_cast<const char*>(memoryAddress + offset), rowLength[i]));
     offset += rowLength[i];
   }
-  auto vp = row::UnsafeRowDynamicVectorBatchDeserializer::deserializeComplex(data, rowType_, pool_.get());
+  auto vp = row::UnsafeRowDeserializer::deserialize(data, rowType_, pool_.get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<RowVector>(vp));
 }
 } // namespace gluten

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -202,7 +202,7 @@ std::string WholeStageResultIterator::getConfigValue(
 void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox::core::QueryCtx>& queryCtx) {
   std::unordered_map<std::string, std::string> configs = {};
   // Find batch size from Spark confs. If found.
-  configs[velox::core::QueryConfig::kPreferredOutputBatchSize] = getConfigValue(kSparkBatchSize, "4096");
+  configs[velox::core::QueryConfig::kPreferredOutputBatchRows] = getConfigValue(kSparkBatchSize, "4096");
   // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.
   // FIXME this uses process-wise off-heap memory which is not for task
   try {

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -89,7 +89,7 @@ JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ExpressionEvaluatorJ
 
   // A query context used for function validation.
   velox::core::QueryCtx queryCtx;
-  auto pool = gluten::GetDefaultWrappedVeloxMemoryPool().get();
+  auto pool = gluten::GetDefaultLeafWrappedVeloxMemoryPool().get();
   // An execution context used for function validation.
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -66,7 +66,7 @@ std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
 std::shared_ptr<ArrowArray> VeloxColumnarBatch::exportArrowArray() {
   auto out = std::make_shared<ArrowArray>();
   EnsureFlattened();
-  velox::exportToArrow(flattened_, *out, GetDefaultWrappedVeloxMemoryPool().get());
+  velox::exportToArrow(flattened_, *out, GetDefaultLeafWrappedVeloxMemoryPool().get());
   return out;
 }
 

--- a/cpp/velox/memory/VeloxMemoryPool.h
+++ b/cpp/velox/memory/VeloxMemoryPool.h
@@ -21,11 +21,14 @@
 #include "velox/common/memory/Memory.h"
 
 namespace gluten {
+class WrappedVeloxMemoryPool;
 
-std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxMemoryPool(
+std::shared_ptr<facebook::velox::memory::MemoryPool> AsWrappedVeloxAggregateMemoryPool(
     MemoryAllocator* allocator,
     const facebook::velox::memory::MemoryPool::Options& options);
 
-std::shared_ptr<facebook::velox::memory::MemoryPool> GetDefaultWrappedVeloxMemoryPool();
+std::shared_ptr<facebook::velox::memory::MemoryPool> GetDefaultWrappedVeloxAggregateMemoryPool();
+
+std::shared_ptr<facebook::velox::memory::MemoryPool> GetDefaultLeafWrappedVeloxMemoryPool();
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -730,7 +730,7 @@ arrow::Status VeloxShuffleWriter::SplitListArray(const velox::RowVector& rv) {
 
     // TODO: rethink the cost of `exportToArrow+ImportArray`
     ArrowArray arrowArray;
-    velox::exportToArrow(column, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
+    velox::exportToArrow(column, arrowArray, GetDefaultLeafWrappedVeloxMemoryPool().get());
 
     auto result = arrow::ImportArray(&arrowArray, arrow_column_types_[col_idx]);
     RETURN_NOT_OK(result);
@@ -766,7 +766,7 @@ arrow::Status VeloxShuffleWriter::SplitBinaryArray(const velox::RowVector& rv) {
 
 arrow::Status VeloxShuffleWriter::VeloxType2ArrowSchema(const velox::TypePtr& type) {
   auto out = std::make_shared<ArrowSchema>();
-  auto rvp = velox::RowVector::createEmpty(type, GetDefaultWrappedVeloxMemoryPool().get());
+  auto rvp = velox::RowVector::createEmpty(type, GetDefaultLeafWrappedVeloxMemoryPool().get());
 
   // get ArrowSchema from velox::RowVector
   velox::exportToArrow(rvp, *out);
@@ -1323,7 +1323,7 @@ arrow::Status VeloxSinglePartShuffleWriter::Split(ColumnarBatch* cb) {
   RETURN_NOT_OK(InitFromRowVector(*vp));
   // 1. convert RowVector to RecordBatch
   ArrowArray arrowArray;
-  velox::exportToArrow(vp, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
+  velox::exportToArrow(vp, arrowArray, GetDefaultLeafWrappedVeloxMemoryPool().get());
 
   auto result = arrow::ImportRecordBatch(&arrowArray, schema_);
   RETURN_NOT_OK(result);

--- a/cpp/velox/tests/ArrowToVeloxTest.cc
+++ b/cpp/velox/tests/ArrowToVeloxTest.cc
@@ -39,14 +39,14 @@ velox::VectorPtr RecordBatch2RowVector(const RecordBatch& rb) {
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
   ASSERT_NOT_OK(ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-  return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
+  return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultLeafWrappedVeloxMemoryPool().get());
 }
 
 void checkBatchEqual(std::shared_ptr<RecordBatch> input_batch, bool checkMetadata = true) {
   velox::VectorPtr vp = RecordBatch2RowVector(*input_batch);
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  velox::exportToArrow(vp, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
+  velox::exportToArrow(vp, arrowArray, GetDefaultLeafWrappedVeloxMemoryPool().get());
   velox::exportToArrow(vp, arrowSchema);
   auto in = gluten::JniGetOrThrow(ImportRecordBatch(&arrowArray, &arrowSchema));
   ASSERT_TRUE(in->Equals(*input_batch, checkMetadata)) << in->ToString() << input_batch->ToString();
@@ -119,7 +119,7 @@ TEST_F(ArrowToVeloxTest, decimalV2A) {
 
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  velox::exportToArrow(row, arrowArray, GetDefaultWrappedVeloxMemoryPool().get());
+  velox::exportToArrow(row, arrowArray, GetDefaultLeafWrappedVeloxMemoryPool().get());
   velox::exportToArrow(row, arrowSchema);
 
   auto in = gluten::JniGetOrThrow(ImportRecordBatch(&arrowArray, &arrowSchema));
@@ -136,7 +136,7 @@ TEST_F(ArrowToVeloxTest, timestampV2A) {
   });
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  EXPECT_ANY_THROW(velox::exportToArrow(row, arrowArray, GetDefaultWrappedVeloxMemoryPool().get()));
+  EXPECT_ANY_THROW(velox::exportToArrow(row, arrowArray, GetDefaultLeafWrappedVeloxMemoryPool().get()));
   velox::exportToArrow(row, arrowSchema);
 }
 

--- a/cpp/velox/tests/ColumnarToRowTest.cc
+++ b/cpp/velox/tests/ColumnarToRowTest.cc
@@ -83,7 +83,7 @@ class ColumnarToRowTest : public ::testing::Test {
     return rb;
   }
 
-  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_ = GetDefaultWrappedVeloxMemoryPool();
+  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_ = GetDefaultLeafWrappedVeloxMemoryPool();
   std::shared_ptr<arrow::MemoryPool> arrowPool_ = GetDefaultWrappedArrowMemoryPool();
 };
 

--- a/cpp/velox/tests/VeloxColumnarToRowTest.cc
+++ b/cpp/velox/tests/VeloxColumnarToRowTest.cc
@@ -40,7 +40,8 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
+    auto vp =
+        velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultLeafWrappedVeloxMemoryPool().get());
     return std::dynamic_pointer_cast<velox::RowVector>(vp);
   }
 
@@ -72,7 +73,7 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
   }
 
  private:
-  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = GetDefaultWrappedVeloxMemoryPool();
+  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = GetDefaultLeafWrappedVeloxMemoryPool();
   std::shared_ptr<arrow::MemoryPool> arrowPool_ = GetDefaultWrappedArrowMemoryPool();
 };
 
@@ -84,7 +85,7 @@ TEST_F(VeloxColumnarToRowTest, timestamp) {
       makeFlatVector<Timestamp>(timeValues),
   });
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto converter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
 
   JniAssertOkOrThrow(
@@ -157,8 +158,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int8_int16) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
 
@@ -191,7 +193,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int32_int64) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -225,7 +227,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_float_double) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -257,7 +259,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool_binary) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -287,7 +289,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_decimal_string) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -318,7 +320,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int64_int64_with_null) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -349,7 +351,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_string) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Write());
@@ -383,7 +385,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool) {
 
   auto row = RecordBatch2VeloxRowVector(*input_batch);
   auto arrowPool = GetDefaultWrappedArrowMemoryPool();
-  auto veloxPool = GetDefaultWrappedVeloxMemoryPool();
+  auto veloxPool = GetDefaultLeafWrappedVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
 
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->Init());

--- a/cpp/velox/tests/VeloxRowToColumnarTest.cc
+++ b/cpp/velox/tests/VeloxRowToColumnarTest.cc
@@ -41,7 +41,8 @@ class VeloxRowToColumnarTest : public ::testing::Test, public test::VectorTestBa
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
+    auto vp =
+        velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultLeafWrappedVeloxMemoryPool().get());
     return std::dynamic_pointer_cast<velox::RowVector>(vp);
   }
 
@@ -74,7 +75,7 @@ class VeloxRowToColumnarTest : public ::testing::Test, public test::VectorTestBa
   }
 
  private:
-  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = GetDefaultWrappedVeloxMemoryPool();
+  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = GetDefaultLeafWrappedVeloxMemoryPool();
   std::shared_ptr<arrow::MemoryPool> arrowPool_ = GetDefaultWrappedArrowMemoryPool();
 };
 

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -218,7 +218,8 @@ std::shared_ptr<ColumnarBatch> RecordBatch2VeloxColumnarBatch(const arrow::Recor
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
   ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-  auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultWrappedVeloxMemoryPool().get());
+  auto vp =
+      velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::GetDefaultLeafWrappedVeloxMemoryPool().get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<velox::RowVector>(vp));
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Velox main change list:
* Refactor UnsafeRowDynamicSerializer.h/UnsafeRowSerializer.h. like remove deserializeComplex function and UnsafeRowDynamicVectorBatchDeserializer class in https://github.com/facebookincubator/velox/pull/4612 and https://github.com/facebookincubator/velox/pull/4610.
* Refactor memory pool related api.  replace `addChild` with `addAggregateChild` and `addLeafChild` in https://github.com/facebookincubator/velox/pull/4629.
* change a little for kPreferredOutputBatchSize config in  https://github.com/facebookincubator/velox/pull/4439.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

