### PR TITLE
[GLUTEN-1623] [VL] Support asinh, acosh, atanh, sec, csc math functions for Velox backend

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.utils
 
-import io.glutenproject.expression.ExpressionMappings._
+import io.glutenproject.expression.ExpressionNames._
 
 object CHExpressionUtil {
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -19,7 +19,7 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.backendsapi.glutendata.GlutenSparkPlanExecApi
 import io.glutenproject.execution.{HashAggregateExecBaseTransformer, VeloxHashAggregateExecTransformer}
-import io.glutenproject.expression.{ExpressionMappings, ExpressionTransformer, GlutenNamedStructTransformer, Sig}
+import io.glutenproject.expression.{ExpressionNames, ExpressionTransformer, GlutenNamedStructTransformer, Sig}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.SparkPlan
@@ -120,5 +120,5 @@ class VeloxSparkPlanExecApi extends GlutenSparkPlanExecApi {
    * Define backend specfic expression mappings.
    */
   override def extraExpressionMappings: Seq[Sig] =
-    Seq(Sig[HLLVeloxAdapter](ExpressionMappings.APPROX_DISTINCT))
+    Seq(Sig[HLLVeloxAdapter](ExpressionNames.APPROX_DISTINCT))
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -368,7 +368,7 @@ object HashJoinLikeExecTransformer {
                             functionMap: java.util.HashMap[String, java.lang.Long]
                            ): ExpressionNode = {
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.EQUAL, Seq(leftType, rightType)))
+      ConverterUtils.makeFuncName(ExpressionNames.EQUAL, Seq(leftType, rightType)))
 
     val expressionNodes = Lists.newArrayList(leftNode, rightNode)
     val typeNode = TypeBuilder.makeBoolean(true)
@@ -380,7 +380,7 @@ object HashJoinLikeExecTransformer {
                         rightNode: ExpressionNode,
                         functionMap: java.util.HashMap[String, java.lang.Long]): ExpressionNode = {
     val functionId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.AND, Seq(BooleanType, BooleanType)))
+      ConverterUtils.makeFuncName(ExpressionNames.AND, Seq(BooleanType, BooleanType)))
 
     val expressionNodes = Lists.newArrayList(leftNode, rightNode)
     val typeNode = TypeBuilder.makeBoolean(true)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
@@ -40,9 +40,9 @@ object AggregateFunctionsBuilder {
 
     aggregateFunc match {
       case first @ First(_, ignoreNull) =>
-        if (ignoreNull) substraitAggFuncName = Some(ExpressionMappings.FIRST_IGNORE_NULL)
+        if (ignoreNull) substraitAggFuncName = Some(ExpressionNames.FIRST_IGNORE_NULL)
       case last @ Last(_, ignoreNulls) =>
-        if (ignoreNulls) substraitAggFuncName = Some(ExpressionMappings.LAST_IGNORE_NULL)
+        if (ignoreNulls) substraitAggFuncName = Some(ExpressionNames.LAST_IGNORE_NULL)
       case _ =>
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
@@ -74,7 +74,7 @@ class GetArrayItemTransformer(substraitExprName: String, left: ExpressionTransfo
     // In Spark, the index of getarrayitem starts from 0
     // But in CH and velox, the index of arrayElement starts from 1, besides index argument must
     // So we need to do transform: rightNode = add(rightNode, 1)
-    val addFunctionName = ConverterUtils.makeFuncName(ExpressionMappings.ADD,
+    val addFunctionName = ConverterUtils.makeFuncName(ExpressionNames.ADD,
       Seq(IntegerType, original.right.dataType), FunctionConfig.OPT)
     val addFunctionId = ExpressionBuilder.newScalarFunction(functionMap, addFunctionName)
     val literalNode = ExpressionBuilder.makeLiteral(1.toInt, IntegerType, false)
@@ -117,7 +117,7 @@ class SequenceTransformer(substraitExprName: String, start: ExpressionTransforme
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
 
     val lessThanFuncId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.LESS_THAN,
+      ConverterUtils.makeFuncName(ExpressionNames.LESS_THAN,
         Seq(original.start.dataType, original.stop.dataType),
         FunctionConfig.OPT))
     val rangeFuncId = ExpressionBuilder.newScalarFunction(functionMap,
@@ -125,18 +125,18 @@ class SequenceTransformer(substraitExprName: String, start: ExpressionTransforme
         Seq(original.start.dataType, original.stop.dataType, original.start.dataType),
         FunctionConfig.OPT))
     val addFuncId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.ADD,
+      ConverterUtils.makeFuncName(ExpressionNames.ADD,
         Seq(original.stop.dataType, original.start.dataType), FunctionConfig.OPT))
     val substractFuncId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.SUBTRACT,
+      ConverterUtils.makeFuncName(ExpressionNames.SUBTRACT,
         Seq(original.stop.dataType, original.start.dataType),
         FunctionConfig.OPT))
     val remainderFuncId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.REMAINDER,
+      ConverterUtils.makeFuncName(ExpressionNames.REMAINDER,
         Seq(original.stop.dataType, original.start.dataType),
         FunctionConfig.OPT))
     val equalFuncId = ExpressionBuilder.newScalarFunction(functionMap,
-      ConverterUtils.makeFuncName(ExpressionMappings.EQUAL,
+      ConverterUtils.makeFuncName(ExpressionNames.EQUAL,
         Seq(original.start.dataType, original.start.dataType),
         FunctionConfig.OPT))
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.expression.ExpressionNames._
 import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.expressions._
@@ -26,219 +27,12 @@ import org.apache.spark.sql.execution.ScalarSubquery
 
 object ExpressionMappings {
 
-  // Aggregation functions used by Substrait plan.
-  final val SUM = "sum"
-  final val AVG = "avg"
-  final val COUNT = "count"
-  final val MIN = "min"
-  final val MAX = "max"
-  final val STDDEV = "stddev"
-  final val STDDEV_SAMP = "stddev_samp"
-  final val STDDEV_POP = "stddev_pop"
-  final val COLLECT_LIST = "collect_list"
-  final val BLOOM_FILTER_AGG = "bloom_filter_agg"
-  final val VAR_SAMP = "var_samp"
-  final val VAR_POP = "var_pop"
-  final val BIT_AND_AGG = "bit_and"
-  final val BIT_OR_AGG = "bit_or"
-  final val BIT_XOR_AGG = "bit_xor"
-  final val CORR = "corr"
-  final val COVAR_POP = "covar_pop"
-  final val COVAR_SAMP = "covar_samp"
-  final val LAST = "last"
-  final val LAST_IGNORE_NULL = "last_ignore_null"
-  final val FIRST = "first"
-  final val FIRST_IGNORE_NULL = "first_ignore_null"
-  final val APPROX_DISTINCT = "approx_distinct"
-
-  // Function names used by Substrait plan.
-  final val ADD = "add"
-  final val SUBTRACT = "subtract"
-  final val MULTIPLY = "multiply"
-  final val DIVIDE = "divide"
-  final val AND = "and"
-  final val OR = "or"
-  final val CAST = "cast"
-  final val COALESCE = "coalesce"
-  final val LIKE = "like"
-  final val RLIKE = "rlike"
-  final val REGEXP_REPLACE = "regexp_replace"
-  final val REGEXP_EXTRACT = "regexp_extract"
-  final val REGEXP_EXTRACT_ALL = "regexp_extract_all"
-  final val EQUAL = "equal"
-  final val LESS_THAN = "lt"
-  final val LESS_THAN_OR_EQUAL = "lte"
-  final val GREATER_THAN = "gt"
-  final val GREATER_THAN_OR_EQUAL = "gte"
-  final val ALIAS = "alias"
-  final val IS_NOT_NULL = "is_not_null"
-  final val IS_NULL = "is_null"
-  final val NOT = "not"
-  final val IS_NAN = "isnan"
-
-  // SparkSQL String functions
-  final val ASCII = "ascii"
-  final val CHR = "chr"
-  final val EXTRACT = "extract"
-  final val ENDS_WITH = "ends_with"
-  final val STARTS_WITH = "starts_with"
-  final val CONCAT = "concat"
-  final val CONTAINS = "contains"
-  final val INSTR = "strpos" // instr
-  final val LENGTH = "char_length" // length
-  final val LOWER = "lower"
-  final val UPPER = "upper"
-  final val LOCATE = "locate"
-  final val LTRIM = "ltrim"
-  final val RTRIM = "rtrim"
-  final val TRIM = "trim"
-  final val LPAD = "lpad"
-  final val RPAD = "rpad"
-  final val REPLACE = "replace"
-  final val REVERSE = "reverse"
-  final val SPLIT = "split"
-  final val SUBSTRING = "substring"
-  final val CONCAT_WS = "concat_ws"
-  final val REPEAT = "repeat"
-  final val TRANSLATE = "translate"
-  final val SPACE = "space"
-
-  // SparkSQL Math functions
-  final val ABS = "abs"
-  final val CEIL = "ceil"
-  final val FLOOR = "floor"
-  final val EXP = "exp"
-  final val POWER = "power"
-  final val PMOD = "pmod"
-  final val ROUND = "round"
-  final val BROUND = "bround"
-  final val SIN = "sin"
-  final val SINH = "sinh"
-  final val TAN = "tan"
-  final val TANH = "tanh"
-  final val BITWISE_NOT = "bitwise_not"
-  final val BITWISE_AND = "bitwise_and"
-  final val BITWISE_OR = "bitwise_or"
-  final val BITWISE_XOR = "bitwise_xor"
-  final val SHIFTLEFT = "shiftleft"
-  final val SHIFTRIGHT = "shiftright"
-  final val SQRT = "sqrt"
-  final val CBRT = "cbrt"
-  final val E = "e"
-  final val PI = "pi"
-  final val HEX = "hex"
-  final val UNHEX = "unhex"
-  final val HYPOT = "hypot"
-  final val SIGN = "sign"
-  final val LOG1P = "log1p"
-  final val LOG2 = "log2"
-  final val LOG = "log"
-  final val RADIANS = "radians"
-  final val GREATEST = "greatest"
-  final val LEAST = "least"
-  final val REMAINDER = "modulus"
-  final val FACTORIAL = "factorial"
-  final val RAND = "rand"
-
-  // PrestoSQL Math functions
-  final val ACOS = "acos"
-  final val ASIN = "asin"
-  final val ATAN = "atan"
-  final val ATAN2 = "atan2"
-  final val COS = "cos"
-  final val COSH = "cosh"
-  final val DEGREES = "degrees"
-  final val LOG10 = "log10"
-
-  // SparkSQL DateTime functions
-  // Fully supporting wait for https://github.com/ClickHouse/ClickHouse/pull/43818
-  final val FROM_UNIXTIME = "from_unixtime"
-  final val DATE_ADD = "date_add"
-  final val DATE_SUB = "date_sub"
-  final val DATE_DIFF = "datediff"
-  final val TO_UNIX_TIMESTAMP = "to_unix_timestamp"
-  final val UNIX_TIMESTAMP = "unix_timestamp"
-  final val ADD_MONTHS = "add_months"
-  final val DATE_FORMAT = "date_format"
-  final val TRUNC = "trunc"
-  final val GET_TIMESTAMP = "get_timestamp" // for function: to_date/to_timestamp
-
-  // JSON functions
-  final val GET_JSON_OBJECT = "get_json_object"
-  final val JSON_ARRAY_LENGTH = "json_array_length"
-  final val TO_JSON = "to_json"
-  final val FROM_JSON = "from_json"
-
-  // Hash functions
-  final val MURMUR3HASH = "murmur3hash"
-  final val XXHASH64 = "xxhash64"
-  final val MD5 = "md5"
-  final val SHA1 = "sha1"
-  final val SHA2 = "sha2"
-  final val CRC32 = "crc32"
-
-  // Array functions
-  final val SIZE = "size"
-  final val CREATE_ARRAY = "array"
-  final val GET_ARRAY_ITEM = "get_array_item"
-  final val ELEMENT_AT = "element_at"
-  final val ARRAY_CONTAINS = "array_contains"
-  final val ARRAY_MAX = "array_max"
-  final val ARRAY_MIN = "array_min"
-  final val SEQUENCE = "sequence"
-  final val SORT_ARRAY = "sort_array"
-  final val ARRAYS_OVERLAP = "arrays_overlap"
-  final val SLICE = "slice"
-
-  // Map functions
-  final val CREATE_MAP = "map"
-  final val GET_MAP_VALUE = "get_map_value"
-  final val MAP_KEYS = "map_keys"
-  final val MAP_VALUES = "map_values"
-  final val MAP_FROM_ARRAYS = "map_from_arrays"
-
-  // struct functions
-  final val GET_STRUCT_FIELD = "get_struct_field"
-  final val NAMED_STRUCT = "named_struct"
-
-  // Spark 3.3
-  final val SPLIT_PART = "split_part"
-  final val MIGHT_CONTAIN = "might_contain"
-
-  // Specific expression
-  final val IF = "if"
-  final val ATTRIBUTE_REFERENCE = "attribute_reference"
-  final val BOUND_REFERENCE = "bound_reference"
-  final val LITERAL = "literal"
-  final val CASE_WHEN = "case_when"
-  final val IN = "in"
-  final val IN_SET = "in_set"
-  final val SCALAR_SUBQUERY = "scalar_subquery"
-  final val EXPLODE = "explode"
-  final val POSEXPLODE = "posexplode"
-  final val CHECK_OVERFLOW = "check_overflow"
-  final val MAKE_DECIMAL = "make_decimal"
-  final val PROMOTE_PRECISION = "promote_precision"
-  final val ROW_CONSTRUCTOR = "row_constructor"
-
-  // Directly use child expression transformer
-  final val KNOWN_FLOATING_POINT_NORMALIZED = "known_floating_point_normalized"
-  final val NORMALIZE_NANAND_ZERO = "normalize_nanand_zero"
-
-  // Window functions used by Substrait plan.
-  final val RANK = "rank"
-  final val DENSE_RANK = "dense_rank"
-  final val ROW_NUMBER = "row_number"
-  final val CUME_DIST = "cume_dist"
-  final val PERCENT_RANK = "percent_rank"
-  final val NTILE = "ntile"
-
-  // Decimal functions
-  final val UNSCALED_VALUE = "unscaled_value"
-
   /** Mapping Spark scalar expression to Substrait function name */
   private val SCALAR_SIGS: Seq[Sig] = Seq(
     Sig[Add](ADD),
+    Sig[Asinh](ASINH),
+    Sig[Acosh](ACOSH),
+    Sig[Atanh](ATANH),
     Sig[Subtract](SUBTRACT),
     Sig[Multiply](MULTIPLY),
     Sig[Divide](DIVIDE),
@@ -445,7 +239,8 @@ object ExpressionMappings {
   lazy val expressionsMap: Map[Class[_], String] = {
     (SCALAR_SIGS ++ AGGREGATE_SIGS ++ WINDOW_SIGS ++
       BackendsApiManager.getSparkPlanExecApiInstance.extraExpressionMappings)
-      .map(s => (s.expClass, s.name)).toMap[Class[_], String]
+      .map(s => (s.expClass, s.name))
+      .toMap[Class[_], String]
   }
 
 }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/TernaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/TernaryExpressionTransformer.scala
@@ -85,7 +85,7 @@ case class StringLocateTransformer(
 
       // isnull(start_pos)
       val isnullFuncName = ConverterUtils.makeFuncName(
-        ExpressionMappings.IS_NULL, Seq(IntegerType), FunctionConfig.OPT)
+        ExpressionNames.IS_NULL, Seq(IntegerType), FunctionConfig.OPT)
       val isnullFuncId = ExpressionBuilder.newScalarFunction(functionMap, isnullFuncName)
       val isnullNode = ExpressionBuilder.makeScalarFunction(
         isnullFuncId, Lists.newArrayList(startNode), TypeBuilder.makeBoolean(false))

--- a/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
@@ -128,7 +128,7 @@ class PosExplodeTransformer(
     val mapFromArraysFuncId = ExpressionBuilder.newScalarFunction(
       funcMap,
       ConverterUtils.makeFuncName(
-        ExpressionMappings.MAP_FROM_ARRAYS,
+        ExpressionNames.MAP_FROM_ARRAYS,
         Seq(sequenceExpr.dataType, original.child.dataType),
         FunctionConfig.OPT))
 
@@ -157,7 +157,7 @@ class PosExplodeTransformer(
     val funcId = ExpressionBuilder.newScalarFunction(
       funcMap,
       ConverterUtils.makeFuncName(
-        ExpressionMappings.POSEXPLODE,
+        ExpressionNames.POSEXPLODE,
         Seq(outputType),
         FunctionConfig.OPT))
 

--- a/gluten-data/src/main/scala/io/glutenproject/backendsapi/glutendata/GlutenValidatorApi.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/backendsapi/glutendata/GlutenValidatorApi.scala
@@ -19,10 +19,12 @@ package io.glutenproject.backendsapi.glutendata
 
 import io.glutenproject.backendsapi.ValidatorApi
 import io.glutenproject.execution.RowToColumnConverter
+import io.glutenproject.expression.ExpressionNames
 import io.glutenproject.expression.ExpressionMappings
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.utils.GlutenExpressionUtil
 import io.glutenproject.vectorized.GlutenNativeExpressionEvaluator
+
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.StructType
@@ -38,7 +40,7 @@ abstract class GlutenValidatorApi extends ValidatorApi {
                   substraitExprName: String,
                   expr: Expression): Boolean = {
     // To handle cast(struct as string) AS col_name expression
-    val key = if (substraitExprName.toLowerCase().equals(ExpressionMappings.ALIAS)) {
+    val key = if (substraitExprName.toLowerCase().equals(ExpressionNames.ALIAS)) {
       ExpressionMappings.expressionsMap.get(expr.asInstanceOf[Alias].child.getClass)
     } else Some(substraitExprName)
     if (key.isEmpty) return false

--- a/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/execution/GlutenHashAggregateExecTransformer.scala
@@ -754,9 +754,9 @@ object VeloxAggregateFunctionsBuilder {
 
     aggregateFunc match {
       case First(_, ignoreNulls) =>
-        if (ignoreNulls) sigName = Some(ExpressionMappings.FIRST_IGNORE_NULL)
+        if (ignoreNulls) sigName = Some(ExpressionNames.FIRST_IGNORE_NULL)
       case Last(_, ignoreNulls) =>
-        if (ignoreNulls) sigName = Some(ExpressionMappings.LAST_IGNORE_NULL)
+        if (ignoreNulls) sigName = Some(ExpressionNames.LAST_IGNORE_NULL)
       case _ =>
     }
 

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -15,17 +15,9 @@
  * limitations under the License.
  */
 
-package io.glutenproject.utils.velox
+package org.apache.spark.sql.catalyst.expressions
 
-import io.glutenproject.utils.BackendTestSettings
-import org.apache.spark.sql.catalyst.expressions.GlutenMathExpressionsSuite
-import org.apache.spark.sql.{GlutenBloomFilterAggregateQuerySuite, GlutenStringFunctionsSuite}
+import org.apache.spark.sql.{GlutenTestConstants, GlutenTestsTrait}
 
-class VeloxTestSettings extends BackendTestSettings {
-  enableSuite[GlutenStringFunctionsSuite]
-  enableSuite[GlutenBloomFilterAggregateQuerySuite]
-    // fallback might_contain, the input argument binary is not same with vanilla spark
-    .exclude("Test NULL inputs for might_contain")
-  enableSuite[GlutenMathExpressionsSuite]
-    .include("asinh", "acosh", "atanh", "sec", "csc")
+class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTrait {
 }

--- a/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.expression
+
+import io.glutenproject.sql.shims.SparkShimLoader
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
+import org.apache.spark.sql.execution.ScalarSubquery
+
+object ExpressionNames {
+
+  // Aggregation functions used by Substrait plan.
+  final val SUM = "sum"
+  final val AVG = "avg"
+  final val COUNT = "count"
+  final val MIN = "min"
+  final val MAX = "max"
+  final val STDDEV = "stddev"
+  final val STDDEV_SAMP = "stddev_samp"
+  final val STDDEV_POP = "stddev_pop"
+  final val COLLECT_LIST = "collect_list"
+  final val BLOOM_FILTER_AGG = "bloom_filter_agg"
+  final val VAR_SAMP = "var_samp"
+  final val VAR_POP = "var_pop"
+  final val BIT_AND_AGG = "bit_and"
+  final val BIT_OR_AGG = "bit_or"
+  final val BIT_XOR_AGG = "bit_xor"
+  final val CORR = "corr"
+  final val COVAR_POP = "covar_pop"
+  final val COVAR_SAMP = "covar_samp"
+  final val LAST = "last"
+  final val LAST_IGNORE_NULL = "last_ignore_null"
+  final val FIRST = "first"
+  final val FIRST_IGNORE_NULL = "first_ignore_null"
+  final val APPROX_DISTINCT = "approx_distinct"
+
+  // Function names used by Substrait plan.
+  final val ADD = "add"
+  final val SUBTRACT = "subtract"
+  final val MULTIPLY = "multiply"
+  final val DIVIDE = "divide"
+  final val AND = "and"
+  final val OR = "or"
+  final val CAST = "cast"
+  final val COALESCE = "coalesce"
+  final val LIKE = "like"
+  final val RLIKE = "rlike"
+  final val REGEXP_REPLACE = "regexp_replace"
+  final val REGEXP_EXTRACT = "regexp_extract"
+  final val REGEXP_EXTRACT_ALL = "regexp_extract_all"
+  final val EQUAL = "equal"
+  final val LESS_THAN = "lt"
+  final val LESS_THAN_OR_EQUAL = "lte"
+  final val GREATER_THAN = "gt"
+  final val GREATER_THAN_OR_EQUAL = "gte"
+  final val ALIAS = "alias"
+  final val IS_NOT_NULL = "is_not_null"
+  final val IS_NULL = "is_null"
+  final val NOT = "not"
+  final val IS_NAN = "isnan"
+
+  // SparkSQL String functions
+  final val ASCII = "ascii"
+  final val CHR = "chr"
+  final val EXTRACT = "extract"
+  final val ENDS_WITH = "ends_with"
+  final val STARTS_WITH = "starts_with"
+  final val CONCAT = "concat"
+  final val CONTAINS = "contains"
+  final val INSTR = "strpos" // instr
+  final val LENGTH = "char_length" // length
+  final val LOWER = "lower"
+  final val UPPER = "upper"
+  final val LOCATE = "locate"
+  final val LTRIM = "ltrim"
+  final val RTRIM = "rtrim"
+  final val TRIM = "trim"
+  final val LPAD = "lpad"
+  final val RPAD = "rpad"
+  final val REPLACE = "replace"
+  final val REVERSE = "reverse"
+  final val SPLIT = "split"
+  final val SUBSTRING = "substring"
+  final val CONCAT_WS = "concat_ws"
+  final val REPEAT = "repeat"
+  final val TRANSLATE = "translate"
+  final val SPACE = "space"
+
+  // SparkSQL Math functions
+  final val ABS = "abs"
+  final val ACOSH = "acosh"
+  final val ASINH = "asinh"
+  final val ATANH = "atanh"
+  final val CEIL = "ceil"
+  final val FLOOR = "floor"
+  final val EXP = "exp"
+  final val POWER = "power"
+  final val PMOD = "pmod"
+  final val ROUND = "round"
+  final val BROUND = "bround"
+  final val SIN = "sin"
+  final val SINH = "sinh"
+  final val TAN = "tan"
+  final val TANH = "tanh"
+  final val BITWISE_NOT = "bitwise_not"
+  final val BITWISE_AND = "bitwise_and"
+  final val BITWISE_OR = "bitwise_or"
+  final val BITWISE_XOR = "bitwise_xor"
+  final val SHIFTLEFT = "shiftleft"
+  final val SHIFTRIGHT = "shiftright"
+  final val SQRT = "sqrt"
+  final val CBRT = "cbrt"
+  final val E = "e"
+  final val PI = "pi"
+  final val HEX = "hex"
+  final val UNHEX = "unhex"
+  final val HYPOT = "hypot"
+  final val SIGN = "sign"
+  final val LOG1P = "log1p"
+  final val LOG2 = "log2"
+  final val LOG = "log"
+  final val RADIANS = "radians"
+  final val GREATEST = "greatest"
+  final val LEAST = "least"
+  final val REMAINDER = "modulus"
+  final val FACTORIAL = "factorial"
+  final val RAND = "rand"
+
+  // PrestoSQL Math functions
+  final val ACOS = "acos"
+  final val ASIN = "asin"
+  final val ATAN = "atan"
+  final val ATAN2 = "atan2"
+  final val COS = "cos"
+  final val COSH = "cosh"
+  final val DEGREES = "degrees"
+  final val LOG10 = "log10"
+
+  // SparkSQL DateTime functions
+  // Fully supporting wait for https://github.com/ClickHouse/ClickHouse/pull/43818
+  final val FROM_UNIXTIME = "from_unixtime"
+  final val DATE_ADD = "date_add"
+  final val DATE_SUB = "date_sub"
+  final val DATE_DIFF = "datediff"
+  final val TO_UNIX_TIMESTAMP = "to_unix_timestamp"
+  final val UNIX_TIMESTAMP = "unix_timestamp"
+  final val ADD_MONTHS = "add_months"
+  final val DATE_FORMAT = "date_format"
+  final val TRUNC = "trunc"
+  final val GET_TIMESTAMP = "get_timestamp" // for function: to_date/to_timestamp
+
+  // JSON functions
+  final val GET_JSON_OBJECT = "get_json_object"
+  final val JSON_ARRAY_LENGTH = "json_array_length"
+  final val TO_JSON = "to_json"
+  final val FROM_JSON = "from_json"
+
+  // Hash functions
+  final val MURMUR3HASH = "murmur3hash"
+  final val XXHASH64 = "xxhash64"
+  final val MD5 = "md5"
+  final val SHA1 = "sha1"
+  final val SHA2 = "sha2"
+  final val CRC32 = "crc32"
+
+  // Array functions
+  final val SIZE = "size"
+  final val CREATE_ARRAY = "array"
+  final val GET_ARRAY_ITEM = "get_array_item"
+  final val ELEMENT_AT = "element_at"
+  final val ARRAY_CONTAINS = "array_contains"
+  final val ARRAY_MAX = "array_max"
+  final val ARRAY_MIN = "array_min"
+  final val SEQUENCE = "sequence"
+  final val SORT_ARRAY = "sort_array"
+  final val ARRAYS_OVERLAP = "arrays_overlap"
+  final val SLICE = "slice"
+
+  // Map functions
+  final val CREATE_MAP = "map"
+  final val GET_MAP_VALUE = "get_map_value"
+  final val MAP_KEYS = "map_keys"
+  final val MAP_VALUES = "map_values"
+  final val MAP_FROM_ARRAYS = "map_from_arrays"
+
+  // struct functions
+  final val GET_STRUCT_FIELD = "get_struct_field"
+  final val NAMED_STRUCT = "named_struct"
+
+  // Spark 3.3
+  final val SPLIT_PART = "split_part"
+  final val MIGHT_CONTAIN = "might_contain"
+  final val SEC = "sec"
+  final val CSC = "csc"
+
+  // Specific expression
+  final val IF = "if"
+  final val ATTRIBUTE_REFERENCE = "attribute_reference"
+  final val BOUND_REFERENCE = "bound_reference"
+  final val LITERAL = "literal"
+  final val CASE_WHEN = "case_when"
+  final val IN = "in"
+  final val IN_SET = "in_set"
+  final val SCALAR_SUBQUERY = "scalar_subquery"
+  final val EXPLODE = "explode"
+  final val POSEXPLODE = "posexplode"
+  final val CHECK_OVERFLOW = "check_overflow"
+  final val MAKE_DECIMAL = "make_decimal"
+  final val PROMOTE_PRECISION = "promote_precision"
+  final val ROW_CONSTRUCTOR = "row_constructor"
+
+  // Directly use child expression transformer
+  final val KNOWN_FLOATING_POINT_NORMALIZED = "known_floating_point_normalized"
+  final val NORMALIZE_NANAND_ZERO = "normalize_nanand_zero"
+
+  // Window functions used by Substrait plan.
+  final val RANK = "rank"
+  final val DENSE_RANK = "dense_rank"
+  final val ROW_NUMBER = "row_number"
+  final val CUME_DIST = "cume_dist"
+  final val PERCENT_RANK = "percent_rank"
+  final val NTILE = "ntile"
+
+  // Decimal functions
+  final val UNSCALED_VALUE = "unscaled_value"
+}

--- a/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
@@ -17,13 +17,13 @@
 package io.glutenproject.sql.shims.spark33
 
 import io.glutenproject.GlutenConfig
-import io.glutenproject.expression.Sig
+import io.glutenproject.expression.{ExpressionNames, Sig}
 import io.glutenproject.sql.shims.{ShimDescriptor, SparkShims}
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{BloomFilterMightContain, Expression, SplitPart}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution}
 import org.apache.spark.sql.connector.expressions.Transform
@@ -44,10 +44,13 @@ class Spark33Shims extends SparkShims {
   override def expressionMappings: Seq[Sig] = {
     val list = if (GlutenConfig.getConf.enableNativeBloomFilter) {
       Seq(
-        Sig[BloomFilterMightContain]("might_contain"),
-        Sig[BloomFilterAggregate]("bloom_filter_agg"))
+        Sig[BloomFilterMightContain](ExpressionNames.MIGHT_CONTAIN),
+        Sig[BloomFilterAggregate](ExpressionNames.BLOOM_FILTER_AGG))
     } else Seq.empty
-    list ++ Seq(Sig[SplitPart]("split_part"))
+    list ++ Seq(
+      Sig[SplitPart](ExpressionNames.SPLIT_PART),
+      Sig[Sec](ExpressionNames.SEC),
+      Sig[Csc](ExpressionNames.CSC))
   }
 
   override def convertPartitionTransforms(


### PR DESCRIPTION
Support asinh, acosh, atanh, sec, csc math functions for Velox backend.

Extract expression constant name from ExpressionMappings to remove hardcoded name in shims.

Fixed #1623