### PR TITLE
[GLUTEN-1476][VL] Enable scan on struct and map types

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -51,10 +51,10 @@ object BackendSettings extends BackendSettingsApi {
     def validateTypes: Boolean = {
       // Collect unsupported types.
       fields.map(_.dataType).collect {
-        case _: ByteType =>
         case _: ArrayType =>
-        case _: MapType =>
-        case _: StructType =>
+        case mapType: MapType if mapType.keyType.isInstanceOf[StructType] =>
+        // Parquet scan of nested map with struct as key type is not supported in Velox.
+        case _: ByteType =>
       }.isEmpty
     }
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/rui-mo/velox.git
+VELOX_BRANCH=wip_name
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/rui-mo/velox.git
-VELOX_BRANCH=wip_name
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -36,6 +36,9 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
 
+  // The key of merge schema option in Parquet reader.
+  protected val mergeSchemaOptionKey = "mergeschema"
+
   def filterExprs(): Seq[Expression]
 
   def outputAttributes(): Seq[Attribute]

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -18,15 +18,14 @@
 package io.glutenproject.execution
 
 import java.util.Objects
-
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.metrics.MetricsUpdater
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExecShim, FileScan}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -45,6 +44,18 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
       fileScan.dataFilters ++ pushdownFilters
     case _ =>
       throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
+  }
+
+  override def doValidateInternal(): Boolean = {
+    scan match {
+      case parquetScan: ParquetScan if parquetScan.options.containsKey(mergeSchemaOptionKey) &&
+        parquetScan.options.get(mergeSchemaOptionKey) == "true" =>
+        logWarning(s"Validation failed for ${this.getClass.toString} due to " +
+          s"$mergeSchemaOptionKey is not supported.")
+        return false
+      case _ =>
+    }
+    super.doValidateInternal()
   }
 
   override def outputAttributes(): Seq[Attribute] = output

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -50,8 +50,8 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     scan match {
       case parquetScan: ParquetScan if parquetScan.options.containsKey(mergeSchemaOptionKey) &&
         parquetScan.options.get(mergeSchemaOptionKey) == "true" =>
-        logWarning(s"Validation failed for ${this.getClass.toString} due to " +
-          s"$mergeSchemaOptionKey is not supported.")
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ",
+          new UnsupportedOperationException(s"$mergeSchemaOptionKey is not supported."))
         return false
       case _ =>
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -123,11 +123,18 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
 
   override def doValidateInternal(): Boolean = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
-    if (!bucketedScan) {
-      super.doValidateInternal()
-    } else {
-      false
+    if (bucketedScan) {
+      logWarning(s"Validation failed for ${this.getClass.toString} due to " +
+        s"bucketed scan is not supported.")
+      return false
     }
+    if (relation.options.exists(option =>
+      option._1 == mergeSchemaOptionKey && option._2 == "true")) {
+      logWarning(s"Validation failed for ${this.getClass.toString} due to " +
+        s"$mergeSchemaOptionKey is not supported.")
+      return false
+    }
+    super.doValidateInternal()
   }
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -124,14 +124,14 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
   override def doValidateInternal(): Boolean = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
     if (bucketedScan) {
-      logWarning(s"Validation failed for ${this.getClass.toString} due to " +
-        s"bucketed scan is not supported.")
+      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ",
+        new UnsupportedOperationException("bucketed scan is not supported"))
       return false
     }
     if (relation.options.exists(option =>
       option._1 == mergeSchemaOptionKey && option._2 == "true")) {
-      logWarning(s"Validation failed for ${this.getClass.toString} due to " +
-        s"$mergeSchemaOptionKey is not supported.")
+      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ",
+        new UnsupportedOperationException(s"$mergeSchemaOptionKey is not supported."))
       return false
     }
     super.doValidateInternal()

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -805,6 +805,11 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-10634 timestamp written and read as INT64 - truncation")
     .exclude("Migration from INT96 to TIMESTAMP_MICROS timestamp type")
     .exclude("SPARK-10365 timestamp written and read as INT64 - TIMESTAMP_MICROS")
+    // Schema clipping.
+    .exclude("SPARK-10301 requested schema clipping - out of order")
+    .exclude("SPARK-10301 requested schema clipping - requested schema contains physical schema")
+    .exclude("SPARK-10301 requested schema clipping - schemas overlap but don't contain each other")
+    .exclude("SPARK-10301 requested schema clipping - deeply nested struct")
   enableSuite[GlutenParquetV2QuerySuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported
     .exclude("SPARK-16632: read Parquet int32 as ByteType and ShortType")
@@ -816,15 +821,128 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-10634 timestamp written and read as INT64 - truncation")
     .exclude("Migration from INT96 to TIMESTAMP_MICROS timestamp type")
     .exclude("SPARK-10365 timestamp written and read as INT64 - TIMESTAMP_MICROS")
+    // Schema clipping.
+    .exclude("SPARK-10301 requested schema clipping - out of order")
+    .exclude("SPARK-10301 requested schema clipping - requested schema contains physical schema")
+    .exclude("SPARK-10301 requested schema clipping - schemas overlap but don't contain each other")
+    .exclude("SPARK-10301 requested schema clipping - deeply nested struct")
   // requires resource files from Vanilla spark jar
   // enableSuite[GlutenParquetRebaseDatetimeV1Suite]
   // enableSuite[GlutenParquetRebaseDatetimeV2Suite]
   enableSuite[GlutenParquetV1SchemaPruningSuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported
     .excludeByPrefix("Spark vectorized reader - ")
+    // Struct reader does not support implicit schema pruning.
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "partial schema intersection - select missing subfield")
+    .exclude("Non-vectorized reader - with partition data column - partial schema intersection - " +
+      "select missing subfield")
+    .exclude("Non-vectorized reader - without partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - with partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in Expand")
+    .exclude("Non-vectorized reader - with partition data column - select nested field in Expand")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetV2SchemaPruningSuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported
     .excludeByPrefix("Spark vectorized reader - ")
+    // Struct reader does not support implicit schema pruning.
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "partial schema intersection - select missing subfield")
+    .exclude("Non-vectorized reader - with partition data column - partial schema intersection - " +
+      "select missing subfield")
+    .exclude("Non-vectorized reader - without partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - with partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in Expand")
+    .exclude("Non-vectorized reader - with partition data column - select nested field in Expand")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetRebaseDatetimeV1Suite]
     // jar path and ignore PARQUET_REBASE_MODE_IN_READ, rewrite some
     .excludeByPrefix("SPARK-31159")
@@ -924,8 +1042,14 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("change column type from float to double")
     .exclude("read float and double together")
   enableSuite[GlutenParquetReadSchemaSuite]
+    // Struct reader does not support implicit schema pruning.
+    .excludeByPrefix("add a nested column")
   enableSuite[GlutenVectorizedParquetReadSchemaSuite]
+    // Struct reader does not support implicit schema pruning.
+    .excludeByPrefix("add a nested column")
   enableSuite[GlutenMergedParquetReadSchemaSuite]
+    // Struct reader does not support implicit schema pruning.
+    .excludeByPrefix("add a nested column")
   enableSuite[GlutenDataSourceV2DataFrameSessionCatalogSuite]
   enableSuite[GlutenDataSourceV2DataFrameSuite]
   enableSuite[GlutenDataSourceV2FunctionSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenArithmeticExpressionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenArithmeticExpressionSuite.scala
@@ -20,5 +20,4 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.GlutenTestsTrait
 
 class GlutenArithmeticExpressionSuite extends ArithmeticExpressionSuite with GlutenTestsTrait {
-
 }

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -634,6 +634,9 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-35640: int as long should throw schema incompatible error")
     // Timestamp is read as INT96.
     .exclude("read dictionary and plain encoded timestamp_millis written as INT64")
+    // Struct reader does not support implicit schema pruning.
+    .exclude("vectorized reader: missing some struct fields")
+    .exclude("vectorized reader: missing all struct fields")
   enableSuite[GlutenParquetV1PartitionDiscoverySuite]
     // Timezone is not supported yet.
     .exclude("Resolve type conflicts - decimals, dates and timestamps in partition column")
@@ -662,6 +665,11 @@ class VeloxTestSettings extends BackendTestSettings {
     // new added in spark-3.3 and need fix later, random failure may caused by memory free
     .exclude("SPARK-39833: pushed filters with project without filter columns")
     .exclude("SPARK-39833: pushed filters with count()")
+    // Schema clipping.
+    .exclude("SPARK-10301 requested schema clipping - out of order")
+    .exclude("SPARK-10301 requested schema clipping - requested schema contains physical schema")
+    .exclude("SPARK-10301 requested schema clipping - schemas overlap but don't contain each other")
+    .exclude("SPARK-10301 requested schema clipping - deeply nested struct")
   enableSuite[GlutenParquetV2QuerySuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported
     .exclude("SPARK-16632: read Parquet int32 as ByteType and ShortType")
@@ -674,12 +682,125 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Migration from INT96 to TIMESTAMP_MICROS timestamp type")
     .exclude("SPARK-10365 timestamp written and read as INT64 - TIMESTAMP_MICROS")
     .exclude("SPARK-36182: read TimestampNTZ as TimestampLTZ")
+    // Schema clipping.
+    .exclude("SPARK-10301 requested schema clipping - out of order")
+    .exclude("SPARK-10301 requested schema clipping - requested schema contains physical schema")
+    .exclude("SPARK-10301 requested schema clipping - schemas overlap but don't contain each other")
+    .exclude("SPARK-10301 requested schema clipping - deeply nested struct")
   enableSuite[GlutenParquetV1SchemaPruningSuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported
     .excludeByPrefix("Spark vectorized reader - ")
+    // Struct reader does not support implicit schema pruning.
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "partial schema intersection - select missing subfield")
+    .exclude("Non-vectorized reader - with partition data column - partial schema intersection - " +
+      "select missing subfield")
+    .exclude("Non-vectorized reader - without partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - with partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in Expand")
+    .exclude("Non-vectorized reader - with partition data column - select nested field in Expand")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetV2SchemaPruningSuite]
     // spark.sql.parquet.enableVectorizedReader=true not supported
     .excludeByPrefix("Spark vectorized reader - ")
+    // Struct reader does not support implicit schema pruning.
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field with disabled nested schema pruning")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and its parent struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select a single complex field and the partition column")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "partial schema intersection - select missing subfield")
+    .exclude("Non-vectorized reader - with partition data column - partial schema intersection - " +
+      "select missing subfield")
+    .exclude("Non-vectorized reader - without partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - with partition data column - empty schema intersection")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "select nested field in aggregation function of Aggregate")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "select nested field in Expand")
+    .exclude("Non-vectorized reader - with partition data column - select nested field in Expand")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38918: nested schema pruning with correlated subqueries")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-34963: extract case-insensitive struct field from struct")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT EXISTS subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated IN subquery")
+    .exclude("Non-vectorized reader - without partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
+    .exclude("Non-vectorized reader - with partition data column - " +
+      "SPARK-38977: schema pruning with correlated NOT IN subquery")
   enableSuite[GlutenParquetRebaseDatetimeV1Suite]
     // jar path and ignore PARQUET_REBASE_MODE_IN_READ, rewrite some
     .excludeByPrefix("SPARK-31159")
@@ -781,8 +902,14 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("change column type from float to double")
     .exclude("read float and double together")
   enableSuite[GlutenParquetReadSchemaSuite]
+    // Struct reader does not support implicit schema pruning.
+    .excludeByPrefix("add a nested column")
   enableSuite[GlutenVectorizedParquetReadSchemaSuite]
+    // Struct reader does not support implicit schema pruning.
+    .excludeByPrefix("add a nested column")
   enableSuite[GlutenMergedParquetReadSchemaSuite]
+    // Struct reader does not support implicit schema pruning.
+    .excludeByPrefix("add a nested column")
   enableSuite[GlutenBucketedReadWithoutHiveSupportSuite]
     // Exclude the following suite for plan changed from SMJ to SHJ.
     .exclude("avoid shuffle when join 2 bucketed tables")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scan on struct and map types are enabled with below limitations:

- Parquet scan of nested map with struct as key type is not supported in Velox (fallback).
- Merge schema option is not supported (fallback).
- Schema pruning is not supported in Velox struct reader (tests disabled).

Depends on: https://github.com/oap-project/velox/pull/290.

\#1476

## How was this patch tested?

Testing on CI.

