### PR TITLE
[GLUTEN-1812][VL] package missing libthrift.so into jar on Ubuntu20/22

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2004.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2004.scala
@@ -62,6 +62,7 @@ class VeloxSharedlibraryLoaderUbuntu2004 extends VeloxSharedlibraryLoader {
       .loadAndCreateLink("libhdfs3.so.1", "libhdfs3.so", false)
       .loadAndCreateLink("libre2.so.5", "libre2.so", false)
       .loadAndCreateLink("libsnappy.so.1", "libsnappy.so", false)
+      .loadAndCreateLink("libthrift-0.13.0.so", "libthrift.so", false)
       .commit()
   }
 }

--- a/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2204.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/VeloxSharedlibraryLoaderUbuntu2204.scala
@@ -47,6 +47,7 @@ class VeloxSharedlibraryLoaderUbuntu2204 extends VeloxSharedlibraryLoader {
       .loadAndCreateLink("libhdfs3.so.1", "libhdfs3.so", false)
       .loadAndCreateLink("libre2.so.9", "libre2.so", false)
       .loadAndCreateLink("libsnappy.so.1", "libsnappy.so", false)
+      .loadAndCreateLink("libthrift-0.16.0.so", "libthrift.so", false)
       .commit()
   }
 }

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -15,12 +15,12 @@ mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests
 
 mkdir -p $THIRDPARTY_LIB
 function process_setup_ubuntu_2004 {
-  cp /usr/lib/x86_64-linux-gnu/{libroken.so.18,libasn1.so.8,libboost_context.so.1.71.0,libboost_regex.so.1.71.0,libcrypto.so.1.1,libnghttp2.so.14,libnettle.so.7,libhogweed.so.5,librtmp.so.1,libssh.so.4,libssl.so.1.1,liblber-2.4.so.2,libsasl2.so.2,libwind.so.0,libheimbase.so.1,libhcrypto.so.4,libhx509.so.5,libkrb5.so.26,libheimntlm.so.0,libgssapi.so.3,libldap_r-2.4.so.2,libcurl.so.4,libdouble-conversion.so.3,libevent-2.1.so.7,libgflags.so.2.2,libunwind.so.8,libglog.so.0,libidn.so.11,libntlm.so.0,libgsasl.so.7,libicudata.so.66,libicuuc.so.66,libxml2.so.2,libre2.so.5,libsnappy.so.1,libpsl.so.5,libbrotlidec.so.1,libbrotlicommon.so.1} $THIRDPARTY_LIB/
+  cp /usr/lib/x86_64-linux-gnu/{libroken.so.18,libasn1.so.8,libboost_context.so.1.71.0,libboost_regex.so.1.71.0,libcrypto.so.1.1,libnghttp2.so.14,libnettle.so.7,libhogweed.so.5,librtmp.so.1,libssh.so.4,libssl.so.1.1,liblber-2.4.so.2,libsasl2.so.2,libwind.so.0,libheimbase.so.1,libhcrypto.so.4,libhx509.so.5,libkrb5.so.26,libheimntlm.so.0,libgssapi.so.3,libldap_r-2.4.so.2,libcurl.so.4,libdouble-conversion.so.3,libevent-2.1.so.7,libgflags.so.2.2,libunwind.so.8,libglog.so.0,libidn.so.11,libntlm.so.0,libgsasl.so.7,libicudata.so.66,libicuuc.so.66,libxml2.so.2,libre2.so.5,libsnappy.so.1,libpsl.so.5,libbrotlidec.so.1,libbrotlicommon.so.1,libthrift-0.13.0.so} $THIRDPARTY_LIB/
   cp /usr/local/lib/{libprotobuf.so.32,libhdfs3.so.1} $THIRDPARTY_LIB/
 }
 
 function process_setup_ubuntu_2204 {
-  cp /usr/lib/x86_64-linux-gnu/{libre2.so.9,libboost_context.so.1.74.0,libboost_regex.so.1.74.0,libdouble-conversion.so.3,libidn.so.12,libglog.so.0,libgflags.so.2.2,libevent-2.1.so.7,libsnappy.so.1,libunwind.so.8,libcurl.so.4,libxml2.so.2,libgsasl.so.7,libicui18n.so.70,libicuuc.so.70,libnghttp2.so.14,libldap-2.5.so.0,liblber-2.5.so.0,libntlm.so.0,librtmp.so.1,libsasl2.so.2,libssh.so.4,libicudata.so.70} $THIRDPARTY_LIB/
+  cp /usr/lib/x86_64-linux-gnu/{libre2.so.9,libboost_context.so.1.74.0,libboost_regex.so.1.74.0,libdouble-conversion.so.3,libidn.so.12,libglog.so.0,libgflags.so.2.2,libevent-2.1.so.7,libsnappy.so.1,libunwind.so.8,libcurl.so.4,libxml2.so.2,libgsasl.so.7,libicui18n.so.70,libicuuc.so.70,libnghttp2.so.14,libldap-2.5.so.0,liblber-2.5.so.0,libntlm.so.0,librtmp.so.1,libsasl2.so.2,libssh.so.4,libicudata.so.70,libthrift-0.16.0.so} $THIRDPARTY_LIB/
   cp /usr/local/lib/{libhdfs3.so.1,libprotobuf.so.32} $THIRDPARTY_LIB/
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr make `dev/package.sh` collect libthrift and load it using java.

(Fixes: \#1812)

## How was this patch tested?
manually test
