### PR TITLE
[GLUTEN-1871][CH]Fix: Remove BroadcastJoinBuilder :: storage_join_map and using guava cache to synchronize access

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
@@ -34,8 +34,6 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 
 public class StorageJoinBuilder implements AutoCloseable {
 
-  public static native int nativeCachedHashTableCount();
-
   public static native void nativeCleanBuildHashTable(String hashTableId, long hashTableData);
 
   private ShuffleInputStream in;

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
@@ -531,7 +531,7 @@ abstract class GlutenClickHouseTPCHAbstractSuite extends WholeStageTransformerSu
       // Spark listener message was not sent in time with ci env.
       // In tpch case, there are more then 10 hbj data has build.
       // Let's just verify it was cleaned ever.
-      assert(StorageJoinBuilder.nativeCachedHashTableCount <= 10)
+      assert(CHBroadcastBuildSideCache.size() <= 10)
     }
 
     ClickHouseLog.clearCache()

--- a/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.h
+++ b/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.h
@@ -23,7 +23,6 @@ public:
 
 private:
     std::shared_ptr<StorageJoinFromReadBuffer> storage_join;
-    std::mutex build_lock_mutex;
 };
 
 
@@ -49,15 +48,9 @@ public:
 
     static void cleanBuildHashTable(const std::string & hash_table_id, jlong instance);
 
-    static size_t cachedHashTableCount() { return storage_join_map.size(); };
-
     static std::shared_ptr<StorageJoinFromReadBuffer> getJoin(const std::string & key);
 
     static void clean();
-
-private:
-    static std::unordered_map<std::string, std::shared_ptr<StorageJoinWrapper>> storage_join_map;
-    static std::mutex join_lock_mutex;
 };
 
 

--- a/cpp-ch/local-engine/jni/BroadcastBuildSideCache.cpp
+++ b/cpp-ch/local-engine/jni/BroadcastBuildSideCache.cpp
@@ -1,0 +1,40 @@
+#include <jni.h>
+#include <jni/SharedPointerWrapper.h>
+#include <jni/jni_common.h>
+#include <Common/JNIUtils.h>
+
+#include "BroadcastBuildSideCache.h"
+
+static jclass Java_CHBroadcastBuildSideCache = nullptr;
+static jmethodID Java_get = nullptr;
+using namespace local_engine;
+
+void BroadcastBuildSideCache::init(JNIEnv * env)
+{
+    /**
+     * Scala object will be compiled into two classes, one is with '$' suffix which is normal class,
+     * and one is utility class which only has static method.
+     *
+     * Here, we use utility class.
+     */
+
+    const char * classSig = "Lio/glutenproject/execution/CHBroadcastBuildSideCache;";
+    Java_CHBroadcastBuildSideCache = CreateGlobalClassReference(env, classSig);
+    Java_get = GetStaticMethodID(env, Java_CHBroadcastBuildSideCache, "get", "(Ljava/lang/String;)J");
+}
+
+void BroadcastBuildSideCache::destroy(JNIEnv * env)
+{
+    env->DeleteGlobalRef(Java_CHBroadcastBuildSideCache);
+}
+
+
+std::shared_ptr<StorageJoinWrapper> BroadcastBuildSideCache::get(const std::string & id)
+{
+    GET_JNIENV(env)
+    jstring s = charTojstring(env, id.c_str());
+    auto result = safeCallStaticLongMethod(env, Java_CHBroadcastBuildSideCache, Java_get, s);
+    CLEAN_JNIENV
+
+    return SharedPointerWrapper<StorageJoinWrapper>::get(result)->get();
+}

--- a/cpp-ch/local-engine/jni/BroadcastBuildSideCache.h
+++ b/cpp-ch/local-engine/jni/BroadcastBuildSideCache.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+// Forward Declarations
+struct JNIEnv_;
+using JNIEnv = JNIEnv_;
+
+namespace local_engine
+{
+class StorageJoinWrapper;
+
+class BroadcastBuildSideCache
+{
+public:
+    static void init(JNIEnv *);
+    static void destroy(JNIEnv *);
+
+    static std::shared_ptr<StorageJoinWrapper> get(const std::string & id);
+};
+}

--- a/cpp-ch/local-engine/jni/SharedPointerWrapper.h
+++ b/cpp-ch/local-engine/jni/SharedPointerWrapper.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <memory>
+#include <jni.h>
+
+namespace local_engine
+{
+template <typename T>
+class SharedPointerWrapper
+{
+    std::shared_ptr<T> pointer;
+
+public:
+    template <typename... ARGS>
+    explicit SharedPointerWrapper(ARGS... a)
+    {
+        pointer = std::make_shared<T>(a...);
+    }
+
+    explicit SharedPointerWrapper(std::shared_ptr<T> obj) { pointer = obj; }
+
+    virtual ~SharedPointerWrapper() noexcept = default;
+
+    jlong instance() const { return reinterpret_cast<jlong>(this); }
+
+    std::shared_ptr<T> get() const { return pointer; }
+
+    static SharedPointerWrapper<T> * get(jlong handle) { return reinterpret_cast<SharedPointerWrapper<T> *>(handle); }
+
+    static void dispose(jlong handle)
+    {
+        auto obj = get(handle);
+        delete obj;
+    }
+};
+}

--- a/cpp-ch/local-engine/jni/jni_common.h
+++ b/cpp-ch/local-engine/jni/jni_common.h
@@ -89,4 +89,13 @@ void safeCallVoidMethod(JNIEnv * env, jobject obj, jmethodID method_id, Args... 
     env->CallVoidMethod(obj, method_id, args...);
     LOCAL_ENGINE_JNI_JMETHOD_END(env);
 }
+
+template <typename... Args>
+jlong safeCallStaticLongMethod(JNIEnv * env, jclass clazz, jmethodID method_id, Args... args)
+{
+    LOCAL_ENGINE_JNI_JMETHOD_START
+    auto ret = env->CallStaticLongMethod(clazz, method_id, args...);
+    LOCAL_ENGINE_JNI_JMETHOD_END(env);
+    return ret;
+}
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the old implementation, we have two caches to for BHJ hashtable.
1. At JVM side, there is a `CHBroadcastBuildSideCache::buildSideRelationCache`, which is used to avoid accessing Broadcast value multiple times.
2. At C++ side there is a ` BroadcastJoinBuilder :: storage_join_map`, which is used to avoid building hash table multiple times.

The `BroadcastJoinBuilder :: storage_join_map`(`std::unorder_map`) isn't thread safe, so we must have a lock to protect it. It turns out that `BroadcastJoinBuilder :: storage_join_map` is redundant, since `buildSideRelationCache` is guava cache which is thread safe.  We can use it at c++ backend to get a hash table without synchronization by ourselves.

(Fixes: \#1871)

## How was this patch tested?

using existed UT

