### PR TITLE
[GLUTEN-1947][VL] Parquet should respect user-specified write options

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
@@ -18,16 +18,25 @@
 package io.glutenproject.spark.sql.execution.datasources.velox;
 
 import io.glutenproject.init.JniInitialized;
+import io.glutenproject.init.JniUtils;
 import org.apache.spark.sql.execution.datasources.VeloxColumnarBatchIterator;
 
 import java.io.IOException;
+import java.util.Map;
 
+/**
+ * The jni file is at `cpp/core/jni/JniWrapper.cc`
+ */
 public class DatasourceJniWrapper extends JniInitialized {
 
   public DatasourceJniWrapper() throws IOException {
   }
 
-  public native long nativeInitDatasource(String filePath, long cSchema);
+  public long nativeInitDatasource(String filePath, long cSchema, Map<String, String> options) {
+    return nativeInitDatasource(filePath, cSchema, JniUtils.toNativeConf(options));
+  }
+
+  public native long nativeInitDatasource(String filePath, long cSchema, byte[] options);
 
   public native void inspectSchema(long instanceId, long cSchemaAddress);
 

--- a/backends-velox/src/main/scala/io/glutenproject/utils/DatasourceUtil.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/DatasourceUtil.scala
@@ -17,6 +17,8 @@
 
 package io.glutenproject.utils
 
+import java.util
+
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.spark.sql.execution.datasources.velox.DatasourceJniWrapper
 import org.apache.arrow.c.ArrowSchema
@@ -35,7 +37,8 @@ object DatasourceUtil {
   def readSchema(file: FileStatus): Option[StructType] = {
     val allocator = ArrowBufferAllocators.contextInstance()
     val datasourceJniWrapper = new DatasourceJniWrapper()
-    val instanceId = datasourceJniWrapper.nativeInitDatasource(file.getPath.toString, -1)
+    val instanceId = datasourceJniWrapper.nativeInitDatasource(
+      file.getPath.toString, -1, new util.HashMap[String, String]())
     val cSchema = ArrowSchema.allocateNew(allocator)
     datasourceJniWrapper.inspectSchema(instanceId, cSchema.memoryAddress())
     try {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetFileFormat.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetFileFormat.scala
@@ -17,9 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.velox
 
-import io.glutenproject.columnarbatch.{ArrowColumnarBatches, IndicatorVector}
-
 import java.io.IOException
+import java.net.URI
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.columnarbatch.{ArrowColumnarBatches, IndicatorVector}
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.spark.sql.execution.datasources.velox.DatasourceJniWrapper
 import io.glutenproject.utils.{ArrowAbiUtil, DatasourceUtil}
@@ -27,17 +32,17 @@ import io.glutenproject.utils.{ArrowAbiUtil, DatasourceUtil}
 import org.apache.arrow.c.ArrowSchema
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
+import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.codec.CodecConfig
+import org.apache.parquet.hadoop.util.ContextUtil
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
 import org.apache.spark.sql.execution.datasources.{FakeRow, GlutenParquetFileFormat, OutputWriter, OutputWriterFactory, VeloxWriteQueue}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkArrowUtil
-import org.apache.spark.sql.vectorized.ColumnarBatch
-
-import java.net.URI
 
 class VeloxParquetFileFormat extends GlutenParquetFileFormat
   with DataSourceRegister with Serializable {
@@ -52,6 +57,17 @@ class VeloxParquetFileFormat extends GlutenParquetFileFormat
                             job: Job,
                             options: Map[String, String],
                             dataSchema: StructType): OutputWriterFactory = {
+    // pass compression to job conf so that the file extension can be aware of it.
+    val conf = ContextUtil.getConfiguration(job)
+    val parquetOptions = new ParquetOptions(options, sparkSession.sessionState.conf)
+    conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
+    // pass options to native so that velox can take user-specified conf to write parquet,
+    // i.e., compression and block size.
+    val sparkOptions = new mutable.HashMap[String, String]()
+    sparkOptions.put(SQLConf.PARQUET_COMPRESSION.key, parquetOptions.compressionCodecClassName)
+    options.get(GlutenConfig.PARQUET_BLOCK_SIZE).foreach { blockSize =>
+      sparkOptions.put(GlutenConfig.PARQUET_BLOCK_SIZE, blockSize)
+    }
 
     new OutputWriterFactory {
       override def getFileExtension(context: TaskAttemptContext): String = {
@@ -72,7 +88,7 @@ class VeloxParquetFileFormat extends GlutenParquetFileFormat
         try {
           ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
           instanceId = datasourceJniWrapper.nativeInitDatasource(
-            originPath, cSchema.memoryAddress())
+            originPath, cSchema.memoryAddress(), sparkOptions.asJava)
         } catch {
           case e: IOException =>
             throw new RuntimeException(e)

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.execution
+
+class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
+  override protected val backend: String = "velox"
+  override protected val resourcePath: String = "/tpch-data-parquet-velox"
+  override protected val fileFormat: String = "parquet"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createTPCHNotNullTables()
+  }
+
+  test("test write parquet with compression codec") {
+    // compression codec details see `VeloxParquetDatasource.cc`
+    Seq("snappy", "gzip", "zstd", "none", "uncompressed")
+      .foreach { codec =>
+        val extension = codec match {
+          case "none" | "uncompressed" => ""
+          case "gzip" => "gz"
+          case _ => codec
+        }
+
+        withTempPath { f =>
+          spark.table("customer").write
+            .format("velox")
+            .option("compression", codec)
+            .save(f.getCanonicalPath)
+          val files = f.list()
+          assert(files.nonEmpty, extension)
+          assert(files.exists(_.contains(extension)), extension)
+
+          val parquetDf = spark.read
+            .format("parquet")
+            .load(f.getCanonicalPath)
+          checkAnswer(parquetDf, spark.table("customer"))
+        }
+      }
+  }
+}

--- a/cpp/velox/compute/VeloxParquetDatasource.cc
+++ b/cpp/velox/compute/VeloxParquetDatasource.cc
@@ -71,31 +71,38 @@ void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::str
 
   type_ = velox::importFromArrow(cSchema);
 
-  auto blockSize = 1024;
+  auto blockSize = 134217728; // 128MB
   if (sparkConfs.find(kParquetBlockSize) != sparkConfs.end()) {
     blockSize = static_cast<int64_t>(stoi(sparkConfs.find(kParquetBlockSize)->second));
   }
-  auto compressionCodec = arrow::Compression::UNCOMPRESSED;
+  auto compressionCodec = arrow::Compression::SNAPPY;
   if (sparkConfs.find(kParquetCompressionCodec) != sparkConfs.end()) {
     auto compressionCodecStr = sparkConfs.find(kParquetCompressionCodec)->second;
-    // spark support uncompressed snappy, gzip, lzo, brotli, lz4, zstd.
+    // spark support none, uncompressed, snappy, gzip, lzo, brotli, lz4, zstd.
     if (boost::iequals(compressionCodecStr, "snappy")) {
       compressionCodec = arrow::Compression::SNAPPY;
     } else if (boost::iequals(compressionCodecStr, "gzip")) {
       compressionCodec = arrow::Compression::GZIP;
     } else if (boost::iequals(compressionCodecStr, "lzo")) {
-      compressionCodec = arrow::Compression::LZO;
+      // arrow does not support write parquet using lzo
+      // https://issues.apache.org/jira/browse/ARROW-12430
+      throw GlutenException("Gluten does not support write parquet using lzo.");
     } else if (boost::iequals(compressionCodecStr, "brotli")) {
+      // please make sure `brotli` is enabled when compiling
       compressionCodec = arrow::Compression::BROTLI;
     } else if (boost::iequals(compressionCodecStr, "lz4")) {
       compressionCodec = arrow::Compression::LZ4;
     } else if (boost::iequals(compressionCodecStr, "zstd")) {
       compressionCodec = arrow::Compression::ZSTD;
+    } else if (boost::iequals(compressionCodecStr, "uncompressed")) {
+      compressionCodec = arrow::Compression::UNCOMPRESSED;
+    } else if (boost::iequals(compressionCodecStr, "none")) {
+      compressionCodec = arrow::Compression::UNCOMPRESSED;
     }
   }
 
   auto properities =
-      ::parquet::WriterProperties::Builder().write_batch_size(blockSize)->compression(compressionCodec)->build();
+      ::parquet::WriterProperties::Builder().max_row_group_length(blockSize)->compression(compressionCodec)->build();
 
   // Setting the ratio to 2 here refers to the grow strategy in the reserve() method of MemoryPool on the arrow side.
   std::unordered_map<std::string, std::string> configData({{velox::core::QueryConfig::kDataBufferGrowRatio, "2"}});

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -46,6 +46,15 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
     sparkContext.setLogLevel("WARN")
   }
 
+  protected override def afterAll(): Unit = {
+    if (TPCHTables != null) {
+      TPCHTables.keys.foreach { v =>
+        spark.sessionState.catalog.dropTempView(v)
+      }
+    }
+    super.afterAll()
+  }
+
   protected def createTPCHNotNullTables(): Unit = {
     TPCHTables = Seq(
       "customer",

--- a/gluten-data/src/main/java/io/glutenproject/init/JniInitialized.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/JniInitialized.java
@@ -17,15 +17,8 @@
 
 package io.glutenproject.init;
 
-import com.google.protobuf.Any;
 import io.glutenproject.GlutenConfig;
 import io.glutenproject.backendsapi.BackendsApiManager;
-import io.glutenproject.substrait.expression.ExpressionBuilder;
-import io.glutenproject.substrait.expression.StringMapNode;
-import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
-import io.glutenproject.substrait.extensions.ExtensionBuilder;
-import io.glutenproject.substrait.plan.PlanBuilder;
-import io.glutenproject.substrait.plan.PlanNode;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.util.memory.TaskResourceManager;
 import org.apache.spark.util.memory.TaskResources;
@@ -38,16 +31,8 @@ public abstract class JniInitialized {
     String prefix = BackendsApiManager.getSettings().getBackendConfigPrefix();
     Map<String, String> nativeConfMap = GlutenConfig.getNativeBackendConf(
         prefix, SQLConf.get().getAllConfs());
-    InitializerJniWrapper.initialize(buildNativeConfNode(nativeConfMap).toProtobuf().toByteArray());
+    InitializerJniWrapper.initialize(JniUtils.toNativeConf(nativeConfMap));
   }
-
-  private static PlanNode buildNativeConfNode(Map<String, String> confs) {
-    StringMapNode stringMapNode = ExpressionBuilder.makeStringMap(confs);
-    AdvancedExtensionNode extensionNode = ExtensionBuilder
-        .makeAdvancedExtension(Any.pack(stringMapNode.toProtobuf()));
-    return PlanBuilder.makePlan(extensionNode);
-  }
-
 
   protected JniInitialized() {
     if (!TaskResources.inSparkTask()) {

--- a/gluten-data/src/main/java/io/glutenproject/init/JniUtils.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/JniUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.init;
+
+import java.util.Map;
+
+import com.google.protobuf.Any;
+import io.glutenproject.substrait.expression.ExpressionBuilder;
+import io.glutenproject.substrait.expression.StringMapNode;
+import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
+import io.glutenproject.substrait.extensions.ExtensionBuilder;
+import io.glutenproject.substrait.plan.PlanBuilder;
+
+public class JniUtils {
+
+    public static byte[] toNativeConf(Map<String, String> confs) {
+        StringMapNode stringMapNode = ExpressionBuilder.makeStringMap(confs);
+        AdvancedExtensionNode extensionNode = ExtensionBuilder
+                .makeAdvancedExtension(Any.pack(stringMapNode.toProtobuf()));
+        return PlanBuilder.makePlan(extensionNode).toProtobuf().toByteArray();
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are some issues for parquet write:

1. the default compression codec should be snappy, but is is uncompression now
2. the compression codec does not respect the user-specified, e.g., `df.write.option('compression', 'zstd').save`
3. the parquet file name does not contain the compression codec

(Fixes: \#1947)

This pr pass the write options to native so that velox can take user-specified conf to write parquet. So far, we only support compression codec and block size.

Besides, this pr add all supported compression codec test

## How was this patch tested?

add tests
