### PR TITLE
[GLUTEN-1474][VL][Fix] Align with spark's cast behavior by allowing decimal

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -215,6 +215,8 @@ void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox
   }
   // To align with Spark's behavior, set casting to int to be truncating.
   configs[velox::core::QueryConfig::kCastIntByTruncate] = std::to_string(true);
+  // To align with Spark's behavior, allow decimal in casting string to int.
+  configs[velox::core::QueryConfig::kCastIntAllowDecimal] = std::to_string(true);
 
   // Spill configs
   configs[velox::core::QueryConfig::kSpillEnabled] = getConfigValue(kSpillEnabled, "true");

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/PHILO-HE/velox.git
-VELOX_BRANCH=test-cast
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=test-cast
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -224,7 +224,7 @@ case class FallbackEmptySchemaRelation() extends Rule[SparkPlan] {
           // Some backends are not eligible to offload plan with zero-column input.
           // If any child have empty output, mark the plan and that child as UNSUPPORTED.
           logWarning(s"May fallback ${p.getClass.toString} and its children because" +
-            s"at least one of its children has empty output.")
+            s" at least one of its children has empty output.")
           TransformHints.tagNotTransformable(p)
           p.children.foreach(child =>
             if (child.output.isEmpty) TransformHints.tagNotTransformable(child))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set a config for velox to correct the cast behavior. The config is newly introduced in a velox patch: https://github.com/oap-project/velox/pull/215

## How was this patch tested?

UT.
