### PR TITLE
[GLUTEN-1585][CH]feat: Use --version-script to limit export symbols

### DIFF
--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -4,6 +4,8 @@ if (COMPILER_CLANG)
 endif ()
 
 option(ENABLE_LOCAL_FORMATS "Use ORC/Parquet input formats defined in utils/local-engine/, notice that it is not stable and has some known issues. We suggest setting it to OFF in production environment." OFF)
+option(ENABLE_HIDE_JEMALLOC "Don't Export jemalloc symbols." ON)
+
 if (ENABLE_LOCAL_FORMATS)
     add_definitions(-DENABLE_LOCAL_FORMATS=1)
 else()
@@ -69,10 +71,13 @@ add_library(${LOCALENGINE_SHARED_LIB} SHARED
         ${functions_sources}
         local_engine_jni.cpp $<TARGET_OBJECTS:clickhouse_malloc>) # why add clickhouse_malloc? check clickhouse PR-8046
 
+if (ENABLE_HIDE_JEMALLOC AND ENABLE_JEMALLOC)
+  target_sources(${LOCALENGINE_SHARED_LIB} PRIVATE
+          jemalloc-compatibility/jemalloc-compatibility.cpp)
+endif()
+
 target_compile_options(${LOCALENGINE_SHARED_LIB} PUBLIC -fPIC
         -Wno-shorten-64-to-32)
-
-target_link_libraries (${LOCALENGINE_SHARED_LIB} PRIVATE )
 
 target_link_libraries(${LOCALENGINE_SHARED_LIB} PUBLIC
         clickhouse_new_delete
@@ -93,40 +98,13 @@ if (ENABLE_LOCAL_FORMATS)
     target_link_libraries(${LOCALENGINE_SHARED_LIB} PUBLIC ch_parquet)
 endif ()
 
-target_link_options(${LOCALENGINE_SHARED_LIB} PRIVATE
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::aws_s3>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::filesystem>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::iostreams>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::program_options>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::regex>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::system>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::context>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::coroutine>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::graph>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:clickhouse_common_io>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:cxx>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:cxxabi>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:common>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_arrow>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_orc>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_icuuc>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_icui18n>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_icudata>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::curl>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::parquet>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::lz4>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::nuraft>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::zstd>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::vectorscan>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::XML>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Net>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Net::SSL>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Util>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::JSON>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Crypto>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Foundation>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:unwind>
-)
+if (ENABLE_HIDE_JEMALLOC OR NOT ENABLE_JEMALLOC)
+    target_link_options(${LOCALENGINE_SHARED_LIB} PRIVATE
+        -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libch-hide-jemalloc.map)
+else()
+    target_link_options(${LOCALENGINE_SHARED_LIB} PRIVATE
+        -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libch.map)
+endif()
 
 #set(CPACK_PACKAGE_VERSION 0.1.0)
 #set(CPACK_GENERATOR "RPM")

--- a/cpp-ch/local-engine/jemalloc-compatibility/jemalloc-compatibility.cpp
+++ b/cpp-ch/local-engine/jemalloc-compatibility/jemalloc-compatibility.cpp
@@ -1,0 +1,85 @@
+
+#include <cstdio>
+#include <cstdlib>
+#include <linux/limits.h>
+#include <dlfcn.h>
+#include <mutex>
+
+namespace
+{
+
+namespace hooks
+{
+    enum class HookType
+    {
+        Required,
+        Optional
+    };
+
+    template <typename Signature, typename Base, HookType Type>
+    struct hook
+    {
+        Signature original = nullptr;
+
+        void init() noexcept
+        {
+            auto ret = dlsym(RTLD_NEXT, Base::identifier);
+            if (!ret && Type == HookType::Optional)
+            {
+                return;
+            }
+            if (!ret)
+            {
+                fprintf(stderr, "Could not find original function %s\n", Base::identifier);
+                abort();
+            }
+            original = reinterpret_cast<Signature>(ret);
+        }
+
+        template <typename... Args>
+        auto operator()(Args... args) const noexcept -> decltype(original(args...))
+        {
+            return original(args...);
+        }
+
+        explicit operator bool() const noexcept { return original; }
+    };
+
+#define HOOK(name, type)                                                                                               \
+    struct name##_t : public hook<decltype(&::name), name##_t, type>                                                   \
+    {                                                                                                                  \
+        static constexpr const char * identifier = #name;                                                               \
+    } name
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+    HOOK(realpath, HookType::Required);
+#pragma GCC diagnostic pop
+#undef HOOK
+
+    std::mutex s_lock;
+    bool isInit = false;
+
+    void init_once() {
+        if (!isInit) {
+            std::lock_guard<std::mutex> lock(s_lock);
+            if (!isInit){
+                hooks::realpath.init();
+                isInit = true;
+            }
+        }
+    }
+}
+}
+extern "C" {
+char * realpath(const char * __restrict __name, char * __restrict __resolved) {
+
+    hooks::init_once();
+
+    if ( __resolved == nullptr) {
+        char* buf = static_cast<char *>(malloc(PATH_MAX +1));
+        return hooks::realpath(__name, buf);
+    }
+    return hooks::realpath(__name, __resolved);
+}
+}

--- a/cpp-ch/local-engine/libch-hide-jemalloc.map
+++ b/cpp-ch/local-engine/libch-hide-jemalloc.map
@@ -1,0 +1,7 @@
+{
+    global:
+      Java_io_glutenproject*;
+      JNI_OnLoad;
+      JNI_OnUnload;
+    local: *;
+};

--- a/cpp-ch/local-engine/libch.map
+++ b/cpp-ch/local-engine/libch.map
@@ -1,0 +1,27 @@
+{
+    global:
+      Java_io_glutenproject*;
+      JNI_OnLoad;
+      JNI_OnUnload;
+      aligned_alloc;
+      calloc;
+      dallocx;
+      free;
+      mallctl;
+      mallctlbymib;
+      mallctlnametomib;
+      malloc;
+      malloc_stats_print;
+      malloc_usable_size;
+      mallocx;
+      memalign;
+      nallocx;
+      posix_memalign;
+      rallocx;
+      realloc;
+      sallocx;
+      sdallocx;
+      valloc;
+      xallocx;
+    local: *;
+};


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is folloup of https://github.com/oap-project/gluten/pull/1517,  I use `-Wl,--exclude-libs` which is cumbersome. In this PR, I use `--version-script` to limit exported symbols. only JNI related symbols are exported by default.

It should fix https://github.com/oap-project/gluten/issues/1585:
1. `operator new` and `delete` are hidden now.  
2. `malloc` and `free` are hidden by default,  `ENABLE_HIDE_JEMALLOC = ON` by default

Hence, jemalloc are called directly in libch.so, we can avoid mixing glibc malloc and jemallloc. Please node with https://github.com/ClickHouse/ClickHouse/pull/45226, we must preload libch.so whatever jemallloc is used or not.

**Drawback**
1. Now，we can ensure jemalloc is called in libch, but java will use  glibc malloc
2. We hook `realpath` which allocalate memory internally.

## How was this patch tested?

using existed UT

