### PR TITLE
[GLUTEN-1957][CH] Add -am param to build dependent modules of shims/spark33

### DIFF
--- a/ep/build-clickhouse/src/package.sh
+++ b/ep/build-clickhouse/src/package.sh
@@ -67,7 +67,7 @@ cp "${GLUTEN_SOURCE}"/README.md "${GLUTEN_SOURCE}"/dist/"${PACKAGE_NAME}"
 # build gluten jar
 cd "${GLUTEN_SOURCE}"
 mvn clean package -Pbackends-clickhouse -Pspark-3.2 -DskipTests -Dcheckstyle.skip
-mvn clean package -Pspark-3.3 -pl shims/spark33 -DskipTests -Dcheckstyle.skip
+mvn clean package -Pspark-3.3 -am -pl shims/spark33 -DskipTests -Dcheckstyle.skip
 
 # build libch.so
 bash "${GLUTEN_SOURCE}"/ep/build-clickhouse/src/build_clickhouse.sh


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add -am param in the step of maven build shim/spark33 to avoid lack of dependency.

(Fixes: \#1957)

