### PR TITLE
[CH] Early throw exception if ColumnarBatch can't convert to CHNativeBlock

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockOutputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockOutputStream.java
@@ -82,10 +82,9 @@ public class BlockOutputStream implements Closeable {
   private native void nativeFlush(long instance);
 
   public void write(ColumnarBatch cb) {
-    CHNativeBlock.fromColumnarBatch(cb).ifPresent(block -> {
-      dataSize.add(block.totalBytes());
-      nativeWrite(instance, block.blockAddress());
-    });
+    CHNativeBlock block = CHNativeBlock.fromColumnarBatch(cb);
+    dataSize.add(block.totalBytes());
+    nativeWrite(instance, block.blockAddress());
   }
 
   public void flush() throws IOException {

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHBlockWriterJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHBlockWriterJniWrapper.java
@@ -36,9 +36,7 @@ public class CHBlockWriterJniWrapper {
     if (instance == 0) {
       instance = nativeCreateInstance();
     }
-    CHNativeBlock.fromColumnarBatch(columnarBatch).ifPresent(block -> {
-      nativeWrite(instance, block.blockAddress());
-    });
+    nativeWrite(instance, CHNativeBlock.fromColumnarBatch(columnarBatch).blockAddress());
   }
 
   public byte[] collectAsByteArray() {

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
@@ -32,7 +32,7 @@ public class CHNativeBlock {
     if (batch.numCols() == 0 || !(batch.column(0) instanceof CHColumnVector)) {
       throw new RuntimeException(
               "Unexpected ColumnarBatch: " + (batch.numCols() == 0 ?
-                      "zero column" : "expected CHColumnVector, but " + batch.column(0).getClass()));
+                      "0 column" : "expected CHColumnVector, but " + batch.column(0).getClass()));
     }
     CHColumnVector columnVector = (CHColumnVector) batch.column(0);
     return new CHNativeBlock(columnVector.getBlockAddress());

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
@@ -21,8 +21,6 @@ import org.apache.spark.sql.execution.utils.CHExecUtil;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
-import java.util.Optional;
-
 public class CHNativeBlock {
   private long blockAddress;
 
@@ -30,12 +28,14 @@ public class CHNativeBlock {
     this.blockAddress = blockAddress;
   }
 
-  public static Optional<CHNativeBlock> fromColumnarBatch(ColumnarBatch batch) {
+  public static CHNativeBlock fromColumnarBatch(ColumnarBatch batch) {
     if (batch.numCols() == 0 || !(batch.column(0) instanceof CHColumnVector)) {
-      return Optional.empty();
+      throw new RuntimeException(
+              "Unexpected ColumnarBatch: " + (batch.numCols() == 0 ?
+                      "zero column" : "expected CHColumnVector, but " + batch.column(0).getClass()));
     }
     CHColumnVector columnVector = (CHColumnVector) batch.column(0);
-    return Optional.of(new CHNativeBlock(columnVector.getBlockAddress()));
+    return new CHNativeBlock(columnVector.getBlockAddress());
   }
 
   private native int nativeNumRows(long blockAddress);

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -141,13 +141,8 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
             }
           }
           val res = operator.release().toColumnarBatch
-          CHNativeBlock
-            .fromColumnarBatch(res)
-            .ifPresent(
-              block => {
-                numOutputRows += block.numRows();
-                numOutputBatches += 1;
-              })
+          numOutputRows += CHNativeBlock.fromColumnarBatch(res).numRows()
+          numOutputBatches += 1
           res
         }
 

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarToRowExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarToRowExec.scala
@@ -113,9 +113,7 @@ class CHColumnarToRowRDD(
           } else {
             val nativeBlock = CHNativeBlock.fromColumnarBatch(batch)
             val beforeConvert = System.nanoTime()
-            val blockAddress = nativeBlock
-              .orElseThrow(() => new IllegalStateException("Logic error"))
-              .blockAddress()
+            val blockAddress = nativeBlock.blockAddress()
             val info = jniWrapper.convertColumnarToRow(blockAddress)
 
             convertTime += NANOSECONDS.toMillis(System.nanoTime() - beforeConvert)
@@ -131,7 +129,7 @@ class CHColumnarToRowRDD(
                   jniWrapper.freeMemory(info.memoryAddress, info.totalSize)
                   closed = true
                 }
-                return result
+                result
               }
 
               override def next: UnsafeRow = {

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -62,8 +62,7 @@ object CHExecUtil extends Logging {
             iter.flatMap(
               batch => {
                 val jniWrapper = new CHBlockConverterJniWrapper()
-                val nativeBlock = CHNativeBlock.fromColumnarBatch(batch)
-                val blockAddress = nativeBlock.get().blockAddress()
+                val blockAddress = CHNativeBlock.fromColumnarBatch(batch).blockAddress()
                 val rowInfo = jniWrapper.convertColumnarToRow(blockAddress)
 
                 // generate rows from a columnar batch
@@ -107,12 +106,10 @@ object CHExecUtil extends Logging {
       val splitIterator = new BlockSplitIterator(
         cbIter
           .map(
-            cb =>
-              CHNativeBlock
-                .fromColumnarBatch(cb)
-                .orElseThrow(() => new IllegalStateException("unsupported columnar batch"))
-                .blockAddress()
-                .asInstanceOf[java.lang.Long])
+            CHNativeBlock
+              .fromColumnarBatch(_)
+              .blockAddress()
+              .asInstanceOf[java.lang.Long])
           .asJava,
         options
       )


### PR DESCRIPTION
## What changes were proposed in this pull request?

We may encounter the failure of converting ColumnarBatch to CHNativeBlock in rare cases, but we are unable to obtain more meaningful error info when it occurs. I think we can early throw exception with more meaningful info in the situation.

