### PR TITLE
[GLUTEN-1972][CORE] Log gluten build info

### DIFF
--- a/dev/gluten-build-info.sh
+++ b/dev/gluten-build-info.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+VELOX_HOME="$1"
+EXTRA_RESOURCE_DIR="$2"
+mkdir -p "$EXTRA_RESOURCE_DIR"
+BUILD_INFO="$EXTRA_RESOURCE_DIR"/gluten-build-info.properties
+
+echo_build_properties() {
+  echo gluten_version="$3"
+  echo java_version="$4"
+  echo scala_version="$5"
+  echo spark_version="$6"
+  echo hadoop_version="$7"
+  echo gcc_version=$(gcc --version | head -n 1)
+  echo branch=$(git rev-parse --abbrev-ref HEAD)
+  echo revision=$(git rev-parse HEAD)
+  echo revision_time=$(git show -s --format=%ci HEAD)
+  echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo url=$(git config --get remote.origin.url)
+  if [ -d "$VELOX_HOME" ]; then
+    echo velox_branch=$(git -C $VELOX_HOME rev-parse --abbrev-ref HEAD)
+    echo velox_revision=$(git -C $VELOX_HOME rev-parse HEAD)
+    echo velox_revision_time=$(git -C $VELOX_HOME show -s --format=%ci HEAD)
+  fi
+}
+
+echo_build_properties "$@" > "$BUILD_INFO"

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -221,7 +221,41 @@
         <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <!-- Include the properties file to provide the build information. -->
+        <directory>${project.build.directory}/extra-resources</directory>
+      </resource>
+    </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-info</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <target>
+                <exec executable="bash" osfamily="unix">
+                  <arg value="${project.basedir}/../dev/gluten-build-info.sh"/>
+                  <arg value="${project.basedir}/../ep/build-velox/build/velox_ep"/>
+                  <arg value="${project.build.directory}/extra-resources"/>
+                  <arg value="${project.version}"/>
+                  <arg value="${java.version}"/>
+                  <arg value="${scala.version}"/>
+                  <arg value="${spark.version}"/>
+                  <arg value="${hadoop.version}"/>
+                </exec>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- compile proto buffer files using copied protoc binary -->
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -77,7 +77,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
   }
 
   private def showGlutenBuildInfo(): Unit = {
-    val veloxInfo = if (veloxEnabled) {
+    val veloxInfo = if (BackendsApiManager.veloxBackend) {
       s"""
         |Velox branch: $VELOX_BRANCH
         |Velox revision: $VELOX_REVISION
@@ -98,7 +98,8 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
         |Build branch: $BRANCH
         |Build revision: $REVISION
         |Build revision time: $REVISION_TIME
-        |Build date: ${BUILD_DATE}${veloxInfo}
+        |Build date: $BUILD_DATE
+        |Repo url: $REPO_URL $veloxInfo
         |======================================
         """.stripMargin
     logInfo(buildInfo)

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -25,6 +25,7 @@ import io.glutenproject.test.TestStats
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
+import org.apache.spark.internal.Logging
 import org.apache.spark.listener.GlutenListenerFactory
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.{GlutenDriverEndpoint, GlutenExecutorEndpoint}
@@ -47,9 +48,11 @@ class GlutenPlugin extends SparkPlugin {
   }
 }
 
-private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
+private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Logging {
 
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
+    showGlutenBuildInfo()
+
     val conf = pluginContext.conf()
     if (conf.getBoolean(GlutenConfig.UT_STATISTIC.key, defaultValue = false)) {
       // Only statistic in UT, not thread safe
@@ -71,6 +74,34 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin {
 
   override def shutdown(): Unit = {
     BackendsApiManager.getContextApiInstance.shutdown()
+  }
+
+  private def showGlutenBuildInfo(): Unit = {
+    val veloxInfo = if (veloxEnabled) {
+      s"""
+        |Velox branch: $VELOX_BRANCH
+        |Velox revision: $VELOX_REVISION
+        |Velox revision time: $VELOX_REVISION_TIME""".stripMargin
+    } else {
+      ""
+    }
+    val buildInfo =
+      s"""
+        |======================================
+        |Gluten build info:
+        |Gluten version: $VERSION
+        |GCC version: $GCC_VERSION
+        |Java version: $JAVA_COMPILE_VERSION
+        |Scala version: $SCALA_COMPILE_VERSION
+        |Spark version: $SPARK_COMPILE_VERSION
+        |Hadoop version: $HADOOP_COMPILE_VERSION
+        |Build branch: $BRANCH
+        |Build revision: $REVISION
+        |Build revision time: $REVISION_TIME
+        |Build date: ${BUILD_DATE}${veloxInfo}
+        |======================================
+        """.stripMargin
+    logInfo(buildInfo)
   }
 
   def setPredefinedConfigs(sc: SparkContext, conf: SparkConf): Unit = {

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendsApiManager.scala
@@ -17,6 +17,8 @@
 
 package io.glutenproject.backendsapi
 
+import io.glutenproject.GlutenConfig
+
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters
@@ -70,6 +72,9 @@ object BackendsApiManager {
   def getBackendName: String = {
     manager.glutenBackendName
   }
+
+  def veloxBackend: Boolean = getBackendName.equalsIgnoreCase(GlutenConfig.GLUTEN_VELOX_BACKEND)
+  def chBackend: Boolean = getBackendName.equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
 
   def getContextApiInstance: ContextApi = {
     manager.contextApi

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -89,7 +89,7 @@ case class GenerateExecTransformer(
   override def supportsColumnar: Boolean = true
 
   override def doValidateInternal(): Boolean = {
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(GlutenConfig.GLUTEN_VELOX_BACKEND)) {
+    if (BackendsApiManager.veloxBackend) {
       return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/BinaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/BinaryExpressionTransformer.scala
@@ -78,10 +78,7 @@ class LikeTransformer(
 
     // CH backend does not support escapeChar, so skip it here.
     val expressionNodes =
-      if (
-        BackendsApiManager.getBackendName
-          .equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
-      ) {
+      if (BackendsApiManager.chBackend) {
         Lists.newArrayList(leftNode, rightNode)
       } else {
         Lists.newArrayList(leftNode, rightNode, escapeCharNode)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
@@ -71,8 +71,7 @@ class DateDiffTransformer(substraitExprName: String, endDate: ExpressionTransfor
       original.endDate.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
 
-    val expressionNodes = if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    val expressionNodes = if (BackendsApiManager.veloxBackend) {
       // In CH backend, datediff params are ('day', startDate, endDate).
       Lists.newArrayList(
         ExpressionBuilder.makeStringLiteral("day"), startDateNode, endDateNode)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
@@ -71,7 +71,7 @@ class DateDiffTransformer(substraitExprName: String, endDate: ExpressionTransfor
       original.endDate.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
 
-    val expressionNodes = if (BackendsApiManager.veloxBackend) {
+    val expressionNodes = if (BackendsApiManager.chBackend) {
       // In CH backend, datediff params are ('day', startDate, endDate).
       Lists.newArrayList(
         ExpressionBuilder.makeStringLiteral("day"), startDateNode, endDateNode)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/MapExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/MapExpressionTransformer.scala
@@ -62,14 +62,12 @@ class GetMapValueTransformer(substraitExprName: String, child: ExpressionTransfo
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     // ClickHouse backend doesn't support fail on error
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND) && failOnError) {
+    if (BackendsApiManager.chBackend && failOnError) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
 
     // Velox backend always fails on error
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_VELOX_BACKEND) && !failOnError) {
+    if (BackendsApiManager.veloxBackend && !failOnError) {
       throw new UnsupportedOperationException(s"not supported yet.")
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/QuaternaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/QuaternaryExpressionTransformer.scala
@@ -35,7 +35,7 @@ class RegExpReplaceTransformer(substraitExprName: String, subject: ExpressionTra
   extends ExpressionTransformer with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(GlutenConfig.GLUTEN_VELOX_BACKEND)) {
+    if (BackendsApiManager.veloxBackend) {
       QuaternaryExpressionTransformer(substraitExprName, subject, regexp, rep, pos, original)
         .doTransform(args)
     }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/TernaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/TernaryExpressionTransformer.scala
@@ -62,8 +62,7 @@ case class StringLocateTransformer(
   original: StringLocate) extends ExpressionTransformer with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    if (BackendsApiManager.chBackend) {
 
       val substrNode = substrExpr.doTransform(args)
       val strNode = strExpr.doTransform(args)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala
@@ -258,9 +258,7 @@ case class Md5Transformer(substraitExprName: String, child: ExpressionTransforme
   with Logging {
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
-    if (
-      BackendsApiManager.getBackendName.equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
-    ) {
+    if (BackendsApiManager.chBackend) {
       // In Spark: md5(str)
       // In CH: lower(hex(md5(str)))
       // So we need to wrap md5(str) with lower and hex in substrait plan for clickhouse backend.

--- a/gluten-core/src/main/scala/io/glutenproject/glutenproject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/glutenproject.scala
@@ -66,7 +66,6 @@ package object glutenproject {
   val REVISION_TIME: String = BuildInfo.revisionTime
   val BUILD_DATE: String = BuildInfo.buildDate
   val REPO_URL: String = BuildInfo.repoUrl
-  val veloxEnabled: Boolean = BuildInfo.veloxBranch != BuildInfo.unknown
   val VELOX_BRANCH: String = BuildInfo.veloxBranch
   val VELOX_REVISION: String = BuildInfo.veloxRevision
   val VELOX_REVISION_TIME: String = BuildInfo.veloxRevisionTime

--- a/gluten-core/src/main/scala/io/glutenproject/glutenproject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/glutenproject.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io
+
+import java.util.Properties
+import scala.util.Try
+
+package object glutenproject {
+  protected object BuildInfo {
+    private val buildFile = "gluten-build-info.properties"
+    private val buildFileStream =
+      Thread.currentThread().getContextClassLoader.getResourceAsStream(buildFile)
+
+    if (buildFileStream == null) {
+      throw new RuntimeException(s"Can not load the core build file: $buildFile")
+    }
+
+    val unknown = "<unknown>"
+    private val props = new Properties()
+
+    try {
+      props.load(buildFileStream)
+    } finally {
+      Try(buildFileStream.close())
+    }
+
+    val version: String = props.getProperty("gluten_version", unknown)
+    val gccVersion: String = props.getProperty("gcc_version", unknown)
+    val javaVersion: String = props.getProperty("java_version", unknown)
+    val scalaVersion: String = props.getProperty("scala_version", unknown)
+    val sparkVersion: String = props.getProperty("spark_version", unknown)
+    val hadoopVersion: String = props.getProperty("hadoop_version", unknown)
+    val branch: String = props.getProperty("branch", unknown)
+    val revision: String = props.getProperty("revision", unknown)
+    val revisionTime: String = props.getProperty("revision_time", unknown)
+    val buildDate: String = props.getProperty("date", unknown)
+    val repoUrl: String = props.getProperty("url", unknown)
+    val veloxBranch: String = props.getProperty("velox_branch", unknown)
+    val veloxRevision: String = props.getProperty("velox_revision", unknown)
+    val veloxRevisionTime: String = props.getProperty("velox_revision_time", unknown)
+  }
+
+  val VERSION: String = BuildInfo.version
+  val GCC_VERSION: String = BuildInfo.gccVersion
+  val JAVA_COMPILE_VERSION: String = BuildInfo.javaVersion
+  val SCALA_COMPILE_VERSION: String = BuildInfo.scalaVersion
+  val SPARK_COMPILE_VERSION: String = BuildInfo.sparkVersion
+  val HADOOP_COMPILE_VERSION: String = BuildInfo.hadoopVersion
+  val BRANCH: String = BuildInfo.branch
+  val REVISION: String = BuildInfo.revision
+  val REVISION_TIME: String = BuildInfo.revisionTime
+  val BUILD_DATE: String = BuildInfo.buildDate
+  val REPO_URL: String = BuildInfo.repoUrl
+  val veloxEnabled: Boolean = BuildInfo.veloxBranch != BuildInfo.unknown
+  val VELOX_BRANCH: String = BuildInfo.veloxBranch
+  val VELOX_REVISION: String = BuildInfo.veloxRevision
+  val VELOX_REVISION_TIME: String = BuildInfo.veloxRevisionTime
+}

--- a/gluten-core/src/main/scala/org/apache/spark/rdd/EmptyRDD.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/rdd/EmptyRDD.scala
@@ -36,9 +36,7 @@ import scala.reflect.ClassTag
 private[spark] class EmptyRDD[T: ClassTag](sc: SparkContext) extends RDD[T](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
-    if (
-      BackendsApiManager.getBackendName.equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
-    ) {
+    if (BackendsApiManager.chBackend) {
       Array(new MyEmptyRDDPartition(0))
     } else {
       Array.empty

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -286,8 +286,7 @@ object WholeStageTransformerSuite extends Logging {
     df: DataFrame,
     noFallBack: Boolean = true,
     skipAssert: Boolean = false): Unit = {
-    if (BackendsApiManager.getBackendName
-      .equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    if (BackendsApiManager.chBackend) {
       // When noFallBack is true, it means there is no fallback plan,
       // otherwise there must be some fallback plans.
       val isFallBack = FallbackUtil.isFallback(df.queryExecution.executedPlan)

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsBaseTrait.scala
@@ -59,8 +59,7 @@ trait GlutenSQLTestsBaseTrait extends SharedSparkSession with GlutenTestsBaseTra
       // .set("spark.sql.optimizer.excludedRules", ConstantFolding.ruleName + "," +
       //     NullPropagation.ruleName)
 
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    if (BackendsApiManager.chBackend) {
       conf
         .set("spark.io.compression.codec", "LZ4")
         .set("spark.gluten.sql.columnar.backend.ch.worker.id", "1")

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenTestsTrait.scala
@@ -105,8 +105,7 @@ trait GlutenTestsTrait extends GlutenTestsCommonTrait {
         // Avoid the code size overflow error in Spark code generation.
         .config("spark.sql.codegen.wholeStage", "false")
 
-      _spark = if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-        GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+      _spark = if (BackendsApiManager.chBackend) {
         sparkBuilder
           .config("spark.io.compression.codec", "LZ4")
           .config("spark.gluten.sql.columnar.backend.ch.worker.id", "1")

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -170,8 +170,7 @@ class GlutenSQLQueryTestSuite extends QueryTest with SharedSparkSession with SQL
     attempt.isSuccess && attempt.get == 0
   }
 
-  private val isCHBackend = BackendsApiManager.getBackendName
-    .equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
+  private val isCHBackend = BackendsApiManager.chBackend
 
   protected override def sparkConf: SparkConf = {
     val conf = super.sparkConf

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
@@ -77,8 +77,7 @@ object ParquetReadBenchmark extends SqlBasedBenchmark {
       .setIfMissing("spark.sql.files.maxPartitionBytes", "1G")
       .setIfMissing("spark.sql.files.openCostInBytes", "1073741824")
 
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    if (BackendsApiManager.chBackend) {
       conf
         .set("spark.io.compression.codec", "LZ4")
         .set("spark.gluten.sql.enable.native.validation", "false")
@@ -231,8 +230,7 @@ object ParquetReadBenchmark extends SqlBasedBenchmark {
   }
 
   override def afterAll(): Unit = {
-    if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    if (BackendsApiManager.chBackend) {
       val libPath = spark.conf.get(
         GlutenConfig.GLUTEN_LIB_PATH,
         SystemParameters

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
@@ -69,8 +69,7 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
       // Avoid the code size overflow error in Spark code generation.
       .config("spark.sql.codegen.wholeStage", "false")
 
-    spark = if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    spark = if (BackendsApiManager.chBackend) {
       sparkBuilder
         .config("spark.io.compression.codec", "LZ4")
         .config("spark.gluten.sql.columnar.backend.ch.worker.id", "1")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -170,8 +170,7 @@ class GlutenSQLQueryTestSuite extends QueryTest with SharedSparkSession with SQL
     attempt.isSuccess && attempt.get == 0
   }
 
-  private val isCHBackend = BackendsApiManager.getBackendName
-    .equalsIgnoreCase(GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)
+  private val isCHBackend = BackendsApiManager.chBackend
 
   protected override def sparkConf: SparkConf = {
     val conf = super.sparkConf

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/joins/GlutenBroadcastJoinSuite.scala
@@ -51,8 +51,7 @@ class GlutenBroadcastJoinSuite extends BroadcastJoinSuite with GlutenTestsCommon
       // Avoid the code size overflow error in Spark code generation.
       .config("spark.sql.codegen.wholeStage", "false")
 
-    spark = if (BackendsApiManager.getBackendName.equalsIgnoreCase(
-      GlutenConfig.GLUTEN_CLICKHOUSE_BACKEND)) {
+    spark = if (BackendsApiManager.chBackend) {
       sparkBuilder
         .config("spark.io.compression.codec", "LZ4")
         .config("spark.gluten.sql.columnar.backend.ch.worker.id", "1")

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -112,23 +112,22 @@
         </executions>
       </plugin>
       <plugin>
-      <artifactId>maven-clean-plugin</artifactId>
-      <version>3.2.0</version>
-      <configuration>
-        <excludeDefaultDirectories>true</excludeDefaultDirectories>
-        <filesets>
-          <fileset>
-            <directory>target</directory>
-            <excludes>
-              <exclude>*3.2*</exclude>
-              <exclude>*3.3*</exclude>
-            </excludes>
-            <followSymlinks>false</followSymlinks>
-          </fileset>
-        </filesets>
-      </configuration>
-    </plugin>
-
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <excludeDefaultDirectories>true</excludeDefaultDirectories>
+          <filesets>
+            <fileset>
+              <directory>target</directory>
+              <excludes>
+                <exclude>*3.2*</exclude>
+                <exclude>*3.3*</exclude>
+              </excludes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,11 @@
           <version>3.0.1</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.4.1</version>
           <configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The build info is important that there is no stable version now. It can help developer find the binary is from which git commit.

```
======================================
Gluten build info:
Gluten version: 0.5.0-SNAPSHOT
GCC version: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
Java version: 1.8.0_362
Scala version: 2.12.15
Spark version: 3.3.1
Hadoop version: 2.7.4
Build branch: build-info
Build revision: 0e21fe8a96ff16973436a1b094e5c50be7c19a52
Build revision time: 2023-06-15 20:02:22 +0800
Build date: 2023-06-15T12:03:39Z
Velox branch: main
Velox revision: f258c6f8e2b8efa7a55a811151715cadd9cf50c3
Velox revision time: 2023-05-30 11:23:21 +0800
======================================
```

(Fixes: \#1972)

## How was this patch tested?

manually test