### PR TITLE
[GLUTEN-1199] Avoid throwing exception from destructor of JavaInputStreamAdaptor

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -114,10 +114,10 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
         std::cout << __func__ << " call JavaInputStreamAdaptor::Close() failed, status:" << status.ToString()
                   << std::endl;
 #endif
-        }
+      }
     } catch (std::exception& e) {
 #ifdef GLUTEN_PRINT_DEBUG
-        std::cout << __func__ << " call JavaInputStreamAdaptor::Close() got exception:" << e.what() << std::endl;
+      std::cout << __func__ << " call JavaInputStreamAdaptor::Close() got exception:" << e.what() << std::endl;
 #endif
     }
   }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -107,14 +107,20 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
   }
 
   ~JavaInputStreamAdaptor() override {
-    auto status = JavaInputStreamAdaptor::Close();
-    if (!status.ok()) {
+    try {
+      auto status = JavaInputStreamAdaptor::Close();
+      if (!status.ok()) {
 #ifdef GLUTEN_PRINT_DEBUG
-      std::cout << __func__ << " call JavaInputStreamAdaptor::Close() failed, status:" << status.ToString()
-                << std::endl;
+        std::cout << __func__ << " call JavaInputStreamAdaptor::Close() failed, status:" << status.ToString()
+                  << std::endl;
+#endif
+        }
+    } catch (std::exception& e) {
+#ifdef GLUTEN_PRINT_DEBUG
+        std::cout << __func__ << " call JavaInputStreamAdaptor::Close() got exception:" << e.what() << std::endl;
 #endif
     }
-  };
+  }
 
   // not thread safe
   arrow::Status Close() override {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`HINT: Throw an exception in destructor is dangerous and you should never let the exception leave destructors. If there are two exceptions propagating, the program will terminate or yield undefined behavior.`

inside function Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_make
1. we new object of JavaInputStreamAdaptor
2. we new object of Reader, and constructor of Reader throw an exception
3. inside JNI_METHOD_END, we will catch this exception
But between step2 and step3, destructor of JavaInputStreamAdaptor is called, then we got another exception, the process terminate.

(Fixes: #1199)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

