### PR TITLE
[GLUTEN-1891] upgrade substrait-java from 0.5.0  to 0.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <fasterxml.version>${fasterxml.spark33.version}</fasterxml.version>
     <junit.version>4.13.1</junit.version>
 
-    <substrait.version>0.5.0</substrait.version>
+    <substrait.version>0.12.0</substrait.version>
     <guava.version>31.1-jre</guava.version>
     <protobuf.version>3.16.3</protobuf.version>
     <protobuf.substrait.version>3.21.7</protobuf.substrait.version>

--- a/substrait/substrait-spark/src/main/scala/io/substrait/debug/RelToVerboseString.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/debug/RelToVerboseString.scala
@@ -94,10 +94,15 @@ class RelToVerboseString(addSuffix: Boolean) extends DefaultRelVisitor[String] {
         builder.append(", ")
         builder.append("filter=").append(filter)
       })
-    read.getGeneralExtension.ifPresent(
-      generalExtension => {
+    read.getExtension.ifPresent(
+      extension => {
         builder.append(", ")
-        builder.append("generalExtension=").append(generalExtension)
+        builder.append("extension=").append(extension)
+      })
+    read.getCommonExtension.ifPresent(
+      extension => {
+        builder.append(", ")
+        builder.append("commonExtension=").append(extension)
       })
   }
   override def visit(namedScan: NamedScan): String = {

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/DefaultExpressionVisitor.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/DefaultExpressionVisitor.scala
@@ -18,7 +18,7 @@ package io.substrait.spark
 
 import io.substrait.`type`.Type
 import io.substrait.expression._
-import io.substrait.function.SimpleExtension
+import io.substrait.extension.SimpleExtension
 
 class DefaultExpressionVisitor[T]
   extends AbstractExpressionVisitor[T, RuntimeException]

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/SparkExtension.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/SparkExtension.scala
@@ -18,7 +18,7 @@ package io.substrait.spark
 
 import io.substrait.spark.expression.ToAggregateFunction
 
-import io.substrait.function.SimpleExtension
+import io.substrait.extension.SimpleExtension
 
 import java.util.Collections
 

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/FunctionConverter.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/FunctionConverter.scala
@@ -27,7 +27,8 @@ import org.apache.spark.substrait.ToSubstraitType
 import com.google.common.collect.{ArrayListMultimap, Multimap}
 import io.substrait.`type`.Type
 import io.substrait.expression.{Expression => SExpression, ExpressionCreator, FunctionArg}
-import io.substrait.function.{ParameterizedType, SimpleExtension, ToTypeString}
+import io.substrait.extension.SimpleExtension
+import io.substrait.function.{ParameterizedType, ToTypeString}
 import io.substrait.utils.Util
 
 import java.{util => ju}

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
@@ -110,4 +110,13 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
 
   @throws[RuntimeException]
   override def visit(stringLiteral: ParameterizedType.StringLiteral): Boolean = false
+
+  override def visit(userDefined: Type.UserDefined): Boolean = {
+    if (!typeToMatch.isInstanceOf[Type.UserDefined]) {
+      return false
+    }
+    // Two user-defined types are equal if they have the same uri AND name
+    val ud = typeToMatch.asInstanceOf[Type.UserDefined]
+    ud.uri() == userDefined.uri() && ud.name() == userDefined.name()
+  }
 }

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/ToAggregateFunction.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/ToAggregateFunction.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 
 import io.substrait.`type`.Type
 import io.substrait.expression.{AggregateFunctionInvocation, Expression => SExpression, ExpressionCreator, FunctionArg}
-import io.substrait.function.SimpleExtension
+import io.substrait.extension.SimpleExtension
 import io.substrait.proto.AggregateFunction
 
 import java.util.Collections

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/ToScalarFunction.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/expression/ToScalarFunction.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 
 import io.substrait.`type`.Type
 import io.substrait.expression.{Expression => SExpression, FunctionArg}
-import io.substrait.function.SimpleExtension
+import io.substrait.extension.SimpleExtension
 
 import scala.collection.JavaConverters
 

--- a/substrait/substrait-spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/substrait/substrait-spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.substrait.ToSubstraitType
 import org.apache.spark.substrait.ToSubstraitType.toNamedStruct
 
-import io.substrait.`type`.Type
 import io.substrait.expression.{Expression => SExpression, ExpressionCreator}
 import io.substrait.plan.{ImmutablePlan, ImmutableRoot, Plan}
 import io.substrait.relation
@@ -210,11 +209,6 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
       relation.Cross.builder
         .left(left)
         .right(right)
-        .deriveRecordType(
-          Type.Struct.builder
-            .from(left.getRecordType)
-            .from(right.getRecordType)
-            .build)
         .build
     } else {
       relation.Join.builder

--- a/substrait/substrait-spark/src/test/scala/io/substrait/spark/SubstraitPlanTestBase.scala
+++ b/substrait/substrait-spark/src/test/scala/io/substrait/spark/SubstraitPlanTestBase.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.util.resourceToString
 import org.apache.spark.sql.test.SharedSparkSession
 
 import io.substrait.debug.TreePrinter
-import io.substrait.expression.proto.FunctionCollector
+import io.substrait.extension.ExtensionCollector
 import io.substrait.plan.{Plan, PlanProtoConverter, ProtoPlanConverter}
 import io.substrait.proto
 import io.substrait.relation.RelProtoConverter
@@ -57,8 +57,8 @@ trait SubstraitPlanTestBase { self: SharedSparkSession =>
     val logicalPlan = plan(sql)
     val substraitRel = convert.visit(logicalPlan)
 
-    val functionCollector = new FunctionCollector
-    val relProtoConverter = new RelProtoConverter(functionCollector)
+    val extensionCollector = new ExtensionCollector
+    val relProtoConverter = new RelProtoConverter(extensionCollector)
     val builder = proto.Plan
       .newBuilder()
       .addRelations(
@@ -71,7 +71,7 @@ trait SubstraitPlanTestBase { self: SharedSparkSession =>
                 .accept(relProtoConverter))
           )
       )
-    functionCollector.addFunctionsToPlan(builder)
+    extensionCollector.addExtensionsToPlan(builder)
     builder.build()
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updates [substrait-java](https://github.com/substrait-io/substrait-java/releases) from 0.5.0 to 0.12.0

Since 0.5.0, substrait-java has gained support for features which I believe you may find useful:
* [AdvancedExtensions](https://github.com/substrait-io/substrait/blob/9b763a008de8fac12622353ce65e856389dd1c0e/proto/substrait/extensions/extensions.proto#L72-L81) which allow adding optimization and enhancement metadata to Rels
* [ExtensionRels](https://github.com/substrait-io/substrait/blob/9b763a008de8fac12622353ce65e856389dd1c0e/proto/substrait/algebra.proto#L267-L285) which allow for adding custom relations (outside of the core spec)
* mapping user-defined types in extensions

This has necessitated some breaking changes, and given that I made a number of said changes, I thought I would try and update the library version for y'all.

## How was this patch tested?
I have not tested this in gluten, I am hoping that a CI run will be sufficient.

