### PR TITLE
[VL] Use get_filename_component to set absolute path for velox arrow proto

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -52,6 +52,7 @@ option(ENABLE_S3 "Enable S3" OFF)
 option(ENABLE_HDFS "Enable HDFS" OFF)
 
 set(root_directory ${PROJECT_BINARY_DIR})
+cmake_path(GET CMAKE_SOURCE_DIR PARENT_PATH GLUTEN_HOME)
 
 if (NOT BUILD_VELOX_BACKEND)
   message(STATUS "Not select any backend, build velox backend default")
@@ -59,7 +60,7 @@ if (NOT BUILD_VELOX_BACKEND)
 endif()
 
 if (NOT DEFINED ARROW_HOME)
-  set(ARROW_HOME ${CMAKE_SOURCE_DIR}/../ep/build-arrow/build)
+  set(ARROW_HOME ${GLUTEN_HOME}/ep/build-arrow/build)
 endif()
 
 #

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -52,7 +52,7 @@ option(ENABLE_S3 "Enable S3" OFF)
 option(ENABLE_HDFS "Enable HDFS" OFF)
 
 set(root_directory ${PROJECT_BINARY_DIR})
-cmake_path(GET CMAKE_SOURCE_DIR PARENT_PATH GLUTEN_HOME)
+get_filename_component(GLUTEN_HOME ${CMAKE_SOURCE_DIR} DIRECTORY)
 
 if (NOT BUILD_VELOX_BACKEND)
   message(STATUS "Not select any backend, build velox backend default")

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 
-set(proto_directory ${CMAKE_CURRENT_SOURCE_DIR}/../../gluten-core/src/main/resources/substrait/proto)
+set(proto_directory ${GLUTEN_HOME}/gluten-core/src/main/resources/substrait/proto)
 set(substrait_proto_directory ${proto_directory}/substrait)
 message(STATUS "Set Proto Directory in ${proto_directory}")
 

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
 endif()
 
 if (NOT DEFINED VELOX_HOME)
-  set(VELOX_HOME ${CMAKE_SOURCE_DIR}/../ep/build-velox/build/velox_ep)
+  set(VELOX_HOME ${GLUTEN_HOME}/ep/build-velox/build/velox_ep)
   message(STATUS "Set VELOX_HOME to ${VELOX_HOME}")
 endif()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, gluten cpp use relative path for VELOX_HOME, ARROW_HOME and proto_directory. Doing so has no problem with cmake compilation, but it will cause some IDEs (such as Jetbrains Clion) fail to correctly obtain the include files of velox, arrow, and proto, and the absolute path must be specified manually.

if this has no other effect, can we get rid of using relative path.

## How was this patch tested?
test compile cpp

