### PR TITLE
[GLUTEN-1682] [CH] fix hasNext will always be true if input is empty

### DIFF
--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -2863,7 +2863,9 @@ bool LocalExecutor::checkAndSetDefaultBlock(size_t current_block_columns, bool h
         const DB::ColumnWithTypeAndName default_col(default_col_ptr, col_type, col_name);
         currentBlock().setColumn(i, default_col);
     }
-    return true;
+    if (cols.size() > 0)
+        return true;
+    return false;
 }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fix that if the current block is empty, it should return false for hasNext.

(Fixes: \#1682)

## How was this patch tested?

This patch was tested manually.
