### PR TITLE
[GLUTEN-1450] [CH] enable forked repository's GITHUB_TOKEN comment in PR

### DIFF
--- a/.github/workflows/clickhouse_be_trigger.yml
+++ b/.github/workflows/clickhouse_be_trigger.yml
@@ -19,7 +19,7 @@
 name: Clickhouse Backend Trigger
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - '.github/**'
       - 'pom.xml'


### PR DESCRIPTION
## What changes were proposed in this pull request?

According to github actions doc, forked repository's GITHUB_TOKEN only has READ permission. 
see https://docs.github.com/en/actions/security-guides/automatic-token-authentication
![image](https://user-images.githubusercontent.com/23639010/233557997-805aef7a-d441-4a04-835d-92c942e698e3.png)

(Fixes: \#1450)

But when we use pull_reuqest_target, forked repository's PR works.
![image](https://user-images.githubusercontent.com/23639010/233559747-d29f383c-c335-4a9b-9bcf-8454f69ef2b1.png)



