### PR TITLE
[GLUTEN-1585][CH]feat: Use --version-script to limit export symbols

### DIFF
--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -72,8 +72,6 @@ add_library(${LOCALENGINE_SHARED_LIB} SHARED
 target_compile_options(${LOCALENGINE_SHARED_LIB} PUBLIC -fPIC
         -Wno-shorten-64-to-32)
 
-target_link_libraries (${LOCALENGINE_SHARED_LIB} PRIVATE )
-
 target_link_libraries(${LOCALENGINE_SHARED_LIB} PUBLIC
         clickhouse_new_delete
         clickhouse_aggregate_functions
@@ -93,40 +91,13 @@ if (ENABLE_LOCAL_FORMATS)
     target_link_libraries(${LOCALENGINE_SHARED_LIB} PUBLIC ch_parquet)
 endif ()
 
-target_link_options(${LOCALENGINE_SHARED_LIB} PRIVATE
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::aws_s3>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::filesystem>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::iostreams>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::program_options>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::regex>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::system>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::context>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::coroutine>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:boost::graph>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:clickhouse_common_io>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:cxx>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:cxxabi>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:common>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_arrow>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_orc>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_icuuc>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_icui18n>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:_icudata>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::curl>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::parquet>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::lz4>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::nuraft>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::zstd>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:ch_contrib::vectorscan>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::XML>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Net>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Net::SSL>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Util>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::JSON>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Crypto>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:Poco::Foundation>
-        -Wl,--exclude-libs,$<TARGET_FILE_NAME:unwind>
-)
+if (ENABLE_JEMALLOC)
+    target_link_options(${LOCALENGINE_SHARED_LIB} PRIVATE
+        -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libch.map)
+else()
+    target_link_options(${LOCALENGINE_SHARED_LIB} PRIVATE
+        -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libch-hide-jemalloc.map)
+endif()
 
 #set(CPACK_PACKAGE_VERSION 0.1.0)
 #set(CPACK_GENERATOR "RPM")

--- a/cpp-ch/local-engine/libch-hide-jemalloc.map
+++ b/cpp-ch/local-engine/libch-hide-jemalloc.map
@@ -1,0 +1,7 @@
+{
+    global:
+      Java_io_glutenproject*;
+      JNI_OnLoad;
+      JNI_OnUnload;
+    local: *;
+};

--- a/cpp-ch/local-engine/libch.map
+++ b/cpp-ch/local-engine/libch.map
@@ -1,0 +1,27 @@
+{
+    global:
+      Java_io_glutenproject*;
+      JNI_OnLoad;
+      JNI_OnUnload;
+      aligned_alloc;
+      calloc;
+      dallocx;
+      free;
+      mallctl;
+      mallctlbymib;
+      mallctlnametomib;
+      malloc;
+      malloc_stats_print;
+      malloc_usable_size;
+      mallocx;
+      memalign;
+      nallocx;
+      posix_memalign;
+      rallocx;
+      realloc;
+      sallocx;
+      sdallocx;
+      valloc;
+      xallocx;
+    local: *;
+};


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is folloup of https://github.com/oap-project/gluten/pull/1517,  I use `-Wl,--exclude-libs` which is cumbersome. In this PR, I use `--version-script` to limit exported symbols. only JNI  and jemalloc symbols are exported by default.

https://github.com/oap-project/gluten/issues/1585 is fix by disabling  jeamlloc(ENABLE_JEMALLOC = OFF),  and then preload it if needed. Please node with https://github.com/ClickHouse/ClickHouse/pull/45226, we also need preload libch.so whatever jemallloc is used or not, otherwise please use `ENABLE_GWP_ASN=OFF`

## How was this patch tested?

using existed UT

