### PR TITLE
[VL] CI: Update mirror of CentOS 7

### DIFF
--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -2,8 +2,18 @@
 
 set -ex
 
-# The connection to centos.org in CI is unstable
-curl -o /etc/yum.repos.d/CentOS-Base.repo https://mirrors.aliyun.com/repo/Centos-7.repo
+CENTOS_MIRROR_URL=https://mirrors.edge.kernel.org/centos
+CENTOS_MIRROR_GPGKEY="${CENTOS_MIRROR_URL}/RPM-GPG-KEY-CentOS-7"
+
+cp /etc/yum.repos.d/CentOS-Base.repo /tmp/CentOS-Base.repo
+sed -i "/^mirrorlist/d;s/^\#baseurl=/baseurl=/" /tmp/CentOS-Base.repo
+sed -i "s|^gpgkey=.*$|gpgkey=${CENTOS_MIRROR_GPGKEY}|" /tmp/CentOS-Base.repo
+sed -i "s|http://mirror.centos.org/centos|${CENTOS_MIRROR_URL}|" /tmp/CentOS-Base.repo
+rm /etc/yum.repos.d/*
+mv /tmp/CentOS-Base.repo /etc/yum.repos.d/
+
+# Disable fastestmirror
+sed -i "s/enabled=1/enabled=0/" /etc/yum/pluginconf.d/fastestmirror.conf 
 
 yum -y install epel-release centos-release-scl
 yum -y install \
@@ -16,5 +26,4 @@ yum -y install \
     ninja-build \
     wget
 
-echo fastestmirror=True >> /etc/dnf/dnf.conf
 ln -s /usr/bin/cmake3 /usr/local/bin/cmake


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Change centos 7 mirror to https://mirrors.edge.kernel.org/centos
* Disable yum plugin fastestmirror because it does not work properly on our server

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

