### PR TITLE
[VL]Fix aarch64 linux arrow-c-data jni lib missing

### DIFF
--- a/ep/build-arrow/src/build_arrow.sh
+++ b/ep/build-arrow/src/build_arrow.sh
@@ -117,7 +117,7 @@ cmake -G Ninja \
 cmake --build . --target install
 popd
 
-CPU_TARGET=${CPU_TARGET:-"x86"}
+CPU_TARGET=${CPU_TARGET:-""}
 if [ $CPU_TARGET == "aarch64" ]; then
   # Arrow C Data Interface CPP libraries
   pushd java

--- a/ep/build-arrow/src/build_arrow.sh
+++ b/ep/build-arrow/src/build_arrow.sh
@@ -117,5 +117,18 @@ cmake -G Ninja \
 cmake --build . --target install
 popd
 
+if [ $CPU_TARGET == "aarch64" ]; then
+  # Arrow C Data Interface CPP libraries
+  pushd java
+  mvn generate-resources -P generate-libs-cdata-all-os -Darrow.c.jni.dist.dir=$ARROW_INSTALL_DIR -N
+  popd
+
+  # Arrow Java libraries
+  pushd java
+  mvn clean install -P arrow-c-data -pl c -am -DskipTests -Dcheckstyle.skip \
+    -Darrow.c.jni.dist.dir=$ARROW_INSTALL_DIR/lib -Dmaven.gitcommitid.skip=true
+  popd
+fi
+
 echo "Successfully built Arrow from Source."
 echo $TARGET_BUILD_COMMIT >"${ARROW_HOME}/arrow-commit.cache"

--- a/ep/build-arrow/src/build_arrow.sh
+++ b/ep/build-arrow/src/build_arrow.sh
@@ -117,6 +117,7 @@ cmake -G Ninja \
 cmake --build . --target install
 popd
 
+CPU_TARGET=${CPU_TARGET:-"x86"}
 if [ $CPU_TARGET == "aarch64" ]; then
   # Arrow C Data Interface CPP libraries
   pushd java


### PR DESCRIPTION
## What changes were proposed in this pull request?

At present, the open source version of arrow directly used by gluten, the arrow-c-data in the maven repo only includes x86 windows/linux/macOS and aarch64 macOS lib, aarch64 linux still needs to run the arrow-c-data install process.

<img width="302" alt="image" src="https://github.com/oap-project/gluten/assets/13622031/62e2dca4-4db5-4747-92d0-cc665a59da5d">


## How was this patch tested?
test in aarch64 linux

