### PR TITLE
[WIP] [CH] Try to decrease build time by reducing unnecessary dependency

### DIFF
--- a/cpp-ch/CMakeLists.txt
+++ b/cpp-ch/CMakeLists.txt
@@ -49,6 +49,16 @@ add_custom_command(
         -DENABLE_MULTITARGET_CODE=ON
         -DENABLE_EXTERN_LOCAL_ENGINE=ON
         -DCOMPILER_FLAGS='-fvisibility=hidden -fvisibility-inlines-hidden'
+        -DENABLE_NLP=OFF
+        -DENABLE_MYSQL=OFF
+        -DENABLE_CASSANDRA=OFF
+        -DENABLE_KAFKA=OFF
+        -DENABLE_ODBC=OFF
+        -DENABLE_GRPC=OFF
+        -DENABLE_LIBPQXX=OFF
+        -DENABLE_NURAFT=OFF
+        -DENABLE_SQLITE=OFF
+        -DENABLE_ROCKSDB=OFF
         -S ${CH_SOURCE_DIR} -G Ninja -B ${CH_BINARY_DIR} &&
         cmake --build ${CH_BINARY_DIR} --target ch\"
         OUTPUT _build_ch

--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -80,7 +80,6 @@ target_link_libraries(${LOCALENGINE_SHARED_LIB} PUBLIC
         clickhouse_common_io
         clickhouse_functions
         clickhouse_parsers
-        clickhouse_storages_system
         substrait
         loggers
         substait_source


### PR DESCRIPTION
remove clickhouse_storages_system dependency

## What changes were proposed in this pull request?

Currently,  we build libch.so with `RelWithDebInfo` for debug info so that we can get stack info once core dump, but the build time increases to 20 minutes, let's try to idecrease build time by reducing unnecessary dependency.

## How was this patch tested?

Using Existed UT.

