### PR TITLE
[GLUTEN-1975][CH] hive text format case-insensitive column matching  

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/hive/CHHiveTableScanExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/hive/CHHiveTableScanExecTransformer.scala
@@ -146,7 +146,6 @@ class CHHiveTableScanExecTransformer(
         outputFieldTypes.append(StructField(x.name, x.dataType))
       })
 
-    // scalastyle:on println
     tableMeta.storage.inputFormat match {
       case Some("org.apache.hadoop.mapred.TextInputFormat") =>
         tableMeta.storage.serde match {
@@ -257,7 +256,7 @@ object CHHiveTableScanExecTransformer {
       hiveTableScan.requestedAttributes,
       hiveTableScan.relation,
       hiveTableScan.partitionPruningPred)(hiveTableScan.session)
-    if (hiveTableScanTransformer.scan == null) {
+    if (hiveTableScanTransformer.scan.isEmpty) {
       Option.empty
     } else {
       Option.apply(hiveTableScanTransformer)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -275,6 +275,24 @@ class GlutenClickHouseHiveTableSuite()
       })
   }
 
+  test("hive text table select complex type columns with fallback") {
+    val sql = s"select int_field, array_field, map_field from $txt_table_name order by int_field"
+    compareResultsAgainstVanillaSpark(sql, true, { _ => }, false)
+  }
+
+  test("hive text table case-insensitive column matching") {
+    val sql = s"select SHORT_FIELD, int_field, LONG_field from $txt_table_name order by int_field"
+    compareResultsAgainstVanillaSpark(
+      sql,
+      true,
+      df => {
+        val txtFileScan = collect(df.queryExecution.executedPlan) {
+          case l: HiveTableScanExecTransformer => l
+        }
+        assert(txtFileScan.size == 1)
+      })
+  }
+
   test("test hive json table") {
     val sql =
       s"""

--- a/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.h
@@ -11,6 +11,8 @@ public:
     explicit JsonFormatFile(DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_);
     ~JsonFormatFile() override = default;
 
+    bool supportSplit() override { return true; }
+
     FormatFile::InputFormatPtr createInputFormat(const DB::Block & header) override;
 };
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -43,7 +43,7 @@ namespace ErrorCodes
     extern const int CANNOT_OPEN_FILE;
     extern const int UNKNOWN_FILE_SIZE;
     extern const int CANNOT_SEEK_THROUGH_FILE;
-    extern const int CANNOT_CLOSE_FILE;
+    extern const int CANNOT_READ_FROM_FILE_DESCRIPTOR;
 }
 }
 
@@ -156,7 +156,7 @@ public:
                 auto n = hdfsRead(fs, fin, buf, buf_size);
                 if (n < 0)
                     throw DB::Exception(
-                        DB::ErrorCodes::CANNOT_SEEK_THROUGH_FILE,
+                        DB::ErrorCodes::CANNOT_READ_FROM_FILE_DESCRIPTOR,
                         "Fail to read HDFS file: {}, error: {}",
                         file_path,
                         std::string(hdfsGetLastError()));

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -83,12 +83,12 @@ public:
     build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, const bool & set_read_util_position) override
     {
         Poco::URI file_uri(file_info.uri_file());
-        std::unique_ptr<DB::ReadBuffer> read_buffer;
-
         std::string uri_path = "hdfs://" + file_uri.getHost();
         if (file_uri.getPort())
             uri_path += ":" + std::to_string(file_uri.getPort());
+
         DB::ReadSettings read_settings;
+        std::unique_ptr<DB::ReadBuffer> read_buffer;
         if (set_read_util_position)
         {
             std::pair<size_t, size_t> start_end_pos
@@ -101,11 +101,12 @@ public:
                 start_end_pos.first,
                 start_end_pos.second);
             read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
-                uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(), read_settings, start_end_pos.second);
+                uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(),
+                read_settings, start_end_pos.second);
+
             if (auto * seekable_in = dynamic_cast<DB::SeekableReadBuffer *>(read_buffer.get()))
-            {
-                seekable_in->seek(start_end_pos.first, SEEK_SET);
-            }
+                if (start_end_pos.first)
+                    seekable_in->seek(start_end_pos.first, SEEK_SET);
         }
         else
         {
@@ -118,87 +119,100 @@ public:
     std::pair<size_t, size_t>
     adjustFileReadStartAndEndPos(size_t read_start_pos, size_t read_end_pos, std::string uri_path, std::string file_path)
     {
-        std::pair<size_t, size_t> result;
-        std::string row_delimiter = "\n";
-        size_t row_delimiter_size = row_delimiter.size();
         std::string hdfs_file_path = uri_path + file_path;
         auto builder = DB::createHDFSBuilder(hdfs_file_path, context->getGlobalContext()->getConfigRef());
         auto fs = DB::createHDFSFS(builder.get());
         hdfsFile fin = hdfsOpenFile(fs.get(), file_path.c_str(), O_RDONLY, 0, 0, 0);
         if (!fin)
-        {
-            throw DB::Exception(
-                DB::ErrorCodes::CANNOT_OPEN_FILE, "Cannot open hdfs file:{}, error: {}", hdfs_file_path, std::string(hdfsGetLastError()));
-        }
+            throw DB::Exception(DB::ErrorCodes::CANNOT_OPEN_FILE, "Cannot open hdfs file:{}, error: {}", hdfs_file_path, std::string(hdfsGetLastError()));
+
+        /// Always close hdfs file before exit function.
+        SCOPE_EXIT({ hdfsCloseFile(fs.get(), fin); });
+
         auto hdfs_file_info = hdfsGetPathInfo(fs.get(), file_path.c_str());
         if (!hdfs_file_info)
-        {
-            hdfsCloseFile(fs.get(), fin);
             throw DB::Exception(
                 DB::ErrorCodes::UNKNOWN_FILE_SIZE,
                 "Cannot find out file size for :{}, error: {}",
                 hdfs_file_path,
                 std::string(hdfsGetLastError()));
-        }
         size_t hdfs_file_size = hdfs_file_info->mSize;
-        auto getFirstRowDelimiterPos = [&](hdfsFS fs, hdfsFile fin, size_t start_pos, size_t hdfs_file_size) -> size_t
+
+        /// initial_pos maybe in the middle of a row, so we need to find the next row start position.
+        auto get_next_line_pos = [&](hdfsFS fs, hdfsFile fin, size_t initial_pos, size_t file_size) -> size_t
         {
-            if (start_pos == 0 || start_pos == hdfs_file_size)
+            if (initial_pos == 0 || initial_pos == file_size)
+                return initial_pos;
+
+            int seek_ret = hdfsSeek(fs, fin, initial_pos);
+            if (seek_ret < 0)
+                throw DB::Exception(DB::ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Fail to seek HDFS file: {}, error: {}", file_path, std::string(hdfsGetLastError()));
+
+            static constexpr size_t buf_size = 1024;
+            char buf[buf_size];
+
+            auto do_read = [&]() -> int
             {
-                return start_pos;
-            }
-            size_t pos = start_pos;
-            int seek_status = hdfsSeek(fs, fin, pos);
-            if (seek_status != 0)
+                auto n = hdfsRead(fs, fin, buf, buf_size);
+                if (n < 0)
+                    throw DB::Exception(
+                        DB::ErrorCodes::CANNOT_SEEK_THROUGH_FILE,
+                        "Fail to read HDFS file: {}, error: {}",
+                        file_path,
+                        std::string(hdfsGetLastError()));
+
+                return n;
+            };
+
+            auto pos = initial_pos;
+            while (1)
             {
-                hdfsCloseFile(fs, fin);
-                throw DB::Exception(
-                    DB::ErrorCodes::CANNOT_SEEK_THROUGH_FILE,
-                    "Fail to seek HDFS file: {}, error: {}",
-                    file_path,
-                    std::string(hdfsGetLastError()));
-            }
-            char s[row_delimiter_size];
-            bool read_flag = true;
-            while (read_flag)
-            {
-                size_t read_size = hdfsRead(fs, fin, s, row_delimiter_size);
-                size_t i = 0;
-                for (; i < read_size && i < row_delimiter_size; ++i)
+                auto n = do_read();
+
+                /// If read to the end of file, return directly.
+                if (n == 0)
+                    return pos;
+
+                /// Search for \n or \r\n or \n\r in buffer.
+                int i = 0;
+                while (i < n)
                 {
-                    if (s[i] != *(row_delimiter.data() + i))
+                    if (buf[i] == '\n')
                     {
-                        break;
+                        if (i + 1 < n)
+                            return buf[i + 1] == '\r' ? pos + i + 2 : pos + i + 1;
+
+                        /// read again if buffer is not enough.
+                        auto m = do_read();
+                        if (m == 0)
+                            return pos + i + 1;
+
+                        return buf[0] == '\r' ? pos + i + 2 : pos + i + 1;
                     }
-                }
-                if (i == row_delimiter_size)
-                {
-                    char r[1];
-                    // The end of row maybe '\n', '\r\n', or '\n\r'
-                    if (hdfsRead(fs, fin, r, 1) != 0 && r[0] == '\r')
+                    else if (buf[i] == '\r')
                     {
-                        return pos + 1 + row_delimiter_size;
+                        if (i + 1 < n)
+                            return buf[i + 1] == '\n' ? pos + i + 2 : pos + i + 1;
+
+                        /// read again if buffer is not enough.
+                        auto m = do_read();
+                        if (m == 0)
+                            return pos + i + 1;
+
+                        return buf[0] == '\n' ? pos + i + 2 : pos + i + 1;
                     }
                     else
-                    {
-                        return pos + row_delimiter_size;
-                    }
+                        ++i;
                 }
-                else
-                {
-                    pos += 1;
-                    hdfsSeek(fs, fin, pos);
-                }
+
+                /// Can't find \n or \r\n or \n\r in current buffer, read again.
+                pos += n;
             }
         };
-        result.first = getFirstRowDelimiterPos(fs.get(), fin, read_start_pos, hdfs_file_size);
-        result.second = getFirstRowDelimiterPos(fs.get(), fin, read_end_pos, hdfs_file_size);
-        int close_status = hdfsCloseFile(fs.get(), fin);
-        if (close_status != 0)
-        {
-            throw DB::Exception(
-                DB::ErrorCodes::CANNOT_CLOSE_FILE, "Fail to close HDFS file: {}, error: {}", file_path, std::string(hdfsGetLastError()));
-        }
+
+        std::pair<size_t, size_t> result;
+        result.first = get_next_line_pos(fs.get(), fin, read_start_pos, hdfs_file_size);
+        result.second = get_next_line_pos(fs.get(), fin, read_end_pos, hdfs_file_size);
         return result;
     }
 };

--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
@@ -20,7 +20,7 @@ FormatFile::InputFormatPtr TextFormatFile::createInputFormat(const DB::Block & h
 
     /// Initialize format params
     size_t max_block_size = file_info.text().max_block_size();
-    DB::RowInputFormatParams params = {max_block_size};
+    DB::RowInputFormatParams params = {.max_block_size = max_block_size};
 
     /// Initialize format settings
     DB::FormatSettings format_settings = DB::getFormatSettings(context);

--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.h
@@ -13,6 +13,8 @@ public:
         DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_);
     ~TextFormatFile() override = default;
 
+    bool supportSplit() override { return true; }
+
     FormatFile::InputFormatPtr createInputFormat(const DB::Block & header) override;
 };
 

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -153,6 +153,7 @@ rm -f jars/protobuf-java-2.5.0.jar
 wget https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.16.3/protobuf-java-3.16.3.jar -P ./jars
 wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/2.0.1/delta-core_2.12-2.0.1.jar -P ./jars
 wget https://repo1.maven.org/maven2/io/delta/delta-storage/2.0.1/delta-storage-2.0.1.jar -P ./jars
+wget https://repo1.maven.org/maven2/io/starburst/openx/data/json-serde/1.3.9-e.10/json-serde-1.3.9-e.10.jar ./jars
 cp gluten-XXXXX-spark-3.2-jar-with-dependencies.jar jars/
 ```
 

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -153,7 +153,7 @@ rm -f jars/protobuf-java-2.5.0.jar
 wget https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.16.3/protobuf-java-3.16.3.jar -P ./jars
 wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/2.0.1/delta-core_2.12-2.0.1.jar -P ./jars
 wget https://repo1.maven.org/maven2/io/delta/delta-storage/2.0.1/delta-storage-2.0.1.jar -P ./jars
-wget https://repo1.maven.org/maven2/io/starburst/openx/data/json-serde/1.3.9-e.10/json-serde-1.3.9-e.10.jar ./jars
+wget https://repo1.maven.org/maven2/io/starburst/openx/data/json-serde/1.3.9-e.10/json-serde-1.3.9-e.10-jar-with-dependencies.jar ./jars
 cp gluten-XXXXX-spark-3.2-jar-with-dependencies.jar jars/
 ```
 
@@ -167,6 +167,7 @@ rm -f jars/protobuf-java-2.5.0.jar
 wget https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.16.3/protobuf-java-3.16.3.jar -P ./jars
 wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/2.2.0/delta-core_2.12-2.2.0.jar -P ./jars
 wget https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/delta-storage-2.2.0.jar -P ./jars
+wget https://repo1.maven.org/maven2/io/starburst/openx/data/json-serde/1.3.9-e.10/json-serde-1.3.9-e.10-jar-with-dependencies.jar ./jars
 cp gluten-XXXXX-spark-3.3-jar-with-dependencies.jar jars/
 ```
 

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -30,6 +30,7 @@ import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
 import io.substrait.proto.RelCommon;
 import io.substrait.proto.Type;
+import javolution.io.Struct.Bool;
 
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -68,14 +69,19 @@ public class ReadRelNode implements RelNode, Serializable {
   public void setDataSchema(StructType schema) {
     this.dataSchema = new StructType();
 
-    // Case-insensitive schema matching
     for (StructField field : schema.fields()) {
+      Boolean found = false;
       for (int i = 0; i < names.size(); i++) {
+        // Case-insensitive schema matching
         if (field.name().equalsIgnoreCase(names.get(i))) {
           this.dataSchema.add(names.get(i), field.dataType(), field.nullable(), field.metadata());
-        } else {
-          this.dataSchema.add(field);
+          found = true;
+          break;
         }
+      }
+
+      if (!found) {
+        this.dataSchema.add(field);
       }
     }
   }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -30,10 +30,10 @@ import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
 import io.substrait.proto.RelCommon;
 import io.substrait.proto.Type;
-import javolution.io.Struct.Bool;
 
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+
 import java.util.Map;
 
 public class ReadRelNode implements RelNode, Serializable {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -30,6 +30,8 @@ import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
 import io.substrait.proto.RelCommon;
 import io.substrait.proto.Type;
+
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import java.util.Map;
 
@@ -64,7 +66,18 @@ public class ReadRelNode implements RelNode, Serializable {
   }
 
   public void setDataSchema(StructType schema) {
-    this.dataSchema = schema;
+    this.dataSchema = new StructType();
+
+    // Case-insensitive schema matching
+    for (StructField field : schema.fields()) {
+      for (int i = 0; i < names.size(); i++) {
+        if (field.name().equalsIgnoreCase(names.get(i))) {
+          this.dataSchema.add(names.get(i), field.dataType(), field.nullable(), field.metadata());
+        } else {
+          this.dataSchema.add(field);
+        }
+      }
+    }
   }
 
   public void setProperties(Map<String, String> properties) {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -74,7 +74,8 @@ public class ReadRelNode implements RelNode, Serializable {
       for (int i = 0; i < names.size(); i++) {
         // Case-insensitive schema matching
         if (field.name().equalsIgnoreCase(names.get(i))) {
-          this.dataSchema = this.dataSchema.add(names.get(i), field.dataType(), field.nullable(), field.metadata());
+          this.dataSchema = this.dataSchema.add(
+            names.get(i), field.dataType(), field.nullable(), field.metadata());
           found = true;
           break;
         }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -67,21 +67,21 @@ public class ReadRelNode implements RelNode, Serializable {
   }
 
   public void setDataSchema(StructType schema) {
+    // this.dataSchema = schema;
     this.dataSchema = new StructType();
-
     for (StructField field : schema.fields()) {
       Boolean found = false;
       for (int i = 0; i < names.size(); i++) {
         // Case-insensitive schema matching
         if (field.name().equalsIgnoreCase(names.get(i))) {
-          this.dataSchema.add(names.get(i), field.dataType(), field.nullable(), field.metadata());
+          this.dataSchema = this.dataSchema.add(names.get(i), field.dataType(), field.nullable(), field.metadata());
           found = true;
           break;
         }
       }
 
       if (!found) {
-        this.dataSchema.add(field);
+        this.dataSchema = this.dataSchema.add(field);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
code changes: 
- support column case-insensitive matching for hive text format file
- fix bug when select complex type columns from hive text table: it is expected to fallback, but actually not as expected. 
- fix bug: select count(1) from hive text table returns wrong results
- improve function adjustFileReadStartAndEndPos

(Fixes: \#1975)

## How was this patch tested?


``` sql 
create table if not exists test_text (string_field string,int_field int,long_field long,float_field float,double_field double,short_field short,byte_field byte, bool_field boolean, decimal_field decimal(23, 12), date_field date, array_field array<int>, array_field_with_null array<int>, map_field map<int, long>, map_field_with_null map<int, long>) stored as textfile; 

insert into test_text select
cast(id as String), 
cast(id as int), 
cast(id as long), 
cast(id as float), 
cast(id as double),
cast(id as short),
cast(id as byte),
id % 2 = 0,
cast((id + 0.56) as decimal(23, 12)), 
date(now()),
array(id+1, id+2, id+3),
array(id+1, null, id+3),
map(id+1, id+2, id+3, id+4),
map() from range(200); 

explain formatted 
 select string_field,
        sum(int_field),
        avg(long_field),
        min(float_field),
        max(double_field),
        sum(short_field),
        sum(decimal_field)
 from test_text
 group by string_field
 order by string_field



```
