### PR TITLE
[GLUTEN-1910][CH] Fix fallback when executing window function: lead, lag and so on

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -68,7 +68,6 @@ object CHExpressionUtil {
   final val STRING_TYPE = "string"
 
   final val CH_AGGREGATE_FUNC_BLACKLIST: Map[String, ValidatorUtil] = Map(
-    STDDEV -> new ValidatorUtil(new DefaultBlackList),
     VAR_SAMP -> new ValidatorUtil(new DefaultBlackList),
     VAR_POP -> new ValidatorUtil(new DefaultBlackList),
     BLOOM_FILTER_AGG -> new ValidatorUtil(new DefaultBlackList),

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -625,7 +625,21 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
         |from nation
         |order by n_regionkey, n_nationkey, n_lead
         |""".stripMargin
-    compareResultsAgainstVanillaSpark(sql, true, { _ => }, false)
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
+  }
+
+  test("window lead / lag with negative offset") {
+    val sql =
+      """
+        |select n_regionkey, n_nationkey,
+        | lead(n_nationkey, -3, 2) OVER (PARTITION BY n_regionkey ORDER BY n_nationkey) as n_lead1,
+        | lead(n_nationkey, 1) OVER (PARTITION BY n_regionkey ORDER BY n_nationkey) as n_lead2,
+        | lag(n_nationkey, -1, 3) OVER (PARTITION BY n_regionkey ORDER BY n_nationkey) as n_lag1,
+        | lag(n_nationkey, 2) OVER (PARTITION BY n_regionkey ORDER BY n_nationkey) as n_lag2
+        |from nation
+        |order by n_regionkey, n_nationkey, n_lead1, n_lead2, n_lag1, n_lag2
+        |""".stripMargin
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
   test("window lead with default value") {
@@ -637,7 +651,7 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
         |order by n_regionkey, n_nationkey, n_lead
         |""".stripMargin
 
-    compareResultsAgainstVanillaSpark(sql, true, { _ => }, false)
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
   test("window lag") {
@@ -648,7 +662,7 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
         |from nation
         |order by n_regionkey, n_nationkey
         |""".stripMargin
-    compareResultsAgainstVanillaSpark(sql, true, { _ => }, false)
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
   test("window lag with default value") {
@@ -659,7 +673,7 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
         |from nation
         |order by n_regionkey, n_nationkey, n_lag
         |""".stripMargin
-    compareResultsAgainstVanillaSpark(sql, true, { _ => }, false)
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
 
   test("window dense_rank") {
@@ -807,6 +821,14 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     val sql =
       """
         |select stddev_samp(l_orderkey), stddev_samp(l_quantity) from lineitem
+        |""".stripMargin
+    compareResultsAgainstVanillaSpark(sql, true, { _ => })
+  }
+
+  test("test stddev") {
+    val sql =
+      """
+        |select stddev(l_orderkey), stddev(l_quantity) from lineitem
         |""".stripMargin
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -162,6 +162,8 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"min", "min"},
     {"max", "max"},
     {"collect_list", "groupArray"},
+    // In Spark, stddev is the alias for stddev_samp.
+    {"stddev", "stddev_samp"},
     {"stddev_samp", "stddev_samp"},
     {"stddev_pop", "stddev_pop"},
     {"bit_and", "groupBitAnd"},

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -17,13 +17,15 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.execution._
-import io.glutenproject.expression.{AliasTransformerBase, ExpressionTransformer, GetStructFieldTransformerBase, HashExpressionTransformerBase, NamedStructTransformerBase, Sha1Transformer, Sha2Transformer, Sig}
+import io.glutenproject.expression._
+import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
+
 import org.apache.spark.ShuffleDependency
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.{GenShuffleWriterParameters, GlutenShuffleWriterWrapper}
 import org.apache.spark.sql.{SparkSession, Strategy}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, CreateNamedStruct, Expression, GetStructField, NamedExpression, Sha1, Sha2}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.optimizer.BuildSide
 import org.apache.spark.sql.catalyst.plans.JoinType
@@ -35,6 +37,8 @@ import org.apache.spark.sql.execution.joins.BuildSideRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import java.util
 
 trait SparkPlanExecApi {
 
@@ -266,4 +270,83 @@ trait SparkPlanExecApi {
     */
   def extraExpressionMappings: Seq[Sig] = Seq.empty
 
+  /**
+   * default function to generate window function node
+   */
+  def genWindowFunctionsNode(
+    windowExpression: Seq[NamedExpression],
+    windowExpressionNodes: util.ArrayList[WindowFunctionNode],
+    originalInputAttributes: Seq[Attribute],
+    args: util.HashMap[String, java.lang.Long]): Unit = {
+
+    windowExpression.map { windowExpr =>
+      val aliasExpr = windowExpr.asInstanceOf[Alias]
+      val columnName = s"${aliasExpr.name}_${aliasExpr.exprId.id}"
+      val wExpression = aliasExpr.child.asInstanceOf[WindowExpression]
+      wExpression.windowFunction match {
+        case wf@(RowNumber() | Rank(_) | DenseRank(_) | CumeDist() | PercentRank(_)) =>
+          val aggWindowFunc = wf.asInstanceOf[AggregateWindowFunction]
+          val frame = aggWindowFunc.frame.asInstanceOf[SpecifiedWindowFrame]
+          val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            WindowFunctionsBuilder.create(args, aggWindowFunc).toInt,
+            new util.ArrayList[ExpressionNode](),
+            columnName,
+            ConverterUtils.getTypeNode(aggWindowFunc.dataType, aggWindowFunc.nullable),
+            WindowExecTransformer.getFrameBound(frame.upper),
+            WindowExecTransformer.getFrameBound(frame.lower),
+            frame.frameType.sql)
+          windowExpressionNodes.add(windowFunctionNode)
+        case aggExpression: AggregateExpression =>
+          val frame = wExpression.windowSpec.
+            frameSpecification.asInstanceOf[SpecifiedWindowFrame]
+          val aggregateFunc = aggExpression.aggregateFunction
+          val substraitAggFuncName = ExpressionMappings.expressionsMap.get(aggregateFunc.getClass)
+          if (substraitAggFuncName.isEmpty) {
+            throw new UnsupportedOperationException(s"Not currently supported: $aggregateFunc.")
+          }
+
+          val childrenNodeList = new util.ArrayList[ExpressionNode]()
+          aggregateFunc.children.foreach(
+            expr => childrenNodeList.add(
+              ExpressionConverter.replaceWithExpressionTransformer(expr,
+                originalInputAttributes).doTransform(args))
+          )
+
+          val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            AggregateFunctionsBuilder.create(args, aggExpression.aggregateFunction).toInt,
+            childrenNodeList,
+            columnName,
+            ConverterUtils.getTypeNode(aggExpression.dataType, aggExpression.nullable),
+            WindowExecTransformer.getFrameBound(frame.upper),
+            WindowExecTransformer.getFrameBound(frame.lower),
+            frame.frameType.sql)
+          windowExpressionNodes.add(windowFunctionNode)
+        case wf@(Lead(_, _, _, _) | Lag(_, _, _, _)) =>
+          val offset_wf = wf.asInstanceOf[FrameLessOffsetWindowFunction]
+          val frame = offset_wf.frame.asInstanceOf[SpecifiedWindowFrame]
+          val childrenNodeList = new util.ArrayList[ExpressionNode]()
+          childrenNodeList.add(ExpressionConverter.replaceWithExpressionTransformer(
+            offset_wf.input,
+            attributeSeq = originalInputAttributes).doTransform(args))
+          childrenNodeList.add(ExpressionConverter.replaceWithExpressionTransformer(
+            offset_wf.offset,
+            attributeSeq = originalInputAttributes).doTransform(args))
+          childrenNodeList.add(ExpressionConverter.replaceWithExpressionTransformer(
+            offset_wf.default,
+            attributeSeq = originalInputAttributes).doTransform(args))
+          val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
+            WindowFunctionsBuilder.create(args, offset_wf).toInt,
+            childrenNodeList,
+            columnName,
+            ConverterUtils.getTypeNode(offset_wf.dataType, offset_wf.nullable),
+            WindowExecTransformer.getFrameBound(frame.upper),
+            WindowExecTransformer.getFrameBound(frame.lower),
+            frame.frameType.sql)
+          windowExpressionNodes.add(windowFunctionNode)
+        case _ =>
+          throw new UnsupportedOperationException("unsupported window function type: " +
+            wExpression.windowFunction)
+      }
+    }
+  }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/AggregateFunctionsBuilder.scala
@@ -29,13 +29,15 @@ object AggregateFunctionsBuilder {
 
     var substraitAggFuncName = ExpressionMappings.expressionsMap.get(aggregateFunc.getClass)
     if (substraitAggFuncName.isEmpty) {
-      throw new UnsupportedOperationException(s"Could not find valid a substrait mapping name for $aggregateFunc.")
+      throw new UnsupportedOperationException(
+        s"Could not find valid a substrait mapping name for $aggregateFunc.")
     }
 
     // Check whether each backend supports this aggregate function.
     if (!BackendsApiManager.getValidatorApiInstance.doExprValidate(
       substraitAggFuncName.get, aggregateFunc)) {
-      throw new UnsupportedOperationException(s"Aggregate function not supported for $aggregateFunc.")
+      throw new UnsupportedOperationException(
+        s"Aggregate function not supported for $aggregateFunc.")
     }
 
     aggregateFunc match {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -234,7 +234,9 @@ object ExpressionMappings {
     Sig[RowNumber](ROW_NUMBER),
     Sig[CumeDist](CUME_DIST),
     Sig[PercentRank](PERCENT_RANK),
-    Sig[NTile](NTILE)
+    Sig[NTile](NTILE),
+    Sig[Lead](LEAD),
+    Sig[Lag](LAG)
   )
 
   lazy val expressionsMap: Map[Class[_], String] = {

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -239,5 +239,23 @@ class ClickHouseTestSettings extends BackendTestSettings {
     // This test will re-run in GlutenExchangeSuite with shuffle partitions > 1
     .exclude("Exchange reuse across the whole plan")
   enableSuite[GlutenReuseExchangeAndSubquerySuite]
+
+  enableSuite[GlutenDataFrameWindowFramesSuite]
+    .exclude(
+      "rows between should accept int/long values as boundary",
+      "reverse preceding/following range between with aggregation"
+    )
+  enableSuite[GlutenDataFrameWindowFunctionsSuite]
+    .exclude(
+      "reuse window partitionBy",
+      "reuse window orderBy",
+      "collect_list in ascending ordered window",
+      "collect_list in descending ordered window",
+      "collect_set in window",
+      "lead/lag with ignoreNulls",
+      "Window spill with less than the inMemoryThreshold",
+      "Window spill with more than the inMemoryThreshold but less than the spillThreshold",
+      "NaN and -0.0 in window partition keys"
+    )
 }
 

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -243,7 +243,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFrameWindowFramesSuite]
     .exclude(
       "rows between should accept int/long values as boundary",
-      "reverse preceding/following range between with aggregation"
+      "reverse preceding/following range between with aggregation",
+      "SPARK-24033: Analysis Failure of OffsetWindowFunction"
     )
   enableSuite[GlutenDataFrameWindowFunctionsSuite]
     .exclude(
@@ -254,6 +255,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "collect_set in window",
       "lead/lag with ignoreNulls",
       "Window spill with less than the inMemoryThreshold",
+      "Window spill with more than the inMemoryThreshold and spillThreshold",
       "Window spill with more than the inMemoryThreshold but less than the spillThreshold",
       "NaN and -0.0 in window partition keys"
     )

--- a/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
@@ -24,7 +24,6 @@ object ExpressionNames {
   final val COUNT = "count"
   final val MIN = "min"
   final val MAX = "max"
-  final val STDDEV = "stddev"
   final val STDDEV_SAMP = "stddev_samp"
   final val STDDEV_POP = "stddev_pop"
   final val COLLECT_LIST = "collect_list"
@@ -229,6 +228,8 @@ object ExpressionNames {
   final val CUME_DIST = "cume_dist"
   final val PERCENT_RANK = "percent_rank"
   final val NTILE = "ntile"
+  final val LEAD = "lead"
+  final val LAG = "lag"
 
   // Decimal functions
   final val UNSCALED_VALUE = "unscaled_value"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix fallback when executing window function: lead, lag, stddev and so on:

Currently, when executing window functions: lead, lag, it will fallback to vanilla spark, because the functions lead, lag miss in `ExpressionMappings`, and `WindowFunctionsBuilder.create` will return empty when getting function mappings by the lead, lag function name.

Close #1910.
(Fixes: #1910)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

