### PR TITLE
[GLUTEN-1714][VL][Fix] Align the implementation for ascii func with latest spark

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/PHILO-HE/velox.git
-VELOX_BRANCH=ascii-func-oap
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=ascii-func-oap
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenStringExpressionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenStringExpressionsSuite.scala
@@ -22,4 +22,17 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.types.IntegerType
 
 class GlutenStringExpressionsSuite extends StringExpressionsSuite with GlutenTestsTrait {
+
+  // Ported from spark 3.3.1, applicable to spark 3.2.3 or higher.
+  test("SPARK-40213: ascii for Latin-1 Supplement characters") {
+    // scalastyle:off
+    checkEvaluation(Ascii(Literal("¥")), 165, create_row("¥"))
+    checkEvaluation(Ascii(Literal("®")), 174, create_row("®"))
+    checkEvaluation(Ascii(Literal("©")), 169, create_row("©"))
+    // scalastyle:on
+    (128 until 256).foreach { c =>
+      checkEvaluation(Ascii(Chr(Literal(c.toLong))), c, create_row(c.toLong))
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark has a fix for ascii function. Since it is more like a bug fix in spark, we are proposing to align the imp. Spark 3.2.2 users should expect the behavior is consistent with spark 3.2.3 for characters whose ascii is above 127. 

## How was this patch tested?
UT.

