### PR TITLE
[GLUTEN-1478][VL][Fix] fix compare function UT in spark3.2

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/yma11/velox.git
-VELOX_BRANCH=compare
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/yma11/velox.git
+VELOX_BRANCH=compare
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -190,11 +190,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenStringFunctionsSuite]
   enableSuite[GlutenRegexpExpressionsSuite]
   enableSuite[GlutenPredicateSuite]
-    .exclude("BinaryComparison: lessThan")
-    .exclude("BinaryComparison: LessThanOrEqual")
-    .exclude("BinaryComparison: GreaterThan")
-    .exclude("BinaryComparison: GreaterThanOrEqual")
-    .exclude("SPARK-32764: compare special double/float values")
   enableSuite[GlutenMathExpressionsSuite]
   enableSuite[GlutenMathFunctionsSuite]
   enableSuite[GlutenSortOrderExpressionsSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix failed UTs in PredicateSuite, including LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, "SPARK-32764: compare special double/float values".

## How was this patch tested?
UT
