### PR TITLE
[GLUTEN-1826][CH] Fix error convert time statistics for RowToCHNativeColumnarExec

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/RowToCHNativeColumnarExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/RowToCHNativeColumnarExec.scala
@@ -61,7 +61,6 @@ case class RowToCHNativeColumnarExec(child: SparkPlan)
             }
 
             private var last_address: Long = 0
-            private var elapse: Long = 0
 
             override def hasNext: Boolean = {
               if (last_address != 0) {
@@ -77,10 +76,9 @@ case class RowToCHNativeColumnarExec(child: SparkPlan)
               val sparkRowIterator = new SparkRowIterator(slice)
               last_address =
                 cvt.convertSparkRowsToCHColumn(sparkRowIterator, fieldNames, fieldTypes);
-              elapse += System.nanoTime() - start
               val block = new CHNativeBlock(last_address)
 
-              convertTime += NANOSECONDS.toMillis(elapse)
+              convertTime += NANOSECONDS.toMillis(System.nanoTime() - start)
               numInputRows += block.numRows()
               numOutputBatches += 1
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix error convert time statistics for RowToCHNativeColumnarExec

Close #1826 .
(Fixes: #1826)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

