### PR TITLE
[VL][BUILD] Pop!_OS as Ubuntu alias

### DIFF
--- a/dev/package.sh
+++ b/dev/package.sh
@@ -35,7 +35,7 @@ function process_setup_centos_7 {
   cp /usr/local/lib/{libre2.so.10,libhdfs3.so.1,libboost_context.so.1.72.0,libboost_filesystem.so.1.72.0,libboost_program_options.so.1.72.0,libboost_system.so.1.72.0,libboost_thread.so.1.72.0,libboost_regex.so.1.72.0,libprotobuf.so.32} $THIRDPARTY_LIB/
 }
 
-if [ "$LINUX_OS" == "ubuntu" ]; then
+if [ "$LINUX_OS" == "ubuntu" || "$LINUX_OS" == "pop" ]; then
   if [ "$VERSION" == "20.04" ]; then
     process_setup_ubuntu_2004
   elif [ "$VERSION" == "22.04" ]; then

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -123,7 +123,7 @@ function check_commit {
 }
 
 function setup {
-  if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then
+  if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" || "$LINUX_DISTRIBUTION" == "pop" ]]; then
     scripts/setup-ubuntu.sh
   elif [[ "$LINUX_DISTRIBUTION" == "centos" ]]; then
     case "$LINUX_VERSION_ID" in

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -161,7 +161,7 @@ git submodule update --init --recursive
 # apply patches
 sed -i 's/^  ninja -C "${BINARY_DIR}" install/  sudo ninja -C "${BINARY_DIR}" install/g' scripts/setup-helper-functions.sh
 sed -i 's/-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17/-march=native -std=c++17 -mno-avx512f/g' scripts/setup-helper-functions.sh
-if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then
+if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" || "$LINUX_DISTRIBUTION" == "pop" ]]; then
   process_setup_ubuntu
 elif [[ "$LINUX_DISTRIBUTION" == "centos" ]]; then
   case "$LINUX_VERSION_ID" in


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pop!_OS is a variant of Ubuntu, it shares most of the libs and version of Ubuntu, with additional GUI-enhanced libs.

```
➜ $ cat /etc/os-release
NAME="Pop!_OS"
VERSION="22.04 LTS"
ID=pop
ID_LIKE="ubuntu debian"
PRETTY_NAME="Pop!_OS 22.04 LTS"
VERSION_ID="22.04"
HOME_URL="https://pop.system76.com"
SUPPORT_URL="https://support.system76.com"
BUG_REPORT_URL="https://github.com/pop-os/pop/issues"
PRIVACY_POLICY_URL="https://system76.com/privacy"
VERSION_CODENAME=jammy
UBUNTU_CODENAME=jammy
LOGO=distributor-logo-pop-os
```

## How was this patch tested?

manual tests with command `dev/buildbundle-veloxbe.sh`