### PR TITLE
[GLUTEN-1747][VL] Change the profile for backends velox and rss

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -75,17 +75,17 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.0'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.0'
       - name: Build for Spark 3.2.1
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.1'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.1'
       - name: Build and run unit test for Spark 3.2.2(other tests)
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest'
+          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -Prss -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest'
       - name: Run CPP unit test
         run: |
           docker exec velox-backend-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
@@ -138,17 +138,17 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.0'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.0'
       - name: Build for Spark 3.2.1
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.1'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.1'
       - name: Build and run unit test for Spark 3.2.2(slow tests)
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
+          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -Prss -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
       - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.2
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -161,11 +161,11 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -DskipTests -Dspark33.version=3.3.0'
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -DskipTests -Dspark33.version=3.3.0'
       - name: Build and Run unit test for Spark 3.3.1
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Pspark-ut'
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -Pspark-ut'
       - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.3
         run: |
           docker exec velox-backend-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -212,7 +212,7 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.2'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2'
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2
         run: |
           docker exec velox-backend-ubuntu2204-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -242,7 +242,7 @@ jobs:
         run: |
           docker exec velox-backend-ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -DskipTests -Dspark33.version=3.3.2'
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -DskipTests -Dspark33.version=3.3.2'
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.3
         run: |
           docker exec velox-backend-ubuntu2204-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -291,7 +291,7 @@ jobs:
         run: |
           docker exec velox-backend-centos8-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.2'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2'
       - name: TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2
         run: |
           docker exec velox-backend-centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -340,7 +340,7 @@ jobs:
         run: |
           docker exec velox-backend-centos7-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.2'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2'
       - name: TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2
         run: |
           docker exec velox-backend-centos7-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -381,7 +381,7 @@ jobs:
         run: |
           docker exec velox-backend-static-build-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -DskipTests -Dspark32.version=3.2.2 && \
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2 && \
           cd /opt/gluten/tools/gluten-it && \
           mvn clean package -Pspark-3.2'
       - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.2 (centos 8)

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -20,7 +20,7 @@
 
   <profiles>
     <profile>
-      <id>backends-velox</id>
+      <id>rss</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>

--- a/dev/buildbundle-veloxbe.sh
+++ b/dev/buildbundle-veloxbe.sh
@@ -4,5 +4,5 @@ BASEDIR=$(dirname $0)
 source "$BASEDIR/builddeps-veloxbe.sh"
 
 cd $GLUTEN_DIR
-mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
-mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -10,8 +10,8 @@ VERSION=$(. /etc/os-release && echo ${VERSION_ID})
 
 # compile gluten jar
 $GLUTEN_DIR/dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON  --enable_hdfs=ON
-mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
-mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests
 
 mkdir -p $THIRDPARTY_LIB
 function process_setup_ubuntu_2004 {

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -69,8 +69,8 @@ make -j
 4. build Gluten and generate the example files
 ```
 cd gluten_home
-mvn clean package -Pspark-3.2 -Pbackends-velox
-mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=11.0.0-gluten -Dexec.skip
+mvn clean package -Pspark-3.2 -Pbackends-velox -Prss
+mvn test -Pspark-3.2 -Pbackends-velox -Prss -pl backends-velox -am -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=11.0.0-gluten -Dexec.skip
 ```
 - After the above operations, the examples files are generated under `gluten_home/backends-velox`
 - You can check it by the command `tree gluten_home/backends-velox/generated-native-benchmark/`

--- a/docs/developers/MicroBenchmarks.md
+++ b/docs/developers/MicroBenchmarks.md
@@ -45,9 +45,9 @@ make -j
 
 # Build gluten. If you are using spark 3.3, replace -Pspark-3.2 with -Pspark-3.3
 cd /path_to_gluten
-mvn clean package -Pspark-3.2 -Pbackends-velox
+mvn clean package -Pspark-3.2 -Pbackends-velox -Prss
 
-mvn test -Pspark-3.2 -Pbackends-velox -pl backends-velox -am \
+mvn test -Pspark-3.2 -Pbackends-velox -Prss -pl backends-velox -am \
 -DtagsToInclude="io.glutenproject.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Darrow.version=11.0.0-gluten -Dexec.skip
 ```
 

--- a/docs/get-started/GlutenUsage.md
+++ b/docs/get-started/GlutenUsage.md
@@ -53,10 +53,11 @@ Please set them via `--`, e.g., `--velox_home=/YOUR/PATH`.
 ## Maven building parameters
 To build different backends, there are 3 parameters can be set via `-P` for mvn.
 
-| Parameters               | Description                                                                                      | Activation state by default |
-|--------------------------|--------------------------------------------------------------------------------------------------|-----------------------------|
-| backends-velox           | Add -Pbackends-velox in maven command to compile the JVM part of Velox backend.                  | disabled                    |
-| backends-clickhouse      | Add -Pbackends-clickhouse in maven command to compile the JVM part of ClickHouse backend.        | disabled                    |
+| Parameters          | Description                                                                                    | Activation state by default |
+|---------------------|------------------------------------------------------------------------------------------------|-----------------------------|
+| backends-velox      | Add -Pbackends-velox in maven command to compile the JVM part of Velox backend.                | disabled                    |
+| backends-clickhouse | Add -Pbackends-clickhouse in maven command to compile the JVM part of ClickHouse backend.      | disabled                    |
+| rss                 | Add -Prss in maven command to compile the JVM part of rss, current only support Velox backend. | disabled                    |
 
 # Gluten jar for deployment
 

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -94,9 +94,9 @@ make -j
 ## compile gluten jvm and package jar
 cd /path_to_gluten
 # For spark3.2.x
-mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
 # For spark3.3.x
-mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests
 ```
 notes：The compilation of `Velox` using the script of `build_velox.sh` may fail caused by `oom`, you can prevent this failure by using the user command of `export NUM_THREADS=4` before executing the above scripts.
 
@@ -121,9 +121,9 @@ make -j
 step 3: package jar
 cd /path_to_gluten
 # For spark3.2.x
-mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
 # For spark3.3.x
-mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests
 ```
 
 ## 2.2 Arrow home directory
@@ -146,9 +146,9 @@ make -j
 step 3: package jar
 cd /path_to_gluten
 # For spark3.2.x
-mvn clean package -Pbackends-velox -Pspark-3.2 -DskipTests
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
 # For spark3.3.x
-mvn clean package -Pbackends-velox -Pspark-3.3 -DskipTests
+mvn clean package -Pbackends-velox -prss -Pspark-3.3 -DskipTests
 ```
 
 ## 2.3 HDFS support
@@ -171,7 +171,7 @@ cmake -DBUILD_VELOX_BACKEND=ON -DENABLE_HDFS=ON ..
 make -j
 
 cd /path_to_gluten
-mvn clean package -Pbackends-velox -Pspark-3.2 -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip
 ```
 It is supported to access data on different HDFS endpoints.
 The endpoint info (hdfs://host:port) contained in a given hdfs file path will be used to initialize an hdfs client.
@@ -279,7 +279,7 @@ cmake -DBUILD_VELOX_BACKEND=ON -DENABLE_S3=ON ..
 make -j
 
 cd /path_to_gluten
-mvn clean package -Pbackends-velox -Pspark-3.2 -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip
+mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -Pfull-scala-compiler -DskipTests -Dcheckstyle.skip
 ```
 Currently to use S3 connector below configurations are required in spark-defaults.conf
 ```

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -48,16 +48,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <profile>
-      <id>backends-velox-without-rss</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.glutenproject</groupId>
-          <artifactId>backends-velox</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -188,23 +188,16 @@
       </properties>
     </profile>
     <profile>
-      <id>backends-velox</id>
+      <id>rss</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
       <modules>
-        <module>gluten-data</module>
         <module>gluten-celeborn</module>
-        <module>backends-velox</module>
       </modules>
-      <properties>
-        <backend_type>velox</backend_type>
-        <arrow.version>11.0.0-gluten</arrow.version>
-        <build_velox_backend>ON</build_velox_backend>
-      </properties>
     </profile>
     <profile>
-      <id>backends-velox-without-rss</id>
+      <id>backends-velox</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>

--- a/tools/gluten-te/ubuntu/dockerfile-build
+++ b/tools/gluten-te/ubuntu/dockerfile-build
@@ -59,6 +59,7 @@ RUN if [ "$BUILD_BACKEND_TYPE" == "velox" ]; \
       DEPS_INSTALL_SCRIPT="bash /opt/gluten/dev/builddeps-veloxbe.sh --build_type=$GLUTEN_BUILD_TYPE --enable_ep_cache=ON"; \
       EXTRA_MAVEN_OPTIONS="-Pspark-3.2 \
                            -Pbackends-velox \
+                           -Prss \
                            -DskipTests \
                            -Dscalastyle.skip=true \
                            -Dcheckstyle.skip=true"; \

--- a/tools/gluten-te/ubuntu/examples/buildhere-veloxbe-dev/scripts/all.sh
+++ b/tools/gluten-te/ubuntu/examples/buildhere-veloxbe-dev/scripts/all.sh
@@ -5,6 +5,7 @@ set -ex
 # Build Gluten
 EXTRA_MAVEN_OPTIONS="-Pspark-3.2 \
                      -Pbackends-velox \
+                     -Prss \
                      -DskipTests \
                      -Dscalastyle.skip=true \
                      -Dcheckstyle.skip=true"

--- a/tools/gluten-te/ubuntu/examples/buildhere-veloxbe/run.sh
+++ b/tools/gluten-te/ubuntu/examples/buildhere-veloxbe/run.sh
@@ -6,6 +6,7 @@ BASEDIR=$(dirname $0)
 
 EXTRA_MAVEN_OPTIONS="-Pspark-3.2 \
                      -Pbackends-velox \
+                     -Prss \
                      -DskipTests \
                      -Dscalastyle.skip=true \
                      -Dcheckstyle.skip=true"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, we found mvn test run failed with `backends-velox-without-rss`, as `gluten-ut` module does not support `backends-velox-without-rss`, and would not add backends dependencies into it. 
Although it works while adding `backends-velox-without-rss` in spark-ut, I found it look awful as we have too many similar config in pom.xml. The `backends-velox` in pom.xml has nothring to do with rss in almost every module except for `backends-velox` module and parent `pom.xml`.
 Thus I recomanded we use `-Pbackends` to define the config for velox and use `-Prss` to define the config for rss module, such as `gluten-celeborn`.

## How was this patch tested?
unit tests
