### PR TITLE
[GLUTEN-1543] Use Spark's function name for substrait mapping if not supported by substrait

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHValidatorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHValidatorApi.scala
@@ -62,18 +62,8 @@ class CHValidatorApi extends ValidatorApi with AdaptiveSparkPlanHelper {
       case _ =>
     }
 
-    true
-  }
-
-  /**
-   * Validate aggregate function for specific backend. If the aggregate function isn't implemented
-   * by the backend, it will fall back to Vanilla Spark.
-   */
-  override def doAggregateFunctionValidate(
-      substraitFuncName: String,
-      func: AggregateFunction): Boolean = {
     if (CHExpressionUtil.CH_AGGREGATE_FUNC_BLACKLIST.isEmpty) return true
-    val value = CHExpressionUtil.CH_AGGREGATE_FUNC_BLACKLIST.get(substraitFuncName)
+    val value = CHExpressionUtil.CH_AGGREGATE_FUNC_BLACKLIST.get(substraitExprName)
     if (value.isEmpty) {
       return true
     }
@@ -83,13 +73,14 @@ class CHValidatorApi extends ValidatorApi with AdaptiveSparkPlanHelper {
         if (inputTypeName.equals(CHExpressionUtil.EMPTY_TYPE)) {
           return false
         } else {
-          for (input <- func.children) {
+          for (input <- expr.children) {
             if (inputTypeName.equals(input.dataType.typeName)) {
               return false
             }
           }
         }
     }
+
     true
   }
 

--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -51,4 +51,5 @@ object CHExpressionUtil {
     COVAR_POP -> Set(EMPTY_TYPE),
     COVAR_SAMP -> Set(EMPTY_TYPE)
   )
+
 }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -47,6 +47,9 @@ object CHExpressionUtil {
     VAR_SAMP -> Set(EMPTY_TYPE),
     VAR_POP -> Set(EMPTY_TYPE),
     BLOOM_FILTER_AGG -> Set(EMPTY_TYPE),
+    BIT_OR_AGG -> Set(EMPTY_TYPE),
+    BIT_AND_AGG -> Set(EMPTY_TYPE),
+    BIT_XOR_AGG -> Set(EMPTY_TYPE),
     CORR -> Set(EMPTY_TYPE),
     COVAR_POP -> Set(EMPTY_TYPE),
     COVAR_SAMP -> Set(EMPTY_TYPE)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -38,9 +38,7 @@ class VeloxBackend extends Backend {
   override def sparkPlanExecApi(): SparkPlanExecApi = new VeloxSparkPlanExecApi
   override def transformerApi(): TransformerApi = new VeloxTransformerApi
   override def validatorApi(): ValidatorApi = new VeloxValidatorApi
-
   override def metricsApi(): MetricsApi = new VeloxMetricsApi
-
   override def settings(): BackendSettings = VeloxBackendSettings
 }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxTransformerApi.scala
@@ -19,5 +19,4 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.backendsapi.glutendata.GlutenTransformerApi
 
-class VeloxTransformerApi extends GlutenTransformerApi {
-}
+class VeloxTransformerApi extends GlutenTransformerApi {}

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxValidatorApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxValidatorApi.scala
@@ -25,8 +25,4 @@ class VeloxValidatorApi extends GlutenValidatorApi {
 
   // Validation is handled in native validator for Velox backend.
   override def doExprValidate(substraitExprName: String, expr: Expression): Boolean = true
-
-  // Validation is handled in native validator for Velox backend.
-  override def doAggregateFunctionValidate(substraitFuncName: String,
-                                           func: AggregateFunction): Boolean = true
 }

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/Yohahaha/velox.git
+VELOX_BRANCH=gluten1543
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/Yohahaha/velox.git
-VELOX_BRANCH=gluten1543
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
@@ -31,7 +31,7 @@ object BackendsApiManager {
       sparkPlanExecApiInstance: SparkPlanExecApi,
       transformerApiInstance: TransformerApi,
       validatorApiInstance: ValidatorApi,
-      metricsApi: MetricsApi,
+      metricsApiInstance: MetricsApi,
       settings: BackendSettings)
 
   private lazy val manager: Wrapper = initializeInternal()
@@ -98,7 +98,7 @@ object BackendsApiManager {
   }
 
   def getMetricsApiInstance: MetricsApi = {
-    manager.metricsApi
+    manager.metricsApiInstance
   }
 
   def getSettings: BackendSettings = {

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
@@ -19,7 +19,6 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.substrait.plan.PlanNode
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.StructType
 
@@ -38,24 +37,6 @@ trait ValidatorApi {
    * @return true by default
    */
   def doExprValidate(substraitExprName: String, expr: Expression): Boolean = true
-
-  /**
-   * Validate aggregate function for specific backend.
-   * If the aggregate function isn't implemented by the backend,
-   * it will fall back to Vanilla Spark.
-   */
-  def doAggregateFunctionValidate(substraitFuncName: String,
-    func: AggregateFunction
-  ): Boolean = doAggregateFunctionValidate(Map(), substraitFuncName, func)
-
-  /**
-   * Validate aggregate function for specific backend.
-   * If the aggregate function isn't implemented by the backend,
-   * it will fall back to Vanilla Spark.
-   */
-  def doAggregateFunctionValidate(blacklist: Map[String, Set[String]],
-    substraitFuncName: String,
-    func: AggregateFunction): Boolean = true
 
   /**
    * Validate against a whole Spark plan, before being interpreted by Gluten.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -33,7 +33,6 @@ import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate._
@@ -67,10 +66,9 @@ abstract class HashAggregateExecBaseTransformer(
     BackendsApiManager.getMetricsApiInstance.genHashAggregateTransformerMetrics(sparkContext)
 
   val sparkConf = sparkContext.getConf
-  val resAttributes: Seq[Attribute] = resultExpressions.map(_.toAttribute)
 
   // The direct outputs of Aggregation.
-  protected val allAggregateResultAttributes: List[Attribute] = {
+  lazy protected val allAggregateResultAttributes: List[Attribute] = {
     val groupingAttributes = groupingExpressions.map(expr => {
       ConverterUtils.getAttrFromExpr(expr).toAttribute
     })

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -150,11 +150,8 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
             val frame = wExpression.windowSpec.
                       frameSpecification.asInstanceOf[SpecifiedWindowFrame]
             val aggregateFunc = aggExpression.aggregateFunction
-            val substraitAggFuncName =
-              ExpressionMappings.aggregate_functions_map.get(aggregateFunc.getClass)
-            // Check whether each backend supports this aggregate function
-            if (!BackendsApiManager.getValidatorApiInstance.doAggregateFunctionValidate(
-              substraitAggFuncName.get, aggregateFunc)) {
+            val substraitAggFuncName = ExpressionMappings.expressionsMap.get(aggregateFunc.getClass)
+            if (substraitAggFuncName.isEmpty) {
               throw new UnsupportedOperationException(s"Not currently supported: $aggregateFunc.")
             }
 
@@ -214,7 +211,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     // Sort By Expressions
     val sortFieldList = new util.ArrayList[SortField]()
     sortOrder.map(order => {
-      val builder = SortField.newBuilder();
+      val builder = SortField.newBuilder()
       val exprNode = ExpressionConverter
         .replaceWithExpressionTransformer(order.child, attributeSeq = child.output)
         .doTransform(args)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -19,6 +19,7 @@ package io.glutenproject.expression
 
 import java.util.Locale
 
+import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.{BasicScanExecTransformer, BatchScanExecTransformer, FileSourceScanExecTransformer}
 import io.glutenproject.substrait.`type`._
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
@@ -33,7 +34,6 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.collection.JavaConverters._
-import scala.util.control.Breaks.{break, breakable}
 
 object ConverterUtils extends Logging {
 
@@ -349,6 +349,7 @@ object ConverterUtils extends Logging {
       case other =>
         throw new UnsupportedOperationException(s"$other is not supported.")
     }
+
     for (idx <- datatypes.indices) {
       typedFuncName = typedFuncName.concat(getTypeSigName(datatypes(idx)))
       // For the last item, no need to append _.

--- a/gluten-core/src/main/scala/io/glutenproject/expression/TernaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/TernaryExpressionTransformer.scala
@@ -18,13 +18,12 @@
 package io.glutenproject.expression
 
 import com.google.common.collect.Lists
-
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, IfThenNode, IntLiteralNode, StringLiteralNode}
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Expression, StringLocate, StringTranslate}
+import org.apache.spark.sql.catalyst.expressions.{Expression, IsNull, StringLocate, StringTranslate}
 import org.apache.spark.sql.types.IntegerType
 import io.glutenproject.substrait.`type`.TypeBuilder
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
@@ -274,7 +274,7 @@ case class Md5Transformer(substraitExprName: String, child: ExpressionTransforme
           FunctionConfig.OPT))
       val md5ChildNode = child.doTransform(args)
       val md5ExprNodes = Lists.newArrayList(md5ChildNode)
-      /// In CH, the output type of md5 is FixedString(16)
+      // In CH, the output type of md5 is FixedString(16)
       val md5TypeNode = TypeBuilder.makeFixedChar(original.nullable, 16)
       val md5FuncNode = ExpressionBuilder.makeScalarFunction(md5FuncId, md5ExprNodes, md5TypeNode)
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/WindowFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/WindowFunctionsBuilder.scala
@@ -17,6 +17,7 @@
 
 package io.glutenproject.expression
 
+import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.expression.ExpressionBuilder
 import org.apache.spark.sql.catalyst.expressions.{Expression, WindowExpression, WindowFunction}
@@ -26,17 +27,17 @@ import scala.util.control.Breaks.{break, breakable}
 object WindowFunctionsBuilder {
   def create(args: java.lang.Object, windowFunc: WindowFunction): Long = {
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val substraitFunc = ExpressionMappings.window_functions_map.get(windowFunc.getClass)
-    if (substraitFunc.isDefined) {
-      val functionName = ConverterUtils.makeFuncName(
-        substraitFunc.get,
-        Seq(windowFunc.dataType),
-        FunctionConfig.OPT)
-      ExpressionBuilder.newScalarFunction(functionMap, functionName)
-    } else {
+    val substraitFunc = ExpressionMappings.expressionsMap.get(windowFunc.getClass)
+    if (substraitFunc.isEmpty) {
       throw new UnsupportedOperationException(
         s"not currently supported: ${windowFunc.getClass.getName}.")
     }
+
+    val functionName = ConverterUtils.makeFuncName(
+      substraitFunc.get,
+      Seq(windowFunc.dataType),
+      FunctionConfig.OPT)
+    ExpressionBuilder.newScalarFunction(functionMap, functionName)
   }
 
   def extractWindowExpression(expr: Expression): WindowExpression = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use Spark's function name for substrait function mapping if some function has not supported by substrait.
Each backend should add their own expression mapping by itself.

Remove validateAggregateFunction method, it could be validated in expression.

Fixes: #1543 

