### PR TITLE
[GLUTEN-1402][ClickHouse-Backend] Fix CHHashAggregate output is error when child is instanceOf InputAdapter.

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -114,8 +114,7 @@ case class CHHashAggregateExecTransformer(
         if (
           (child.find(_.isInstanceOf[Exchange]).isEmpty
             && child.find(_.isInstanceOf[QueryStageExec]).isEmpty)
-          || (child.isInstanceOf[InputAdapter]
-            && child.asInstanceOf[InputAdapter].child.isInstanceOf[UnionExecTransformer])
+          || child.isInstanceOf[InputAdapter]
         ) {
           for (attr <- child.output) {
             typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -720,6 +720,22 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     compareResultsAgainstVanillaSpark(sql, true, df => {})
   }
 
+  test("issue-1402 Logical error: 'Invalid number of columns in chunk pushed to OutputPort.") {
+    val sql =
+      """
+        |SELECT LTRIM(o_orderpriority, '-') ltm, count(*) AS order_count
+        |FROM orders
+        |WHERE o_orderdate >= date '1993-07-01'
+        |  AND o_orderdate < date '1993-07-01' + interval 3 month
+        |  AND EXISTS ( SELECT * FROM lineitem WHERE l_orderkey = o_orderkey
+        |  AND l_commitdate
+        |    < l_receiptdate)
+        |GROUP BY ltm
+        |ORDER BY ltm;
+        |""".stripMargin
+    compareResultsAgainstVanillaSpark(sql, true, df => {})
+  }
+
   override protected def runTPCHQuery(
       queryNum: Int,
       tpchQueries: String = tpchQueries,


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `CHHashAggregateExec` has child is instanceOf InputAdapter. Will use wrong iuput and output

