### PR TITLE
[GLUTEN-1429][CH] trigger clickhouse CI job on specific files change

### DIFF
--- a/.github/workflows/clickhouse_be_trigger.yml
+++ b/.github/workflows/clickhouse_be_trigger.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+name: Clickhouse Backend Trigger
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'pom.xml'
+      - 'backends-clickhouse/**'
+      - 'gluten-core/**'
+      - 'gluten-ut/**'
+      - 'shims/**'
+      - 'tools/gluten-it/**'
+      - 'tools/gluten-te/**'
+      - 'cpp-ch/**'
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Add comment to PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT="Run Gluten Clickhouse CI"
+          URL=$(jq -r .pull_request.comments_url "$GITHUB_EVENT_PATH")
+          curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d "{\"body\":\"$COMMENT\"}" "${URL}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable trigger gluten Clickhouse CI on specific files change.

## How was this patch tested?

1. Please grant github workflow `read and write permissions` in repo settings.
![AHLtIwJPeC](https://user-images.githubusercontent.com/23639010/233264322-fc38c378-53e5-4c82-8f32-4bbfccee0911.jpg)

2.  Once PR files change may affect Gluten Clickhouse CI,  github workflow `Clickhouse Backend Trigger` with comment this PR, like 
`Run Gluten Clickhouse CI`
![image](https://user-images.githubusercontent.com/23639010/233266542-a7cc9fde-637a-487f-b917-3002d2d840f3.png)

3. Please set jenkins job trigger on specific comment.
![U81Fubt4Ii](https://user-images.githubusercontent.com/23639010/233320060-8bad4af4-e49d-441b-b6b7-9637e6b96a55.jpg)




