### PR TITLE
[GLUTEN-1369][Core] Move config 'spark.gluten.enabled' to GlutenConfig from QueryPlanSelector

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.extension.GlutenPlan
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
@@ -252,6 +254,18 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         }
         assert(adaptiveSparkPlanExec.size == 3)
         assert(adaptiveSparkPlanExec(1) == adaptiveSparkPlanExec(2))
+    }
+  }
+
+  test("Test 'spark.gluten.enabled' false") {
+    withSQLConf(("spark.gluten.enabled", "false")) {
+      runTPCHQuery(2) {
+        df =>
+          val glutenPlans = collect(df.queryExecution.executedPlan) {
+            case glutenPlan: GlutenPlan => glutenPlan
+          }
+          assert(glutenPlans.isEmpty)
+      }
     }
   }
 }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.extension.GlutenPlan
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
@@ -718,6 +720,18 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
         |order by n_regionkey
         |""".stripMargin
     compareResultsAgainstVanillaSpark(sql, true, df => {})
+  }
+
+  test("Test 'spark.gluten.enabled' false") {
+    withSQLConf(("spark.gluten.enabled", "false")) {
+      runTPCHQuery(2) {
+        df =>
+          val glutenPlans = df.queryExecution.executedPlan.collect {
+            case glutenPlan: GlutenPlan => glutenPlan
+          }
+          assert(glutenPlans.isEmpty)
+      }
+    }
   }
 
   override protected def runTPCHQuery(

--- a/gluten-core/src/main/scala/io/glutenproject/utils/QueryPlanSelector.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/QueryPlanSelector.scala
@@ -18,6 +18,8 @@
 package io.glutenproject.utils
 
 import io.glutenproject.backendsapi.BackendsApiManager
+
+import io.glutenproject.GlutenConfig
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.QueryPlan
@@ -41,8 +43,6 @@ object LogicalPlanSelector extends QueryPlanSelector[LogicalPlan] {
  * execution.
  */
 abstract class QueryPlanSelector[T <: QueryPlan[_]] extends Logging {
-  var ENABLE_BY_DEFAULT = true
-  val CONF_KEY = "spark.gluten.enabled"
 
   private[this] def stackTrace(max: Int = 5): String = {
     val trim: Int = 6
@@ -59,8 +59,9 @@ abstract class QueryPlanSelector[T <: QueryPlan[_]] extends Logging {
           s"plan:\n${plan.treeString}\n" +
           "=========================")
     }
-    val conf: Option[String] = session.conf.getOption(CONF_KEY)
-    val ret = conf.flatMap((x: String) => Try(x.toBoolean).toOption).getOrElse(ENABLE_BY_DEFAULT)
+    val conf: Option[String] = session.conf.getOption(GlutenConfig.GLUTEN_ENABLE_KEY)
+    val ret = conf.flatMap((x: String) =>
+      Try(x.toBoolean).toOption).getOrElse(GlutenConfig.GLUTEN_ENABLE_BY_DEFAULT)
     logInfo(s"shouldUseGluten: $ret")
     ret & validate(plan)
   }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -16,13 +16,10 @@
  */
 package io.glutenproject
 
-import io.glutenproject.GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY
-
+import com.google.common.collect.ImmutableList
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
-
-import com.google.common.collect.ImmutableList
 
 import java.util
 import java.util.Locale
@@ -295,6 +292,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 }
 
 object GlutenConfig {
+  var GLUTEN_ENABLE_BY_DEFAULT = true
+  val GLUTEN_ENABLE_KEY = "spark.gluten.enabled"
 
   val GLUTEN_LIB_NAME = "spark.gluten.sql.columnar.libname"
   val GLUTEN_LIB_PATH = "spark.gluten.sql.columnar.libpath"

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -16,10 +16,11 @@
  */
 package io.glutenproject
 
-import com.google.common.collect.ImmutableList
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
+
+import com.google.common.collect.ImmutableList
 
 import java.util
 import java.util.Locale


### PR DESCRIPTION
## What changes were proposed in this pull request?
Move the config 'spark.gluten.enabled' to GlutenConfig from QueryPlanSelector

(Fixes: #1369 )

Close #1369 .

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

