### PR TITLE
[GLUTEN-1551][VL][Fix] Trim leading/tailing white space in casting string to int

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -214,6 +214,8 @@ void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox
     configs[velox::core::QueryConfig::kCastIntByTruncate] = std::to_string(true);
     // To align with Spark's behavior, allow decimal in casting string to int.
     configs[velox::core::QueryConfig::kCastIntAllowDecimal] = std::to_string(true);
+    // To align with Spark's behavior, trim leading and trailing white space.
+    configs[velox::core::QueryConfig::kCastIntTrimWhitespace] = std::to_string(true);
 
     // Set the max memory of partial aggregation as 3/4 of offheap size.
     auto maxMemory =

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=fix-cast-with-trim
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix semantic issues in cast function. This PR depends on https://github.com/oap-project/velox/pull/235.

## How was this patch tested?

Test under velox lib.
