### PR TITLE
[GLUTEN-1983][VL] Fix serialization errors by removing unused VeloxColumnarToRowExec.LOG

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.types._
-import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.NANOSECONDS
@@ -40,7 +39,6 @@ import org.apache.spark.util.memory.TaskResources
 
 case class VeloxColumnarToRowExec(child: SparkPlan)
   extends ColumnarToRowExecBase(child = child) {
-  private val LOG = LoggerFactory.getLogger(classOf[VeloxColumnarToRowExec])
 
   override def nodeName: String = "VeloxColumnarToRowExec"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove the unused `VeloxColumnarToRowExec` that's causing `Task not serializable` errors.

```
Caused by: org.apache.spark.SparkException: Task not serializable
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:444)
	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:416)
	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:163)
	at org.apache.spark.SparkContext.clean(SparkContext.scala:2578)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitions$1(RDD.scala:860)
	...
Caused by: java.io.NotSerializableException: com.palantir.sls.logging.log4j.slf4j.SlsLog4jSlf4jLogger
Serialization stack:
	- object not serializable (class: com.palantir.sls.logging.log4j.slf4j.SlsLog4jSlf4jLogger, value: com.palantir.sls.logging.log4j.slf4j.SlsLog4jSlf4jLogger@7d832514)
	- field (class: org.apache.spark.sql.execution.GlutenColumnarToRowExec, name: LOG, type: interface org.slf4j.Logger)
	- object (class org.apache.spark.sql.execution.GlutenColumnarToRowExec, GlutenColumnarToRowExec
+- ^(2) ProjectExecTransformer [i_item_sk#63]
   +- ^(2) GlutenFilterExecTransformer ((isnotnull(i_manufact_id#76) AND (i_manufact_id#76 = 350)) AND isnotnull(i_item_sk#63))
      +- GlutenRowToArrowColumnar
         +- BatchScan ...
```

The field wasn't used. `VeloxColumnarToRowExec` calls `logInfo` on the `org.apache.spark.internal.Logging` trait it inherits.  That one [correctly handles serialization (Github)](https://github.com/apache/spark/blob/49dc2dbcbb1d763d8ee0f2034e82347eebe50d0f/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala#L39-L41).

## How was this patch tested?
Existing tests.