### PR TITLE
[GLUTEN-1928][Core] Support to add the custom expressions transformer by Spark conf

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -19,6 +19,7 @@ package io.glutenproject
 
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.expression.ExpressionMappings
 import io.glutenproject.extension.{ColumnarOverrides, ColumnarQueryStagePrepOverrides, OthersExtensionOverrides, StrategyOverrides}
 import io.glutenproject.test.TestStats
 
@@ -29,11 +30,11 @@ import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.{GlutenDriverEndpoint, GlutenExecutorEndpoint}
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.utils.ExpressionUtil
 import org.apache.spark.util.SparkResourcesUtil
 
 import java.util
 import java.util.{Collections, Objects}
-
 import scala.language.implicitConversions
 
 class GlutenPlugin extends SparkPlugin {
@@ -47,7 +48,6 @@ class GlutenPlugin extends SparkPlugin {
 }
 
 private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
-//  private var glutenDriverEndpoint: GlutenDriverEndpoint = _
 
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
     val conf = pluginContext.conf()
@@ -62,6 +62,10 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
     BackendsApiManager.getContextApiInstance.initialize(conf)
     GlutenDriverEndpoint.glutenDriverEndpointRef = (new GlutenDriverEndpoint).self
     GlutenListenerFactory.addToSparkListenerBus(sc)
+    ExpressionMappings.expressionExtensionTransformer =
+      ExpressionUtil.extendedExpressionTransformer(
+        conf.get(GlutenConfig.GLUTEN_EXTENDED_EXPRESSION_TRAN_CONF, "")
+      )
     Collections.emptyMap()
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -519,6 +519,66 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           replaceWithExpressionTransformer(sha2.left, attributeSeq),
           replaceWithExpressionTransformer(sha2.right, attributeSeq),
           sha2)
+      case namedStruct: CreateNamedStruct =>
+        BackendsApiManager.getSparkPlanExecApiInstance
+          .genNamedStructTransformer(substraitExprName.get, namedStruct, attributeSeq)
+      case elementAt: ElementAt =>
+        new BinaryArgumentsCollectionOperationTransformer(
+          substraitExprName.get,
+          left = replaceWithExpressionTransformer(elementAt.left, attributeSeq),
+          right = replaceWithExpressionTransformer(elementAt.right, attributeSeq),
+          elementAt
+        )
+      case arrayContains: ArrayContains =>
+        new BinaryArgumentsCollectionOperationTransformer(
+          substraitExprName.get,
+          left = replaceWithExpressionTransformer(arrayContains.left, attributeSeq),
+          right = replaceWithExpressionTransformer(arrayContains.right, attributeSeq),
+          arrayContains
+        )
+      case arrayMax: ArrayMax =>
+        new UnaryArgumentCollectionOperationTransformer(
+          substraitExprName.get,
+          replaceWithExpressionTransformer(arrayMax.child, attributeSeq),
+          arrayMax)
+      case arrayMin: ArrayMin =>
+        new UnaryArgumentCollectionOperationTransformer(
+          substraitExprName.get,
+          replaceWithExpressionTransformer(arrayMin.child, attributeSeq),
+          arrayMin)
+      case mapKeys: MapKeys =>
+        new UnaryArgumentCollectionOperationTransformer(
+          substraitExprName.get,
+          replaceWithExpressionTransformer(mapKeys.child, attributeSeq),
+          mapKeys)
+      case mapValues: MapValues =>
+        new UnaryArgumentCollectionOperationTransformer(
+          substraitExprName.get,
+          replaceWithExpressionTransformer(mapValues.child, attributeSeq),
+          mapValues)
+      case seq: Sequence =>
+        new SequenceTransformer(
+          substraitExprName.get,
+          replaceWithExpressionTransformer(seq.start, attributeSeq),
+          replaceWithExpressionTransformer(seq.stop, attributeSeq),
+          seq.stepOpt.map(replaceWithExpressionTransformer(_, attributeSeq)),
+          seq
+        )
+      case j: JsonTuple =>
+        val children = j.children.map(child =>
+          replaceWithExpressionTransformer(child, attributeSeq))
+        new JsonTupleExpressionTransformer(substraitExprName.get, children.toArray, j)
+      case extendedExpr
+        if ExpressionMappings.expressionExtensionTransformer
+          .extensionExpressionsMapping.contains(extendedExpr.getClass) =>
+        // Use extended expression transformer to replace custom expression
+        ExpressionMappings.expressionExtensionTransformer
+          .replaceWithExtensionExpressionTransformer(
+            substraitExprName.get,
+            extendedExpr,
+            attributeSeq)
+      // The other expression case must be put before LeafExpression, UnaryExpression,
+      // BinaryExpression, TernaryExpression, QuaternaryExpression
       case l: LeafExpression =>
         LeafExpressionTransformer(substraitExprName.get, l)
       case u: UnaryExpression =>
@@ -568,55 +628,6 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           replaceWithExpressionTransformer(q.fourth, attributeSeq),
           q
         )
-      case namedStruct: CreateNamedStruct =>
-        BackendsApiManager.getSparkPlanExecApiInstance
-          .genNamedStructTransformer(substraitExprName.get, namedStruct, attributeSeq)
-      case element_at: ElementAt =>
-        new BinaryArgumentsCollectionOperationTransformer(
-          substraitExprName.get,
-          left = replaceWithExpressionTransformer(element_at.left, attributeSeq),
-          right = replaceWithExpressionTransformer(element_at.right, attributeSeq),
-          element_at
-        )
-      case arrayContains: ArrayContains =>
-        new BinaryArgumentsCollectionOperationTransformer(
-          substraitExprName.get,
-          left = replaceWithExpressionTransformer(arrayContains.left, attributeSeq),
-          right = replaceWithExpressionTransformer(arrayContains.right, attributeSeq),
-          arrayContains
-        )
-      case arrayMax: ArrayMax =>
-        new UnaryArgumentCollectionOperationTransformer(
-          substraitExprName.get,
-          replaceWithExpressionTransformer(arrayMax.child, attributeSeq),
-          arrayMax)
-      case arrayMin: ArrayMin =>
-        new UnaryArgumentCollectionOperationTransformer(
-          substraitExprName.get,
-          replaceWithExpressionTransformer(arrayMin.child, attributeSeq),
-          arrayMin)
-      case mapKeys: MapKeys =>
-        new UnaryArgumentCollectionOperationTransformer(
-          substraitExprName.get,
-          replaceWithExpressionTransformer(mapKeys.child, attributeSeq),
-          mapKeys)
-      case mapValues: MapValues =>
-        new UnaryArgumentCollectionOperationTransformer(
-          substraitExprName.get,
-          replaceWithExpressionTransformer(mapValues.child, attributeSeq),
-          mapValues)
-      case seq: Sequence =>
-        new SequenceTransformer(
-          substraitExprName.get,
-          replaceWithExpressionTransformer(seq.start, attributeSeq),
-          replaceWithExpressionTransformer(seq.stop, attributeSeq),
-          seq.stepOpt.map(replaceWithExpressionTransformer(_, attributeSeq)),
-          seq
-        )
-      case j : JsonTuple =>
-        val children = j.children.map(child =>
-          replaceWithExpressionTransformer(child, attributeSeq))
-        new JsonTupleExpressionTransformer(substraitExprName.get, children.toArray, j)
       case expr =>
         logWarning(s"${expr.getClass} or $expr is not currently supported.")
         throw new UnsupportedOperationException(

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -18,6 +18,7 @@ package io.glutenproject.expression
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ExpressionNames._
+import io.glutenproject.extension.ExpressionExtensionTrait
 import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.expressions._
@@ -239,11 +240,17 @@ object ExpressionMappings {
     Sig[Lag](LAG)
   )
 
-  lazy val expressionsMap: Map[Class[_], String] = {
+  def expressionsMap: Map[Class[_], String] =
+    defaultExpressionsMap ++
+      expressionExtensionTransformer.extensionExpressionsMapping.map(s => (s.expClass, s.name))
+        .toMap[Class[_], String]
+
+  private lazy val defaultExpressionsMap: Map[Class[_], String] = {
     (SCALAR_SIGS ++ AGGREGATE_SIGS ++ WINDOW_SIGS ++
       BackendsApiManager.getSparkPlanExecApiInstance.extraExpressionMappings)
       .map(s => (s.expClass, s.name))
       .toMap[Class[_], String]
   }
 
+  var expressionExtensionTransformer: ExpressionExtensionTrait = _
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension
+
+import io.glutenproject.expression.{ExpressionTransformer, Sig}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+
+trait ExpressionExtensionTrait {
+  /**
+   * Generate the extension expressions list,
+   * format: Sig[XXXExpression]("XXXExpressionName")
+   */
+  def extensionExpressionsMapping: Seq[Sig]
+
+  /**
+   * Replace extension expression to transformer.
+   */
+  def replaceWithExtensionExpressionTransformer(
+    substraitExprName: String,
+    expr: Expression,
+    attributeSeq: Seq[Attribute]): ExpressionTransformer
+}
+
+case class DefaultExpressionExtensionTransformer() extends ExpressionExtensionTrait with Logging {
+
+  /**
+   * Generate the extension expressions list,
+   * format: Sig[XXXExpression]("XXXExpressionName")
+   */
+  override def extensionExpressionsMapping: Seq[Sig] = Seq.empty[Sig]
+
+  /**
+   * Replace extension expression to transformer.
+   */
+  override def replaceWithExtensionExpressionTransformer(
+    substraitExprName: String,
+    expr: Expression,
+    attributeSeq: Seq[Attribute]): ExpressionTransformer = {
+    logWarning(s"${expr.getClass} or $expr is not currently supported.")
+    throw new UnsupportedOperationException(
+      s"${expr.getClass} or $expr is not currently supported.")
+  }
+}

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -18,12 +18,12 @@
 package io.glutenproject.utils.clickhouse
 
 import io.glutenproject.utils.BackendTestSettings
+
 import org.apache.spark.sql._
 import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.{FallbackStrategiesSuite, GlutenExchangeSuite, GlutenReuseExchangeAndSubquerySuite}
-import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.extension.{GlutenCustomerExtensionSuite, GlutenSessionExtensionSuite}
+import org.apache.spark.sql.extension.{GlutenCustomerExpressionTransformerSuite, GlutenCustomerExtensionSuite, GlutenSessionExtensionSuite}
 
 class ClickHouseTestSettings extends BackendTestSettings {
 
@@ -273,6 +273,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
 
   enableSuite[GlutenSessionExtensionSuite]
   enableSuite[GlutenCustomerExtensionSuite]
+  enableSuite[GlutenCustomerExpressionTransformerSuite]
 
   enableSuite[GlutenDataFrameAggregateSuite]
     .exclude(

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -33,13 +33,14 @@ import org.apache.spark.sql.execution.datasources.text.{GlutenTextV1Suite, Glute
 import org.apache.spark.sql.execution.datasources.v2.GlutenFileTableSuite
 import org.apache.spark.sql.execution.exchange.GlutenEnsureRequirementsSuite
 import org.apache.spark.sql.execution.joins.{GlutenBroadcastJoinSuite, GlutenExistenceJoinSuite, GlutenInnerJoinSuite, GlutenOuterJoinSuite}
-import org.apache.spark.sql.extension.{GlutenCustomerExtensionSuite, GlutenSessionExtensionSuite}
+import org.apache.spark.sql.extension.{GlutenCustomerExpressionTransformerSuite, GlutenCustomerExtensionSuite, GlutenSessionExtensionSuite}
 import org.apache.spark.sql.sources.{GlutenBucketedReadWithoutHiveSupportSuite, GlutenBucketedWriteWithoutHiveSupportSuite, GlutenCreateTableAsSelectSuite, GlutenDDLSourceLoadSuite, GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuite, GlutenDisableUnnecessaryBucketedScanWithoutHiveSupportSuiteAE, GlutenExternalCommandRunnerSuite, GlutenFilteredScanSuite, GlutenFiltersSuite, GlutenInsertSuite, GlutenPartitionedWriteSuite, GlutenPathOptionSuite, GlutenPrunedScanSuite, GlutenResolvedDataSourceSuite, GlutenSaveLoadSuite, GlutenTableScanSuite}
 
 class VeloxTestSettings extends BackendTestSettings {
 
   enableSuite[GlutenSessionExtensionSuite]
   enableSuite[GlutenCustomerExtensionSuite]
+  enableSuite[GlutenCustomerExpressionTransformerSuite]
 
   enableSuite[GlutenDataFrameAggregateSuite]
     .exclude(

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerExpressionTransformer.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerExpressionTransformer.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.extension
+
+import com.google.common.collect.Lists
+
+import io.glutenproject.expression._
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
+import io.glutenproject.extension.ExpressionExtensionTrait
+import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+
+class CustomAddExpressionTransformer(
+  substraitExprName: String,
+  left: ExpressionTransformer,
+  right: ExpressionTransformer,
+  original: Expression) extends ExpressionTransformer with Logging {
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
+    val leftNode = left.doTransform(args)
+    val rightNode = right.doTransform(args)
+    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionId = ExpressionBuilder.newScalarFunction(
+      functionMap,
+      ConverterUtils.makeFuncName(
+        substraitExprName,
+        original.children.map(_.dataType),
+        FunctionConfig.OPT))
+
+    val expressionNodes = Lists.newArrayList(leftNode, rightNode)
+    val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)
+    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
+  }
+}
+
+case class CustomerExpressionTransformer() extends ExpressionExtensionTrait {
+
+  /**
+   * Generate the extension expressions list,
+   * format: Sig[XXXExpression]("XXXExpressionName")
+   */
+  override def extensionExpressionsMapping: Seq[Sig] = Seq(
+    Sig[CustomAdd]("add")
+  )
+
+  /**
+   * Replace extension expression to transformer.
+   */
+  override def replaceWithExtensionExpressionTransformer(
+    substraitExprName: String,
+    expr: Expression,
+    attributeSeq: Seq[Attribute]): ExpressionTransformer = expr match {
+    case custom: CustomAdd =>
+      new CustomAddExpressionTransformer(
+        substraitExprName,
+        ExpressionConverter.replaceWithExpressionTransformer(custom.left, attributeSeq),
+        ExpressionConverter.replaceWithExpressionTransformer(custom.right, attributeSeq),
+        custom)
+    case other =>
+      throw new UnsupportedOperationException(
+        s"${expr.getClass} or $expr is not currently supported.")
+  }
+}

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExpressionTransformerSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExpressionTransformerSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.extension
+
+import io.glutenproject.execution.ProjectExecTransformer
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{GlutenSQLTestsTrait, Row}
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.{IntervalUtils, TypeUtils}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{AbstractDataType, CalendarIntervalType, DayTimeIntervalType, TypeCollection, YearMonthIntervalType}
+import org.apache.spark.unsafe.types.CalendarInterval
+
+case class CustomAdd(
+  left: Expression,
+  right: Expression,
+  failOnError: Boolean = SQLConf.get.ansiEnabled) extends BinaryArithmetic {
+
+  def this(left: Expression, right: Expression) = this(left, right, SQLConf.get.ansiEnabled)
+
+  override def inputType: AbstractDataType = TypeCollection.NumericAndInterval
+
+  override def symbol: String = "+"
+
+  override def decimalMethod: String = "$plus"
+
+  override def calendarIntervalMethod: String = if (failOnError) "addExact" else "add"
+
+  private lazy val numeric = TypeUtils.getNumeric(dataType, failOnError)
+
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = dataType match {
+    case CalendarIntervalType if failOnError =>
+      IntervalUtils.addExact(
+        input1.asInstanceOf[CalendarInterval], input2.asInstanceOf[CalendarInterval])
+    case CalendarIntervalType =>
+      IntervalUtils.add(
+        input1.asInstanceOf[CalendarInterval], input2.asInstanceOf[CalendarInterval])
+    case _: DayTimeIntervalType =>
+      Math.addExact(input1.asInstanceOf[Long], input2.asInstanceOf[Long])
+    case _: YearMonthIntervalType =>
+      Math.addExact(input1.asInstanceOf[Int], input2.asInstanceOf[Int])
+    case _ => numeric.plus(input1, input2)
+  }
+
+  override def exactMathMethod: Option[String] = Some("addExact")
+
+  override protected def withNewChildrenInternal(
+    newLeft: Expression,
+    newRight: Expression
+    ): CustomAdd = copy(left = newLeft, right = newRight)
+}
+
+class GlutenCustomerExpressionTransformerSuite extends GlutenSQLTestsTrait {
+
+  override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.sql.adaptive.enabled", "false")
+      .set("spark.gluten.sql.columnar.extended.expressions.transformer",
+        "org.apache.spark.sql.extension.CustomerExpressionTransformer")
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val (expressionInfo, builder) =
+      FunctionRegistryBase.build[CustomAdd]("custom_add", None)
+    spark.sessionState.functionRegistry.registerFunction(
+      FunctionIdentifier.apply("custom_add"),
+      expressionInfo,
+      builder
+    )
+  }
+
+  test("test custom expression transformer") {
+    spark.createDataFrame(
+      Seq((1, 1.1), (2, 2.2)))
+      .createOrReplaceTempView("custom_table")
+
+    val df = spark.sql(
+      s"""
+        |select custom_add(_1, 100), custom_add(_2, 200) from custom_table
+        |""".stripMargin)
+    checkAnswer(df,
+      Seq(Row(101, 201.1), Row(102, 202.2)))
+
+    val projectTransformer = df.queryExecution.executedPlan.collect {
+      case p: ProjectExecTransformer => p
+    }
+    assert(!projectTransformer.isEmpty, s"query plan: ${df.queryExecution.executedPlan}")
+  }
+}

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -33,6 +33,8 @@ case class GlutenNumaBindingInfo(
 class GlutenConfig(conf: SQLConf) extends Logging {
   import GlutenConfig._
 
+  def enableGluten: Boolean = conf.getConf(ENABLED_GLUTEN)
+
   def enableAnsiMode: Boolean = conf.ansiEnabled
 
   // FIXME the option currently controls both JVM and native validation against a Substrait plan.
@@ -195,12 +197,12 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def softAffinityLogLevel: String = conf.getConf(SOFT_AFFINITY_LOG_LEVEL)
 
   // A comma-separated list of classes for the extended columnar pre rules
-  def extendedColumnarPreRules: String =
-    conf.getConfString("spark.gluten.sql.columnar.extended.columnar.pre.rules", "")
+  def extendedColumnarPreRules: String = conf.getConf(EXTENDED_COLUMNAR_PRE_RULES)
 
   // A comma-separated list of classes for the extended columnar post rules
-  def extendedColumnarPostRules: String =
-    conf.getConfString("spark.gluten.sql.columnar.extended.columnar.post.rules", "")
+  def extendedColumnarPostRules: String = conf.getConf(EXTENDED_COLUMNAR_POST_RULES)
+
+  def extendedExpressionTransformer: String = conf.getConf(EXTENDED_EXPRESSION_TRAN_CONF)
 
   def printStackOnValidateFailure: Boolean =
     conf.getConf(VALIDATE_FAILURE_PRINT_STACK_ENABLED)
@@ -305,6 +307,9 @@ object GlutenConfig {
   val GLUTEN_SUPPORTED_PYTHON_UDFS = "spark.gluten.supported.python.udfs"
   val GLUTEN_SUPPORTED_SCALA_UDFS = "spark.gluten.supported.scala.udfs"
 
+  val GLUTEN_EXTENDED_EXPRESSION_TRAN_CONF =
+    "spark.gluten.sql.columnar.extended.expressions.transformer"
+
   var ins: GlutenConfig = _
 
   def getConf: GlutenConfig = {
@@ -396,6 +401,13 @@ object GlutenConfig {
     // return
     nativeConfMap
   }
+
+  val ENABLED_GLUTEN =
+    buildConf("spark.gluten.enabled")
+      .internal()
+      .doc("Whether to enable gluten. Default value is true.")
+      .booleanConf
+      .createWithDefault(true)
 
   // FIXME the option currently controls both JVM and native validation against a Substrait plan.
   val NATIVE_VALIDATION_ENABLED =
@@ -871,4 +883,21 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(false)
 
+  val EXTENDED_COLUMNAR_PRE_RULES =
+    buildConf("spark.gluten.sql.columnar.extended.columnar.pre.rules")
+    .doc("A comma-separated list of classes for the extended columnar pre rules.")
+    .stringConf
+    .createWithDefaultString("")
+
+  val EXTENDED_COLUMNAR_POST_RULES =
+    buildConf("spark.gluten.sql.columnar.extended.columnar.post.rules")
+      .doc("A comma-separated list of classes for the extended columnar post rules.")
+      .stringConf
+      .createWithDefaultString("")
+
+  val EXTENDED_EXPRESSION_TRAN_CONF =
+    buildConf(GLUTEN_EXTENDED_EXPRESSION_TRAN_CONF)
+      .doc("A class for the extended expressions transformer.")
+      .stringConf
+      .createWithDefaultString("")
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -885,9 +885,9 @@ object GlutenConfig {
 
   val EXTENDED_COLUMNAR_PRE_RULES =
     buildConf("spark.gluten.sql.columnar.extended.columnar.pre.rules")
-    .doc("A comma-separated list of classes for the extended columnar pre rules.")
-    .stringConf
-    .createWithDefaultString("")
+      .doc("A comma-separated list of classes for the extended columnar pre rules.")
+      .stringConf
+      .createWithDefaultString("")
 
   val EXTENDED_COLUMNAR_POST_RULES =
     buildConf("spark.gluten.sql.columnar.extended.columnar.post.rules")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support to add the custom expressions transformer by Spark conf: Add a spark.gluten.sql.columnar.extended.expressions.transformer to specify the extended expression transformer class;

Close #1928.

(Fixes: #1928)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

