### PR TITLE
[VL] fix the crash problem caused by SIMD instructions execution

### DIFF
--- a/cpp/core/memory/HbwAllocator.h
+++ b/cpp/core/memory/HbwAllocator.h
@@ -41,6 +41,10 @@ class HbwMemoryAllocator final : public MemoryAllocator {
 
   bool unreserveBytes(int64_t size) override;
 
+  std::string toString() const override {
+    return "HbwMemoryAllocator";
+  }
+
   int64_t getBytes() const override;
 
  private:

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -113,6 +113,12 @@ int64_t ListenableMemoryAllocator::getBytes() const {
   return bytes_;
 }
 
+std::string ListenableMemoryAllocator::toString() const {
+  std::string str = "ListenableMemoryAllocator delegate:";
+  str += delegated_->toString();
+  return str;
+}
+
 bool StdMemoryAllocator::allocate(int64_t size, void** out) {
   *out = std::malloc(size);
   bytes_ += size;
@@ -170,6 +176,10 @@ bool StdMemoryAllocator::unreserveBytes(int64_t size) {
 
 int64_t StdMemoryAllocator::getBytes() const {
   return bytes_;
+}
+
+std::string StdMemoryAllocator::toString() const {
+  return "StdMemoryAllocator";
 }
 
 std::shared_ptr<MemoryAllocator> defaultMemoryAllocator() {

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "arrow/memory_pool.h"
@@ -44,6 +45,8 @@ class MemoryAllocator {
   virtual bool unreserveBytes(int64_t size) = 0;
 
   virtual int64_t getBytes() const = 0;
+
+  virtual std::string toString() const = 0;
 };
 
 class AllocationListener {
@@ -81,6 +84,8 @@ class ListenableMemoryAllocator final : public MemoryAllocator {
 
   int64_t getBytes() const override;
 
+  std::string toString() const override;
+
  private:
   MemoryAllocator* delegated_;
   std::shared_ptr<AllocationListener> listener_;
@@ -106,6 +111,8 @@ class StdMemoryAllocator final : public MemoryAllocator {
   bool unreserveBytes(int64_t size) override;
 
   int64_t getBytes() const override;
+
+  std::string toString() const override;
 
  private:
   std::atomic_int64_t bytes_{0};

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -114,7 +114,14 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedSize);
     void* buffer;
     try {
-      if (!glutenAlloc_->allocateAligned(alignment_, alignedSize, &buffer)) {
+      bool succeed = false;
+      if (alignment_ > velox::memory::MemoryAllocator::kMinAlignment) {
+        succeed = glutenAlloc_->allocateAligned(alignment_, alignedSize, &buffer);
+      } else {
+        succeed = glutenAlloc_->allocate(alignedSize, &buffer);
+      }
+
+      if (!succeed) {
         VELOX_FAIL(fmt::format("VeloxMemoryPool: Failed to allocate {} bytes", alignedSize))
       }
     } catch (std::exception& e) {
@@ -133,11 +140,18 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedSize);
     void* buffer;
     try {
-      bool succeed = glutenAlloc_->allocateAligned(alignment_, alignedSize, &buffer);
+      bool succeed = false, zerod = false;
+      if (alignment_ > velox::memory::MemoryAllocator::kMinAlignment) {
+        succeed = glutenAlloc_->allocateAligned(alignment_, alignedSize, &buffer);
+      } else {
+        succeed = glutenAlloc_->allocateZeroFilled(alignedSize, 1, &buffer);
+        zerod = true;
+      }
+
       if (!succeed) {
         VELOX_FAIL(fmt::format(
             "VeloxMemoryPool: Failed to allocate (zero filled) {} members, {} bytes for each", alignedSize, 1))
-      } else {
+      } else if (!zerod) {
         memset(buffer, 0, alignedSize);
       }
     } catch (std::exception& e) {
@@ -163,7 +177,13 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedNewSize);
     void* newP;
     try {
-      bool succeed = glutenAlloc_->allocateAligned(alignment_, alignedNewSize, &newP);
+      bool succeed = false;
+      if (alignment_ > velox::memory::MemoryAllocator::kMinAlignment) {
+        succeed = glutenAlloc_->allocateAligned(alignment_, alignedNewSize, &newP);
+      } else {
+        succeed = glutenAlloc_->allocate(alignedNewSize, &newP);
+      }
+
       VELOX_CHECK(succeed)
     } catch (std::exception& e) {
       free(p, alignedSize);

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -114,7 +114,7 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedSize);
     void* buffer;
     try {
-      if (!glutenAlloc_->allocate(alignedSize, &buffer)) {
+      if (!glutenAlloc_->allocateAligned(alignment_, alignedSize, &buffer)) {
         VELOX_FAIL(fmt::format("VeloxMemoryPool: Failed to allocate {} bytes", alignedSize))
       }
     } catch (std::exception& e) {
@@ -133,10 +133,12 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedSize);
     void* buffer;
     try {
-      bool succeed = glutenAlloc_->allocateZeroFilled(alignedSize, 1, &buffer);
+      bool succeed = glutenAlloc_->allocateAligned(alignment_, alignedSize, &buffer);
       if (!succeed) {
         VELOX_FAIL(fmt::format(
             "VeloxMemoryPool: Failed to allocate (zero filled) {} members, {} bytes for each", alignedSize, 1))
+      } else {
+        memset(buffer, 0, alignedSize);
       }
     } catch (std::exception& e) {
       release(alignedSize);
@@ -161,7 +163,7 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
     reserve(alignedNewSize);
     void* newP;
     try {
-      bool succeed = glutenAlloc_->allocate(alignedNewSize, &newP);
+      bool succeed = glutenAlloc_->allocateAligned(alignment_, alignedNewSize, &newP);
       VELOX_CHECK(succeed)
     } catch (std::exception& e) {
       free(p, alignedSize);
@@ -375,10 +377,11 @@ class VeloxMemoryPool final : public velox::memory::MemoryPool {
 
   std::string toString() const override {
     return fmt::format(
-        "Memory Pool[{} {} {}]",
+        "Velox Memory Pool[{} {} {} {}]",
         name_,
         kindString(kind_),
-        velox::memory::MemoryAllocator::kindString(veloxAlloc_->kind()));
+        velox::memory::MemoryAllocator::kindString(veloxAlloc_->kind()),
+        glutenAlloc_->toString());
   }
 
   uint64_t freeBytes() const override {


### PR DESCRIPTION
## What changes were proposed in this pull request?

some SIMD instructions (xmovdqa...) need work at the start address of 16B aligned, otherwise, crash.

After this modification, allocating operations will keep consistency with the `velox::MallocAllocator::allocateBytes、allocateZeroFilled`.

the corresponding `oap-project/velox` [PR](https://github.com/oap-project/velox/pull/317)

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

