### PR TITLE
[GLUTEN-1582][CH] Improve txt/json read by use native engine

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -112,6 +112,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.starburst.openx.data</groupId>
+      <artifactId>json-serde</artifactId>
+      <version>1.3.9-e.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -20,7 +20,7 @@ import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi._
 import io.glutenproject.expression.WindowFunctionsBuilder
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{MergeTreeReadFormat, OrcReadFormat, ParquetReadFormat}
+import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{JsonReadFormat, MergeTreeReadFormat, OrcReadFormat, ParquetReadFormat, TextReadFormat}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Alias, DenseRank, Lag, Lead, NamedExpression, Rank, RowNumber}
@@ -93,6 +93,8 @@ object CHBackendSettings extends BackendSettings with Logging {
       case ParquetReadFormat => validateFilePath
       case OrcReadFormat => true
       case MergeTreeReadFormat => true
+      case TextReadFormat => true
+      case JsonReadFormat => true
       case _ => false
     }
   }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -53,8 +53,35 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
       "extraTime" -> SQLMetrics.createTimingMetric(sparkContext, "extra operators time")
     )
 
+  override def genHiveTableScanTransformerMetrics(
+      sparkContext: SparkContext): Map[String, SQLMetric] =
+    Map(
+      "inputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
+      "inputVectors" -> SQLMetrics.createMetric(sparkContext, "number of input vectors"),
+      "inputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of input bytes"),
+      "rawInputRows" -> SQLMetrics.createMetric(sparkContext, "number of raw input rows"),
+      "rawInputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of raw input bytes"),
+      "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+      "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
+      "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
+      "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"),
+      "inputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for data"),
+      "outputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for output"),
+      "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files read"),
+      "metadataTime" -> SQLMetrics.createTimingMetric(sparkContext, "metadata time"),
+      "filesSize" -> SQLMetrics.createSizeMetric(sparkContext, "size of files read"),
+      "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions read"),
+      "pruningTime" ->
+        SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time"),
+      "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+      "extraTime" -> SQLMetrics.createTimingMetric(sparkContext, "extra operators time")
+    )
+
   override def genBatchScanTransformerMetricsUpdater(
       metrics: Map[String, SQLMetric]): MetricsUpdater = new BatchScanMetricsUpdater(metrics)
+
+  override def genHiveTableScanTransformerMetricsUpdater(
+      metrics: Map[String, SQLMetric]): MetricsUpdater = new HiveTableScanMetricsUpdater(metrics)
 
   override def genFileSourceScanTransformerMetrics(
       sparkContext: SparkContext): Map[String, SQLMetric] =

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -48,6 +48,7 @@ import org.apache.spark.sql.execution.joins.{BuildSideRelation, ClickHouseBuildS
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.utils.CHExecUtil
 import org.apache.spark.sql.extension.ClickHouseAnalysis
+import org.apache.spark.sql.hive.CHHiveTableScanExecTransformer
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -379,4 +380,14 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
     new CHSha1Transformer(substraitExprName, child, original)
   }
 
+  /**
+   * Generate an BasicScanExecTransformer to transfrom hive table scan. Currently only for CH
+   * backend.
+   * @param child
+   * @return
+   */
+  override def genHiveTableScanExecTransformer(
+      child: SparkPlan): Option[HiveTableScanExecTransformer] = {
+    CHHiveTableScanExecTransformer.transform(child)
+  }
 }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.metrics
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+
+class HiveTableScanMetricsUpdater(val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+
+  val scanTime: SQLMetric = metrics("scanTime")
+  val outputRows: SQLMetric = metrics("outputRows")
+  val outputVectors: SQLMetric = metrics("outputVectors")
+  val outputBytes: SQLMetric = metrics("outputBytes")
+  val inputRows: SQLMetric = metrics("inputRows")
+  val inputBytes: SQLMetric = metrics("inputBytes")
+  val extraTime: SQLMetric = metrics("extraTime")
+  val inputWaitTime: SQLMetric = metrics("inputWaitTime")
+  val outputWaitTime: SQLMetric = metrics("outputWaitTime")
+
+  override def updateInputMetrics(inputMetrics: InputMetricsWrapper): Unit = {}
+
+  override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
+    if (opMetrics != null) {
+      val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
+      if (!operatorMetrics.metricsList.isEmpty) {
+        val metricsData = operatorMetrics.metricsList.get(0)
+        scanTime += (metricsData.time / 1000L).toLong
+        inputWaitTime += (metricsData.inputWaitTime / 1000L).toLong
+        outputWaitTime += (metricsData.outputWaitTime / 1000L).toLong
+        outputVectors += metricsData.outputVectors
+        MetricsUtil.updateExtraTimeMetric(
+          metricsData,
+          extraTime,
+          outputRows,
+          outputBytes,
+          inputRows,
+          inputBytes,
+          HiveTableScanMetricsUpdater.INCLUDING_PROCESSORS,
+          HiveTableScanMetricsUpdater.CH_PLAN_NODE_NAME
+        )
+      }
+    }
+  }
+}
+
+object HiveTableScanMetricsUpdater {
+  val INCLUDING_PROCESSORS = Array("MergeTreeInOrder", "SubstraitFileSource")
+  val CH_PLAN_NODE_NAME = Array("MergeTreeInOrder", "SubstraitFileSource")
+}

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
@@ -19,7 +19,8 @@ package io.glutenproject.metrics
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 
-class HiveTableScanMetricsUpdater(val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+class HiveTableScanMetricsUpdater(@transient val metrics: Map[String, SQLMetric])
+  extends MetricsUpdater {
 
   val scanTime: SQLMetric = metrics("scanTime")
   val outputRows: SQLMetric = metrics("outputRows")

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/hive/CHHiveTableScanExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/hive/CHHiveTableScanExecTransformer.scala
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.execution.{HiveTableScanExecTransformer, TransformContext}
+import io.glutenproject.metrics.MetricsUpdater
+import io.glutenproject.sql.shims.SparkShimLoader
+import io.glutenproject.substrait.SubstraitContext
+import io.glutenproject.substrait.rel.ReadRelNode
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, DynamicPruningExpression, Expression}
+import org.apache.spark.sql.connector.read.{InputPartition, SupportsRuntimeFiltering}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, InMemoryFileIndex}
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.execution.datasources.v2.json.JsonScan
+import org.apache.spark.sql.execution.datasources.v2.text.TextScan
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.hive.execution.HiveTableScanExec
+import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import org.apache.hadoop.fs.Path
+
+import scala.collection.JavaConverters
+import scala.collection.mutable.ArrayBuffer
+
+class CHHiveTableScanExecTransformer(
+    requestedAttributes: Seq[Attribute],
+    relation: HiveTableRelation,
+    partitionPruningPred: Seq[Expression])(session: SparkSession)
+  extends HiveTableScanExec(requestedAttributes, relation, partitionPruningPred)(session)
+  with HiveTableScanExecTransformer {
+
+  @transient lazy val scan: Option[FileScan] = getHiveTableFileScan
+
+  @transient override lazy val metrics: Map[String, SQLMetric] =
+    BackendsApiManager.getMetricsApiInstance.genHiveTableScanTransformerMetrics(sparkContext)
+
+  override def filterExprs(): Seq[Expression] = Seq.empty
+
+  override def outputAttributes(): Seq[Attribute] = output
+
+  override def getPartitions: Seq[Seq[InputPartition]] = filteredPartitions
+
+  override def getFlattenPartitions: Seq[InputPartition] = filteredPartitions.flatten
+
+  override def getPartitionSchemas: StructType = relation.tableMeta.partitionSchema
+
+  override def getScan: Option[FileScan] = scan
+
+  override def getInputFilePaths: Seq[String] = {
+    val inputPaths = scan match {
+      case fileScan: FileScan => fileScan.fileIndex.inputFiles.toSeq
+      case _ => Seq.empty
+    }
+    inputPaths
+  }
+
+  /**
+   * Returns all the RDDs of ColumnarBatch which generates the input rows.
+   *
+   * @note
+   *   Right now we support up to two RDDs
+   */
+  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
+    Seq.empty
+  }
+
+  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = {
+    Seq((this, null))
+  }
+
+  override def getStreamedLeafPlan: SparkPlan = {
+    this
+  }
+
+  override def metricsUpdater(): MetricsUpdater =
+    BackendsApiManager.getMetricsApiInstance.genBatchScanTransformerMetricsUpdater(metrics)
+
+  override def supportsColumnar(): Boolean = GlutenConfig.getConf.enableColumnarIterator
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    doExecuteColumnarInternal()
+  }
+
+  private val filteredPartitions: Seq[Seq[InputPartition]] = {
+    scan match {
+      case Some(f) =>
+        val dataSourceFilters = partitionPruningPred.flatMap {
+          case DynamicPruningExpression(e) => DataSourceStrategy.translateRuntimeFilter(e)
+          case _ => None
+        }
+        if (dataSourceFilters.nonEmpty) {
+          // the cast is safe as runtime filters are only assigned if the scan can be filtered
+          val filterableScan = f.asInstanceOf[SupportsRuntimeFiltering]
+          filterableScan.filter(dataSourceFilters.toArray)
+          // call toBatch again to get filtered partitions
+          val newPartitions = f.toBatch.planInputPartitions()
+          newPartitions.map(Seq(_))
+        } else {
+          f.toBatch().planInputPartitions().map(Seq(_))
+        }
+      case _ =>
+        Seq.empty
+    }
+  }
+
+  private def getHiveTableFileScan: Option[FileScan] = {
+    val tableMeta = relation.tableMeta
+    val fileIndex = new InMemoryFileIndex(
+      session,
+      Seq.apply(new Path(tableMeta.location)),
+      Map.empty,
+      Option.apply(tableMeta.schema))
+    val planOutput =
+      if (output.nonEmpty) output.asInstanceOf[Seq[AttributeReference]]
+      else relation.dataCols
+    var hasComplexType = false
+    val outputFieldTypes = new ArrayBuffer[StructField]()
+    planOutput.foreach(
+      x => {
+        hasComplexType = if (!hasComplexType) {
+          x.dataType.isInstanceOf[StructType] ||
+          x.dataType.isInstanceOf[MapType] ||
+          x.dataType.isInstanceOf[ArrayType]
+        } else hasComplexType
+        outputFieldTypes.append(StructField(x.name, x.dataType))
+      })
+    tableMeta.storage.inputFormat match {
+      case Some("org.apache.hadoop.mapred.TextInputFormat") =>
+        tableMeta.storage.serde match {
+          case Some("org.openx.data.jsonserde.JsonSerDe") =>
+            Option.apply(
+              JsonScan(
+                session,
+                fileIndex,
+                tableMeta.schema,
+                StructType(outputFieldTypes.toArray),
+                tableMeta.partitionSchema,
+                new CaseInsensitiveStringMap(JavaConverters.mapAsJavaMap(tableMeta.properties)),
+                Array.empty,
+                partitionPruningPred,
+                Seq.empty
+              ))
+          case _ =>
+            val scan = SparkShimLoader.getSparkShims.getTextScan(
+              session,
+              fileIndex,
+              tableMeta.schema,
+              StructType(outputFieldTypes.toArray),
+              tableMeta.partitionSchema,
+              new CaseInsensitiveStringMap(JavaConverters.mapAsJavaMap(tableMeta.properties)),
+              partitionPruningPred,
+              Seq.empty
+            )
+            if (!hasComplexType) {
+              Option.apply(scan)
+            } else {
+              Option.empty
+            }
+        }
+      case _ => Option.empty
+    }
+  }
+
+  override def doTransform(context: SubstraitContext): TransformContext = {
+    val transformCtx = super.doTransform(context)
+    if (
+      transformCtx.root != null
+      && transformCtx.root.isInstanceOf[ReadRelNode]
+      && scan.get.isInstanceOf[TextScan]
+    ) {
+      val readRelNode = transformCtx.root.asInstanceOf[ReadRelNode]
+      readRelNode.setDataSchema(relation.tableMeta.dataSchema)
+      readRelNode.setProperties(JavaConverters.mapAsJavaMap(relation.tableMeta.storage.properties))
+    }
+    transformCtx
+  }
+}
+
+object CHHiveTableScanExecTransformer {
+
+  def transform(plan: SparkPlan): Option[HiveTableScanExecTransformer] = {
+    if (!plan.isInstanceOf[HiveTableScanExec]) {
+      return Option.empty
+    }
+    val hiveTableScan = plan.asInstanceOf[HiveTableScanExec]
+    val hiveTableScanTransformer = new CHHiveTableScanExecTransformer(
+      hiveTableScan.requestedAttributes,
+      hiveTableScan.relation,
+      hiveTableScan.partitionPruningPred)(hiveTableScan.session)
+    if (hiveTableScanTransformer.scan == null) {
+      Option.empty
+    } else {
+      Option.apply(hiveTableScanTransformer)
+    }
+  }
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.execution
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.utils.UTSystemParameters
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, GlutenQueryTest, Row, SparkSession}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.test.SharedSparkSession
+
+import org.scalatest.BeforeAndAfterAll
+
+case class AllDataTypesWithComplextType(
+    string_field: String,
+    int_field: java.lang.Integer,
+    long_field: java.lang.Long,
+    float_field: java.lang.Float,
+    double_field: java.lang.Double,
+    short_field: java.lang.Short,
+    byte_field: java.lang.Byte,
+    boolean_field: java.lang.Boolean,
+    decimal_field: java.math.BigDecimal,
+    date_field: java.sql.Date,
+    array: Seq[Int],
+    arrayContainsNull: Seq[Option[Int]],
+    map: Map[Int, Long],
+    mapValueContainsNull: Map[Int, Option[Long]]
+)
+
+class GlutenClickHouseHiveTableSuite(var testAppName: String)
+  extends GlutenQueryTest
+  with AdaptiveSparkPlanHelper
+  with SharedSparkSession
+  with BeforeAndAfterAll {
+
+  override protected def sparkConf: SparkConf = {
+    new SparkConf()
+      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
+      .set("spark.memory.offHeap.enabled", "true")
+      .set("spark.memory.offHeap.size", "536870912")
+      .set("spark.sql.catalogImplementation", "hive")
+      .set("spark.sql.adaptive.enabled", "true")
+      .set("spark.sql.files.maxPartitionBytes", "1g")
+      .set("spark.serializer", "org.apache.spark.serializer.JavaSerializer")
+      .set("spark.sql.shuffle.partitions", "5")
+      .set("spark.sql.adaptive.enabled", "false")
+      .set("spark.sql.files.minPartitionNum", "1")
+      .set(
+        "spark.sql.catalog.spark_catalog",
+        "org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog")
+      .set("spark.databricks.delta.maxSnapshotLineageLength", "20")
+      .set("spark.databricks.delta.snapshotPartitions", "1")
+      .set("spark.databricks.delta.properties.defaults.checkpointInterval", "5")
+      .set("spark.databricks.delta.stalenessLimit", "3600000")
+      .set("spark.gluten.sql.columnar.columnartorow", "true")
+      .set("spark.gluten.sql.columnar.backend.ch.worker.id", "1")
+      .set(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
+      .set("spark.gluten.sql.columnar.iterator", "true")
+      .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
+      .set("spark.gluten.sql.enable.native.validation", "false")
+      .set("spark.gluten.sql.columnar.forceshuffledhashjoin", "true")
+      .set(
+        "spark.sql.warehouse.dir",
+        getClass.getResource("/").getPath + "unit-tests-working-home/spark-warehouse")
+      .setMaster("local[*]")
+  }
+
+  override protected def spark: SparkSession = {
+    SparkSession
+      .builder()
+      .config(sparkConf)
+      .enableHiveSupport()
+      .getOrCreate()
+  }
+
+  private val txt_table_name = "hive_txt_test"
+  private val json_table_name = "hive_json_test"
+  private val txt_table_create_sql = "create table if not exists %s (".format(txt_table_name) +
+    "string_field string," +
+    "int_field int," +
+    "long_field long," +
+    "float_field float," +
+    "double_field double," +
+    "short_field short," +
+    "byte_field byte," +
+    "bool_field boolean," +
+    "decimal_field decimal(23, 12)," +
+    "date_field date," +
+    "array_field array<int>," +
+    "array_field_with_null array<int>," +
+    "map_field map<int, long>," +
+    "map_field_with_null map<int, long>) stored as textfile"
+  private val json_table_create_sql = "create table if not exists %s (".format(json_table_name) +
+    "string_field string," +
+    "int_field int," +
+    "long_field long," +
+    "float_field float," +
+    "double_field double," +
+    "short_field short," +
+    "byte_field byte," +
+    "bool_field boolean," +
+    "decimal_field decimal(23, 12)," +
+    "date_field date," +
+    "array_field array<int>," +
+    "array_field_with_null array<int>," +
+    "map_field map<int,long>," +
+    "map_field_with_null map<int,long>) " +
+    "ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'" +
+    "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'" +
+    "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'"
+
+  def genTestData(): Seq[AllDataTypesWithComplextType] = {
+    (0 to 199).map {
+      i =>
+        AllDataTypesWithComplextType(
+          s"$i",
+          i,
+          i.toLong,
+          i.toFloat,
+          i.toDouble,
+          i.toShort,
+          i.toByte,
+          i % 2 == 0,
+          new java.math.BigDecimal(i + ".56"),
+          new java.sql.Date(System.currentTimeMillis()),
+          Seq.apply(i + 1, i + 2, i + 3),
+          Seq.apply(Option.apply(i + 1), Option.empty, Option.apply(i + 3)),
+          Map.apply((i + 1, i + 2), (i + 3, i + 4)),
+          Map.empty
+        )
+    }
+  }
+
+  protected def initializeTable(table_name: String, table_create_sql: String): Unit = {
+    spark.createDataFrame(genTestData()).createOrReplaceTempView("tmp_t")
+    val truncate_sql = "truncate table %s".format(table_name)
+    spark.sql(table_create_sql)
+    spark.sql(truncate_sql)
+    spark.sql("insert into %s select * from tmp_t".format(table_name))
+  }
+
+  def this() {
+    this("GlutenClickHouseHiveTableTest")
+  }
+
+  protected def vanillaSparkConfs(): Seq[(String, String)] = {
+    List(("spark.gluten.enabled", "false"))
+  }
+
+  override protected def beforeAll(): Unit = {
+    initializeTable(txt_table_name, txt_table_create_sql)
+    initializeTable(json_table_name, json_table_create_sql)
+  }
+
+  override def afterAll(): Unit = {
+    spark.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+  }
+
+  /**
+   * run a query with native engine as well as vanilla spark then compare the result set for
+   * correctness check
+   */
+  protected def compareResultsAgainstVanillaSpark(
+      sqlStr: String,
+      compareResult: Boolean = true,
+      customCheck: DataFrame => Unit): DataFrame = {
+    var expected: Seq[Row] = null
+    withSQLConf(vanillaSparkConfs(): _*) {
+      val df = spark.sql(sqlStr)
+      expected = df.collect()
+    }
+    val df = spark.sql(sqlStr)
+    if (compareResult) {
+      checkAnswer(df, expected)
+    }
+    customCheck(df)
+    df
+  }
+
+  test("test hive text table") {
+    val sql =
+      s"""
+         | select string_field,
+         |        sum(int_field),
+         |        avg(long_field),
+         |        min(float_field),
+         |        max(double_field),
+         |        sum(short_field),
+         |        sum(decimal_field)
+         | from $txt_table_name
+         | group by string_field
+         | order by string_field
+         |""".stripMargin
+    compareResultsAgainstVanillaSpark(
+      sql,
+      true,
+      df => {
+        val txtFileScan = collect(df.queryExecution.executedPlan) {
+          case l: HiveTableScanExecTransformer => l
+        }
+        assert(txtFileScan.size == 1)
+      })
+  }
+
+  test("test hive json table") {
+    val sql =
+      s"""
+         | select string_field,
+         |        sum(int_field),
+         |        avg(long_field),
+         |        min(float_field),
+         |        max(double_field),
+         |        sum(short_field),
+         |        sum(decimal_field)
+         | from $json_table_name
+         | group by string_field
+         | order by string_field
+         |""".stripMargin
+    compareResultsAgainstVanillaSpark(
+      sql,
+      true,
+      df => {
+        val jsonFileScan = collect(df.queryExecution.executedPlan) {
+          case l: HiveTableScanExecTransformer => l
+        }
+        assert(jsonFileScan.size == 1)
+      })
+  }
+
+  test("test hive json table complex data type") {
+    val sql =
+      s"""
+         | select array_field, map_field from $json_table_name
+         | where string_field != '' and int_field > 0
+         |""".stripMargin
+    compareResultsAgainstVanillaSpark(
+      sql,
+      true,
+      df => {
+        val jsonFileScan = collect(df.queryExecution.executedPlan) {
+          case l: HiveTableScanExecTransformer => l
+        }
+        assert(jsonFileScan.size == 1)
+      }
+    )
+  }
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.cpp
@@ -5,7 +5,7 @@
 #include <Common/Exception.h>
 #include <Common/StringUtils.h>
 #include <Common/logger_useful.h>
-// clang-format off
+
 #if USE_PARQUET
 #include <Storages/SubstraitSource/ParquetFormatFile.h>
 #endif
@@ -13,7 +13,10 @@
 #if USE_ORC
 #include <Storages/SubstraitSource/OrcFormatFile.h>
 #endif
-// clang-format on
+#if USE_HIVE
+#include <Storages/SubstraitSource/TextFormatFile.h>
+#endif
+#include <Storages/SubstraitSource/JsonFormatFile.h>
 
 namespace DB
 {
@@ -53,6 +56,17 @@ FormatFilePtr FormatFileUtil::createFile(
     }
 #endif
 
+#if USE_HIVE
+    if (file.has_text())
+    {
+        return std::make_shared<TextFormatFile>(context, file, read_buffer_builder);
+    }
+#endif
+
+    if (file.has_json())
+    {
+        return std::make_shared<JsonFormatFile>(context, file, read_buffer_builder);
+    }
     throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Format not supported:{}", file.DebugString());
     __builtin_unreachable();
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
@@ -19,8 +19,8 @@ public:
     struct InputFormat
     {
     public:
-        DB::InputFormatPtr input;
         std::unique_ptr<DB::ReadBuffer> read_buffer;
+        DB::InputFormatPtr input;
     };
     using InputFormatPtr = std::shared_ptr<InputFormat>;
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.cpp
@@ -1,0 +1,28 @@
+#include "JsonFormatFile.h"
+
+#include <Formats/FormatSettings.h>
+#include <Formats/FormatFactory.h>
+#include <Processors/Formats/Impl/JSONEachRowRowInputFormat.h>
+
+namespace local_engine
+{
+
+JsonFormatFile::JsonFormatFile(DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_)
+    :FormatFile(context_, file_info_, read_buffer_builder_) {}
+
+FormatFile::InputFormatPtr JsonFormatFile::createInputFormat(const DB::Block & header) 
+{
+    auto res = std::make_shared<FormatFile::InputFormat>();
+    res->read_buffer = std::move(read_buffer_builder->build(file_info, true));
+    DB::FormatSettings format_settings = DB::getFormatSettings(context);
+    format_settings.with_names_use_header = true;
+    format_settings.skip_unknown_fields = true;
+    size_t max_block_size = file_info.json().max_block_size();
+    DB::RowInputFormatParams in_params = {max_block_size};
+    std::shared_ptr<DB::JSONEachRowRowInputFormat> json_input_format = 
+        std::make_shared<DB::JSONEachRowRowInputFormat>(*(res->read_buffer), header, in_params, format_settings, false);
+    res->input = json_input_format;
+    return res;
+}
+
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "config.h"
+#include <Storages/SubstraitSource/FormatFile.h>
+
+namespace local_engine
+{
+class JsonFormatFile : public FormatFile
+{
+public:
+    explicit JsonFormatFile(DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_);
+    ~JsonFormatFile() override = default;
+    FormatFile::InputFormatPtr createInputFormat(const DB::Block & header) override;
+    std::optional<size_t> getTotalRows() override  { return 1; }
+    bool supportSplit() override { return true; }
+};
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -6,7 +6,10 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromS3.h>
 #include <IO/S3Common.h>
+#include <IO/SeekableReadBuffer.h>
+#include <IO/S3/getObjectInfo.h>
 #include <Interpreters/Context_fwd.h>
+#include <Storages/HDFS/HDFSCommon.h>
 #include <Storages/HDFS/ReadBufferFromHDFS.h>
 #include <Storages/StorageS3Settings.h>
 #include <Storages/SubstraitSource/ReadBufferBuilder.h>
@@ -17,14 +20,16 @@
 #include <Poco/URI.h>
 #include "IO/ReadSettings.h"
 
-#include <Poco/Logger.h>
+#include <Common/Throttler.h>
+#include <Common/safe_cast.h>
 #include <Common/logger_useful.h>
+#include <Poco/Logger.h>
+#include <hdfs/hdfs.h>
 
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/FileCacheFactory.h>
 #include <Interpreters/Cache/FileCacheSettings.h>
 
-#include <IO/S3/getObjectInfo.h>
 #include <aws/s3/model/CopyObjectRequest.h>
 #include <aws/s3/model/DeleteObjectsRequest.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
@@ -34,6 +39,10 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int CANNOT_OPEN_FILE;
+    extern const int UNKNOWN_FILE_SIZE;
+    extern const int CANNOT_SEEK_THROUGH_FILE;
+    extern const int CANNOT_CLOSE_FILE;
 }
 }
 
@@ -45,7 +54,7 @@ public:
     explicit LocalFileReadBufferBuilder(DB::ContextPtr context_) : ReadBufferBuilder(context_) { }
     ~LocalFileReadBufferBuilder() override = default;
 
-    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info) override
+    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, const bool &) override
     {
         Poco::URI file_uri(file_info.uri_file());
         std::unique_ptr<DB::ReadBuffer> read_buffer;
@@ -69,7 +78,7 @@ public:
     explicit HDFSFileReadBufferBuilder(DB::ContextPtr context_) : ReadBufferBuilder(context_) { }
     ~HDFSFileReadBufferBuilder() override = default;
 
-    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info) override
+    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, const bool & set_read_util_position) override
     {
         Poco::URI file_uri(file_info.uri_file());
         std::unique_ptr<DB::ReadBuffer> read_buffer;
@@ -78,9 +87,107 @@ public:
         if (file_uri.getPort())
             uri_path += ":" + std::to_string(file_uri.getPort());
         DB::ReadSettings read_settings;
-        read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
-            uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(), read_settings);
+        if (set_read_util_position) 
+        {
+            std::pair<size_t, size_t> start_end_pos = adjustFileReadStartAndEndPos(file_info.start(), file_info.start() + file_info.length(),
+                    uri_path, file_uri.getPath());
+            LOG_DEBUG(&Poco::Logger::get("ReadBufferBuilder"), "File read start and end position adjusted from {},{} to {},{}",
+                    file_info.start(), file_info.start() + file_info.length(), start_end_pos.first, start_end_pos.second);
+            read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
+                uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(),
+                read_settings, start_end_pos.second);
+            if (auto * seekable_in = dynamic_cast<DB::SeekableReadBuffer *>(read_buffer.get()))
+            {
+                seekable_in->seek(start_end_pos.first, SEEK_SET);
+            }
+        }
+        else
+        {
+            read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
+                uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(),
+                read_settings);
+        }
         return read_buffer;
+    }
+
+    std::pair<size_t, size_t> adjustFileReadStartAndEndPos(
+        size_t read_start_pos,
+        size_t read_end_pos,
+        std::string uri_path,
+        std::string file_path)
+    {
+        std::pair<size_t, size_t> result;
+        std::string row_delimiter = "\n";
+        size_t row_delimiter_size = row_delimiter.size();
+        std::string hdfs_file_path = uri_path + file_path;
+        auto builder = DB::createHDFSBuilder(hdfs_file_path, context->getGlobalContext()->getConfigRef());
+        auto fs = DB::createHDFSFS(builder.get());
+        hdfsFile fin = hdfsOpenFile(fs.get(), file_path.c_str(), O_RDONLY, 0, 0, 0);
+        if (!fin)
+        {
+            throw DB::Exception(DB::ErrorCodes::CANNOT_OPEN_FILE, "Cannot open hdfs file:{}, error: {}", hdfs_file_path, std::string(hdfsGetLastError()));
+        }
+        auto hdfs_file_info = hdfsGetPathInfo(fs.get(), file_path.c_str());
+        if (!hdfs_file_info)
+        {
+            hdfsCloseFile(fs.get(), fin);
+            throw DB::Exception(DB::ErrorCodes::UNKNOWN_FILE_SIZE, "Cannot find out file size for :{}, error: {}", hdfs_file_path, std::string(hdfsGetLastError()));
+        }
+        size_t hdfs_file_size = hdfs_file_info->mSize;
+        auto getFirstRowDelimiterPos = [&](hdfsFS fs, hdfsFile fin, size_t start_pos, size_t hdfs_file_size) -> size_t
+        {
+            if (start_pos == 0 || start_pos == hdfs_file_size)
+            {
+                return start_pos;
+            }
+            size_t pos = start_pos;
+            int seek_status = hdfsSeek(fs, fin, pos);
+            if (seek_status != 0)
+            {
+                hdfsCloseFile(fs, fin);
+                throw DB::Exception(DB::ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Fail to seek HDFS file: {}, error: {}", file_path, std::string(hdfsGetLastError()));
+            }
+            char s[row_delimiter_size];
+            bool read_flag = true;
+            while (read_flag)
+            {
+                size_t read_size = hdfsRead(fs, fin, s, row_delimiter_size);
+                size_t i = 0;
+                for (; i < read_size && i < row_delimiter_size; ++i)
+                {
+                    if (s[i] != *(row_delimiter.data() + i))
+                    {
+                        break;
+                    }
+                }
+                if (i == row_delimiter_size)
+                {
+                    char r[1];
+                    // The end of row maybe '\n', '\r\n', or '\n\r'
+                    if (hdfsRead(fs, fin, r, 1) != 0 && r[0] == '\r')
+                    {
+                        return pos + 1 + row_delimiter_size;
+                    }
+                    else
+                    {
+                        return pos + row_delimiter_size;
+                    }
+                }
+                else
+                {
+                    pos += 1;
+                    hdfsSeek(fs, fin, pos);
+                }
+            }
+        };
+        result.first = getFirstRowDelimiterPos(fs.get(), fin, read_start_pos, hdfs_file_size);
+        result.second = getFirstRowDelimiterPos(fs.get(), fin, read_end_pos, hdfs_file_size);
+        int close_status = hdfsCloseFile(fs.get(), fin);
+        if (close_status != 0)
+        {
+            throw DB::Exception(DB::ErrorCodes::CANNOT_CLOSE_FILE, "Fail to close HDFS file: {}, error: {}", file_path, std::string(hdfsGetLastError()));
+        }
+        return result;
     }
 };
 #endif
@@ -110,7 +217,7 @@ public:
 
     ~S3FileReadBufferBuilder() override = default;
 
-    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info) override
+    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, const bool &) override
     {
         Poco::URI file_uri(file_info.uri_file());
         const auto client = getClient();
@@ -215,7 +322,7 @@ public:
     explicit AzureBlobReadBuffer(DB::ContextPtr context_) : ReadBufferBuilder(context_) { }
     ~AzureBlobReadBuffer() override = default;
 
-    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info)
+    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, const bool &)
     {
         Poco::URI file_uri(file_info.uri_file());
         std::unique_ptr<DB::ReadBuffer> read_buffer;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.h
@@ -14,8 +14,7 @@ public:
     explicit ReadBufferBuilder(DB::ContextPtr context_) : context(context_) { }
     virtual ~ReadBufferBuilder() = default;
     /// build a new read buffer
-    virtual std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info) = 0;
-
+    virtual std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, const bool & set_read_util_position=false) = 0;
 protected:
     DB::ContextPtr context;
 };

--- a/cpp-ch/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
@@ -69,7 +69,10 @@ SubstraitFileSource::SubstraitFileSource(
         /// file partition keys are read from the file path
         for (const auto & key : partition_keys)
         {
-            to_read_header.erase(key);
+            if (to_read_header.findByName(key))
+            {
+                to_read_header.erase(key);
+            }
         }
     }
 }
@@ -83,7 +86,6 @@ DB::Chunk SubstraitFileSource::generate()
             /// all files finished
             return {};
         }
-
         DB::Chunk chunk;
         if (file_reader->pull(chunk))
         {

--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
@@ -1,0 +1,107 @@
+#include "TextFormatFile.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <Core/Defines.h>
+#include <Formats/FormatSettings.h>
+#include <IO/SeekableReadBuffer.h>
+#include <IO/PeekableReadBuffer.h>
+#include <Storages/HDFS/ReadBufferFromHDFS.h>
+#include <Processors/Formats/IRowInputFormat.h>
+
+namespace local_engine
+{
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+
+static DB::FormatSettings updateFormatSettings(const DB::FormatSettings & settings, const DB::Block & header)
+{
+    DB::FormatSettings updated = settings;
+    updated.skip_unknown_fields = true;
+    updated.with_names_use_header = true;
+    updated.date_time_input_format = DB::FormatSettings::DateTimeInputFormat::BestEffort;
+    updated.csv.delimiter = updated.hive_text.fields_delimiter;
+    if (settings.hive_text.input_field_names.empty())
+        updated.hive_text.input_field_names = header.getNames();
+    return updated;
+}
+
+TextFormatFile::TextFormatFile(DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_)
+    :FormatFile(context_, file_info_, read_buffer_builder_) {}
+
+FormatFile::InputFormatPtr TextFormatFile::createInputFormat(const DB::Block & header)
+{
+    auto res = std::make_shared<FormatFile::InputFormat>();
+    res->read_buffer = std::move(read_buffer_builder->build(file_info, true));
+    DB::FormatSettings format_settings = DB::getFormatSettings(context);
+    format_settings.with_names_use_header = true;
+    format_settings.skip_unknown_fields = true;
+    std::string text_field_delimiter = file_info.text().field_delimiter();
+    size_t max_block_size = file_info.text().max_block_size();
+    format_settings.hive_text.fields_delimiter = *text_field_delimiter.data();
+    DB::RowInputFormatParams in_params = {max_block_size};
+    std::shared_ptr<local_engine::TextRowInputFormat> txt_input_format = 
+        std::make_shared<local_engine::TextRowInputFormat>(header, *(res->read_buffer), in_params, format_settings, file_info.text().schema());
+    res->input = txt_input_format;
+    return res;
+}
+
+TextRowInputFormat::TextRowInputFormat(
+    const DB::Block & header_, 
+    DB::ReadBuffer & in_, 
+    const DB::RowInputFormatParams & params_, 
+    const DB::FormatSettings & format_settings_,
+    const substrait::NamedStruct & input_schema_)
+    : TextRowInputFormat(header_, std::make_unique<DB::PeekableReadBuffer>(in_), params_, updateFormatSettings(format_settings_, header_))
+{
+    input_schema = input_schema_;
+}
+
+TextRowInputFormat::TextRowInputFormat(
+    const DB::Block & header_, std::shared_ptr<DB::PeekableReadBuffer> buf_, const DB::RowInputFormatParams & params_, const DB::FormatSettings & format_settings_)
+    : DB::CSVRowInputFormat(
+        header_, buf_, params_, true, false, format_settings_, std::make_unique<TextFormatReader>(*buf_, format_settings_))
+{
+}
+
+void TextRowInputFormat::readPrefix()
+{
+    CSVRowInputFormat::readPrefix();
+    std::vector<std::string> column_names = column_mapping->names_of_columns;
+    for (size_t i = 0; i < column_names.size(); ++i)
+    {
+        for (int j = 0; j < input_schema.names_size(); ++j) 
+        {
+            const char * file_field_name = input_schema.names(j).data();
+            if (strcasecmp(file_field_name, column_names[i].data()) == 0) 
+            {
+                auto column_index = column_mapping->column_indexes_for_input_fields[i];
+                if (column_index && static_cast<int>(*column_index) != j)
+                {
+                    column_mapping->column_indexes_for_input_fields[j] = std::optional<size_t>(i);
+                    column_mapping->column_indexes_for_input_fields[i] = std::optional<size_t>();
+                }
+                break;
+            }
+        }
+    }
+}
+
+TextFormatReader::TextFormatReader(DB::PeekableReadBuffer & buf_, const DB::FormatSettings & format_settings_)
+    :DB::CSVFormatReader(buf_, format_settings_), input_field_names(format_settings_.hive_text.input_field_names)
+{
+}
+
+std::vector<String> TextFormatReader::readNames()
+{
+    DB::PeekableReadBufferCheckpoint checkpoint{*buf, true};
+    auto values = readHeaderRow();
+    input_field_names.resize(values.size());
+    return input_field_names;
+}
+
+}

--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config.h"
+#include <memory>
+#include <Columns/IColumn.h>
+#include <IO/ReadBuffer.h>
+#include <IO/PeekableReadBuffer.h>
+#include <Storages/SubstraitSource/FormatFile.h>
+#include <Processors/Formats/IRowInputFormat.h>
+#include <Processors/Formats/Impl/CSVRowInputFormat.h>
+
+namespace local_engine
+{
+class TextFormatFile : public FormatFile
+{
+public:
+    explicit TextFormatFile(DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_);
+    ~TextFormatFile() override = default;
+    FormatFile::InputFormatPtr createInputFormat(const DB::Block & header) override;
+    std::optional<size_t> getTotalRows() override  { return 1; }
+    bool supportSplit() override { return true; }
+};
+
+class TextFormatReader final : public DB::CSVFormatReader
+{
+public:
+    explicit TextFormatReader(DB::PeekableReadBuffer & buf_, const DB::FormatSettings & format_settings_);
+private:
+    std::vector<String> readNames() override;
+    std::vector<String> input_field_names;
+    
+};
+
+/// A stream for input data in Text format.
+class TextRowInputFormat final : public DB::CSVRowInputFormat
+{
+public:
+    TextRowInputFormat(
+        const DB::Block & header_, 
+        DB::ReadBuffer & in_, 
+        const DB::RowInputFormatParams & params_, 
+        const DB::FormatSettings & format_settings_,
+        const substrait::NamedStruct & input_schema
+    );
+
+    String getName() const override { return "TextRowInputFormat"; }
+
+protected:
+    void readPrefix() override;
+
+private:
+
+    substrait::NamedStruct input_schema;
+
+    TextRowInputFormat(
+        const DB::Block & header_, std::shared_ptr<DB::PeekableReadBuffer> buf_, const DB::RowInputFormatParams & params_, const DB::FormatSettings & format_settings_);
+};
+
+
+}

--- a/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -132,6 +132,14 @@ message ReadRel {
       message ArrowReadOptions {}
       message OrcReadOptions {}
       message DwrfReadOptions {}
+      message TextReadOptions {
+        string field_delimiter = 1;
+        uint64 max_block_size = 2;
+        NamedStruct schema = 3;
+      }
+      message JsonReadOptions {
+        uint64 max_block_size = 1;
+      }
 
       // The format of the files.
       oneof file_format {
@@ -140,7 +148,9 @@ message ReadRel {
         OrcReadOptions orc = 11;
         google.protobuf.Any extension = 12;
         DwrfReadOptions dwrf = 13;
-      }
+        TextReadOptions text = 14;
+        JsonReadOptions json = 15;
+     }
     }
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
@@ -37,7 +37,11 @@ trait MetricsApi extends Serializable {
 
   def genBatchScanTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
 
+  def genHiveTableScanTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
+
   def genBatchScanTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
+
+  def genHiveTableScanTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
 
   def genFileSourceScanTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -66,6 +66,14 @@ trait SparkPlanExecApi {
    */
   def genFilterExecTransformer(condition: Expression, child: SparkPlan): FilterExecBaseTransformer
 
+  /**
+  * Generate BasicScanTransformer
+   * @param child
+   * @return
+   */
+  def genHiveTableScanExecTransformer(child: SparkPlan) : Option[HiveTableScanExecTransformer] =
+    Option.empty
+
   /** Generate HashAggregateExecTransformer. */
   def genHashAggregateExecTransformer(
       requiredChildDistributionExpressions: Option[Seq[Expression]],

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HiveTableScanExecTransformer.scala
@@ -1,0 +1,24 @@
+/*
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+
+trait HiveTableScanExecTransformer extends BasicScanExecTransformer {
+
+  def getScan: Option[FileScan]
+}

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -20,7 +20,7 @@ package io.glutenproject.expression
 import java.util.Locale
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.{BasicScanExecTransformer, BatchScanExecTransformer, FileSourceScanExecTransformer}
+import io.glutenproject.execution.{BasicScanExecTransformer, BatchScanExecTransformer, FileSourceScanExecTransformer, HiveTableScanExecTransformer}
 import io.glutenproject.substrait.`type`._
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.substrait.proto.Type
@@ -391,6 +391,16 @@ object ConverterUtils extends Logging {
           case "ParquetFileFormat" => ReadFileFormat.ParquetReadFormat
           case "DwrfFileFormat" => ReadFileFormat.DwrfReadFormat
           case "DeltaMergeTreeFileFormat" => ReadFileFormat.MergeTreeReadFormat
+          case _ => ReadFileFormat.UnknownFormat
+        }
+      case f: HiveTableScanExecTransformer =>
+        f.getScan match {
+          case Some(f) =>
+            f.getClass.getSimpleName match {
+              case "TextScan" => ReadFileFormat.TextReadFormat
+              case "JsonScan" => ReadFileFormat.JsonReadFormat
+              case _ => ReadFileFormat.UnknownFormat
+            }
           case _ => ReadFileFormat.UnknownFormat
         }
       case _ => ReadFileFormat.UnknownFormat

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -23,7 +23,6 @@ import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar._
 import io.glutenproject.utils.{ColumnarShuffleUtil, LogLevelUtil, PhysicalPlanSelector}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.GlutenRemoveRedundantSorts
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
@@ -468,7 +467,13 @@ case class TransformPreOverrides(isAdaptiveContextOrTopParentExchange: Boolean)
       case p =>
         logDebug(s"Transformation for ${p.getClass} is currently not supported.")
         val children = plan.children.map(replaceWithTransformerPlan)
-        p.withNewChildren(children)
+        val planTransformer = p.withNewChildren(children)
+        p.getClass.getSimpleName match {
+          case "HiveTableScanExec" =>
+            BackendsApiManager.getSparkPlanExecApiInstance
+              .genHiveTableScanExecTransformer(p).getOrElse(planTransformer)
+          case _ => planTransformer
+        }
     }
   }
 
@@ -574,10 +579,10 @@ case class TransformPostOverrides(session: SparkSession, isAdaptiveContext: Bool
       val child = replaceWithTransformerPlan(plan.child)
       logDebug(s"ColumnarPostOverrides RowToArrowColumnarExec(${child.getClass})")
       BackendsApiManager.getSparkPlanExecApiInstance.genRowToColumnarExec(child)
-    // The ColumnarShuffleExchangeExec node may be the top node, so we cannot remove it.
-    // e.g. select /* REPARTITION */ from testData, and the AQE create shuffle stage will check
-    // if the transformed is instance of ShuffleExchangeLike, so we need to remove it in AQE mode
-    // have tested gluten-it TPCH when AQE OFF
+      // The ColumnarShuffleExchangeExec node may be the top node, so we cannot remove it.
+      // e.g. select /* REPARTITION */ from testData, and the AQE create shuffle stage will check
+      // if the transformed is instance of ShuffleExchangeLike, so we need to remove it in AQE
+      // mode have tested gluten-it TPCH when AQE OFF
     case ColumnarToRowExec(child: ColumnarShuffleExchangeExec)
       if isAdaptiveContext =>
       replaceWithTransformerPlan(child)

--- a/gluten-data/src/main/scala/io/glutenproject/backendsapi/glutendata/GlutenMetricsApi.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/backendsapi/glutendata/GlutenMetricsApi.scala
@@ -63,6 +63,39 @@ abstract class GlutenMetricsApi extends MetricsApi with Logging{
   override def genBatchScanTransformerMetricsUpdater(
       metrics: Map[String, SQLMetric]): MetricsUpdater = new BatchScanMetricsUpdater(metrics)
 
+  override def genHiveTableScanTransformerMetrics(
+      sparkContext: SparkContext): Map[String, SQLMetric] =
+    Map(
+      "rawInputRows" -> SQLMetrics.createMetric(sparkContext, "number of raw input rows"),
+      "rawInputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of raw input bytes"),
+      "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+      "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors"),
+      "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
+      "scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime of scan"),
+      "wallNanos" -> SQLMetrics.createNanoTimingMetric(
+        sparkContext, "totaltime of scan and filter"),
+      "cpuCount" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
+      "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
+      "numFiles" -> SQLMetrics.createMetric(sparkContext, "number of files read"),
+      "metadataTime" -> SQLMetrics.createTimingMetric(sparkContext, "metadata time"),
+      "filesSize" -> SQLMetrics.createSizeMetric(sparkContext, "size of files read"),
+      "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions read"),
+      "pruningTime" ->
+        SQLMetrics.createTimingMetric(sparkContext, "dynamic partition pruning time"),
+      "numMemoryAllocations" -> SQLMetrics.createMetric(
+        sparkContext, "number of memory allocations"),
+      "numDynamicFiltersAccepted" -> SQLMetrics.createMetric(
+        sparkContext, "number of dynamic filters accepted"),
+      "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+      "skippedSplits" -> SQLMetrics.createMetric(sparkContext, "number of skipped splits"),
+      "processedSplits" -> SQLMetrics.createMetric(sparkContext, "number of processed splits"),
+      "skippedStrides" -> SQLMetrics.createMetric(sparkContext, "number of skipped row groups"),
+      "processedStrides" -> SQLMetrics.createMetric(sparkContext, "number of processed row groups")
+    )
+
+  override def genHiveTableScanTransformerMetricsUpdater(
+        metrics: Map[String, SQLMetric]): MetricsUpdater = new HiveTableScanMetricsUpdater(metrics)
+
   override def genFileSourceScanTransformerMetrics(
       sparkContext: SparkContext): Map[String, SQLMetric] =
     Map(

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.metrics
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
+
+class HiveTableScanMetricsUpdater (val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+
+  val rawInputRows: SQLMetric = metrics("rawInputRows")
+  val rawInputBytes: SQLMetric = metrics("rawInputBytes")
+  val outputRows: SQLMetric = metrics("outputRows")
+  val outputVectors: SQLMetric = metrics("outputVectors")
+  val outputBytes: SQLMetric = metrics("outputBytes")
+  val wallNanos: SQLMetric = metrics("wallNanos")
+  val cpuCount: SQLMetric = metrics("cpuCount")
+  val scanTime: SQLMetric = metrics("scanTime")
+  val peakMemoryBytes: SQLMetric = metrics("peakMemoryBytes")
+  val numMemoryAllocations: SQLMetric = metrics("numMemoryAllocations")
+
+  // Number of dynamic filters received.
+  val numDynamicFiltersAccepted: SQLMetric = metrics("numDynamicFiltersAccepted")
+  val skippedSplits: SQLMetric = metrics("skippedSplits")
+  val processedSplits: SQLMetric = metrics("processedSplits")
+  val skippedStrides: SQLMetric = metrics("skippedStrides")
+  val processedStrides: SQLMetric = metrics("processedStrides")
+
+  override def updateInputMetrics(inputMetrics: InputMetricsWrapper): Unit = {
+    inputMetrics.bridgeIncBytesRead(rawInputBytes.value)
+    inputMetrics.bridgeIncRecordsRead(rawInputRows.value)
+  }
+
+  override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
+    if (opMetrics != null) {
+      val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
+      rawInputRows += operatorMetrics.rawInputRows
+      rawInputBytes += operatorMetrics.rawInputBytes
+      outputRows += operatorMetrics.outputRows
+      outputVectors += operatorMetrics.outputVectors
+      outputBytes += operatorMetrics.outputBytes
+      wallNanos += operatorMetrics.wallNanos
+      cpuCount += operatorMetrics.cpuCount
+      scanTime += operatorMetrics.scanTime
+      peakMemoryBytes += operatorMetrics.peakMemoryBytes
+      numMemoryAllocations += operatorMetrics.numMemoryAllocations
+      // Number of dynamic filters received.
+      numDynamicFiltersAccepted += operatorMetrics.numDynamicFiltersAccepted
+      skippedSplits += operatorMetrics.skippedSplits
+      processedSplits += operatorMetrics.processedSplits
+      skippedStrides += operatorMetrics.skippedStrides
+      processedStrides += operatorMetrics.processedStrides
+    }
+  }
+}

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/HiveTableScanMetricsUpdater.scala
@@ -20,8 +20,8 @@ package io.glutenproject.metrics
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 
-class HiveTableScanMetricsUpdater (val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
-
+class HiveTableScanMetricsUpdater (@transient val metrics: Map[String, SQLMetric])
+  extends MetricsUpdater {
   val rawInputRows: SQLMetric = metrics("rawInputRows")
   val rawInputBytes: SQLMetric = metrics("rawInputBytes")
   val outputRows: SQLMetric = metrics("outputRows")

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -208,6 +208,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def taskStageId: Int = conf.getConf(BENCHMARK_TASK_STAGEID)
   def taskPartitionId: Int = conf.getConf(BENCHMARK_TASK_PARTITIONID)
   def taskId: Long = conf.getConf(BENCHMARK_TASK_TASK_ID)
+  def getInputRowMaxBlockSize: Long =
+    conf.getConfString("spark.gluten.sql.input.row.max.block.size", "8192").toLong
 }
 
 object GlutenConfig {

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -25,7 +25,10 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.Distribution
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.FileSourceScanExec
-import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.v2.text.TextScan
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 sealed abstract class ShimDescriptor
 
@@ -51,4 +54,14 @@ trait SparkShims {
       readFunction: (PartitionedFile) => Iterator[InternalRow],
       filePartitions: Seq[FilePartition],
       fileSourceScanExec: FileSourceScanExec): FileScanRDD
+
+  def getTextScan(
+      sparkSession: SparkSession,
+      fileIndex: PartitioningAwareFileIndex,
+      dataSchema: StructType,
+      readDataSchema: StructType,
+      readPartitionSchema: StructType,
+      options: CaseInsensitiveStringMap,
+      partitionFilters: Seq[Expression] = Seq.empty,
+      dataFilters: Seq[Expression] = Seq.empty): TextScan
 }

--- a/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
@@ -26,8 +26,11 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClusteredDistribution}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.FileSourceScanExec
-import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class Spark32Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
@@ -51,5 +54,24 @@ class Spark32Shims extends SparkShims {
       filePartitions: Seq[FilePartition],
       fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
     new FileScanRDD(sparkSession, readFunction, filePartitions)
+  }
+
+  override def getTextScan(
+      sparkSession: SparkSession,
+      fileIndex: PartitioningAwareFileIndex,
+      dataSchema: StructType,
+      readDataSchema: StructType,
+      readPartitionSchema: StructType,
+      options: CaseInsensitiveStringMap,
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): TextScan = {
+    new TextScan(
+      sparkSession,
+      fileIndex,
+      readDataSchema,
+      readPartitionSchema,
+      options,
+      partitionFilters,
+      dataFilters)
   }
 }

--- a/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
@@ -28,9 +28,11 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class Spark33Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
@@ -72,5 +74,25 @@ class Spark33Shims extends SparkShims {
           fileSourceScanExec.relation.partitionSchema.fields),
       fileSourceScanExec.metadataColumns
     )
+  }
+
+  override def getTextScan(
+      sparkSession: SparkSession,
+      fileIndex: PartitioningAwareFileIndex,
+      dataSchema: StructType,
+      readDataSchema: StructType,
+      readPartitionSchema: StructType,
+      options: CaseInsensitiveStringMap,
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): TextScan = {
+    new TextScan(
+      sparkSession,
+      fileIndex,
+      dataSchema,
+      readDataSchema,
+      readPartitionSchema,
+      options,
+      partitionFilters,
+      dataFilters)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improve read txt/json format hive table by use native engine 

(Fixes: \#1582)

## How was this patch tested?
unit tests, manual tests

This is tested on clickhouse-backend. The tested query  `select l_linenumber,count(*) from linenumber_t where l_linenumber <3   group by l_linenumber limit 3` , the tested table has about 63000000 rows, and stored as textfile, which archived about 100% improvement.

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

