### PR TITLE
[GLUTEN-1817][CH] Fix: Initialize global thread pool at backend initalization

### DIFF
--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -644,6 +644,8 @@ void BackendInitializerUtil::init(const std::string & conf_plan)
 
             initCompiledExpressionCache();
             LOG_INFO(logger, "Init compiled expressions cache factory.");
+
+            GlobalThreadPool::initialize();
         });
 }
 

--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -144,7 +144,7 @@ StringRef VariableLengthDataReader::readUnalignedBytes(const char * buffer, size
 
 Field VariableLengthDataReader::readDecimal(const char * buffer, size_t length) const
 {
-    assert(sizeof(Decimal128) <= length);
+    assert(sizeof(Decimal128) >= length);
 
     char decimal128_fix_data[sizeof(Decimal128)] = {};
     memcpy(decimal128_fix_data + sizeof(Decimal128) - length, buffer, length); // padding


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refer to https://github.com/ClickHouse/ClickHouse/pull/11668, let's initialize `GlobalThreadPool` at process startup to avoid race. 
`BackendInitializerUtil::init` is called when `Dirver` and `Worker`  initialize Plugin which is at process startup

(Fixes: \#1817)

## How was this patch tested?

Uisng existed UTs

