### PR TITLE
[GLUTEN-1928][Core] Followup: fix the custom expressions transformer ut bug

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -294,6 +294,15 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       throw new UnsupportedOperationException(s"Not supported: $expr.")
     }
     expr match {
+      case extendedExpr
+        if ExpressionMappings.expressionExtensionTransformer
+          .extensionExpressionsMapping.contains(extendedExpr.getClass) =>
+        // Use extended expression transformer to replace custom expression first
+        ExpressionMappings.expressionExtensionTransformer
+          .replaceWithExtensionExpressionTransformer(
+            substraitExprName.get,
+            extendedExpr,
+            attributeSeq)
       case c: CreateArray =>
         val children =
           c.children.map(child => replaceWithExpressionTransformer(child, attributeSeq))
@@ -568,15 +577,6 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         val children = j.children.map(child =>
           replaceWithExpressionTransformer(child, attributeSeq))
         new JsonTupleExpressionTransformer(substraitExprName.get, children.toArray, j)
-      case extendedExpr
-        if ExpressionMappings.expressionExtensionTransformer
-          .extensionExpressionsMapping.contains(extendedExpr.getClass) =>
-        // Use extended expression transformer to replace custom expression
-        ExpressionMappings.expressionExtensionTransformer
-          .replaceWithExtensionExpressionTransformer(
-            substraitExprName.get,
-            extendedExpr,
-            attributeSeq)
       // The other expression case must be put before LeafExpression, UnaryExpression,
       // BinaryExpression, TernaryExpression, QuaternaryExpression
       case l: LeafExpression =>

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -242,8 +242,7 @@ object ExpressionMappings {
 
   def expressionsMap: Map[Class[_], String] =
     defaultExpressionsMap ++
-      expressionExtensionTransformer.extensionExpressionsMapping.map(s => (s.expClass, s.name))
-        .toMap[Class[_], String]
+      expressionExtensionTransformer.extensionExpressionsMapping
 
   private lazy val defaultExpressionsMap: Map[Class[_], String] = {
     (SCALAR_SIGS ++ AGGREGATE_SIGS ++ WINDOW_SIGS ++

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -21,11 +21,18 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
 trait ExpressionExtensionTrait {
+
   /**
    * Generate the extension expressions list,
    * format: Sig[XXXExpression]("XXXExpressionName")
    */
-  def extensionExpressionsMapping: Seq[Sig]
+  def expressionSigList: Seq[Sig]
+
+  /**
+   * Generate the extension expressions mapping map
+   */
+  def extensionExpressionsMapping: Map[Class[_], String] =
+    expressionSigList.map(s => (s.expClass, s.name)).toMap[Class[_], String]
 
   /**
    * Replace extension expression to transformer.
@@ -42,7 +49,7 @@ case class DefaultExpressionExtensionTransformer() extends ExpressionExtensionTr
    * Generate the extension expressions list,
    * format: Sig[XXXExpression]("XXXExpressionName")
    */
-  override def extensionExpressionsMapping: Seq[Sig] = Seq.empty[Sig]
+  override def expressionSigList: Seq[Sig] = Seq.empty[Sig]
 
   /**
    * Replace extension expression to transformer.

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerExpressionTransformer.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerExpressionTransformer.scala
@@ -50,13 +50,14 @@ class CustomAddExpressionTransformer(
 
 case class CustomerExpressionTransformer() extends ExpressionExtensionTrait {
 
+  lazy val expressionSigs = Seq(
+    Sig[CustomAdd]("add")
+  )
   /**
    * Generate the extension expressions list,
    * format: Sig[XXXExpression]("XXXExpressionName")
    */
-  override def extensionExpressionsMapping: Seq[Sig] = Seq(
-    Sig[CustomAdd]("add")
-  )
+  override def expressionSigList: Seq[Sig] = expressionSigs
 
   /**
    * Replace extension expression to transformer.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support to add the custom expressions transformer by Spark conf:
Add a spark.gluten.sql.columnar.extended.expressions.transformer to specify the extended expression transformer class;

(Fixes: #1928)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

