### PR TITLE
[VL] Adjust batch size to 4096

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -206,6 +206,7 @@ void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox
   std::unordered_map<std::string, std::string> configs = {};
   // Find batch size from Spark confs. If found.
   configs[velox::core::QueryConfig::kPreferredOutputBatchRows] = getConfigValue(kSparkBatchSize, "4096");
+  configs[velox::core::QueryConfig::kMaxOutputBatchRows] = getConfigValue(kSparkBatchSize, "4096");
   // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.
   // FIXME this uses process-wise off-heap memory which is not for task
   try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adjust some configurations for outputBatchRows function to guarantee the return value is close to 4K.
https://github.com/oap-project/velox/blob/main/velox/exec/Operator.cpp#L291-L313

## How was this patch tested?
Jenkens tpch/tpcds test.

Tpch    1406.02 -> 1355.66
Tpcds  1964.01 -> 1955.21