### PR TITLE
[VL][BUILD] Fix use pre-build arrow/parquet/thrift lib

### DIFF
--- a/cpp/CMake/BuildGTest.cmake
+++ b/cpp/CMake/BuildGTest.cmake
@@ -8,6 +8,10 @@ set(GLUTEN_GTEST_SOURCE_URL
     "https://github.com/google/googletest/archive/refs/tags/v${GLUTEN_GTEST_VERSION}.tar.gz"
     )
 
+if(DEFINED ENV{GLUTEN_GTEST_SOURCE_URL})
+  set(GLUTEN_GTEST_SOURCE_URL "$ENV{GLUTEN_GTEST_SOURCE_URL}")
+endif()
+
 message(STATUS "Building gtest from source")
 FetchContent_Declare(
     gtest

--- a/cpp/CMake/BuildGoogleBenchmark.cmake
+++ b/cpp/CMake/BuildGoogleBenchmark.cmake
@@ -24,6 +24,10 @@ set(GLUTEN_GBENCHMARK_SOURCE_URL
     "https://github.com/ursa-labs/thirdparty/releases/download/latest/gbenchmark-${GLUTEN_GBENCHMARK_BUILD_VERSION}.tar.gz")
 set(GLUTEN_GBENCHMARK_BUILD_SHA256_CHECKSUM "1f71c72ce08d2c1310011ea6436b31e39ccab8c2db94186d26657d41747c85d6")
 
+if(DEFINED ENV{GLUTEN_GBENCHMARK_SOURCE_URL})
+  set(GLUTEN_GBENCHMARK_SOURCE_URL "$ENV{GLUTEN_GBENCHMARK_SOURCE_URL}")
+endif()
+
 set(GBENCHMARK_CMAKE_ARGS "-fPIC -w")
 
 message(STATUS "Building google benchmark from source")

--- a/cpp/CMake/ConfigArrow.cmake
+++ b/cpp/CMake/ConfigArrow.cmake
@@ -46,9 +46,10 @@ endfunction()
 
 message(STATUS "Use existing ARROW libraries")
 
-set(ARROW_LIB_DIR "${ARROW_ROOT}/lib")
-set(ARROW_LIB64_DIR "${ARROW_ROOT}/lib64")
-set(ARROW_INCLUDE_DIR "${ARROW_ROOT}/include")
+set(ARROW_INSTALL_DIR "${ARROW_HOME}/arrow_install")
+set(ARROW_LIB_DIR "${ARROW_INSTALL_DIR}/lib")
+set(ARROW_LIB64_DIR "${ARROW_INSTALL_DIR}/lib64")
+set(ARROW_INCLUDE_DIR "${ARROW_INSTALL_DIR}/include")
 
 message(STATUS "Set Arrow Library Directory in ${ARROW_LIB_DIR} or ${ARROW_LIB64_DIR}")
 message(STATUS "Set Arrow Include Directory in ${ARROW_INCLUDE_DIR}")
@@ -56,7 +57,7 @@ message(STATUS "Set Arrow Include Directory in ${ARROW_INCLUDE_DIR}")
 if(EXISTS ${ARROW_INCLUDE_DIR}/arrow)
   set(ARROW_INCLUDE_SRC_DIR ${ARROW_INCLUDE_DIR})
 else()
-  message(FATAL_ERROR "Arrow headers not found in ${ARROW_ROOT}.")
+  message(FATAL_ERROR "Arrow headers not found in ${ARROW_INCLUDE_DIR}/arrow.")
 endif()
 
 # Copy arrow headers

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -58,8 +58,8 @@ if (NOT BUILD_VELOX_BACKEND)
   set(BUILD_VELOX_BACKEND ON)
 endif()
 
-if (NOT DEFINED ARROW_ROOT)
-  set(ARROW_ROOT ${CMAKE_SOURCE_DIR}/../ep/build-arrow/build/arrow_install)
+if (NOT DEFINED ARROW_HOME)
+  set(ARROW_HOME ${CMAKE_SOURCE_DIR}/../ep/build-arrow/build)
 endif()
 
 #
@@ -103,7 +103,6 @@ endif()
 #
 # Dependencies
 #
-
 
 include(ConfigArrow)
 

--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -13,13 +13,13 @@ ENABLE_HBM=OFF
 ENABLE_S3=OFF
 ENABLE_HDFS=OFF
 NPROC=$(nproc --ignore=2)
-ARROW_ROOT=
+ARROW_HOME=
 VELOX_HOME=
 
 for arg in "$@"; do
   case $arg in
-  --arrow_root=*)
-    ARROW_ROOT=("${arg#*=}")
+  --arrow_home=*)
+    ARROW_home=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
   --velox_home=*)
@@ -77,9 +77,9 @@ CURRENT_DIR=$(
   cd "$(dirname "$BASH_SOURCE")"
   pwd
 )
-#gluten cpp will find arrow lib from ARROW_ROOT
-if [ "$ARROW_ROOT" == "" ]; then
-  ARROW_ROOT="$CURRENT_DIR/../ep/build-arrow/build/arrow_install"
+#gluten cpp will find arrow lib from ARROW_HOME
+if [ "$ARROW_HOME" == "" ]; then
+  ARROW_HOME="$CURRENT_DIR/../ep/build-arrow/build"
 fi
 
 #gluten cpp will find velox lib from VELOX_HOME
@@ -89,7 +89,7 @@ fi
 
 echo "Building gluten cpp part..."
 echo "CMAKE Arguments:"
-echo "ARROW_ROOT=${ARROW_ROOT}"
+echo "ARROW_HOME=${ARROW_HOME}"
 echo "VELOX_HOME=${VELOX_HOME}"
 echo "BUILD_TYPE=${BUILD_TYPE}"
 echo "BUILD_VELOX_BACKEND=${BUILD_VELOX_BACKEND}"
@@ -108,7 +108,7 @@ mkdir build
 cd build
 cmake .. \
   -DBUILD_TESTS=${BUILD_TESTS} \
-  -DARROW_ROOT=${ARROW_ROOT} \
+  -DARROW_HOME=${ARROW_HOME} \
   -DBUILD_JEMALLOC=${BUILD_JEMALLOC} \
   -DBUILD_VELOX_BACKEND=${BUILD_VELOX_BACKEND} \
   -DVELOX_HOME=${VELOX_HOME} \

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -268,7 +268,7 @@ endif()
 if(Thrift_FOUND)
   target_link_libraries(velox PUBLIC thrift::thrift)
 else()
-  add_velox_dependency(thrift "${VELOX_BUILD_PATH}/third_party/arrow_ep/src/arrow_ep-build/thrift_ep-install/lib/libthrift.a")
+  add_velox_dependency(thrift "${ARROW_HOME}/arrow_ep/cpp/build/thrift_ep-install/lib/libthrift.a")
 endif()
 
 if(BUILD_TESTS)

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -7,6 +7,7 @@ ENABLE_S3=OFF
 ENABLE_HDFS=OFF
 BUILD_TYPE=release
 VELOX_HOME=""
+ARROW_HOME=""
 ENABLE_EP_CACHE=OFF
 ENABLE_BENCHMARK=OFF
 RUN_SETUP_SCRIPT=ON
@@ -18,6 +19,10 @@ for arg in "$@"; do
   case $arg in
   --velox_home=*)
     VELOX_HOME=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --arrow_home=*)
+    ARROW_HOME=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
   --enable_s3=*)
@@ -68,9 +73,12 @@ function compile {
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_S3=ON"
   fi
 
-  ARROW_ROOT=$CURRENT_DIR/../../build-arrow/build/arrow_install
-  if [ -d "$ARROW_ROOT" ]; then
-    COMPILE_OPTION="$COMPILE_OPTION -DArrow_DIR=${ARROW_ROOT} -DParquet_DIR=${ARROW_ROOT}"
+  # Let Velox use pre-build arrow,parquet,thrift.
+  if [ "$ARROW_HOME" == "" ]; then
+    ARROW_HOME=$CURRENT_DIR/../../build-arrow/build
+    if [ -d "$ARROW_HOME" ]; then
+      COMPILE_OPTION="$COMPILE_OPTION -DArrow_HOME=${ARROW_HOME}"
+    fi
   fi
 
   COMPILE_OPTION="$COMPILE_OPTION -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -4,8 +4,6 @@ set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
 VELOX_BRANCH=main
-VELOX_REPO=https://github.com/Yohahaha/velox.git
-VELOX_BRANCH=fix-arrow
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -4,6 +4,8 @@ set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
 VELOX_BRANCH=main
+VELOX_REPO=https://github.com/Yohahaha/velox.git
+VELOX_BRANCH=fix-arrow
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF


### PR DESCRIPTION
In Ubuntu, thrift will be installed manually in setup scripts, but Arrow still compile thrift, then Velox use system thrift and pre-build arrow/parquet.
In Centos, Velox could not found system thrift, so it will compile Arrow and thrift twice.
Since Arrow will compile thrift in all environments, lets use these pre-build shared libs to save time and keep toolchain consistency.

Support native dependency could be overrided by env variables.