### PR TITLE
[GLUTEN-1858][CORE] Add PlanOneRowRelation to make gluten work with OneRowRelation

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -17,12 +17,13 @@
 
 package io.glutenproject.execution
 
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.types.{Decimal, DecimalType, StringType, StructField, StructType}
-import org.apache.spark.sql.Row
 import scala.collection.JavaConverters
 
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.RDDScanExec
 import org.apache.spark.sql.functions.{avg, col}
+import org.apache.spark.sql.types.{DecimalType, StringType, StructField, StructType}
 
 class TestOperator extends WholeStageTransformerSuite {
 
@@ -418,5 +419,14 @@ class TestOperator extends WholeStageTransformerSuite {
           plan.isInstanceOf[BatchScanExecTransformer]}) == 1)
         }
       }
+  }
+
+  test("test OneRowRelation") {
+    val df = sql("SELECT 1")
+    checkAnswer(df, Row(1))
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(_.isInstanceOf[RDDScanExec]).isDefined)
+    assert(plan.find(_.isInstanceOf[ProjectExecTransformer]).isDefined)
+    assert(plan.find(_.isInstanceOf[RowToArrowColumnarExec]).isDefined)
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -659,6 +659,7 @@ case class ColumnarOverrideRules(session: SparkSession)
     }
     tagBeforeTransformHitsRules :::
     List(
+      (spark: SparkSession) => PlanOneRowRelation(spark),
       (_: SparkSession) => FallbackEmptySchemaRelation(),
       (_: SparkSession) => AddTransformHintRule(),
       (_: SparkSession) => TransformPreOverrides(

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -23,6 +23,8 @@ import io.glutenproject.execution._
 import io.glutenproject.utils.PhysicalPlanSelector
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.FullOuter
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -36,6 +38,7 @@ import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.execution.python.EvalPythonExec
+import org.apache.spark.sql.types.StringType
 import org.apache.spark.api.python.EvalPythonExecTransformer
 
 import scala.util.control.Breaks.{break, breakable}
@@ -201,6 +204,31 @@ case class FallbackOneRowRelation(session: SparkSession) extends Rule[SparkPlan]
       plan.foreach(TransformHints.tagNotTransformable)
     }
     plan
+  }
+}
+
+
+/**
+ * This rule plans [[RDDScanExec]] with a fake schema to make gluten work, because gluten
+ * does not support empty output relation, see [[FallbackEmptySchemaRelation]].
+ */
+case class PlanOneRowRelation(spark: SparkSession) extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!GlutenConfig.getConf.enableOneRowRelationColumnar) {
+      return plan
+    }
+
+    plan.transform {
+      // We should make sure the output does not change, e.g.
+      // Window
+      //   OneRowRelation
+      case u: UnaryExecNode if u.child.isInstanceOf[RDDScanExec] &&
+        u.child.asInstanceOf[RDDScanExec].name == "OneRowRelation" &&
+        u.outputSet != u.child.outputSet =>
+        val rdd = spark.sparkContext.parallelize(InternalRow(null) :: Nil, 1)
+        val attr = AttributeReference("fake_column", StringType)()
+        u.withNewChildren(RDDScanExec(attr :: Nil, rdd, "OneRowRelation") :: Nil)
+    }
   }
 }
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -90,6 +90,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enablePreferColumnar: Boolean = conf.getConf(COLUMNAR_PREFER_ENABLED)
 
+  def enableOneRowRelationColumnar: Boolean = conf.getConf(COLUMNAR_ONE_ROW_RELATION_ENABLED)
+
   def enableColumnarIterator: Boolean = conf.getConf(COLUMNAR_ITERATOR_ENABLED)
 
   def physicalJoinOptimizationThrottle: Integer =
@@ -543,6 +545,13 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.columnar.preferColumnar")
       .internal()
       .doc("Prefer to use columnar operators if set to true.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COLUMNAR_ONE_ROW_RELATION_ENABLED =
+    buildConf("spark.gluten.sql.columnar.oneRowRelation")
+      .internal()
+      .doc("Enable or disable columnar `OneRowRelation`.")
       .booleanConf
       .createWithDefault(true)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds a new rule `PlanOneRowRelation` which inject a fake schema for `OneRowRelation`. As gluten does not support work with empty output relation.

BTW, if we want to validate data result with vanilla spark and gluten, please disable constant folding
`set spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.ConstantFolding`

(Fixes: \#1858)

## How was this patch tested?

add test
