### PR TITLE
[VL] Short decimal should memcpy int64 data to arrow int128

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -514,7 +514,7 @@ arrow::Status VeloxShuffleWriter::SplitFixedWidthValueBuffer(const velox::RowVec
             auto end = partition_2_row_offset_[pid + 1];
             for (; pos < end; ++pos) {
               auto row_id = row_offset_2_row_id_[pos];
-              const uint64_t value = reinterpret_cast<const uint64_t *>(src_addr)[row_id]; // copy
+              const uint64_t value = reinterpret_cast<const uint64_t*>(src_addr)[row_id]; // copy
               memcpy(dst_pid_base, &value, sizeof(uint64_t));
               dst_pid_base += 1;
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/oap-project/gluten/pull/1370 fixed the core dump error for decimal data. However, we found that the correctness of shuffle write is wrong. We cannot directly use SplitFixedType<uint64_t> method to handle short decimal. In velox short decimal is stored in int64, arrow always use int128 to store decimal, so we should copy int64 data to int128 dst.

## How was this patch tested?
Run 1T tpcds, and compare results.


