### PR TITLE
[GLUTEN-1843][CH]Bug fix for HiveScanExecTransformer infer dirty partitions

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -127,7 +127,7 @@ class GlutenClickHouseHiveTableSuite()
     "array_field array<int>," +
     "array_field_with_null array<int>," +
     "map_field map<int, long>," +
-    "map_field_with_null map<int, long>," +
+    "map_field_with_null map<int, long>, " +
     "day string) partitioned by(day) stored as textfile"
   private val json_table_create_sql = "create table if not exists %s (".format(json_table_name) +
     "string_field string," +
@@ -144,7 +144,7 @@ class GlutenClickHouseHiveTableSuite()
     "array_field_with_null array<int>," +
     "map_field map<int,long>," +
     "map_field_with_null map<int,long>, " +
-    "day string) partitioned by (day) " +
+    "day string) partitioned by(day)" +
     "ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'" +
     "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'" +
     "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'"
@@ -498,8 +498,7 @@ class GlutenClickHouseHiveTableSuite()
     assert(succ, true)
     val sql =
       s"""
-         | select count(*) from $txt_table_name
-         | where day = '2023-06-05'
+         | select string_field, day, count(*) from $txt_table_name group by string_field, day
          |""".stripMargin
     compareResultsAgainstVanillaSpark(
       sql,

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -496,6 +496,9 @@ class GlutenClickHouseHiveTableSuite()
     val partitionPath = tablePath + "/" + "_temp_day=2023_06_05kids"
     val succ = fs.mkdirs(new Path(partitionPath))
     assert(succ, true)
+    val partitionDataFilePath = partitionPath + "/abc.txt"
+    val createSucc = fs.createNewFile(new Path(partitionDataFilePath))
+    assert(createSucc, true)
     val sql =
       s"""
          | select string_field, day, count(*) from $txt_table_name group by string_field, day

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 import org.apache.spark.sql.test.SharedSparkSession
 
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterAll
 
 import java.io.File
@@ -93,6 +94,7 @@ class GlutenClickHouseHiveTableSuite()
       .set(
         "spark.sql.warehouse.dir",
         getClass.getResource("/").getPath + "unit-tests-working-home/spark-warehouse")
+      .set("spark.hive.exec.dynamic.partition.mode", "nonstrict")
       .setMaster("local[*]")
   }
 
@@ -125,8 +127,8 @@ class GlutenClickHouseHiveTableSuite()
     "array_field array<int>," +
     "array_field_with_null array<int>," +
     "map_field map<int, long>," +
-    "map_field_with_null map<int, long>) stored as textfile"
-
+    "map_field_with_null map<int, long>," +
+    "day string) partitioned by(day) stored as textfile"
   private val json_table_create_sql = "create table if not exists %s (".format(json_table_name) +
     "string_field string," +
     "int_field int," +
@@ -141,7 +143,8 @@ class GlutenClickHouseHiveTableSuite()
     "array_field array<int>," +
     "array_field_with_null array<int>," +
     "map_field map<int,long>," +
-    "map_field_with_null map<int,long>) " +
+    "map_field_with_null map<int,long>, " +
+    "day string) partitioned by (day) " +
     "ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'" +
     "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'" +
     "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'"
@@ -172,12 +175,21 @@ class GlutenClickHouseHiveTableSuite()
     }
   }
 
-  protected def initializeTable(table_name: String, table_create_sql: String): Unit = {
+  protected def initializeTable(
+      table_name: String,
+      table_create_sql: String,
+      partition: String): Unit = {
     spark.createDataFrame(genTestData()).createOrReplaceTempView("tmp_t")
     val truncate_sql = "truncate table %s".format(table_name)
+    val drop_sql = "drop table if exists %s".format(table_name)
+    spark.sql(drop_sql)
     spark.sql(table_create_sql)
     spark.sql(truncate_sql)
-    spark.sql("insert into %s select * from tmp_t".format(table_name))
+    if (partition != null) {
+      spark.sql("insert into %s select *, %s from tmp_t".format(table_name, partition))
+    } else {
+      spark.sql("insert into %s select * from tmp_t".format(table_name))
+    }
   }
 
   override def beforeAll(): Unit = {
@@ -477,4 +489,27 @@ class GlutenClickHouseHiveTableSuite()
       })
   }
 
+  test("test hive text table with illegal partition path") {
+    val path = new Path(sparkConf.get("spark.sql.warehouse.dir"))
+    val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
+    val tablePath = path.toUri.getPath + "/" + txt_table_name
+    val partitionPath = tablePath + "/" + "_temp_day=2023_06_05kids"
+    val succ = fs.mkdirs(new Path(partitionPath))
+    assert(succ, true)
+    val sql =
+      s"""
+         | select count(*) from $txt_table_name
+         | where day = '2023-06-05'
+         |""".stripMargin
+    compareResultsAgainstVanillaSpark(
+      sql,
+      true,
+      df => {
+        val txtFileScan = collect(df.queryExecution.executedPlan) {
+          case l: HiveTableScanExecTransformer => l
+        }
+        assert(txtFileScan.size == 1)
+      }
+    )
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -61,24 +61,7 @@ class HiveTableScanExecTransformer(requestedAttributes: Seq[Attribute],
 
   override def filterExprs(): Seq[Expression] = Seq.empty
 
-  override def outputAttributes(): Seq[Attribute] = {
-    var outputEmptyOrOnlyPartitionColumns = true
-    if (output.isEmpty) {
-      outputEmptyOrOnlyPartitionColumns = true
-    } else {
-      output.foreach(
-        x => {
-          if (!relation.partitionCols.contains(x)) {
-            outputEmptyOrOnlyPartitionColumns = false
-          }
-        })
-    }
-    if (outputEmptyOrOnlyPartitionColumns) {
-      output ++ relation.dataCols
-    } else {
-      output
-    }
-  }
+  override def outputAttributes(): Seq[Attribute] = output
 
   override def getPartitions: Seq[Seq[InputPartition]] = filteredPartitions
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -61,7 +61,24 @@ class HiveTableScanExecTransformer(requestedAttributes: Seq[Attribute],
 
   override def filterExprs(): Seq[Expression] = Seq.empty
 
-  override def outputAttributes(): Seq[Attribute] = output
+  override def outputAttributes(): Seq[Attribute] = {
+    var outputEmptyOrOnlyPartitionColumns = true
+    if (output.isEmpty) {
+      outputEmptyOrOnlyPartitionColumns = true
+    } else {
+      output.foreach(
+        x => {
+          if (!relation.partitionCols.contains(x)) {
+            outputEmptyOrOnlyPartitionColumns = false
+          }
+        })
+    }
+    if (outputEmptyOrOnlyPartitionColumns) {
+      output ++ relation.dataCols
+    } else {
+      output
+    }
+  }
 
   override def getPartitions: Seq[Seq[InputPartition]] = filteredPartitions
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -30,9 +30,7 @@ import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, DynamicPruningExpression, Expression}
 import org.apache.spark.sql.connector.read.{InputPartition, SupportsRuntimeFiltering}
 import org.apache.spark.sql.execution.SparkPlan
-
-import org.apache.spark.sql.execution.datasources.CatalogFileIndex
-import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.{CatalogFileIndex, DataSourceStrategy}
 import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.execution.datasources.v2.json.JsonScan
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
@@ -128,6 +126,7 @@ class HiveTableScanExecTransformer(requestedAttributes: Seq[Attribute],
       tableMeta,
       tableMeta.stats.map(_.sizeInBytes.toLong).getOrElse(defaultTableSize))
     val fileIndex = catalogFileIndex.filterPartitions(partitionPruningPred)
+
     val planOutput = output.asInstanceOf[Seq[AttributeReference]]
     var hasComplexType = false
     val outputFieldTypes = new ArrayBuffer[StructField]()

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -24,15 +24,15 @@ import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.rel.ReadRelNode
-import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.catalog.{ExternalCatalogUtils, HiveTableRelation}
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, DynamicPruningExpression, Expression}
 import org.apache.spark.sql.connector.read.{InputPartition, SupportsRuntimeFiltering}
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.datasources.{CatalogFileIndex, DataSourceStrategy, InMemoryFileIndex}
-import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, FileStatusCache, InMemoryFileIndex, PartitionPath, PartitionSpec}
+
+import org.apache.spark.sql.execution.datasources.CatalogFileIndex
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.execution.datasources.v2.json.JsonScan
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
@@ -119,7 +119,7 @@ class HiveTableScanExecTransformer(requestedAttributes: Seq[Attribute],
         Seq.empty
     }
   }
-  
+
   private def getHiveTableFileScan: Option[FileScan] = {
     val tableMeta = relation.tableMeta
     val defaultTableSize = session.sessionState.conf.defaultSizeInBytes


### PR DESCRIPTION
## What changes were proposed in this pull request?
When scan a hive txt table, HiveTableScanExecTransformer would get partitions use FileIndex, In the implements, the implementation is InMemoryFileIndex. If no partition spec defined, it would inter partitions by itself, and validate the partition columns, if the partition path is illegal, such as `hdfs://testcluster/abc/_temp_day=20221106abcwda11`, the exception will throws, and the query will be failed.

So here we defined the partition spec first in InMemoryIndex, which will fiter the dirty partitons like above

(Fixes: \#1843)

## How was this patch tested?
unit tests


