### PR TITLE
[GLUTEN-1868][VL] Optimize ColumnarToRow to reuse the allocated Buffer in native side.

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -193,7 +193,7 @@ class ColumnarToRowRDD(@transient sc: SparkContext, rdd: RDD[ColumnarBatch],
             }
             val info = jniWrapper.nativeColumnarToRowWrite(batchHandle, c2rId)
 
-            convertTime += (System.currentTimeMillis() - convertTime)
+            convertTime += (System.currentTimeMillis() - beforeConvert)
 
             new Iterator[InternalRow] {
               var rowId = 0

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -181,7 +181,7 @@ class ColumnarToRowRDD(@transient sc: SparkContext, rdd: RDD[ColumnarBatch],
                 .rowIterator().asScala.map(toUnsafe)
             }
           } else {
-            val beforeConvert = System.nanoTime()
+            val beforeConvert = System.currentTimeMillis()
             val offloaded =
               ArrowColumnarBatches.ensureOffloaded(ArrowBufferAllocators.contextInstance(), batch)
             val batchHandle = GlutenColumnarBatches.getNativeHandle(offloaded)
@@ -193,7 +193,7 @@ class ColumnarToRowRDD(@transient sc: SparkContext, rdd: RDD[ColumnarBatch],
             }
             val info = jniWrapper.nativeColumnarToRowWrite(batchHandle, c2rId)
 
-            convertTime += NANOSECONDS.toMillis(System.nanoTime() - beforeConvert)
+            convertTime += (System.currentTimeMillis() - convertTime)
 
             new Iterator[InternalRow] {
               var rowId = 0

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -133,73 +133,90 @@ class ColumnarToRowRDD(@transient sc: SparkContext, rdd: RDD[ColumnarBatch],
   private def f: Iterator[ColumnarBatch] => Iterator[InternalRow] = { batches =>
     // TODO:: pass the jni jniWrapper and arrowSchema  and serializeSchema method by broadcast
     val jniWrapper = new NativeColumnarToRowJniWrapper()
+    // Init NativeColumnarToRow with the first ColumnarBatch
+    var c2rId = -1L
+    var closed = false
+    if (batches.hasNext) {
+      val res: Iterator[Iterator[InternalRow]] = new Iterator[Iterator[InternalRow]] {
 
-    batches.flatMap { batch =>
-      numInputBatches += 1
-      numOutputRows += batch.numRows()
-
-      val nonGlutenBatch = batch.numCols() > 0 &&
-        !batch.column(0).isInstanceOf[ArrowWritableColumnVector] &&
-        !batch.column(0).isInstanceOf[IndicatorVector]
-      if (batch.numRows == 0) {
-        logInfo(s"Skip ColumnarBatch of ${batch.numRows} rows, ${batch.numCols} cols")
-        Iterator.empty
-      } else if (this.output.isEmpty || nonGlutenBatch) {
-        // Fallback to ColumnarToRow of vanilla Spark.
-        val localOutput = this.output
-        numInputBatches += 1
-        numOutputRows += batch.numRows()
-
-        val toUnsafe = UnsafeProjection.create(localOutput, localOutput)
-        if (nonGlutenBatch) {
-          batch.rowIterator().asScala.map(toUnsafe)
-        } else {
-          ArrowColumnarBatches
-            .ensureLoaded(ArrowBufferAllocators.contextInstance(), batch)
-            .rowIterator().asScala.map(toUnsafe)
+        TaskResources.addRecycler(100) {
+          if (!closed) {
+            jniWrapper.nativeClose(c2rId)
+            closed = true
+          }
         }
-      } else {
-        var info: NativeColumnarToRowInfo = null
-        val beforeConvert = System.nanoTime()
-        val offloaded =
-          ArrowColumnarBatches.ensureOffloaded(ArrowBufferAllocators.contextInstance(), batch)
-        val batchHandle = GlutenColumnarBatches.getNativeHandle(offloaded)
-        info = jniWrapper.nativeConvertColumnarToRow(
-          batchHandle,
-          NativeMemoryAllocators.contextInstance().getNativeInstanceId)
 
-        convertTime += NANOSECONDS.toMillis(System.nanoTime() - beforeConvert)
-
-        new Iterator[InternalRow] {
-          var rowId = 0
-          val row = new UnsafeRow(batch.numCols())
-          var closed = false
-
-          TaskResources.addRecycler(100) {
-            if (!closed) {
-              jniWrapper.nativeClose(info.instanceID)
-              closed = true
-            }
+        override def hasNext: Boolean = {
+          val itHasNext = batches.hasNext
+          if (!itHasNext && !closed) {
+            jniWrapper.nativeClose(c2rId)
+            closed = true
           }
+          itHasNext
+        }
 
-          override def hasNext: Boolean = {
-            val result = rowId < batch.numRows()
-            if (!result && !closed) {
-              jniWrapper.nativeClose(info.instanceID)
-              closed = true
+        override def next(): Iterator[InternalRow] = {
+          val batch = batches.next()
+          numInputBatches += 1
+          numOutputRows += batch.numRows()
+
+          val nonGlutenBatch = batch.numCols() > 0 &&
+            !batch.column(0).isInstanceOf[ArrowWritableColumnVector] &&
+            !batch.column(0).isInstanceOf[IndicatorVector]
+          if (batch.numRows == 0) {
+            logInfo(s"Skip ColumnarBatch of ${batch.numRows} rows, ${batch.numCols} cols")
+            Iterator.empty
+          } else if (output.isEmpty || nonGlutenBatch) {
+            // Fallback to ColumnarToRow of vanilla Spark.
+            val localOutput = output
+            numInputBatches += 1
+            numOutputRows += batch.numRows()
+
+            val toUnsafe = UnsafeProjection.create(localOutput, localOutput)
+            if (nonGlutenBatch) {
+              batch.rowIterator().asScala.map(toUnsafe)
+            } else {
+              ArrowColumnarBatches
+                .ensureLoaded(ArrowBufferAllocators.contextInstance(), batch)
+                .rowIterator().asScala.map(toUnsafe)
             }
-            result
-          }
+          } else {
+            val beforeConvert = System.nanoTime()
+            val offloaded =
+              ArrowColumnarBatches.ensureOffloaded(ArrowBufferAllocators.contextInstance(), batch)
+            val batchHandle = GlutenColumnarBatches.getNativeHandle(offloaded)
 
-          override def next: UnsafeRow = {
-            if (rowId >= batch.numRows()) throw new NoSuchElementException
-            val (offset, length) = (info.offsets(rowId), info.lengths(rowId))
-            row.pointTo(null, info.memoryAddress + offset, length.toInt)
-            rowId += 1
-            row
+            if (c2rId == -1) {
+              c2rId = jniWrapper.nativeColumnarToRowInit(
+                batchHandle,
+                NativeMemoryAllocators.contextInstance().getNativeInstanceId)
+            }
+            val info = jniWrapper.nativeColumnarToRowWrite(batchHandle, c2rId)
+
+            convertTime += NANOSECONDS.toMillis(System.nanoTime() - beforeConvert)
+
+            new Iterator[InternalRow] {
+              var rowId = 0
+              val row = new UnsafeRow(batch.numCols())
+
+              override def hasNext: Boolean = {
+                rowId < batch.numRows()
+              }
+
+              override def next: UnsafeRow = {
+                if (rowId >= batch.numRows()) throw new NoSuchElementException
+                val (offset, length) = (info.offsets(rowId), info.lengths(rowId))
+                row.pointTo(null, info.memoryAddress + offset, length.toInt)
+                rowId += 1
+                row
+              }
+            }
           }
         }
       }
+      res.flatten
+    } else {
+      Iterator.empty
     }
   }
 

--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -79,13 +79,7 @@ class Backend : public std::enable_shared_from_this<Backend> {
       MemoryAllocator* allocator,
       std::shared_ptr<ColumnarBatch> cb) {
     auto memoryPool = asWrappedArrowMemoryPool(allocator);
-    std::shared_ptr<ArrowSchema> cSchema = cb->exportArrowSchema();
-    std::shared_ptr<ArrowArray> cArray = cb->exportArrowArray();
-    ARROW_ASSIGN_OR_RAISE(
-        std::shared_ptr<arrow::RecordBatch> rb, arrow::ImportRecordBatch(cArray.get(), cSchema.get()));
-    ArrowSchemaRelease(cSchema.get());
-    ArrowArrayRelease(cArray.get());
-    return std::make_shared<ArrowColumnarToRowConverter>(rb, memoryPool);
+    return std::make_shared<ArrowColumnarToRowConverter>(memoryPool);
   }
 
   virtual std::shared_ptr<RowToColumnarConverter> getRowToColumnarConverter(

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -569,8 +569,8 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToR
   env->SetIntArrayRegion(lengthsArr, 0, numRows, lengthsSrc);
   long address = reinterpret_cast<long>(columnarToRowConverter->getBufferAddress());
 
-  jobject nativeColumnarToRowInfo = env->NewObject(
-      nativeColumnarToRowInfoClass, nativeColumnarToRowInfoConstructor, offsetsArr, lengthsArr, address);
+  jobject nativeColumnarToRowInfo =
+      env->NewObject(nativeColumnarToRowInfoClass, nativeColumnarToRowInfoConstructor, offsetsArr, lengthsArr, address);
   return nativeColumnarToRowInfo;
   JNI_METHOD_END(nullptr)
 }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -286,7 +286,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   nativeColumnarToRowInfoClass =
       createGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/NativeColumnarToRowInfo;");
-  nativeColumnarToRowInfoConstructor = getMethodIdOrError(env, nativeColumnarToRowInfoClass, "<init>", "(J[I[IJ)V");
+  nativeColumnarToRowInfoConstructor = getMethodIdOrError(env, nativeColumnarToRowInfoClass, "<init>", "([I[IJ)V");
 
   javaReservationListenerClass = createGlobalClassReference(
       env,
@@ -570,7 +570,7 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToR
   long address = reinterpret_cast<long>(columnarToRowConverter->getBufferAddress());
 
   jobject nativeColumnarToRowInfo = env->NewObject(
-      nativeColumnarToRowInfoClass, nativeColumnarToRowInfoConstructor, instanceId, offsetsArr, lengthsArr, address);
+      nativeColumnarToRowInfoClass, nativeColumnarToRowInfoConstructor, offsetsArr, lengthsArr, address);
   return nativeColumnarToRowInfo;
   JNI_METHOD_END(nullptr)
 }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -524,15 +524,14 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator
   JNI_METHOD_END()
 }
 
-JNIEXPORT jobject JNICALL
-Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeConvertColumnarToRow( // NOLINT
+JNIEXPORT jlong JNICALL
+Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToRowInit( // NOLINT
     JNIEnv* env,
     jobject,
     jlong batchHandle,
     jlong allocatorId) {
   JNI_METHOD_START
   std::shared_ptr<ColumnarBatch> cb = glutenColumnarbatchHolder.lookup(batchHandle);
-  int64_t numRows = cb->getNumRows();
   // convert the record batch to spark unsafe row.
   auto* allocator = reinterpret_cast<MemoryAllocator*>(allocatorId);
   if (allocator == nullptr) {
@@ -541,16 +540,26 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeConvertColu
   auto backend = gluten::createBackend();
   std::shared_ptr<ColumnarToRowConverter> columnarToRowConverter =
       gluten::jniGetOrThrow(backend->getColumnar2RowConverter(allocator, cb));
-  gluten::jniAssertOkOrThrow(
-      columnarToRowConverter->init(),
-      "Native convert columnar to row: Init "
-      "ColumnarToRowConverter failed");
-  gluten::jniAssertOkOrThrow(
-      columnarToRowConverter->write(), "Native convert columnar to row: ColumnarToRowConverter write failed");
+  int64_t instanceID = columnarToRowConverterHolder.insert(columnarToRowConverter);
+  return instanceID;
+  JNI_METHOD_END(-1)
+}
+
+JNIEXPORT jobject JNICALL
+Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToRowWrite( // NOLINT
+    JNIEnv* env,
+    jobject,
+    jlong batchHandle,
+    jlong instanceId) {
+  JNI_METHOD_START
+  auto columnarToRowConverter = columnarToRowConverterHolder.lookup(instanceId);
+  std::shared_ptr<ColumnarBatch> cb = glutenColumnarbatchHolder.lookup(batchHandle);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   const auto& offsets = columnarToRowConverter->getOffsets();
   const auto& lengths = columnarToRowConverter->getLengths();
-  int64_t instanceID = columnarToRowConverterHolder.insert(columnarToRowConverter);
+
+  auto numRows = cb->getNumRows();
 
   auto offsetsArr = env->NewIntArray(numRows);
   auto offsetsSrc = reinterpret_cast<const jint*>(offsets.data());
@@ -561,7 +570,7 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeConvertColu
   long address = reinterpret_cast<long>(columnarToRowConverter->getBufferAddress());
 
   jobject nativeColumnarToRowInfo = env->NewObject(
-      nativeColumnarToRowInfoClass, nativeColumnarToRowInfoConstructor, instanceID, offsetsArr, lengthsArr, address);
+      nativeColumnarToRowInfoClass, nativeColumnarToRowInfoConstructor, instanceId, offsetsArr, lengthsArr, address);
   return nativeColumnarToRowInfo;
   JNI_METHOD_END(nullptr)
 }

--- a/cpp/core/operators/c2r/ArrowColumnarToRowConverter.h
+++ b/cpp/core/operators/c2r/ArrowColumnarToRowConverter.h
@@ -23,14 +23,13 @@ namespace gluten {
 
 class ArrowColumnarToRowConverter final : public ColumnarToRowConverter {
  public:
-  ArrowColumnarToRowConverter(std::shared_ptr<arrow::RecordBatch> rb, std::shared_ptr<arrow::MemoryPool> memoryPool)
-      : ColumnarToRowConverter(memoryPool), rb_(rb) {}
+  ArrowColumnarToRowConverter(std::shared_ptr<arrow::MemoryPool> memoryPool) : ColumnarToRowConverter(memoryPool) {}
 
-  arrow::Status init() override;
-
-  arrow::Status write() override;
+  arrow::Status write(std::shared_ptr<ColumnarBatch> cb) override;
 
  private:
+  arrow::Status init();
+
   arrow::Status fillBuffer(
       int32_t& rowStart,
       int32_t batchRows,

--- a/cpp/core/operators/c2r/ColumnarToRow.h
+++ b/cpp/core/operators/c2r/ColumnarToRow.h
@@ -24,6 +24,7 @@
 #include <arrow/record_batch.h>
 #include <arrow/type.h>
 #include <arrow/util/bit_util.h>
+#include "memory/ColumnarBatch.h"
 
 #include <boost/align.hpp>
 
@@ -35,8 +36,7 @@ class ColumnarToRowConverter {
 
   virtual ~ColumnarToRowConverter() = default;
 
-  virtual arrow::Status init() = 0;
-  virtual arrow::Status write() = 0;
+  virtual arrow::Status write(std::shared_ptr<ColumnarBatch> cb = nullptr) = 0;
 
   uint8_t* getBufferAddress() {
     return bufferAddress_;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -108,7 +108,7 @@ arrow::Result<std::shared_ptr<ColumnarToRowConverter>> VeloxBackend::getColumnar
     auto arrowPool = asWrappedArrowMemoryPool(allocator);
     auto veloxPool = asWrappedVeloxAggregateMemoryPool(allocator);
     auto ctxVeloxPool = veloxPool->addLeafChild("columnar_to_row_velox");
-    return std::make_shared<VeloxColumnarToRowConverter>(veloxBatch->getFlattenedRowVector(), arrowPool, ctxVeloxPool);
+    return std::make_shared<VeloxColumnarToRowConverter>(arrowPool, ctxVeloxPool);
   } else {
     return Backend::getColumnar2RowConverter(allocator, cb);
   }

--- a/cpp/velox/compute/VeloxColumnarToRowConverter.h
+++ b/cpp/velox/compute/VeloxColumnarToRowConverter.h
@@ -29,17 +29,16 @@ namespace gluten {
 class VeloxColumnarToRowConverter final : public ColumnarToRowConverter {
  public:
   VeloxColumnarToRowConverter(
-      facebook::velox::RowVectorPtr rv,
       std::shared_ptr<arrow::MemoryPool> arrowPool,
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool)
-      : ColumnarToRowConverter(arrowPool), rv_(rv), veloxPool_(veloxPool) {}
+      : ColumnarToRowConverter(arrowPool), veloxPool_(veloxPool) {}
 
-  arrow::Status init() override;
-
-  arrow::Status write() override;
+  arrow::Status write(std::shared_ptr<ColumnarBatch> cb) override;
 
  private:
   void resumeVeloxVector();
+
+  arrow::Status init();
 
   facebook::velox::RowVectorPtr rv_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;

--- a/cpp/velox/tests/ColumnarToRowTest.cc
+++ b/cpp/velox/tests/ColumnarToRowTest.cc
@@ -36,9 +36,9 @@ class ColumnarToRowTest : public ::testing::Test {
  public:
   void testRecordBatchEqual(std::shared_ptr<arrow::RecordBatch> inputBatch) {
     std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-        std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-    GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-    GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+        std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+    auto columnarBatch = std::make_shared<ArrowColumnarBatch>(inputBatch);
+    GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(columnarBatch));
 
     int64_t numRows = inputBatch->num_rows();
 
@@ -65,12 +65,9 @@ class ColumnarToRowTest : public ::testing::Test {
   }
 
   void testConvertBatch(std::shared_ptr<RecordBatch> inputBatch) {
-    auto converter = std::make_shared<ArrowColumnarToRowConverter>(inputBatch, arrowPool_);
-    jniAssertOkOrThrow(
-        converter->init(),
-        "Native convert columnar to row: Init "
-        "ColumnarToRowConverter failed");
-    jniAssertOkOrThrow(converter->write(), "Native convert columnar to row: ColumnarToRowConverter write failed");
+    auto converter = std::make_shared<ArrowColumnarToRowConverter>(arrowPool_);
+    auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+    jniAssertOkOrThrow(converter->write(cb), "Native convert columnar to row: ColumnarToRowConverter write failed");
   }
 
  private:
@@ -171,9 +168,9 @@ TEST_F(ColumnarToRowTest, Buffer_int8_int16) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -203,9 +200,9 @@ TEST_F(ColumnarToRowTest, Buffer_int32_int64) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -235,9 +232,9 @@ TEST_F(ColumnarToRowTest, Buffer_float_double) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -265,9 +262,9 @@ TEST_F(ColumnarToRowTest, Buffer_bool_binary) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -294,9 +291,9 @@ TEST_F(ColumnarToRowTest, Buffer_decimal_string) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -325,9 +322,9 @@ TEST_F(ColumnarToRowTest, Buffer_int64_int64_with_null) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -354,9 +351,9 @@ TEST_F(ColumnarToRowTest, Buffer_string) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -386,10 +383,10 @@ TEST_F(ColumnarToRowTest, Buffer_bool) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(inputBatch, getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
 
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 

--- a/cpp/velox/tests/VeloxColumnarToRowTest.cc
+++ b/cpp/velox/tests/VeloxColumnarToRowTest.cc
@@ -46,9 +46,9 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
 
   void testRecordBatchEqual(std::shared_ptr<arrow::RecordBatch> inputBatch) {
     auto row = recordBatch2VeloxRowVector(*inputBatch);
-    auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool_, veloxPool_);
-    GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-    GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+    auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool_, veloxPool_);
+    auto columnarBatch = std::make_shared<VeloxColumnarBatch>(row);
+    GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(columnarBatch));
 
     int64_t numRows = inputBatch->num_rows();
 
@@ -85,13 +85,9 @@ TEST_F(VeloxColumnarToRowTest, timestamp) {
   });
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto converter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-
-  jniAssertOkOrThrow(
-      converter->init(),
-      "Native convert columnar to row: Init "
-      "ColumnarToRowConverter failed");
-  jniAssertOkOrThrow(converter->write(), "Native convert columnar to row: ColumnarToRowConverter write failed");
+  auto converter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  jniAssertOkOrThrow(converter->write(cb), "Native convert columnar to row: ColumnarToRowConverter write failed");
 }
 
 TEST_F(VeloxColumnarToRowTest, Int_64) {
@@ -158,10 +154,10 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int8_int16) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
 
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -193,9 +189,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int32_int64) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -227,9 +223,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_float_double) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -259,9 +255,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool_binary) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -289,9 +285,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_decimal_string) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -320,9 +316,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int64_int64_with_null) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -351,9 +347,9 @@ TEST_F(VeloxColumnarToRowTest, Buffer_string) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 
@@ -385,10 +381,10 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool) {
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
   auto veloxPool = getDefaultVeloxLeafMemoryPool();
-  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool, veloxPool);
+  auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
 
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+  auto cb = std::make_shared<VeloxColumnarBatch>(row);
+  GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
   uint8_t* address = columnarToRowConverter->getBufferAddress();
 

--- a/cpp/velox/tests/VeloxRowToColumnarTest.cc
+++ b/cpp/velox/tests/VeloxRowToColumnarTest.cc
@@ -47,9 +47,10 @@ class VeloxRowToColumnarTest : public ::testing::Test, public test::VectorTestBa
 
   void testRecordBatchEqual(std::shared_ptr<arrow::RecordBatch> inputBatch) {
     auto row = recordBatch2VeloxRowVector(*inputBatch);
-    auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(row, arrowPool_, veloxPool_);
-    GLUTEN_THROW_NOT_OK(columnarToRowConverter->init());
-    GLUTEN_THROW_NOT_OK(columnarToRowConverter->write());
+    auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool_, veloxPool_);
+
+    auto columnarBatch = std::make_shared<VeloxColumnarBatch>(row);
+    GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(columnarBatch));
 
     int64_t numRows = inputBatch->num_rows();
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowInfo.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowInfo.java
@@ -18,14 +18,11 @@
 package io.glutenproject.vectorized;
 
 public class NativeColumnarToRowInfo {
-  public long instanceID;
   public int[] offsets;
   public int[] lengths;
   public long memoryAddress;
 
-  public NativeColumnarToRowInfo(long instanceID,
-                                 int[] offsets, int[] lengths, long memoryAddress) {
-    this.instanceID = instanceID;
+  public NativeColumnarToRowInfo(int[] offsets, int[] lengths, long memoryAddress) {
     this.offsets = offsets;
     this.lengths = lengths;
     this.memoryAddress = memoryAddress;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
@@ -26,8 +26,12 @@ public class NativeColumnarToRowJniWrapper extends JniInitialized {
   public NativeColumnarToRowJniWrapper() throws IOException {
   }
 
-  public native NativeColumnarToRowInfo nativeConvertColumnarToRow(
+  public native  long nativeColumnarToRowInit(
       long batchHandle, long allocatorId)
+      throws RuntimeException;
+
+  public native NativeColumnarToRowInfo nativeColumnarToRowWrite(
+      long batchHandle, long instanceId)
       throws RuntimeException;
 
   public native void nativeClose(long instanceID);

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -62,7 +62,7 @@ object ExecUtil {
 
       TaskResources.addRecycler(100) {
         if (!closed) {
-          jniWrapper.nativeClose(info.instanceID)
+          jniWrapper.nativeClose(instanceId)
           closed = true
         }
       }
@@ -70,7 +70,7 @@ object ExecUtil {
       override def hasNext: Boolean = {
         val result = rowId < batch.numRows()
         if (!result && !closed) {
-          jniWrapper.nativeClose(info.instanceID)
+          jniWrapper.nativeClose(instanceId)
           closed = true
         }
         result

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -50,10 +50,10 @@ object ExecUtil {
     val offloaded =
       ArrowColumnarBatches.ensureOffloaded(ArrowBufferAllocators.contextInstance(), batch)
     val batchHandle = GlutenColumnarBatches.getNativeHandle(offloaded)
-    info = jniWrapper.nativeConvertColumnarToRow(
+    val instanceId = jniWrapper.nativeColumnarToRowInit(
       batchHandle,
       NativeMemoryAllocators.contextInstance().getNativeInstanceId)
-
+    info = jniWrapper.nativeColumnarToRowWrite(batchHandle, instanceId)
 
     new Iterator[InternalRow] {
       var rowId = 0


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR make all the ColumnarBatch in one partition to use same buffer as much as possible.

https://github.com/oap-project/gluten/issues/1868

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

