### PR TITLE
[GLUTEN-1772] Pass batch size to native

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -212,7 +212,7 @@ std::string WholeStageResultIterator::getConfigValue(
 
 void WholeStageResultIterator::setConfToQueryContext(const std::shared_ptr<velox::core::QueryCtx>& queryCtx) {
   std::unordered_map<std::string, std::string> configs = {};
-  // Find batch size from Spark confs. If found.
+  // Find batch size from Spark confs. If found, set the preferred and max batch size.
   configs[velox::core::QueryConfig::kPreferredOutputBatchRows] = getConfigValue(kSparkBatchSize, "4096");
   configs[velox::core::QueryConfig::kMaxOutputBatchRows] = getConfigValue(kSparkBatchSize, "4096");
   // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -281,6 +281,9 @@ object GlutenConfig {
   val GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY = "spark.gluten.memory.offHeap.size.in.bytes"
   val GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY = "spark.gluten.memory.task.offHeap.size.in.bytes"
 
+  // Batch size.
+  val GLUTEN_MAX_BATCH_SIZE_KEY = "spark.gluten.sql.columnar.maxBatchSize"
+
   // Whether load DLL from jars
   val GLUTEN_LOAD_LIB_FROM_JAR = "spark.gluten.loadLibFromJar"
   val GLUTEN_LOAD_LIB_FROM_JAR_DEFAULT = false
@@ -312,7 +315,8 @@ object GlutenConfig {
     val nativeConfMap = new util.HashMap[String, String]()
     val keys = ImmutableList.of(
       GLUTEN_SAVE_DIR,
-      GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY
+      GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY,
+      GLUTEN_MAX_BATCH_SIZE_KEY
     )
     keys.forEach(
       k => {
@@ -322,7 +326,6 @@ object GlutenConfig {
       })
 
     val keyWithDefault = ImmutableList.of(
-      (SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key, "4096"),
       (SQLConf.CASE_SENSITIVE.key, "false")
     )
     keyWithDefault.forEach(e => nativeConfMap.put(e._1, conf.getOrElse(e._1, e._2)))
@@ -626,7 +629,7 @@ object GlutenConfig {
       .createWithDefault(100)
 
   val COLUMNAR_MAX_BATCH_SIZE =
-    buildConf("spark.gluten.sql.columnar.maxBatchSize")
+    buildConf(GLUTEN_MAX_BATCH_SIZE_KEY)
       .internal()
       .intConf
       .createWithDefault(4096)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pass `spark.gluten.sql.columnar.maxBatchSize` to native.
Fixes https://github.com/oap-project/gluten/issues/1772.

## How was this patch tested?

under test

