### PR TITLE
[GLUTEN-1205][VL][FOLLOWUP] Refactor shuffle partition writer

### DIFF
--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -191,7 +191,7 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
         shuffle/HashPartitioner.cc
         shuffle/RoundRobinPartitioner.cc
         shuffle/SinglePartPartitioner.cc
-        shuffle/PartitionWriter.cc
+        shuffle/PartitionWriterCreator.cc
         shuffle/LocalPartitionWriter.cc
         shuffle/rss/RemotePartitionWriter.cc
         shuffle/rss/CelebornPartitionWriter.cc

--- a/cpp/core/benchmarks/CompressionBenchmark.cc
+++ b/cpp/core/benchmarks/CompressionBenchmark.cc
@@ -51,7 +51,7 @@ using arrow::RecordBatchReader;
 using arrow::Status;
 using gluten::ArrowShuffleWriter;
 using gluten::GlutenException;
-using gluten::SplitOptions;
+using gluten::ShuffleWriterOptions;
 
 namespace gluten {
 

--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -92,9 +92,14 @@ class Backend : public std::enable_shared_from_this<Backend> {
     return std::make_shared<gluten::RowToColumnarConverter>(cSchema);
   }
 
-  virtual std::shared_ptr<ShuffleWriter>
-  makeShuffleWriter(int numPartitions, const SplitOptions& options, const std::string& batchType) {
-    GLUTEN_ASSIGN_OR_THROW(auto shuffle_writer, ArrowShuffleWriter::create(numPartitions, std::move(options)));
+  virtual std::shared_ptr<ShuffleWriter> makeShuffleWriter(
+      int numPartitions,
+      std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator,
+      const ShuffleWriterOptions& options,
+      const std::string& batchType) {
+    GLUTEN_ASSIGN_OR_THROW(
+        auto shuffle_writer,
+        ArrowShuffleWriter::create(numPartitions, std::move(partitionWriterCreator), std::move(options)));
     return shuffle_writer;
   }
 

--- a/cpp/core/shuffle/ArrowShuffleWriter.h
+++ b/cpp/core/shuffle/ArrowShuffleWriter.h
@@ -26,7 +26,7 @@
 #include <random>
 
 #include "jni/JniCommon.h"
-#include "shuffle/PartitionWriter.h"
+#include "shuffle/PartitionWriterCreator.h"
 #include "shuffle/Partitioner.h"
 #include "shuffle/ShuffleWriter.h"
 #include "shuffle/utils.h"
@@ -48,7 +48,10 @@ class ArrowShuffleWriter final : public ShuffleWriter {
   };
 
  public:
-  static arrow::Result<std::shared_ptr<ArrowShuffleWriter>> create(uint32_t numPartitions, SplitOptions options);
+  static arrow::Result<std::shared_ptr<ArrowShuffleWriter>> create(
+      uint32_t numPartitions,
+      std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator,
+      ShuffleWriterOptions options);
 
   typedef uint32_t row_offset_type;
 
@@ -96,7 +99,11 @@ class ArrowShuffleWriter final : public ShuffleWriter {
   }
 
  protected:
-  ArrowShuffleWriter(int32_t numPartitions, SplitOptions options) : ShuffleWriter(numPartitions, options) {}
+  ArrowShuffleWriter(
+      int32_t numPartitions,
+      std::shared_ptr<PartitionWriterCreator> partitionWriterCreator,
+      ShuffleWriterOptions options)
+      : ShuffleWriter(numPartitions, partitionWriterCreator, options) {}
 
   arrow::Status init();
 

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -22,6 +22,7 @@
 #include "shuffle/PartitionWriter.h"
 #include "shuffle/ShuffleWriter.h"
 
+#include "PartitionWriterCreator.h"
 #include "utils.h"
 #include "utils/macros.h"
 
@@ -29,13 +30,7 @@ namespace gluten {
 
 class LocalPartitionWriter : public ShuffleWriter::PartitionWriter {
  public:
-  static arrow::Result<std::shared_ptr<LocalPartitionWriter>> create(
-      ShuffleWriter* shuffleWriter,
-      int32_t numPartitions);
-
- public:
-  LocalPartitionWriter(ShuffleWriter* shuffleWriter, int32_t numPartitions)
-      : PartitionWriter(shuffleWriter, numPartitions) {}
+  explicit LocalPartitionWriter(ShuffleWriter* shuffleWriter) : PartitionWriter(shuffleWriter) {}
 
   arrow::Status init() override;
 
@@ -63,4 +58,10 @@ class LocalPartitionWriter : public ShuffleWriter::PartitionWriter {
   std::shared_ptr<arrow::ipc::IpcPayload> schema_payload_;
 };
 
+class LocalPartitionWriterCreator : public ShuffleWriter::PartitionWriterCreator {
+ public:
+  LocalPartitionWriterCreator();
+
+  arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> Make(ShuffleWriter* shuffleWriter) override;
+};
 } // namespace gluten

--- a/cpp/core/shuffle/PartitionWriterCreator.cc
+++ b/cpp/core/shuffle/PartitionWriterCreator.cc
@@ -15,21 +15,6 @@
  * limitations under the License.
  */
 
-#include "shuffle/PartitionWriter.h"
-#include "shuffle/LocalPartitionWriter.h"
-#include "shuffle/rss/RemotePartitionWriter.h"
+#include "PartitionWriterCreator.h"
 
-namespace gluten {
-
-arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> ShuffleWriter::PartitionWriter::make(
-    ShuffleWriter* shuffleWriter,
-    int32_t numPartitions) {
-  const std::string& partitionWriterType = shuffleWriter->options().partition_writer_type;
-  if (partitionWriterType == "local") {
-    return LocalPartitionWriter::create(shuffleWriter, numPartitions);
-  } else {
-    return RemotePartitionWriter::Make(shuffleWriter, numPartitions);
-  }
-}
-
-} // namespace gluten
+namespace gluten {} // namespace gluten

--- a/cpp/core/shuffle/PartitionWriterCreator.h
+++ b/cpp/core/shuffle/PartitionWriterCreator.h
@@ -17,22 +17,17 @@
 
 #pragma once
 
+#include "shuffle/PartitionWriter.h"
 #include "shuffle/ShuffleWriter.h"
 
 namespace gluten {
 
-class ShuffleWriter::PartitionWriter {
+class ShuffleWriter::PartitionWriterCreator {
  public:
-  PartitionWriter(ShuffleWriter* shuffleWriter) : shuffleWriter_(shuffleWriter) {}
-  virtual ~PartitionWriter() = default;
+  PartitionWriterCreator() = default;
+  virtual ~PartitionWriterCreator() = default;
 
-  virtual arrow::Status init() = 0;
-
-  virtual arrow::Status evictPartition(int32_t partitionId) = 0;
-
-  virtual arrow::Status stop() = 0;
-
-  ShuffleWriter* shuffleWriter_;
+  virtual arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> Make(ShuffleWriter* shuffleWriter) = 0;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -44,6 +44,10 @@ class ShuffleWriter {
 
   virtual arrow::Status stop() = 0;
 
+  int32_t numPartitions() const {
+    return numPartitions_;
+  }
+
   int64_t totalBytesWritten() const {
     return totalBytesWritten_;
   }
@@ -88,7 +92,7 @@ class ShuffleWriter {
     return combineBuffer_;
   }
 
-  SplitOptions& options() {
+  ShuffleWriterOptions& options() {
     return options_;
   }
 
@@ -124,14 +128,23 @@ class ShuffleWriter {
 
   class Partitioner;
 
+  class PartitionWriterCreator;
+
  protected:
-  ShuffleWriter(int32_t numPartitions, SplitOptions options)
-      : numPartitions_(numPartitions), options_(std::move(options)) {}
+  ShuffleWriter(
+      int32_t numPartitions,
+      std::shared_ptr<PartitionWriterCreator> partitionWriterCreator,
+      ShuffleWriterOptions options)
+      : numPartitions_(numPartitions),
+        partitionWriterCreator_(std::move(partitionWriterCreator)),
+        options_(std::move(options)) {}
   virtual ~ShuffleWriter() = default;
 
   int32_t numPartitions_;
+
+  std::shared_ptr<PartitionWriterCreator> partitionWriterCreator_;
   // options
-  SplitOptions options_;
+  ShuffleWriterOptions options_;
 
   int64_t totalBytesWritten_ = 0;
   int64_t totalBytesEvicted_ = 0;

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.h
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.h
@@ -22,6 +22,7 @@
 #include "shuffle/rss/RemotePartitionWriter.h"
 #include "shuffle/type.h"
 
+#include "shuffle/PartitionWriterCreator.h"
 #include "shuffle/utils.h"
 #include "utils/macros.h"
 
@@ -29,13 +30,10 @@ namespace gluten {
 
 class CelebornPartitionWriter : public RemotePartitionWriter {
  public:
-  static arrow::Result<std::shared_ptr<CelebornPartitionWriter>> create(
-      ShuffleWriter* shuffleWriter,
-      int32_t numPartitions);
-
- private:
-  CelebornPartitionWriter(ShuffleWriter* shuffleWriter, int32_t numPartitions)
-      : RemotePartitionWriter(shuffleWriter, numPartitions) {}
+  CelebornPartitionWriter(ShuffleWriter* shuffleWriter, std::shared_ptr<CelebornClient> celebornClient)
+      : RemotePartitionWriter(shuffleWriter) {
+    celebornClient_ = celebornClient;
+  }
 
   arrow::Status init() override;
 
@@ -50,6 +48,16 @@ class CelebornPartitionWriter : public RemotePartitionWriter {
   std::shared_ptr<arrow::io::BufferOutputStream> celebornBufferOs_;
 
   std::shared_ptr<CelebornClient> celebornClient_;
+};
+
+class CelebornPartitionWriterCreator : public ShuffleWriter::PartitionWriterCreator {
+ public:
+  explicit CelebornPartitionWriterCreator(std::shared_ptr<CelebornClient> client);
+
+  arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> Make(ShuffleWriter* shuffleWriter) override;
+
+ private:
+  std::shared_ptr<CelebornClient> client_;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/rss/RemotePartitionWriter.cc
+++ b/cpp/core/shuffle/rss/RemotePartitionWriter.cc
@@ -16,18 +16,5 @@
  */
 
 #include "shuffle/rss/RemotePartitionWriter.h"
-#include "shuffle/rss/CelebornPartitionWriter.h"
 
-namespace gluten {
-
-arrow::Result<std::shared_ptr<RemotePartitionWriter>> RemotePartitionWriter::Make(
-    ShuffleWriter* shuffleWriter,
-    int32_t numPartitions) {
-  const std::string& partitionWriterType = shuffleWriter->options().partition_writer_type;
-  if (partitionWriterType == "celeborn") {
-    return CelebornPartitionWriter::create(shuffleWriter, numPartitions);
-  }
-  return arrow::Status::NotImplemented("Partition Writer Type " + partitionWriterType + " not supported yet.");
-}
-
-} // namespace gluten
+namespace gluten {} // namespace gluten

--- a/cpp/core/shuffle/rss/RemotePartitionWriter.h
+++ b/cpp/core/shuffle/rss/RemotePartitionWriter.h
@@ -23,13 +23,7 @@ namespace gluten {
 
 class RemotePartitionWriter : public ShuffleWriter::PartitionWriter {
  public:
-  static arrow::Result<std::shared_ptr<RemotePartitionWriter>> Make(
-      ShuffleWriter* shuffleWriter,
-      int32_t numPartitions);
-
- public:
-  RemotePartitionWriter(ShuffleWriter* shuffleWriter, int32_t numPartitions)
-      : PartitionWriter(shuffleWriter, numPartitions) {}
+  explicit RemotePartitionWriter(ShuffleWriter* shuffleWriter) : PartitionWriter(shuffleWriter) {}
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/type.h
+++ b/cpp/core/shuffle/type.h
@@ -45,7 +45,7 @@ struct ReaderOptions {
   static ReaderOptions defaults();
 };
 
-struct SplitOptions {
+struct ShuffleWriterOptions {
   int64_t offheap_per_task = 0;
   int32_t buffer_size = kDefaultShuffleWriterBufferSize;
   int32_t push_buffer_max_size = kDefaultShuffleWriterBufferSize;
@@ -65,13 +65,11 @@ struct SplitOptions {
 
   std::shared_ptr<arrow::MemoryPool> memory_pool = getDefaultArrowMemoryPool();
 
-  std::shared_ptr<CelebornClient> celeborn_client;
-
   arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
 
   std::string partitioning_name;
 
-  static SplitOptions defaults();
+  static ShuffleWriterOptions defaults();
 };
 
 namespace type {

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -167,13 +167,20 @@ std::shared_ptr<RowToColumnarConverter> VeloxBackend::getRowToColumnarConverter(
   return std::make_shared<VeloxRowToColumnarConverter>(cSchema, veloxPool);
 }
 
-std::shared_ptr<ShuffleWriter>
-VeloxBackend::makeShuffleWriter(int numPartitions, const SplitOptions& options, const std::string& batchType) {
+std::shared_ptr<ShuffleWriter> VeloxBackend::makeShuffleWriter(
+    int numPartitions,
+    std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partition_writer_creator,
+    const ShuffleWriterOptions& options,
+    const std::string& batchType) {
   if (batchType == "velox") {
-    GLUTEN_ASSIGN_OR_THROW(auto shuffle_writer, VeloxShuffleWriter::create(numPartitions, std::move(options)));
+    GLUTEN_ASSIGN_OR_THROW(
+        auto shuffle_writer,
+        VeloxShuffleWriter::create(numPartitions, std::move(partition_writer_creator), std::move(options)));
     return shuffle_writer;
   } else {
-    GLUTEN_ASSIGN_OR_THROW(auto shuffle_writer, ArrowShuffleWriter::create(numPartitions, std::move(options)));
+    GLUTEN_ASSIGN_OR_THROW(
+        auto shuffle_writer,
+        ArrowShuffleWriter::create(numPartitions, std::move(partition_writer_creator), std::move(options)));
     return shuffle_writer;
   }
 }

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -51,8 +51,11 @@ class VeloxBackend final : public Backend {
       MemoryAllocator* allocator,
       struct ArrowSchema* cSchema) override;
 
-  std::shared_ptr<ShuffleWriter>
-  makeShuffleWriter(int numPartitions, const SplitOptions& options, const std::string& batchType) override;
+  std::shared_ptr<ShuffleWriter> makeShuffleWriter(
+      int numPartitions,
+      std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partition_writer_creator,
+      const ShuffleWriterOptions& options,
+      const std::string& batchType) override;
 
   std::shared_ptr<Metrics> getMetrics(ColumnarBatchIterator* rawIter, int64_t exportNanos) override {
     auto iter = static_cast<WholeStageResultIterator*>(rawIter);

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -24,6 +24,7 @@
 #include "arrow/array/util.h"
 #include "arrow/result.h"
 
+#include "shuffle/PartitionWriterCreator.h"
 #include "shuffle/Partitioner.h"
 #include "shuffle/ShuffleWriter.h"
 #include "shuffle/utils.h"
@@ -91,7 +92,10 @@ class VeloxShuffleWriter final : public ShuffleWriter {
     uint64_t value_offset;
   };
 
-  static arrow::Result<std::shared_ptr<VeloxShuffleWriter>> create(uint32_t numPartitions, SplitOptions options);
+  static arrow::Result<std::shared_ptr<VeloxShuffleWriter>> create(
+      uint32_t numPartitions,
+      std::shared_ptr<PartitionWriterCreator> partition_writer_creator,
+      ShuffleWriterOptions options);
 
   arrow::Status split(ColumnarBatch* cb) override;
 
@@ -160,7 +164,11 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   }
 
  protected:
-  VeloxShuffleWriter(uint32_t numPartitions, const SplitOptions& options) : ShuffleWriter(numPartitions, options) {}
+  VeloxShuffleWriter(
+      uint32_t numPartitions,
+      std::shared_ptr<PartitionWriterCreator> partition_writer_creator,
+      const ShuffleWriterOptions& options)
+      : ShuffleWriter(numPartitions, partition_writer_creator, options) {}
 
   arrow::Status init();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Change SplitOptions to ShuffleWriterOptions.
2. Remove num_partitions from PartitionWriter's constructor, and add NumPartitions() function in ShuffleWriter.
3. Add parent class RssClient for CelebornClient to support clients of multiple RSS engines.
4. Remove celeborn_client in ShuffleWriterOptions, and add PartitionWriterCreator to receive instantiated RssClient.

