### PR TITLE
[GLUTEN-1537] add source info to nodename

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformerExec.scala
@@ -170,7 +170,15 @@ case class WholeStageTransformerExec(child: SparkPlan)(val transformStageId: Int
   // It's misleading with "Codegen" used. But we have to keep "WholeStageCodegen" prefixed to
   // make whole stage transformer clearly plotted in UI, like spark's whole stage codegen.
   // See buildSparkPlanGraphNode in SparkPlanGraph.scala of Spark.
-  override def nodeName: String = s"WholeStageCodegenTransformer ($transformStageId)"
+  override def nodeName: String = {
+    var fullName = s"WholeStageCodegenTransformer ($transformStageId)"
+    child.foreach(c => {
+      if (c.isInstanceOf[FileSourceScanExecTransformer]) {
+        fullName = c.nodeName + " + " + fullName
+      }
+    })
+    fullName
+  }
 
   override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = {
     child.asInstanceOf[TransformSupport].getBuildPlans


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr add source info to nodename so they can be shown in SparkUI.

(Fixes: \#1537)

## How was this patch tested?

manual tests

This patch involves UI changes:
![image](https://user-images.githubusercontent.com/20960838/235052083-599bdf5f-f208-427d-b9c5-c00a781c858c.png)


