### PR TITLE
[VL] Add quotes for CPU_TARGET to avoid warning

### DIFF
--- a/ep/build-arrow/src/build_arrow.sh
+++ b/ep/build-arrow/src/build_arrow.sh
@@ -118,7 +118,7 @@ cmake --build . --target install
 popd
 
 CPU_TARGET=${CPU_TARGET:-""}
-if [ $CPU_TARGET == "aarch64" ]; then
+if [ "$CPU_TARGET" == "aarch64" ]; then
   # Arrow C Data Interface CPP libraries
   pushd java
   mvn generate-resources -P generate-libs-cdata-all-os -Darrow.c.jni.dist.dir=$ARROW_INSTALL_DIR -N


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add quotes out side CPU_TARGET variable to avoid warining if CPU_TARGET is empty string.

