### PR TITLE
[GLUTEN-1767][CH]Bug fix posexplode function argument check error

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1,4 +1,4 @@
-/*:
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -904,7 +904,7 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
   //      assert(StorageJoinBuilder.nativeCachedHashTableCount == 0)
   //    }
   //  }
-    
+
   test("test 'Bug fix posexplode function: https://github.com/oap-project/gluten/issues/1767'") {
     spark.sql(
       """

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1,4 +1,4 @@
-/*
+/*:
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -904,6 +904,21 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
   //      assert(StorageJoinBuilder.nativeCachedHashTableCount == 0)
   //    }
   //  }
+    
+  test("test 'Bug fix posexplode function: https://github.com/oap-project/gluten/issues/1767'") {
+    spark.sql(
+      """
+        | create table test_tbl(id bigint, data map<string, string>) using parquet;
+        |""".stripMargin
+    )
+
+    spark.sql("INSERT INTO test_tbl values(1, map('k', 'v'))")
+    val sql = """
+                | select id from test_tbl lateral view
+                | posexplode(split(data['k'], ',')) tx as a, b""".stripMargin
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
+  }
+
   override protected def runTPCHQuery(
       queryNum: Int,
       tpchQueries: String = tpchQueries,


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#1767)

posexplode in clickhouse backend will make the convert: 
posexplode(array_or_map) -> CH: arrayJoin(map), in which map = mapFromArrays(range(length(array_or_map)), array_or_map)

But somethimes in mapFromArrays the second argument type is nullable, which can not pass the arugment check.

And when use the posexplode function to transfrom value from a map, like posexplode(split(map['key'], ',')), in clickhosue backend will  use the arrayElement function to extract the map value, and it would force the convert the key argument to UInt32, and this also will be check as illegal argument .

## How was this patch tested?

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

