### PR TITLE
[VL] Refactor VeloxMemoryPool and VeloxInitializer

### DIFF
--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -78,7 +78,7 @@ class Backend : public std::enable_shared_from_this<Backend> {
   virtual arrow::Result<std::shared_ptr<ColumnarToRowConverter>> getColumnar2RowConverter(
       MemoryAllocator* allocator,
       std::shared_ptr<ColumnarBatch> cb) {
-    auto memoryPool = asWrappedArrowMemoryPool(allocator);
+    auto memoryPool = asArrowMemoryPool(allocator);
     return std::make_shared<ArrowColumnarToRowConverter>(memoryPool);
   }
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -157,7 +157,7 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
   }
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
-    GLUTEN_ASSIGN_OR_THROW(auto buffer, arrow::AllocateResizableBuffer(nbytes, getDefaultArrowMemoryPool().get()))
+    GLUTEN_ASSIGN_OR_THROW(auto buffer, arrow::AllocateResizableBuffer(nbytes, defaultArrowMemoryPool().get()))
     GLUTEN_ASSIGN_OR_THROW(int64_t bytes_read, Read(nbytes, buffer->mutable_data()));
     GLUTEN_THROW_NOT_OK(buffer->Resize(bytes_read, false));
     buffer->ZeroPadding();
@@ -772,7 +772,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   if (allocator == nullptr) {
     gluten::jniThrow("Memory pool does not exist or has been closed");
   }
-  shuffleWriterOptions.memory_pool = asWrappedArrowMemoryPool(allocator);
+  shuffleWriterOptions.memory_pool = asArrowMemoryPool(allocator);
 
   jclass cls = env->FindClass("java/lang/Thread");
   jmethodID mid = env->GetStaticMethodID(cls, "currentThread", "()Ljava/lang/Thread;");
@@ -954,7 +954,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
   if (allocator == nullptr) {
     gluten::jniThrow("Memory pool does not exist or has been closed");
   }
-  auto pool = asWrappedArrowMemoryPool(allocator);
+  auto pool = asArrowMemoryPool(allocator);
   std::shared_ptr<arrow::io::InputStream> in = std::make_shared<JavaInputStreamAdaptor>(env, jniIn);
   ReaderOptions options = ReaderOptions::defaults();
   options.ipc_read_options.memory_pool = pool.get();

--- a/cpp/core/memory/ArrowMemoryPool.cc
+++ b/cpp/core/memory/ArrowMemoryPool.cc
@@ -20,47 +20,47 @@
 
 namespace gluten {
 
-std::shared_ptr<arrow::MemoryPool> asWrappedArrowMemoryPool(MemoryAllocator* allocator) {
-  return std::make_shared<WrappedArrowMemoryPool>(allocator);
+std::shared_ptr<arrow::MemoryPool> asArrowMemoryPool(MemoryAllocator* allocator) {
+  return std::make_shared<ArrowMemoryPool>(allocator);
 }
 
-std::shared_ptr<arrow::MemoryPool> getDefaultArrowMemoryPool() {
-  static auto staticPool = asWrappedArrowMemoryPool(defaultMemoryAllocator().get());
+std::shared_ptr<arrow::MemoryPool> defaultArrowMemoryPool() {
+  static auto staticPool = asArrowMemoryPool(defaultMemoryAllocator().get());
   return staticPool;
 }
 
-arrow::Status WrappedArrowMemoryPool::Allocate(int64_t size, int64_t alignment, uint8_t** out) {
+arrow::Status ArrowMemoryPool::Allocate(int64_t size, int64_t alignment, uint8_t** out) {
   if (!allocator_->allocateAligned(alignment, size, reinterpret_cast<void**>(out))) {
     return arrow::Status::Invalid("WrappedMemoryPool: Error allocating " + std::to_string(size) + " bytes");
   }
   return arrow::Status::OK();
 }
 
-arrow::Status WrappedArrowMemoryPool::Reallocate(int64_t oldSize, int64_t newSize, int64_t alignment, uint8_t** ptr) {
+arrow::Status ArrowMemoryPool::Reallocate(int64_t oldSize, int64_t newSize, int64_t alignment, uint8_t** ptr) {
   if (!allocator_->reallocateAligned(*ptr, alignment, oldSize, newSize, reinterpret_cast<void**>(ptr))) {
     return arrow::Status::Invalid("WrappedMemoryPool: Error reallocating " + std::to_string(newSize) + " bytes");
   }
   return arrow::Status::OK();
 }
 
-void WrappedArrowMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
+void ArrowMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
   allocator_->free(buffer, size);
 }
 
-int64_t WrappedArrowMemoryPool::bytes_allocated() const {
+int64_t ArrowMemoryPool::bytes_allocated() const {
   // fixme use self accountant
   return allocator_->getBytes();
 }
 
-int64_t WrappedArrowMemoryPool::total_bytes_allocated() const {
+int64_t ArrowMemoryPool::total_bytes_allocated() const {
   throw GlutenException("Not implement");
 }
 
-int64_t WrappedArrowMemoryPool::num_allocations() const {
+int64_t ArrowMemoryPool::num_allocations() const {
   throw GlutenException("Not implement");
 }
 
-std::string WrappedArrowMemoryPool::backend_name() const {
+std::string ArrowMemoryPool::backend_name() const {
   return "gluten allocator";
 }
 

--- a/cpp/core/memory/ArrowMemoryPool.h
+++ b/cpp/core/memory/ArrowMemoryPool.h
@@ -21,13 +21,13 @@
 
 namespace gluten {
 
-std::shared_ptr<arrow::MemoryPool> asWrappedArrowMemoryPool(MemoryAllocator* allocator);
+std::shared_ptr<arrow::MemoryPool> asArrowMemoryPool(MemoryAllocator* allocator);
 
-std::shared_ptr<arrow::MemoryPool> getDefaultArrowMemoryPool();
+std::shared_ptr<arrow::MemoryPool> defaultArrowMemoryPool();
 
-class WrappedArrowMemoryPool final : public arrow::MemoryPool {
+class ArrowMemoryPool final : public arrow::MemoryPool {
  public:
-  explicit WrappedArrowMemoryPool(MemoryAllocator* allocator) : allocator_(allocator) {}
+  explicit ArrowMemoryPool(MemoryAllocator* allocator) : allocator_(allocator) {}
 
   arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override;
 

--- a/cpp/core/shuffle/type.h
+++ b/cpp/core/shuffle/type.h
@@ -63,7 +63,7 @@ struct ShuffleWriterOptions {
   int64_t thread_id = -1;
   int64_t task_attempt_id = -1;
 
-  std::shared_ptr<arrow::MemoryPool> memory_pool = getDefaultArrowMemoryPool();
+  std::shared_ptr<arrow::MemoryPool> memory_pool = defaultArrowMemoryPool();
 
   arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
 

--- a/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
+++ b/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
@@ -95,7 +95,7 @@ class GoogleBenchmarkColumnarToRow {
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
   }
 
  protected:
@@ -152,7 +152,7 @@ class GoogleBenchmarkColumnarToRowCacheScanBenchmark : public GoogleBenchmarkCol
 
     // reuse the columnarToRowConverter for batches caused system % increase a lot
     auto arrowPool = getDefaultArrowMemoryPool();
-    auto ctxPool = getDefaultVeloxLeafMemoryPool();
+    auto ctxPool = defaultLeafVeloxMemoryPool();
     for (auto _ : state) {
       for (const auto& vector : vectors) {
         auto row = std::dynamic_pointer_cast<velox::RowVector>(vector);
@@ -202,7 +202,7 @@ class GoogleBenchmarkColumnarToRowIterateScanBenchmark : public GoogleBenchmarkC
         arrow::default_memory_pool(), ::parquet::ParquetFileReader::Open(file_), properties_, &parquetReader));
 
     auto arrowPool = getDefaultArrowMemoryPool();
-    auto ctxPool = getDefaultVeloxLeafMemoryPool();
+    auto ctxPool = defaultLeafVeloxMemoryPool();
     for (auto _ : state) {
       ASSERT_NOT_OK(parquetReader->GetRecordBatchReader(rowGroupIndices_, columnIndices_, &recordBatchReader));
       TIME_NANO_OR_THROW(elapseRead, recordBatchReader->ReadNext(&recordBatch));

--- a/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
+++ b/cpp/velox/benchmarks/ColumnarToRowBenchmark.cc
@@ -151,7 +151,7 @@ class GoogleBenchmarkColumnarToRowCacheScanBenchmark : public GoogleBenchmarkCol
     std::cout << " parquet parse done elapsed time = " << elapseRead / 1000000 << " rows = " << numRows << std::endl;
 
     // reuse the columnarToRowConverter for batches caused system % increase a lot
-    auto arrowPool = getDefaultArrowMemoryPool();
+    auto arrowPool = defaultArrowMemoryPool();
     auto ctxPool = defaultLeafVeloxMemoryPool();
     for (auto _ : state) {
       for (const auto& vector : vectors) {
@@ -201,7 +201,7 @@ class GoogleBenchmarkColumnarToRowIterateScanBenchmark : public GoogleBenchmarkC
     ASSERT_NOT_OK(::parquet::arrow::FileReader::Make(
         arrow::default_memory_pool(), ::parquet::ParquetFileReader::Open(file_), properties_, &parquetReader));
 
-    auto arrowPool = getDefaultArrowMemoryPool();
+    auto arrowPool = defaultArrowMemoryPool();
     auto ctxPool = defaultLeafVeloxMemoryPool();
     for (auto _ : state) {
       ASSERT_NOT_OK(parquetReader->GetRecordBatchReader(rowGroupIndices_, columnIndices_, &recordBatchReader));

--- a/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
+++ b/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
@@ -99,14 +99,14 @@ class GoogleBenchmarkParquetWrite {
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+    return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
   }
 
   std::shared_ptr<ColumnarBatch> recordBatch2VeloxColumnarBatch(const arrow::RecordBatch& rb) {
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
     return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<velox::RowVector>(vp));
   }
 

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -38,9 +38,9 @@ std::shared_ptr<ResultIterator> getResultIterator(
     std::shared_ptr<Backend> backend,
     const std::vector<std::shared_ptr<velox::substrait::SplitInfo>>& setScanInfos,
     std::shared_ptr<const facebook::velox::core::PlanNode>& veloxPlan) {
-  auto veloxPool = asWrappedVeloxAggregateMemoryPool(allocator);
+  auto veloxPool = asAggregateVeloxMemoryPool(allocator);
   auto ctxPool = veloxPool->addAggregateChild("query_benchmark_result_iterator");
-  auto resultPool = getDefaultVeloxLeafMemoryPool();
+  auto resultPool = defaultLeafVeloxMemoryPool();
 
   std::vector<std::shared_ptr<ResultIterator>> inputIter;
   auto veloxPlanConverter = std::make_unique<VeloxPlanConverter>(inputIter, resultPool);
@@ -57,7 +57,6 @@ std::shared_ptr<ResultIterator> getResultIterator(
 
   auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
       ctxPool,
-      resultPool,
       veloxPlan,
       scanIds,
       setScanInfos,

--- a/cpp/velox/compute/ArrowTypeUtils.cc
+++ b/cpp/velox/compute/ArrowTypeUtils.cc
@@ -29,7 +29,7 @@ using namespace facebook;
 namespace gluten {
 
 void toArrowSchema(const std::shared_ptr<const velox::RowType>& rowType, struct ArrowSchema* out) {
-  exportToArrow(velox::BaseVector::create(rowType, 0, getDefaultVeloxLeafMemoryPool().get()), *out);
+  exportToArrow(velox::BaseVector::create(rowType, 0, defaultLeafVeloxMemoryPool().get()), *out);
 }
 
 std::shared_ptr<arrow::Schema> toArrowSchema(const std::shared_ptr<const velox::RowType>& rowType) {

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -105,7 +105,7 @@ arrow::Result<std::shared_ptr<ColumnarToRowConverter>> VeloxBackend::getColumnar
     std::shared_ptr<ColumnarBatch> cb) {
   auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
   if (veloxBatch != nullptr) {
-    auto arrowPool = asWrappedArrowMemoryPool(allocator);
+    auto arrowPool = asArrowMemoryPool(allocator);
     auto veloxPool = asAggregateVeloxMemoryPool(allocator);
     auto ctxVeloxPool = veloxPool->addLeafChild("columnar_to_row_velox");
     return std::make_shared<VeloxColumnarToRowConverter>(arrowPool, ctxVeloxPool);

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -71,11 +71,11 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
     inputIters_ = std::move(inputs);
   }
 
-  auto veloxPool = asWrappedVeloxAggregateMemoryPool(allocator);
+  auto veloxPool = asAggregateVeloxMemoryPool(allocator);
   auto ctxPool = veloxPool->addAggregateChild("result_iterator");
   // TODO: wait shuffle split velox to velox, then the input ColumnBatch is RowVector, no need pool to convert
   // https://github.com/oap-project/gluten/issues/1434
-  auto resultPool = getDefaultVeloxLeafMemoryPool();
+  auto resultPool = defaultLeafVeloxMemoryPool();
   // auto resultPool = veloxPool->addLeafChild("input_row_vector_pool");
   auto veloxPlanConverter = std::make_unique<VeloxPlanConverter>(inputIters_, resultPool);
   veloxPlan_ = veloxPlanConverter->toVeloxPlan(substraitPlan_);
@@ -91,11 +91,11 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter = std::make_unique<WholeStageResultIteratorMiddleStage>(
-        ctxPool, resultPool, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
+        ctxPool, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
     return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
   } else {
     auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
-        ctxPool, resultPool, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
+        ctxPool, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
     return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
   }
 }
@@ -106,7 +106,7 @@ arrow::Result<std::shared_ptr<ColumnarToRowConverter>> VeloxBackend::getColumnar
   auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
   if (veloxBatch != nullptr) {
     auto arrowPool = asWrappedArrowMemoryPool(allocator);
-    auto veloxPool = asWrappedVeloxAggregateMemoryPool(allocator);
+    auto veloxPool = asAggregateVeloxMemoryPool(allocator);
     auto ctxVeloxPool = veloxPool->addLeafChild("columnar_to_row_velox");
     return std::make_shared<VeloxColumnarToRowConverter>(arrowPool, ctxVeloxPool);
   } else {
@@ -118,7 +118,7 @@ std::shared_ptr<RowToColumnarConverter> VeloxBackend::getRowToColumnarConverter(
     MemoryAllocator* allocator,
     struct ArrowSchema* cSchema) {
   // TODO: wait to fix task memory pool
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   // AsWrappedVeloxAggregateMemoryPool(allocator)->addChild("row_to_columnar", velox::memory::MemoryPool::Kind::kLeaf);
   return std::make_shared<VeloxRowToColumnarConverter>(cSchema, veloxPool);
 }

--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -75,55 +75,56 @@ const std::string kSpillThresholdRatio = "spark.gluten.sql.columnar.backend.velo
 
 namespace gluten {
 
+void VeloxInitializer::log(const std::unordered_map<std::string, std::string>& conf) {
+  std::ostringstream oss;
+  oss << "STARTUP: VeloxInitializer conf = {\n";
+  for (auto& [k, v] : conf) {
+    oss << " {" << k << ", " << v << "}\n";
+  }
+  oss << "}\n";
+  oss << "memPoolOptions = {";
+  oss << " alignment:" << memPoolOptions_.alignment;
+  oss << ", capacity:" << (memPoolOptions_.capacity >> 20) << "M";
+  oss << ", trackUsage:" << (int)memPoolOptions_.trackUsage;
+  oss << " }\n";
+  oss << "spillThreshold = " << (spillThreshold_ >> 20) << "M";
+  LOG(INFO) << oss.str();
+}
+
 void VeloxInitializer::init(const std::unordered_map<std::string, std::string>& conf) {
   // Setup and register.
   velox::filesystems::registerLocalFileSystem();
 
-  std::unordered_map<std::string, std::string> configurationValues;
-
   // mem cap ratio
-  float_t memCapRatio;
-  {
-    auto got = conf.find(kMemoryCapRatio);
-    if (got == conf.end()) {
-      // not found
-      memCapRatio = 0.75;
-    } else {
-      memCapRatio = std::stof(got->second);
-    }
+  float_t memCapRatio = 0.75;
+  auto got = conf.find(kMemoryCapRatio);
+  if (got != conf.end()) {
+    memCapRatio = std::stof(got->second);
   }
 
   // mem tracker
-  int64_t maxMemory;
-  {
-    auto got = conf.find(kSparkOffHeapMemory); // per executor, shared by tasks for creating iterator
-    if (got == conf.end()) {
-      // not found
-      maxMemory = facebook::velox::memory::kMaxMemory;
-    } else {
-      maxMemory = (long)(memCapRatio * (double)std::stol(got->second));
-    }
+  int64_t maxMemory = facebook::velox::memory::kMaxMemory;
+  got = conf.find(kSparkOffHeapMemory); // per executor, shared by tasks for creating iterator
+  if (got != conf.end()) {
+    maxMemory = (long)(memCapRatio * (double)std::stol(got->second));
   }
 
   memPoolOptions_ = {facebook::velox::memory::MemoryAllocator::kMaxAlignment, maxMemory};
 
   // spill threshold ratio (out of the memory cap)
-  float_t spillThresholdRatio;
-  {
-    auto got = conf.find(kSpillThresholdRatio);
-    if (got == conf.end()) {
-      // not found
-      spillThresholdRatio = 0.6;
-    } else {
-      spillThresholdRatio = std::stof(got->second);
-    }
+  float_t spillThresholdRatio = 0.6;
+  got = conf.find(kSpillThresholdRatio);
+  if (got != conf.end()) {
+    spillThresholdRatio = std::stof(got->second);
   }
+
   spillThreshold_ = (int64_t)(spillThresholdRatio * (float_t)maxMemory);
 
 #ifdef ENABLE_HDFS
   velox::filesystems::registerHdfsFileSystem();
 #endif
 
+  std::unordered_map<std::string, std::string> configurationValues;
 #ifdef ENABLE_S3
   velox::filesystems::registerS3FileSystem();
 
@@ -166,6 +167,9 @@ void VeloxInitializer::init(const std::unordered_map<std::string, std::string>& 
 
   initCache(conf);
   initIOExecutor(conf);
+
+  log(conf);
+
   auto properties = std::make_shared<const velox::core::MemConfig>(configurationValues);
   auto hiveConnector =
       velox::connector::getConnectorFactory(velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)
@@ -183,7 +187,7 @@ void VeloxInitializer::init(const std::unordered_map<std::string, std::string>& 
   }
 }
 
-velox::memory::MemoryAllocator* VeloxInitializer::getAsyncDataCache() {
+velox::memory::MemoryAllocator* VeloxInitializer::getAsyncDataCache() const {
   return asyncDataCache_.get();
 }
 

--- a/cpp/velox/compute/VeloxInitializer.h
+++ b/cpp/velox/compute/VeloxInitializer.h
@@ -47,7 +47,7 @@ class VeloxInitializer {
 
   static std::shared_ptr<VeloxInitializer> get();
 
-  facebook::velox::memory::MemoryAllocator* getAsyncDataCache();
+  facebook::velox::memory::MemoryAllocator* getAsyncDataCache() const;
 
   const facebook::velox::memory::MemoryPool::Options& getMemoryPoolOptions() const {
     return memPoolOptions_;
@@ -65,6 +65,8 @@ class VeloxInitializer {
   void init(const std::unordered_map<std::string, std::string>& conf);
   void initCache(const std::unordered_map<std::string, std::string>& conf);
   void initIOExecutor(const std::unordered_map<std::string, std::string>& conf);
+
+  void log(const std::unordered_map<std::string, std::string>& conf);
 
   std::string getCacheFilePrefix() {
     return "cache." + boost::lexical_cast<std::string>(boost::uuids::random_generator()()) + ".";

--- a/cpp/velox/compute/VeloxParquetDatasource.cc
+++ b/cpp/velox/compute/VeloxParquetDatasource.cc
@@ -45,7 +45,7 @@ namespace gluten {
 void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::string>& sparkConfs) {
   auto backend = std::dynamic_pointer_cast<gluten::VeloxBackend>(gluten::createBackend());
 
-  auto veloxPool = asWrappedVeloxAggregateMemoryPool(gluten::defaultMemoryAllocator().get());
+  auto veloxPool = asAggregateVeloxMemoryPool(gluten::defaultMemoryAllocator().get());
   pool_ = veloxPool->addLeafChild("velox_parquet_write");
 
   if (strncmp(filePath_.c_str(), "file:", 5) == 0) {

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -260,7 +260,6 @@ std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig()
 
 WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
     std::shared_ptr<velox::memory::MemoryPool> pool,
-    std::shared_ptr<velox::memory::MemoryPool> resultLeafPool,
     const std::shared_ptr<const velox::core::PlanNode>& planNode,
     const std::vector<velox::core::PlanNodeId>& scanNodeIds,
     const std::vector<std::shared_ptr<velox::substrait::SplitInfo>>& scanInfos,
@@ -268,7 +267,7 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
     const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap,
     const SparkTaskInfo taskInfo)
-    : WholeStageResultIterator(pool, resultLeafPool, planNode, confMap),
+    : WholeStageResultIterator(pool, planNode, confMap),
       scanNodeIds_(scanNodeIds),
       scanInfos_(scanInfos),
       streamIds_(streamIds) {
@@ -379,13 +378,12 @@ WholeStageResultIteratorFirstStage::extractPartitionColumnAndValue(const std::st
 
 WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
     std::shared_ptr<velox::memory::MemoryPool> pool,
-    std::shared_ptr<velox::memory::MemoryPool> resultLeafPool,
     const std::shared_ptr<const velox::core::PlanNode>& planNode,
     const std::vector<velox::core::PlanNodeId>& streamIds,
     const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap,
     const SparkTaskInfo taskInfo)
-    : WholeStageResultIterator(pool, resultLeafPool, planNode, confMap), streamIds_(streamIds) {
+    : WholeStageResultIterator(pool, planNode, confMap), streamIds_(streamIds) {
   std::unordered_set<velox::core::PlanNodeId> emptySet;
   velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -15,10 +15,9 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
  public:
   WholeStageResultIterator(
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
-      std::shared_ptr<facebook::velox::memory::MemoryPool> resultLeafPool,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::unordered_map<std::string, std::string>& confMap)
-      : veloxPlan_(planNode), confMap_(confMap), pool_(pool), resultLeafPool_(resultLeafPool) {
+      : veloxPlan_(planNode), confMap_(confMap), pool_(pool) {
     getOrderedNodeIds(veloxPlan_, orderedNodeIds_);
   }
 
@@ -35,10 +34,6 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
     collectMetrics();
     metrics_->veloxToArrow = exportNanos;
     return metrics_;
-  }
-
-  facebook::velox::memory::MemoryPool* getPool() const {
-    return pool_.get();
   }
 
   std::shared_ptr<facebook::velox::Config> createConnectorConfig();
@@ -77,7 +72,6 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
   std::unordered_map<std::string, std::string> confMap_;
 
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
-  std::shared_ptr<facebook::velox::memory::MemoryPool> resultLeafPool_;
 
   std::shared_ptr<Metrics> metrics_ = nullptr;
 
@@ -92,7 +86,6 @@ class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator
  public:
   WholeStageResultIteratorFirstStage(
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
-      std::shared_ptr<facebook::velox::memory::MemoryPool> resultLeafPool,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::vector<facebook::velox::core::PlanNodeId>& scanNodeIds,
       const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos,
@@ -118,7 +111,6 @@ class WholeStageResultIteratorMiddleStage final : public WholeStageResultIterato
  public:
   WholeStageResultIteratorMiddleStage(
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
-      std::shared_ptr<facebook::velox::memory::MemoryPool> resultLeafPool,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::vector<facebook::velox::core::PlanNodeId>& streamIds,
       const std::string spillDir,

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -103,7 +103,7 @@ JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_PlanEvaluatorJniWrap
 
   // A query context used for function validation.
   velox::core::QueryCtx queryCtx;
-  auto pool = gluten::getDefaultVeloxLeafMemoryPool().get();
+  auto pool = gluten::defaultLeafVeloxMemoryPool().get();
   // An execution context used for function validation.
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -66,7 +66,7 @@ std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
 std::shared_ptr<ArrowArray> VeloxColumnarBatch::exportArrowArray() {
   auto out = std::make_shared<ArrowArray>();
   ensureFlattened();
-  velox::exportToArrow(flattened_, *out, getDefaultVeloxLeafMemoryPool().get());
+  velox::exportToArrow(flattened_, *out, defaultLeafVeloxMemoryPool().get());
   return out;
 }
 

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -44,12 +44,8 @@ std::shared_ptr<velox::memory::MemoryUsageTracker> createMemoryUsageTracker(
   if (parent == nullptr) {
     if (options.trackUsage) {
       auto tracker = velox::memory::MemoryUsageTracker::create(options.capacity, options.checkUsageLeak);
-      tracker->setHighUsageCallback([=](velox::memory::MemoryUsageTracker& t) {
-        if (t.reservedBytes() >= spillThreshold) {
-          return true;
-        }
-        return false;
-      });
+      tracker->setHighUsageCallback(
+          [=](velox::memory::MemoryUsageTracker& t) { return t.reservedBytes() >= spillThreshold; });
       return tracker;
     }
     return nullptr;
@@ -65,17 +61,17 @@ std::shared_ptr<velox::memory::MemoryUsageTracker> createMemoryUsageTracker(
 
 //  The code is originated from /velox/common/memory/Memory.h
 //  Removed memory manager.
-class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
+class VeloxMemoryPool final : public velox::memory::MemoryPool {
  public:
   using DestructionCallback = std::function<void(MemoryPool*)>;
 
   // Should perhaps make this method private so that we only create node through
   // parent.
-  WrappedVeloxMemoryPool(
-      velox::memory::MemoryAllocator* veloxAlloc,
+  VeloxMemoryPool(
+      std::shared_ptr<velox::memory::MemoryPool> parent,
       const std::string& name,
       Kind kind,
-      std::shared_ptr<velox::memory::MemoryPool> parent,
+      velox::memory::MemoryAllocator* veloxAlloc,
       gluten::MemoryAllocator* glutenAlloc,
       DestructionCallback destructionCb,
       int64_t spillThreshold,
@@ -87,7 +83,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
         destructionCb_(std::move(destructionCb)),
         localMemoryUsage_{} {}
 
-  ~WrappedVeloxMemoryPool() {
+  ~VeloxMemoryPool() {
     const auto remainingBytes = memoryUsageTracker_->currentBytes();
     VELOX_CHECK_EQ(
         0,
@@ -119,7 +115,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
     void* buffer;
     try {
       if (!glutenAlloc_->allocate(alignedSize, &buffer)) {
-        VELOX_FAIL(fmt::format("WrappedVeloxMemoryPool: Failed to allocate {} bytes", alignedSize))
+        VELOX_FAIL(fmt::format("VeloxMemoryPool: Failed to allocate {} bytes", alignedSize))
       }
     } catch (std::exception& e) {
       release(alignedSize);
@@ -140,7 +136,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
       bool succeed = glutenAlloc_->allocateZeroFilled(alignedSize, 1, &buffer);
       if (!succeed) {
         VELOX_FAIL(fmt::format(
-            "WrappedVeloxMemoryPool: Failed to allocate (zero filled) {} members, {} bytes for each", alignedSize, 1))
+            "VeloxMemoryPool: Failed to allocate (zero filled) {} members, {} bytes for each", alignedSize, 1))
       }
     } catch (std::exception& e) {
       release(alignedSize);
@@ -171,7 +167,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
       free(p, alignedSize);
       release(alignedNewSize);
       VELOX_MEM_ALLOC_ERROR(fmt::format(
-          "WrappedVeloxMemoryPool {} failed with {} new bytes and {} old bytes from {}, cause: {}",
+          "VeloxMemoryPool {} failed with {} new bytes and {} old bytes from {}, cause: {}",
           __FUNCTION__,
           newSize,
           size,
@@ -192,7 +188,7 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
 
     auto alignedSize = sizeAlign(size);
     if (!glutenAlloc_->free(p, alignedSize)) {
-      VELOX_FAIL(fmt::format("WrappedVeloxMemoryPool: Failed to free {} bytes", alignedSize))
+      VELOX_FAIL(fmt::format("VeloxMemoryPool: Failed to free {} bytes", alignedSize))
     }
     release(alignedSize);
   }
@@ -334,8 +330,8 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
       MemoryPool::Kind kind,
       bool /*unused*/,
       std::shared_ptr<facebook::velox::memory::MemoryReclaimer> /*unused*/) override {
-    return std::make_shared<WrappedVeloxMemoryPool>(
-        veloxAlloc_, name, kind, parent, glutenAlloc_, nullptr, -1, Options{.alignment = alignment_});
+    return std::make_shared<VeloxMemoryPool>(
+        parent, name, kind, veloxAlloc_, glutenAlloc_, nullptr, -1, Options{.alignment = alignment_});
   }
 
   // Gets the memory allocation stats of the MemoryPoolImpl attached to the
@@ -426,26 +422,15 @@ class WrappedVeloxMemoryPool final : public velox::memory::MemoryPool {
   velox::memory::MemoryUsage subtreeMemoryUsage_;
 };
 
-std::shared_ptr<velox::memory::MemoryPool> asWrappedVeloxAggregateMemoryPool(gluten::MemoryAllocator* allocator) {
-  static std::atomic_uint32_t id = 0;
-  auto pool = getDefaultVeloxAggregateMemoryPool()->addAggregateChild("wrapped_root" + std::to_string(id++));
-  auto wrapped = std::dynamic_pointer_cast<WrappedVeloxMemoryPool>(pool);
-  VELOX_CHECK_NOT_NULL(wrapped);
-  wrapped->setGlutenAllocator(allocator);
-  return pool;
-}
-
-std::shared_ptr<velox::memory::MemoryPool> getDefaultVeloxAggregateMemoryPool() {
-  facebook::velox::memory::MemoryPool::Options options;
-  int64_t spillThreshold;
-  options = gluten::VeloxInitializer::get()->getMemoryPoolOptions();
-  spillThreshold = gluten::VeloxInitializer::get()->getSpillThreshold();
+static std::shared_ptr<velox::memory::MemoryPool> rootVeloxMemoryPool() {
+  auto options = gluten::VeloxInitializer::get()->getMemoryPoolOptions();
+  int64_t spillThreshold = gluten::VeloxInitializer::get()->getSpillThreshold();
   static auto veloxAlloc = facebook::velox::memory::MemoryAllocator::createDefaultInstance();
-  static std::shared_ptr<WrappedVeloxMemoryPool> defaultPoolRoot = std::make_shared<WrappedVeloxMemoryPool>(
-      veloxAlloc.get(),
+  static std::shared_ptr<VeloxMemoryPool> defaultPoolRoot = std::make_shared<VeloxMemoryPool>(
+      nullptr,
       "root",
       velox::memory::MemoryPool::Kind::kAggregate,
-      nullptr,
+      veloxAlloc.get(),
       defaultMemoryAllocator().get(),
       nullptr,
       spillThreshold,
@@ -453,9 +438,18 @@ std::shared_ptr<velox::memory::MemoryPool> getDefaultVeloxAggregateMemoryPool() 
   return defaultPoolRoot;
 }
 
-std::shared_ptr<velox::memory::MemoryPool> getDefaultVeloxLeafMemoryPool() {
-  static std::shared_ptr<velox::memory::MemoryPool> defaultPool =
-      getDefaultVeloxAggregateMemoryPool()->addLeafChild("default_pool");
+std::shared_ptr<velox::memory::MemoryPool> defaultLeafVeloxMemoryPool() {
+  static std::shared_ptr<velox::memory::MemoryPool> defaultPool = rootVeloxMemoryPool()->addLeafChild("default_leaf");
   return defaultPool;
 }
+
+std::shared_ptr<velox::memory::MemoryPool> asAggregateVeloxMemoryPool(gluten::MemoryAllocator* allocator) {
+  static std::atomic_uint32_t id = 0;
+  auto pool = rootVeloxMemoryPool()->addAggregateChild("wrapped_root" + std::to_string(id++));
+  auto wrapped = std::dynamic_pointer_cast<VeloxMemoryPool>(pool);
+  VELOX_CHECK_NOT_NULL(wrapped);
+  wrapped->setGlutenAllocator(allocator);
+  return pool;
+}
+
 } // namespace gluten

--- a/cpp/velox/memory/VeloxMemoryPool.h
+++ b/cpp/velox/memory/VeloxMemoryPool.h
@@ -21,12 +21,9 @@
 #include "velox/common/memory/Memory.h"
 
 namespace gluten {
-class WrappedVeloxMemoryPool;
 
-std::shared_ptr<facebook::velox::memory::MemoryPool> asWrappedVeloxAggregateMemoryPool(MemoryAllocator* allocator);
+std::shared_ptr<facebook::velox::memory::MemoryPool> asAggregateVeloxMemoryPool(MemoryAllocator* allocator);
 
-std::shared_ptr<facebook::velox::memory::MemoryPool> getDefaultVeloxAggregateMemoryPool();
-
-std::shared_ptr<facebook::velox::memory::MemoryPool> getDefaultVeloxLeafMemoryPool();
+std::shared_ptr<facebook::velox::memory::MemoryPool> defaultLeafVeloxMemoryPool();
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -189,7 +189,7 @@ arrow::Status VeloxShuffleWriter::split(ColumnarBatch* cb) {
     RETURN_NOT_OK(initFromRowVector(*vp));
     // 1. convert RowVector to RecordBatch
     ArrowArray arrowArray;
-    velox::exportToArrow(vp, arrowArray, getDefaultVeloxLeafMemoryPool().get());
+    velox::exportToArrow(vp, arrowArray, defaultLeafVeloxMemoryPool().get());
 
     auto result = arrow::ImportRecordBatch(&arrowArray, schema_);
     RETURN_NOT_OK(result);
@@ -703,7 +703,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
 
       // TODO: rethink the cost of `exportToArrow+ImportArray`
       ArrowArray arrowArray;
-      velox::exportToArrow(column, arrowArray, getDefaultVeloxLeafMemoryPool().get());
+      velox::exportToArrow(column, arrowArray, defaultLeafVeloxMemoryPool().get());
 
       auto result = arrow::ImportArray(&arrowArray, arrowColumnTypes_[colIdx]);
       RETURN_NOT_OK(result);
@@ -739,7 +739,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
 
   arrow::Status VeloxShuffleWriter::veloxType2ArrowSchema(const velox::TypePtr& type) {
     auto out = std::make_shared<ArrowSchema>();
-    auto rvp = velox::RowVector::createEmpty(type, getDefaultVeloxLeafMemoryPool().get());
+    auto rvp = velox::RowVector::createEmpty(type, defaultLeafVeloxMemoryPool().get());
 
     // get ArrowSchema from velox::RowVector
     velox::exportToArrow(rvp, *out);

--- a/cpp/velox/tests/ArrowToVeloxTest.cc
+++ b/cpp/velox/tests/ArrowToVeloxTest.cc
@@ -39,14 +39,14 @@ velox::VectorPtr recordBatch2RowVector(const RecordBatch& rb) {
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
   ASSERT_NOT_OK(ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-  return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+  return velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
 }
 
 void checkBatchEqual(std::shared_ptr<RecordBatch> inputBatch, bool checkMetadata = true) {
   velox::VectorPtr vp = recordBatch2RowVector(*inputBatch);
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  velox::exportToArrow(vp, arrowArray, getDefaultVeloxLeafMemoryPool().get());
+  velox::exportToArrow(vp, arrowArray, defaultLeafVeloxMemoryPool().get());
   velox::exportToArrow(vp, arrowSchema);
   auto in = gluten::jniGetOrThrow(ImportRecordBatch(&arrowArray, &arrowSchema));
   ASSERT_TRUE(in->Equals(*inputBatch, checkMetadata)) << in->ToString() << inputBatch->ToString();
@@ -119,7 +119,7 @@ TEST_F(ArrowToVeloxTest, decimalV2A) {
 
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  velox::exportToArrow(row, arrowArray, getDefaultVeloxLeafMemoryPool().get());
+  velox::exportToArrow(row, arrowArray, defaultLeafVeloxMemoryPool().get());
   velox::exportToArrow(row, arrowSchema);
 
   auto in = gluten::jniGetOrThrow(ImportRecordBatch(&arrowArray, &arrowSchema));
@@ -136,7 +136,7 @@ TEST_F(ArrowToVeloxTest, timestampV2A) {
   });
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
-  velox::exportToArrow(row, arrowArray, getDefaultVeloxLeafMemoryPool().get());
+  velox::exportToArrow(row, arrowArray, defaultLeafVeloxMemoryPool().get());
   velox::exportToArrow(row, arrowSchema);
   ArrowArrayRelease(&arrowArray);
 }

--- a/cpp/velox/tests/ColumnarToRowTest.cc
+++ b/cpp/velox/tests/ColumnarToRowTest.cc
@@ -36,7 +36,7 @@ class ColumnarToRowTest : public ::testing::Test {
  public:
   void testRecordBatchEqual(std::shared_ptr<arrow::RecordBatch> inputBatch) {
     std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-        std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+        std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
     auto columnarBatch = std::make_shared<ArrowColumnarBatch>(inputBatch);
     GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(columnarBatch));
 
@@ -81,7 +81,7 @@ class ColumnarToRowTest : public ::testing::Test {
   }
 
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_ = defaultLeafVeloxMemoryPool();
-  std::shared_ptr<arrow::MemoryPool> arrowPool_ = getDefaultArrowMemoryPool();
+  std::shared_ptr<arrow::MemoryPool> arrowPool_ = defaultArrowMemoryPool();
 };
 
 TEST_F(ColumnarToRowTest, decimal) {
@@ -168,7 +168,7 @@ TEST_F(ColumnarToRowTest, Buffer_int8_int16) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -200,7 +200,7 @@ TEST_F(ColumnarToRowTest, Buffer_int32_int64) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -232,7 +232,7 @@ TEST_F(ColumnarToRowTest, Buffer_float_double) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -262,7 +262,7 @@ TEST_F(ColumnarToRowTest, Buffer_bool_binary) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -291,7 +291,7 @@ TEST_F(ColumnarToRowTest, Buffer_decimal_string) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -322,7 +322,7 @@ TEST_F(ColumnarToRowTest, Buffer_int64_int64_with_null) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -351,7 +351,7 @@ TEST_F(ColumnarToRowTest, Buffer_string) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
 
@@ -383,7 +383,7 @@ TEST_F(ColumnarToRowTest, Buffer_bool) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   std::shared_ptr<ArrowColumnarToRowConverter> columnarToRowConverter =
-      std::make_shared<ArrowColumnarToRowConverter>(getDefaultArrowMemoryPool());
+      std::make_shared<ArrowColumnarToRowConverter>(defaultArrowMemoryPool());
 
   auto cb = std::make_shared<ArrowColumnarBatch>(inputBatch);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));

--- a/cpp/velox/tests/ColumnarToRowTest.cc
+++ b/cpp/velox/tests/ColumnarToRowTest.cc
@@ -80,7 +80,7 @@ class ColumnarToRowTest : public ::testing::Test {
     return rb;
   }
 
-  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_ = getDefaultVeloxLeafMemoryPool();
+  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_ = defaultLeafVeloxMemoryPool();
   std::shared_ptr<arrow::MemoryPool> arrowPool_ = getDefaultArrowMemoryPool();
 };
 

--- a/cpp/velox/tests/VeloxColumnarToRowTest.cc
+++ b/cpp/velox/tests/VeloxColumnarToRowTest.cc
@@ -40,7 +40,7 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
     return std::dynamic_pointer_cast<velox::RowVector>(vp);
   }
 
@@ -72,7 +72,7 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
   }
 
  private:
-  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = getDefaultVeloxLeafMemoryPool();
+  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = defaultLeafVeloxMemoryPool();
   std::shared_ptr<arrow::MemoryPool> arrowPool_ = getDefaultArrowMemoryPool();
 };
 
@@ -84,7 +84,7 @@ TEST_F(VeloxColumnarToRowTest, timestamp) {
       makeFlatVector<Timestamp>(timeValues),
   });
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto converter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   jniAssertOkOrThrow(converter->write(cb), "Native convert columnar to row: ColumnarToRowConverter write failed");
@@ -153,7 +153,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int8_int16) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
 
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -188,7 +188,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int32_int64) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
@@ -222,7 +222,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_float_double) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
@@ -254,7 +254,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool_binary) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
@@ -284,7 +284,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_decimal_string) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
@@ -315,7 +315,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int64_int64_with_null) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
@@ -346,7 +346,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_string) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
   GLUTEN_THROW_NOT_OK(columnarToRowConverter->write(cb));
@@ -380,7 +380,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool) {
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
   auto arrowPool = getDefaultArrowMemoryPool();
-  auto veloxPool = getDefaultVeloxLeafMemoryPool();
+  auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
 
   auto cb = std::make_shared<VeloxColumnarBatch>(row);

--- a/cpp/velox/tests/VeloxColumnarToRowTest.cc
+++ b/cpp/velox/tests/VeloxColumnarToRowTest.cc
@@ -73,7 +73,7 @@ class VeloxColumnarToRowTest : public ::testing::Test, public test::VectorTestBa
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = defaultLeafVeloxMemoryPool();
-  std::shared_ptr<arrow::MemoryPool> arrowPool_ = getDefaultArrowMemoryPool();
+  std::shared_ptr<arrow::MemoryPool> arrowPool_ = defaultArrowMemoryPool();
 };
 
 TEST_F(VeloxColumnarToRowTest, timestamp) {
@@ -83,7 +83,7 @@ TEST_F(VeloxColumnarToRowTest, timestamp) {
   auto row = makeRowVector({
       makeFlatVector<Timestamp>(timeValues),
   });
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto converter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -152,7 +152,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int8_int16) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
 
@@ -187,7 +187,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int32_int64) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -221,7 +221,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_float_double) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -253,7 +253,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool_binary) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -283,7 +283,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_decimal_string) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -314,7 +314,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int64_int64_with_null) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -345,7 +345,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_string) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
   auto cb = std::make_shared<VeloxColumnarBatch>(row);
@@ -379,7 +379,7 @@ TEST_F(VeloxColumnarToRowTest, Buffer_bool) {
   makeInputBatch(inputData, schema, &inputBatch);
 
   auto row = recordBatch2VeloxRowVector(*inputBatch);
-  auto arrowPool = getDefaultArrowMemoryPool();
+  auto arrowPool = defaultArrowMemoryPool();
   auto veloxPool = defaultLeafVeloxMemoryPool();
   auto columnarToRowConverter = std::make_shared<VeloxColumnarToRowConverter>(arrowPool, veloxPool);
 

--- a/cpp/velox/tests/VeloxRowToColumnarTest.cc
+++ b/cpp/velox/tests/VeloxRowToColumnarTest.cc
@@ -41,7 +41,7 @@ class VeloxRowToColumnarTest : public ::testing::Test, public test::VectorTestBa
     ArrowArray arrowArray;
     ArrowSchema arrowSchema;
     ASSERT_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+    auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
     return std::dynamic_pointer_cast<velox::RowVector>(vp);
   }
 
@@ -75,7 +75,7 @@ class VeloxRowToColumnarTest : public ::testing::Test, public test::VectorTestBa
   }
 
  private:
-  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = getDefaultVeloxLeafMemoryPool();
+  std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = defaultLeafVeloxMemoryPool();
   std::shared_ptr<arrow::MemoryPool> arrowPool_ = getDefaultArrowMemoryPool();
 };
 

--- a/cpp/velox/tests/VeloxRowToColumnarTest.cc
+++ b/cpp/velox/tests/VeloxRowToColumnarTest.cc
@@ -76,7 +76,7 @@ class VeloxRowToColumnarTest : public ::testing::Test, public test::VectorTestBa
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> veloxPool_ = defaultLeafVeloxMemoryPool();
-  std::shared_ptr<arrow::MemoryPool> arrowPool_ = getDefaultArrowMemoryPool();
+  std::shared_ptr<arrow::MemoryPool> arrowPool_ = defaultArrowMemoryPool();
 };
 
 TEST_F(VeloxRowToColumnarTest, Int_64) {

--- a/cpp/velox/utils/VeloxArrowUtils.cc
+++ b/cpp/velox/utils/VeloxArrowUtils.cc
@@ -28,7 +28,7 @@ arrow::Result<std::shared_ptr<ColumnarBatch>> recordBatch2VeloxColumnarBatch(con
   ArrowSchema arrowSchema;
   RETURN_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
   auto vp =
-      facebook::velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::getDefaultVeloxLeafMemoryPool().get());
+      facebook::velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<facebook::velox::RowVector>(vp));
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. refactor WrappedVeloxMemoryPool, rename `WrappedVeloxMemoryPool` to `VeloxMemoryPool`, the class's new name is consistent with the file name.
3. rename `getDefaultVeloxAggregateMemoryPool` to `rootVeloxMemoryPool`, and replace it in the source file.
4. give the related `APIs` more meaningful names.
5. call `log()` in `VeloxInitializer::init()` to record startup information.
6. delete `resultLeafPool` of `WholeStageResultIterator`, it's unnecessary to do this. 

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

