### PR TITLE
[VL] refactor setBackendFactory

### DIFF
--- a/cpp/core/compute/Backend.cc
+++ b/cpp/core/compute/Backend.cc
@@ -24,17 +24,17 @@ static BackendFactoryContext* getBackendFactoryContext() {
   return backendFactoryCtx;
 }
 
-void setBackendFactory(BackendFactory1 factory, const std::unordered_map<std::string, std::string>& sparkConfs) {
+void setBackendFactory(BackendFactoryWithConf factory, const std::unordered_map<std::string, std::string>& sparkConfs) {
   getBackendFactoryContext()->set(factory, sparkConfs);
 #ifdef GLUTEN_PRINT_DEBUG
-  std::cout << "Set backend factory1." << std::endl;
+  std::cout << "Set backend factory with conf." << std::endl;
 #endif
 }
 
-void setBackendFactory(BackendFactory2 factory) {
+void setBackendFactory(BackendFactory factory) {
   getBackendFactoryContext()->set(factory);
 #ifdef GLUTEN_PRINT_DEBUG
-  std::cout << "Set backend factory2." << std::endl;
+  std::cout << "Set backend factory." << std::endl;
 #endif
 }
 

--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -124,11 +124,7 @@ using BackendFactory = std::shared_ptr<Backend> (*)();
 struct BackendFactoryContext {
   std::mutex mutex;
 
-  enum {
-    kBackendFactoryInvalid,
-    kBackendFactoryDefault,
-    kBackendFactoryWithConf
-  } type = kBackendFactoryInvalid;
+  enum { kBackendFactoryInvalid, kBackendFactoryDefault, kBackendFactoryWithConf } type = kBackendFactoryInvalid;
 
   union {
     BackendFactoryWithConf backendFactoryWithConf;

--- a/cpp/core/tests/BackendTest.cc
+++ b/cpp/core/tests/BackendTest.cc
@@ -55,8 +55,12 @@ class DummyBackend final : public Backend {
   };
 };
 
+static std::shared_ptr<Backend> DummyBackendFactory() {
+  return std::make_shared<DummyBackend>();
+}
+
 TEST(TestExecBackend, CreateBackend) {
-  setBackendFactory([] { return std::make_shared<DummyBackend>(); });
+  setBackendFactory(DummyBackendFactory);
   auto backendP = createBackend();
   auto& backend = *backendP.get();
   ASSERT_EQ(typeid(backend), typeid(DummyBackend));

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -35,11 +35,15 @@ namespace {
 
 std::unordered_map<std::string, std::string> bmConfMap = {{gluten::kSparkBatchSize, FLAGS_batch_size}};
 
+std::shared_ptr<gluten::Backend> VeloxBackendFactory(const std::unordered_map<std::string, std::string>& sparkConfs) {
+  return std::make_shared<gluten::VeloxBackend>(sparkConfs);
+}
+
 } // anonymous namespace
 
 void initVeloxBackend(std::unordered_map<std::string, std::string>& conf) {
-  gluten::setBackendFactory([&] { return std::make_shared<gluten::VeloxBackend>(conf); });
-  gluten::VeloxInitializer::initialize(conf);
+  gluten::setBackendFactory(VeloxBackendFactory, conf);
+  gluten::VeloxInitializer::create(conf);
 }
 
 void initVeloxBackend() {

--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -266,10 +266,12 @@ void VeloxInitializer::initIOExecutor(const std::unordered_map<std::string, std:
   }
 }
 
-void VeloxInitializer::initialize(const std::unordered_map<std::string, std::string>& conf) {
+void VeloxInitializer::create(const std::unordered_map<std::string, std::string>& conf) {
   std::lock_guard<std::mutex> lockGuard(mutex_);
   if (instance_ != nullptr) {
-    throw gluten::GlutenException("VeloxInitializer already set");
+    // throw gluten::GlutenException("VeloxInitializer already set");
+    assert(false);
+    abort();
   }
   instance_.reset(new gluten::VeloxInitializer(conf));
 }

--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -269,9 +269,8 @@ void VeloxInitializer::initIOExecutor(const std::unordered_map<std::string, std:
 void VeloxInitializer::create(const std::unordered_map<std::string, std::string>& conf) {
   std::lock_guard<std::mutex> lockGuard(mutex_);
   if (instance_ != nullptr) {
-    // throw gluten::GlutenException("VeloxInitializer already set");
     assert(false);
-    abort();
+    throw gluten::GlutenException("VeloxInitializer already set");
   }
   instance_.reset(new gluten::VeloxInitializer(conf));
 }

--- a/cpp/velox/compute/VeloxInitializer.h
+++ b/cpp/velox/compute/VeloxInitializer.h
@@ -43,7 +43,7 @@ class VeloxInitializer {
     }
   }
 
-  static void initialize(const std::unordered_map<std::string, std::string>& conf);
+  static void create(const std::unordered_map<std::string, std::string>& conf);
 
   static std::shared_ptr<VeloxInitializer> get();
 

--- a/cpp/velox/jni/JniWrapper.cc
+++ b/cpp/velox/jni/JniWrapper.cc
@@ -33,7 +33,13 @@
 
 using namespace facebook;
 
-static std::unordered_map<std::string, std::string> sparkConfs;
+namespace {
+
+std::shared_ptr<gluten::Backend> VeloxBackendFactory(const std::unordered_map<std::string, std::string>& sparkConfs) {
+  return std::make_shared<gluten::VeloxBackend>(sparkConfs);
+}
+
+} // namespace
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,9 +85,9 @@ JNIEXPORT void JNICALL Java_io_glutenproject_init_InitializerJniWrapper_initiali
     jclass clazz,
     jbyteArray planArray) {
   JNI_METHOD_START
-  sparkConfs = gluten::getConfMap(env, planArray);
-  gluten::setBackendFactory([] { return std::make_shared<gluten::VeloxBackend>(sparkConfs); });
-  gluten::VeloxInitializer::initialize(sparkConfs);
+  auto sparkConfs = gluten::getConfMap(env, planArray);
+  gluten::setBackendFactory(VeloxBackendFactory, sparkConfs);
+  gluten::VeloxInitializer::create(sparkConfs);
   JNI_METHOD_END()
 }
 


### PR DESCRIPTION
in the function of `Java_io_glutenproject_init_InitializerJniWrapper_initialize`, we save the return value of `gluten::getConfMap()` to static global variable sparkConfs.

it's wrong because two calls will overwrite the previous `sparkConfs`.

so, `setBackendFactory` should keep the both of the factory method and sparkConfs

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

