### PR TITLE
[VL] Make git checkout script in get_arrow.sh use an unique local tag name

### DIFF
--- a/ep/build-arrow/src/get_arrow.sh
+++ b/ep/build-arrow/src/get_arrow.sh
@@ -34,8 +34,12 @@ function checkout_code {
     echo "Arrow source folder $ARROW_SOURCE_DIR already exists..."
     cd $ARROW_SOURCE_DIR
     git init .
-    git fetch $ARROW_REPO tag $ARROW_BRANCH
+    EXISTS=$(git show-ref refs/tags/build_$TARGET_BUILD_COMMIT || true)
+    if [ -z "$EXISTS" ]; then
+      git fetch $ARROW_REPO $TARGET_BUILD_COMMIT:refs/tags/build_$TARGET_BUILD_COMMIT
+    fi
     git reset --hard HEAD
+    git checkout refs/tags/build_$TARGET_BUILD_COMMIT
   else
     git clone $ARROW_REPO -b $ARROW_BRANCH $ARROW_SOURCE_DIR
     cd $ARROW_SOURCE_DIR

--- a/ep/build-arrow/src/get_arrow.sh
+++ b/ep/build-arrow/src/get_arrow.sh
@@ -29,6 +29,7 @@ for arg in "$@"; do
 done
 
 function checkout_code {
+  TARGET_BUILD_COMMIT="$(git ls-remote $ARROW_REPO $ARROW_BRANCH | awk '{print $1;}')"
   ARROW_SOURCE_DIR="$CURRENT_DIR/../build/arrow_ep"
   if [ -d $ARROW_SOURCE_DIR ]; then
     echo "Arrow source folder $ARROW_SOURCE_DIR already exists..."

--- a/ep/build-arrow/src/get_arrow.sh
+++ b/ep/build-arrow/src/get_arrow.sh
@@ -43,6 +43,7 @@ function checkout_code {
   else
     git clone $ARROW_REPO -b $ARROW_BRANCH $ARROW_SOURCE_DIR
     cd $ARROW_SOURCE_DIR
+    git checkout $TARGET_BUILD_COMMIT
   fi
 }
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -142,12 +142,12 @@ if [ -d $VELOX_SOURCE_DIR ]; then
   echo "Velox source folder $VELOX_SOURCE_DIR already exists..."
   cd $VELOX_SOURCE_DIR
   git init .
-  EXISTS=$(git show-ref refs/heads/build_$TARGET_BUILD_COMMIT || true)
+  EXISTS=$(git show-ref refs/tags/build_$TARGET_BUILD_COMMIT || true)
   if [ -z "$EXISTS" ]; then
-    git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:build_$TARGET_BUILD_COMMIT
+    git fetch $VELOX_REPO $TARGET_BUILD_COMMIT:refs/tags/build_$TARGET_BUILD_COMMIT
   fi
   git reset --hard HEAD
-  git checkout build_$TARGET_BUILD_COMMIT
+  git checkout refs/tags/build_$TARGET_BUILD_COMMIT
 else
   git clone $VELOX_REPO -b $VELOX_BRANCH $VELOX_SOURCE_DIR
   cd $VELOX_SOURCE_DIR


### PR DESCRIPTION
Follow-up to https://github.com/oap-project/gluten/pull/1660

Why doing this is not over-engineering (correct me if I am wrong):
1. It makes the checkout code 100% same with the checkout code in get_velox.sh. 
2. It fixes a bug when changing to another tag (e.g `ARROW_BRANCH=apache-arrow-13.0.0`), say if we upgrade to `apache-arrow-13.0.0`, `apache-arrow-12.0.0` will be wrongly kept and used without any message reported, simple to reproduce.
