### PR TITLE
[VL] Install deps to system as needed while building velox

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -71,10 +71,19 @@ function compile {
   COMPILE_TYPE=$(if [[ "$BUILD_TYPE" == "debug" ]] || [[ "$BUILD_TYPE" == "Debug" ]]; then echo 'debug'; else echo 'release'; fi)
   echo "COMPILE_OPTION: "$COMPILE_OPTION
   make $COMPILE_TYPE EXTRA_CMAKE_FLAGS="${COMPILE_OPTION}"
-  echo "INSTALL xsimd gtest."
-  cd _build/$COMPILE_TYPE/_deps
-  sudo cmake --install xsimd-build/
-  sudo cmake --install gtest-build/
+
+  # Install deps to system as needed
+  if [ -d "_build/$COMPILE_TYPE/_deps" ]; then
+    cd _build/$COMPILE_TYPE/_deps
+    if [ -d xsimd-build ]; then
+      echo "INSTALL xsimd."
+      sudo cmake --install xsimd-build/
+    fi
+    if [ -d gtest-build ]; then
+      echo "INSTALL gtest."
+      sudo cmake --install gtest-build/
+    fi
+  fi
 }
 
 function check_commit {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip installing xsimd and gtest if they are not built in velox project.

Required by https://github.com/oap-project/velox/pull/185

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

