### PR TITLE
[GLUTEN-CORE] [VL] Avoid duplicate window column name

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -131,7 +131,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     val windowExpressions = new util.ArrayList[WindowFunctionNode]()
     windowExpression.map { windowExpr =>
         val aliasExpr = windowExpr.asInstanceOf[Alias]
-        val columnName = s"${aliasExpr.name}#${aliasExpr.exprId.id}"
+        val columnName = s"${aliasExpr.name}_${aliasExpr.exprId.id}"
         val wExpression = aliasExpr.child.asInstanceOf[WindowExpression]
         wExpression.windowFunction match {
           case wf @ (RowNumber() | Rank(_) | DenseRank(_) | CumeDist() | PercentRank(_)) =>

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -131,7 +131,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     val windowExpressions = new util.ArrayList[WindowFunctionNode]()
     windowExpression.map { windowExpr =>
         val aliasExpr = windowExpr.asInstanceOf[Alias]
-        val columnName = aliasExpr.name
+        val columnName = s"${aliasExpr.name}#${aliasExpr.exprId.id}"
         val wExpression = aliasExpr.child.asInstanceOf[WindowExpression]
         wExpression.windowFunction match {
           case wf @ (RowNumber() | Rank(_) | DenseRank(_) | CumeDist() | PercentRank(_)) =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some function will have same window column name, but their result are different, such as first(expr) and first(expr, true).