### PR TITLE
[GLUTEN-2103][VL] feat: allow to dump the fallback information for plan validation

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHValidatorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHValidatorApi.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi.clickhouse
 import io.glutenproject.backendsapi.ValidatorApi
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.utils.CHExpressionUtil
+import io.glutenproject.validate.NativePlanValidatorInfo
 import io.glutenproject.vectorized.CHNativeExpressionEvaluator
 
 import org.apache.spark.internal.Logging
@@ -35,6 +36,11 @@ class CHValidatorApi extends ValidatorApi with AdaptiveSparkPlanHelper {
   override def doValidate(plan: PlanNode): Boolean = {
     val validator = new CHNativeExpressionEvaluator()
     validator.doValidate(plan.toProtobuf.toByteArray)
+  }
+
+  override def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidatorInfo = {
+    // not applicable for now but may implement in future
+    return null;
   }
 
   /**

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/Validator.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/Validator.scala
@@ -20,8 +20,8 @@ package io.glutenproject.backendsapi.velox
 import io.glutenproject.backendsapi.ValidatorApi
 import io.glutenproject.execution.RowToColumnConverter
 import io.glutenproject.substrait.plan.PlanNode
+import io.glutenproject.validate.NativePlanValidatorInfo
 import io.glutenproject.vectorized.NativePlanEvaluator
-
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.StructType
@@ -34,6 +34,11 @@ class Validator extends ValidatorApi {
   override def doValidate(plan: PlanNode): Boolean = {
     val validator = new NativePlanEvaluator()
     validator.doValidate(plan.toProtobuf.toByteArray)
+  }
+
+  override def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidatorInfo = {
+    val validator = new NativePlanEvaluator()
+    validator.doValidateWithFallBackLog(plan.toProtobuf.toByteArray)
   }
 
   override def doSparkPlanValidate(plan: SparkPlan): Boolean = true

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -60,7 +60,7 @@ object BackendSettings extends BackendSettingsApi {
         // scalastyle:off println
         println(
           s"Validation failed for ${this.getClass.toString}" +
-            s"due to Not supported: data type $unsupportedDataType. in file schema. ")
+            s" due to: data type $unsupportedDataType. in file schema. ")
         // scalastyle:on println
       }
       unsupportedDataTypes.isEmpty
@@ -73,7 +73,7 @@ object BackendSettings extends BackendSettingsApi {
         // scalastyle:off println
         println(
           s"Validation failed for ${this.getClass.toString}" +
-            s"due to Not supported: input path doesn't contain split info. ")
+            s"due to: input path doesn't contain split info. ")
         // scalastyle:on println
         return false
       }
@@ -91,7 +91,7 @@ object BackendSettings extends BackendSettingsApi {
           // scalastyle:off println
           println(
             s"Validation failed for ${this.getClass.toString}" +
-              s"due to Not supported: data type $unsupportedDataType. in file schema. ")
+              s" due to: data type $unsupportedDataType. in file schema. ")
           // scalastyle:on println
         }
         unsupportedDataTypes.isEmpty

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -51,8 +51,8 @@ object BackendSettings extends BackendSettingsApi {
     def validateTypes: Boolean = {
       // Collect unsupported types.
       val unsupportedDataTypes = fields.map(_.dataType).collect {
-        case _: ByteType =>
-        case _: ArrayType =>
+        case _: ByteType => "ByteType"
+        case _: ArrayType => "ArrayType"
         case _: MapType if mapType.keyType.isInstanceOf[StructType] => "StructType in MapType"
         // Parquet scan of nested map with struct as key type is not supported in Velox.
       }
@@ -60,7 +60,7 @@ object BackendSettings extends BackendSettingsApi {
         // scalastyle:off println
         println(
           s"Validation failed for ${this.getClass.toString}" +
-            s"due to Not supported: data type $unsupportedDataType in file schema. ")
+            s"due to Not supported: data type $unsupportedDataType. in file schema. ")
         // scalastyle:on println
       }
       unsupportedDataTypes.isEmpty
@@ -83,9 +83,18 @@ object BackendSettings extends BackendSettingsApi {
     format match {
       case ParquetReadFormat => validateTypes && validateFilePath
       case DwrfReadFormat => true
-      case OrcReadFormat => fields.map(_.dataType).collect {
-        case _: TimestampType =>
-      }.isEmpty
+      case OrcReadFormat =>
+        val unsupportedDataTypes = fields.map(_.dataType).collect {
+          case _: TimestampType => "TimestampType"
+        }
+        for (unsupportedDataType <- unsupportedDataTypes) {
+          // scalastyle:off println
+          println(
+            s"Validation failed for ${this.getClass.toString}" +
+              s"due to Not supported: data type $unsupportedDataType. in file schema. ")
+          // scalastyle:on println
+        }
+        unsupportedDataTypes.isEmpty
       case _ => false
     }
   }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -53,7 +53,7 @@ object BackendSettings extends BackendSettingsApi {
       val unsupportedDataTypes = fields.map(_.dataType).collect {
         case _: ByteType => "ByteType"
         case _: ArrayType => "ArrayType"
-        case _: MapType if mapType.keyType.isInstanceOf[StructType] => "StructType in MapType"
+        case mapType: MapType if mapType.keyType.isInstanceOf[StructType] => "StructType as Key in MapType"
         // Parquet scan of nested map with struct as key type is not supported in Velox.
       }
       for (unsupportedDataType <- unsupportedDataTypes) {

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -57,7 +57,13 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val validator = new NativePlanEvaluator()
-      validator.doValidate(planNode.toProtobuf.toByteArray)
+      val isSupported = validator.doValidate(planNode.toProtobuf.toByteArray)
+      if (!isSupported) {
+        logValidateFailureWithoutThrowable(
+          s"Validation failed for ${this.getClass.toString}" +
+            s"due to native check failure. ")
+      }
+      isSupported
     } else {
       true
     }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -64,7 +64,7 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -50,7 +50,7 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
     val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
@@ -64,7 +64,7 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -49,21 +49,25 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
         substraitContext, leftCondition, child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        this.appendValidateLog(
+          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
         return false
     }
     val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val validator = new NativePlanEvaluator()
-      val isSupported = validator.doValidate(planNode.toProtobuf.toByteArray)
-      if (!isSupported) {
-        logValidateFailureWithoutThrowable(
-          s"Validation failed for ${this.getClass.toString}" +
-            s"due to native check failure. ")
+      val validateInfo = validator.doValidateWithFallBackLog(planNode.toProtobuf.toByteArray)
+      if (!validateInfo.isSupported) {
+        val logs = validateInfo.getFallbackInfo()
+        for (i <- 0 until logs.size()) {
+          this.appendValidateLog(logs.get(i))
+        }
+        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
+          s"due to native check failure.")
+        return false
       }
-      isSupported
+      true
     } else {
       true
     }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -59,9 +59,9 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
       val validator = new NativePlanEvaluator()
       val validateInfo = validator.doValidateWithFallBackLog(planNode.toProtobuf.toByteArray)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -45,27 +45,6 @@ std::shared_ptr<gluten::Backend> VeloxBackendFactory(const std::unordered_map<st
 extern "C" {
 #endif
 
-static jclass nativePlanValidatorInfoClass;
-static jmethodID nativePlanvalidatorInfoConstructor;
-
-jmethodID getMethodIdOrError(JNIEnv* env, jclass thisClass, const char* name, const char* sig) {
-  jmethodID ret = getMethodId(env, thisClass, name, sig);
-  if (ret == nullptr) {
-    std::string errorMessage = "Unable to find method " + std::string(name) + " within signature" + std::string(sig);
-    gluten::jniThrow(errorMessage);
-  }
-  return ret;
-}
-
-jclass createGlobalClassReferenceOrError(JNIEnv* env, const char* className) {
-  jclass globalClass = createGlobalClassReference(env, className);
-  if (globalClass == nullptr) {
-    std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for" + std::string(className);
-    gluten::jniThrow(errorMessage);
-  }
-  return globalClass;
-}
-
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   JNIEnv* env;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), jniVersion) != JNI_OK) {
@@ -76,10 +55,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   google::InitGoogleLogging("gluten");
   FLAGS_logtostderr = true;
   gluten::getJniErrorsState()->initialize(env);
-  nativePlanValidatorInfoClass =
-      createGlobalClassReferenceOrError(env, "Lio/glutenproject/validate/NativePlanValidatorInfo;");
-  nativePlanvalidatorInfoConstructor =
-      getMethodIdOrError(env, nativePlanValidatorInfoClass, "<init>", "(Z[Ljava/lang/String;)V");
 #ifdef GLUTEN_PRINT_DEBUG
   std::cout << "Loaded Velox backend." << std::endl;
 #endif
@@ -89,7 +64,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 void JNI_OnUnload(JavaVM* vm, void* reserved) {
   JNIEnv* env;
   vm->GetEnv(reinterpret_cast<void**>(&env), jniVersion);
-  env->DeleteGlobalRef(nativePlanValidatorInfoClass);
   google::ShutdownGoogleLogging();
 }
 
@@ -161,20 +135,25 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeDoValidateWithFal
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 
   velox::substrait::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
+  jclass infoCls = env->FindClass("Lio/glutenproject/validate/NativePlanValidatorInfo;");
+  if (infoCls == nullptr) {
+    std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for NativePlanValidatorInfo";
+    gluten::jniThrow(errorMessage);
+  }
+  jmethodID method = env->GetMethodID(infoCls, "<init>", "(ILjava/lang/String;)V");
   try {
     auto isSupported = planValidator.validate(subPlan);
     auto logs = planValidator.getValidateLog();
-    auto ret_logs = env->NewObjectArray(logs.size(), env->FindClass("java/lang/String"), nullptr);
+    std::string concatLog;
     for (int i = 0; i < logs.size(); i++) {
-      env->SetObjectArrayElement(ret_logs, i, env->NewStringUTF(logs[i].c_str()));
+      concatLog += logs[i] + "@";
     }
-    return env->NewObject(nativePlanValidatorInfoClass, nativePlanvalidatorInfoConstructor, isSupported, ret_logs);
+    return env->NewObject(infoCls, method, isSupported, env->NewStringUTF(concatLog.c_str()));
   } catch (std::invalid_argument& e) {
     LOG(INFO) << "Failed to validate substrait plan because " << e.what();
     // return false;
     auto isSupported = false;
-    auto ret_logs = env->NewObjectArray(0, env->FindClass("java/lang/String"), nullptr);
-    return env->NewObject(nativePlanValidatorInfoClass, nativePlanvalidatorInfoConstructor, isSupported, ret_logs);
+    return env->NewObject(infoCls, method, isSupported, env->NewStringUTF(""));
   }
   JNI_METHOD_END(nullptr)
 }

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -79,7 +79,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   nativePlanValidatorInfoClass =
       createGlobalClassReferenceOrError(env, "Lio/glutenproject/validate/NativePlanValidatorInfo;");
   nativePlanvalidatorInfoConstructor =
-      getMethodIdOrError(env, nativePlanValidatorInfoClass, "<init>", "(ZLjava/util/Vector;)V");
+      getMethodIdOrError(env, nativePlanValidatorInfoClass, "<init>", "(Z[Ljava/lang/String;)V");
 #ifdef GLUTEN_PRINT_DEBUG
   std::cout << "Loaded Velox backend." << std::endl;
 #endif

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -138,7 +138,7 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeDoValidateWithFal
   jclass infoCls = env->FindClass("Lio/glutenproject/validate/NativePlanValidatorInfo;");
   if (infoCls == nullptr) {
     std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for NativePlanValidatorInfo";
-    gluten::jniThrow(errorMessage);
+    throw gluten::GlutenException(errorMessage);
   }
   jmethodID method = env->GetMethodID(infoCls, "<init>", "(ILjava/lang/String;)V");
   try {

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -280,6 +280,32 @@ Spark3.3 has 387 functions in total. ~240 are commonly used. Velox's functions h
 
 > Velox doesn't support [ANSI mode](https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html)), so as Gluten. Once ANSI mode is enabled in Spark config, Gluten will fallback to Vanilla Spark.
 
+To identify what can be offloaded in a query and detailed fallback reasons, user can follow below steps to retrieve corresponding logs.
+```
+1) Enable Gluten by proper [configuration](https://github.com/oap-project/gluten/blob/main/docs/Configuration.md).
+
+2) Disable Spark AQE to trigger plan validation in Gluten
+spark.sql.adaptive.enabled = false
+
+3) Check physical plan 
+sparkSession.sql("your_sql").explain()
+```
+
+With above steps, you will get a physical plan output like:
+```
+== Physical Plan ==
+-Execute InsertIntoHiveTable (7)
+  +- Coalesce (6)
+    +- VeloxColumnarToRowExec (5)
+      +- ^ ProjectExecTransformer (3)
+        +- GlutenRowToArrowColumnar (2)
+          +- Scan hive default.extracted_db_pins (1)
+
+```
+"GlutenRowToArrowColumnar" and "VeloxColumnarToRowExec" indicate there is a fallback and you may find related log with key words "due to" like:
+```
+native validation failed due to: in ProjectRel, Scalar function name not registered: get_struct_field, called with arguments: (ROW<col_0:INTEGER,col_1:BIGINT,col_2:BIGINT>, INTEGER).
+```
 
 # 4 High-Bandwidth Memory (HBM) support
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/yma11/velox.git
+VELOX_BRANCH=log-refine
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/yma11/velox.git
-VELOX_BRANCH=log-refine
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidatorInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidatorInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.glutenproject.validate;
+
+import java.util.Vector;
+public class NativePlanValidatorInfo {
+    private final boolean isSupported;
+    private final Vector<String> fallbackInfo;
+    NativePlanValidatorInfo(boolean isSupported, Vector<String> fallbackInfo) {
+        this.isSupported = isSupported;
+        this.fallbackInfo = fallbackInfo;
+    }
+    public boolean isSupported(){
+        return isSupported;
+    }
+    public Vector<String> getFallbackInfo(){
+        return fallbackInfo;
+    }
+}

--- a/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidatorInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidatorInfo.java
@@ -20,10 +20,12 @@ package io.glutenproject.validate;
 import java.util.Vector;
 public class NativePlanValidatorInfo {
     private final boolean isSupported;
-    private final Vector<String> fallbackInfo;
-    NativePlanValidatorInfo(boolean isSupported, Vector<String> fallbackInfo) {
+    private Vector<String> fallbackInfo = new Vector<>();
+    NativePlanValidatorInfo(boolean isSupported, String[] fallbackInfo) {
         this.isSupported = isSupported;
-        this.fallbackInfo = fallbackInfo;
+        for(int i = 0; i < fallbackInfo.length; i++) {
+            this.fallbackInfo.add(fallbackInfo[i]);
+        }
     }
     public boolean isSupported(){
         return isSupported;

--- a/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidatorInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidatorInfo.java
@@ -18,19 +18,24 @@
 package io.glutenproject.validate;
 
 import java.util.Vector;
+
 public class NativePlanValidatorInfo {
-    private final boolean isSupported;
-    private Vector<String> fallbackInfo = new Vector<>();
-    NativePlanValidatorInfo(boolean isSupported, String[] fallbackInfo) {
+    private final Vector<String> fallbackInfo = new Vector<>();
+    private final int isSupported;
+    public NativePlanValidatorInfo(int isSupported, String fallbackInfo) {
         this.isSupported = isSupported;
-        for(int i = 0; i < fallbackInfo.length; i++) {
-            this.fallbackInfo.add(fallbackInfo[i]);
+        String[] splitInfo = fallbackInfo.split("@");
+        for(int i = 0; i < splitInfo.length; i++) {
+            this.fallbackInfo.add(splitInfo[i]);
         }
     }
+
     public boolean isSupported(){
-        return isSupported;
+        return isSupported == 1;
     }
-    public Vector<String> getFallbackInfo(){
-        return fallbackInfo;
-    }
+
+   public Vector<String> getFallbackInfo() {
+       return fallbackInfo;
+   }
 }
+

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.expression.{ExpressionMappings, ExpressionNames}
 import io.glutenproject.substrait.plan.PlanNode
+import io.glutenproject.validate.NativePlanValidatorInfo
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.StructType
@@ -88,6 +89,7 @@ trait ValidatorApi {
    */
   def doValidate(plan: PlanNode): Boolean
 
+  def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidatorInfo
   /**
    * Validate the input schema.
    * Transformers like UnionExecTransformer that do not generate Substrait plan

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -181,7 +181,7 @@ abstract class FilterExecTransformerBase(val cond: Expression,
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true
@@ -274,7 +274,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true
@@ -404,8 +404,6 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
 case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with GlutenPlan {
   override def supportsColumnar: Boolean = true
 
-  var validateLog: Vector[String] = Vector()
-
   override def output: Seq[Attribute] = {
     children.map(_.output).transpose.map { attrs =>
       val firstAttr = attrs.head
@@ -447,8 +445,8 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
 
   def doValidate(): Boolean = {
     if (!BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)) {
-      validateLog = validateLog :+ "Validation failed for" +
-        " UnionExecTransformer due to schema check failed."
+      this.appendValidateLog("Validation failed for" +
+        " UnionExecTransformer due to schema check failed.")
       return false
     }
     true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -156,7 +156,7 @@ abstract class FilterExecTransformerBase(val cond: Expression,
     } catch {
       case e: Throwable =>
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to ${e.getMessage}")
+          s" due to: ${e.getMessage}")
         return false
     }
 
@@ -165,7 +165,7 @@ abstract class FilterExecTransformerBase(val cond: Expression,
       if (!(child.isInstanceOf[DataSourceScanExec] ||
         child.isInstanceOf[DataSourceV2ScanExecBase])) {
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {child is not DataSourceScanExec or DataSourceV2ScanExecBase}")
+          s" due to: {child is not DataSourceScanExec or DataSourceV2ScanExecBase}")
         return false
       }
     }
@@ -181,7 +181,7 @@ abstract class FilterExecTransformerBase(val cond: Expression,
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true
@@ -260,7 +260,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
     } catch {
       case e: Throwable =>
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to ${e.getMessage}")
+          s" due to: ${e.getMessage}")
         return false
     }
     // Then, validate the generated plan in native engine.
@@ -274,7 +274,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true
@@ -446,7 +446,7 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
   def doValidate(): Boolean = {
     if (!BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)) {
       this.appendValidateLog("Validation failed for" +
-        " UnionExecTransformer due to schema check failed.")
+        " UnionExecTransformer due to: schema check failed.")
       return false
     }
     true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -176,9 +176,9 @@ abstract class FilterExecTransformerBase(val cond: Expression,
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")
@@ -269,9 +269,9 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size() ) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -84,7 +84,7 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
       .supportsReadFileFormat(
         fileFormat, schema.fields, getPartitionSchemas.nonEmpty, getInputFilePaths)) {
       this.appendValidateLog(
-        s"Validation failed for ${this.getClass.toString} due to Not supported: {$fileFormat}")
+        s"Validation failed for ${this.getClass.toString} due to: {$fileFormat}")
       return false
     }
 
@@ -94,7 +94,7 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
 
@@ -108,7 +108,7 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -103,9 +103,9 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -108,7 +108,7 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -50,7 +50,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
     scan match {
       case parquetScan: ParquetScan if parquetScan.options.containsKey(mergeSchemaOptionKey) &&
         parquetScan.options.get(mergeSchemaOptionKey) == "true" =>
-        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ",
+        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to: ",
           new UnsupportedOperationException(s"$mergeSchemaOptionKey is not supported."))
         return false
       case _ =>

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -246,7 +246,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -241,9 +241,9 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -211,13 +211,13 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     if (!BackendsApiManager.getSettings.supportExpandExec()) {
       this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {ExpandExec}. ")
+          s" due to: {ExpandExec}. ")
       return false
     }
     if (projections.isEmpty) {
       this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {empty projections in ExpandExec}. ")
+          s" due to: {empty projections in ExpandExec}. ")
       return false
     }
 
@@ -232,7 +232,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
 
@@ -246,7 +246,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -124,13 +124,13 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
   override def doValidateInternal(): Boolean = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
     if (bucketedScan) {
-      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ",
+      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to: ",
         new UnsupportedOperationException("bucketed scan is not supported"))
       return false
     }
     if (relation.options.exists(option =>
       option._1 == mergeSchemaOptionKey && option._2 == "true")) {
-      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to ",
+      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to: ",
         new UnsupportedOperationException(s"$mergeSchemaOptionKey is not supported."))
       return false
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -115,8 +115,8 @@ case class GenerateExecTransformer(
       getRelNode(context, operatorId, child.output, null, generatorNode, childOutputNodes, true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        this.appendValidateLog(
+          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -116,7 +116,7 @@ case class GenerateExecTransformer(
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -170,7 +170,7 @@ abstract class HashAggregateExecBaseTransformer(
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -134,7 +134,7 @@ abstract class HashAggregateExecBaseTransformer(
       case n: NullType => true
       case other => this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {data type ${dataType}}");
+          s" due to: {data type ${dataType}}");
         false
     }
   }
@@ -149,7 +149,7 @@ abstract class HashAggregateExecBaseTransformer(
       } catch {
         case e: Throwable =>
           this.appendValidateLog(
-            s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+            s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
           return false
       }
     }
@@ -170,7 +170,7 @@ abstract class HashAggregateExecBaseTransformer(
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -165,9 +165,9 @@ abstract class HashAggregateExecBaseTransformer(
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -260,7 +260,7 @@ trait HashJoinLikeExecTransformer
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -226,7 +226,7 @@ trait HashJoinLikeExecTransformer
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
-      logValidateFailureWithoutThrowable(
+      this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
           s"due to Not supported: {Join type ${hashJoinType}}")
       return false
@@ -245,20 +245,25 @@ trait HashJoinLikeExecTransformer
         substraitContext, substraitContext.nextOperatorId(this.nodeName), validation = true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        this.appendValidateLog(
+          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
         return false
     }
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
-      if (!isSupported) {
-        logValidateFailureWithoutThrowable(
-          s"Validation failed for ${this.getClass.toString}" +
-            s"due to native check failure. ")
+      val validateInfo = BackendsApiManager.getValidatorApiInstance
+        .doValidateWithFallBackLog(planNode)
+      if (!validateInfo.isSupported) {
+        val logs = validateInfo.getFallbackInfo()
+        for (i <- 0 until logs.size()) {
+          this.appendValidateLog(logs.get(i))
+        }
+        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
+          s"due to native check failure.")
+        return false
       }
-      isSupported
+      true
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -226,6 +226,9 @@ trait HashJoinLikeExecTransformer
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
+      logValidateFailureWithoutThrowable(
+        s"Validation failed for ${this.getClass.toString}" +
+          s"due to Not supported: {Join type ${hashJoinType}}")
       return false
     }
     val relNode = try {
@@ -249,7 +252,13 @@ trait HashJoinLikeExecTransformer
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-      BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      if (!isSupported) {
+        logValidateFailureWithoutThrowable(
+          s"Validation failed for ${this.getClass.toString}" +
+            s"due to native check failure. ")
+      }
+      isSupported
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -255,9 +255,9 @@ trait HashJoinLikeExecTransformer
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -228,7 +228,7 @@ trait HashJoinLikeExecTransformer
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
       this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {Join type ${hashJoinType}}")
+          s" due to: {Join type ${hashJoinType}}")
       return false
     }
     val relNode = try {
@@ -246,7 +246,7 @@ trait HashJoinLikeExecTransformer
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
     // Then, validate the generated plan in native engine.
@@ -260,7 +260,7 @@ trait HashJoinLikeExecTransformer
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -102,9 +102,9 @@ case class LimitTransformer(child: SparkPlan,
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -99,7 +99,13 @@ case class LimitTransformer(child: SparkPlan,
 
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(context, Lists.newArrayList(relNode))
-      BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      if (!isSupported) {
+        logValidateFailureWithoutThrowable(
+          s"Validation failed for ${this.getClass.toString}" +
+            s"due to native check failure. ")
+      }
+      isSupported
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -92,20 +92,25 @@ case class LimitTransformer(child: SparkPlan,
       getRelNode(context, operatorId, offset, count, child.output, null, true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        this.appendValidateLog(
+          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
         return false
     }
 
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(context, Lists.newArrayList(relNode))
-      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
-      if (!isSupported) {
-        logValidateFailureWithoutThrowable(
-          s"Validation failed for ${this.getClass.toString}" +
-            s"due to native check failure. ")
+      val validateInfo = BackendsApiManager.getValidatorApiInstance
+        .doValidateWithFallBackLog(planNode)
+      if (!validateInfo.isSupported) {
+        val logs = validateInfo.getFallbackInfo()
+        for (i <- 0 until logs.size()) {
+          this.appendValidateLog(logs.get(i))
+        }
+        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
+          s"due to native check failure.")
+        return false
       }
-      isSupported
+      true
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -107,7 +107,7 @@ case class LimitTransformer(child: SparkPlan,
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -93,7 +93,7 @@ case class LimitTransformer(child: SparkPlan,
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
 
@@ -107,7 +107,7 @@ case class LimitTransformer(child: SparkPlan,
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -274,7 +274,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -246,7 +246,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
 
   override def doValidateInternal(): Boolean = {
     if (!BackendsApiManager.getSettings.supportSortExec()) {
-      logValidateFailureWithoutThrowable(
+      this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
           s"due to Not supported: {SortExec}. ")
       return false
@@ -259,20 +259,25 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
         substraitContext, sortOrder, child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        this.appendValidateLog(
+          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
         return false
     }
 
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
-      if (!isSupported) {
-        logValidateFailureWithoutThrowable(
-          s"Validation failed for ${this.getClass.toString}" +
-            s"due to native check failure. ")
+      val validateInfo = BackendsApiManager.getValidatorApiInstance
+        .doValidateWithFallBackLog(planNode)
+      if (!validateInfo.isSupported) {
+        val logs = validateInfo.getFallbackInfo()
+        for (i <- 0 until logs.size()) {
+          this.appendValidateLog(logs.get(i))
+        }
+        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
+          s"due to native check failure.")
+        return false
       }
-      isSupported
+      true
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -269,9 +269,9 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -248,7 +248,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     if (!BackendsApiManager.getSettings.supportSortExec()) {
       this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {SortExec}. ")
+          s" due to: {SortExec}. ")
       return false
     }
     val substraitContext = new SubstraitContext
@@ -260,7 +260,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
 
@@ -274,7 +274,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -258,7 +258,7 @@ case class SortMergeJoinExecTransformer(
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
       this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {Join type ${joinType}}")
+          s" due to: {Join type ${joinType}}")
       return false
     }
     val relNode = try {
@@ -276,7 +276,7 @@ case class SortMergeJoinExecTransformer(
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
     // Then, validate the generated plan in native engine.
@@ -290,7 +290,7 @@ case class SortMergeJoinExecTransformer(
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -290,7 +290,7 @@ case class SortMergeJoinExecTransformer(
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -285,9 +285,9 @@ case class SortMergeJoinExecTransformer(
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -256,6 +256,9 @@ case class SortMergeJoinExecTransformer(
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
+      logValidateFailureWithoutThrowable(
+        s"Validation failed for ${this.getClass.toString}" +
+          s"due to Not supported: {Join type ${joinType}}")
       return false
     }
     val relNode = try {
@@ -279,7 +282,13 @@ case class SortMergeJoinExecTransformer(
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-      BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      if (!isSupported) {
+        logValidateFailureWithoutThrowable(
+          s"Validation failed for ${this.getClass.toString}" +
+            s"due to native check failure. ")
+      }
+      isSupported
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -83,6 +83,9 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
     }
 
   }
+  def logValidateFailureWithoutThrowable(msg: => String): Unit = {
+      logOnLevel(validateFailureLogLevel, msg)
+  }
 
   /**
    * Returns all the RDDs of ColumnarBatch which generates the input rows.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -54,7 +54,11 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
 
   lazy val validateFailureLogLevel = GlutenConfig.getConf.validateFailureLogLevel
   lazy val printStackOnValidateFailure = GlutenConfig.getConf.printStackOnValidateFailure
+  var validateLog: Vector[String] = Vector()
 
+  def appendValidateLog (log: String): Unit = {
+    validateLog = validateLog :+ log
+  }
   /**
    * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
    */
@@ -81,11 +85,10 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
     } else {
       logOnLevel(validateFailureLogLevel, msg)
     }
-
   }
-  def logValidateFailureWithoutThrowable(msg: => String): Unit = {
-      logOnLevel(validateFailureLogLevel, msg)
-  }
+//  def logValidateFailureWithoutThrowable(msg: => String): Unit = {
+//      logOnLevel(validateFailureLogLevel, msg)
+//  }
 
   /**
    * Returns all the RDDs of ColumnarBatch which generates the input rows.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -54,11 +54,7 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
 
   lazy val validateFailureLogLevel = GlutenConfig.getConf.validateFailureLogLevel
   lazy val printStackOnValidateFailure = GlutenConfig.getConf.printStackOnValidateFailure
-  var validateLog: Vector[String] = Vector()
 
-  def appendValidateLog (log: String): Unit = {
-    validateLog = validateLog :+ log
-  }
   /**
    * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
    */

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -201,9 +201,9 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
       if (!validateInfo.isSupported) {
-        val logs = validateInfo.getFallbackInfo()
-        for (i <- 0 until logs.size()) {
-          this.appendValidateLog(logs.get(i))
+        val fallbackInfo = validateInfo.getFallbackInfo()
+        for (i <- 0 until fallbackInfo.size()) {
+          this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
           s"due to native check failure.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -177,7 +177,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     if (!BackendsApiManager.getSettings.supportWindowExec(windowExpression)) {
       this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
-          s"due to Not supported: {windowExpression}. ")
+          s" due to: {windowExpression}. ")
       return false
     }
     val substraitContext = new SubstraitContext
@@ -191,7 +191,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     } catch {
       case e: Throwable =>
         this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
         return false
     }
 
@@ -206,7 +206,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to native check failure.")
+          s" due to: native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -206,7 +206,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
           this.appendValidateLog(fallbackInfo.get(i))
         }
         this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s"due to native check failure.")
+          s" due to native check failure.")
         return false
       }
       true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -175,7 +175,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
 
   override def doValidateInternal(): Boolean = {
     if (!BackendsApiManager.getSettings.supportWindowExec(windowExpression)) {
-      logValidateFailureWithoutThrowable(
+      this.appendValidateLog(
         s"Validation failed for ${this.getClass.toString}" +
           s"due to Not supported: {windowExpression}. ")
       return false
@@ -190,21 +190,26 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
         orderSpec, child.output, operatorId, null, validation = true)
     } catch {
       case e: Throwable =>
-        logValidateFailure(
-          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}", e)
+        this.appendValidateLog(
+          s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
         return false
     }
 
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext,
         Lists.newArrayList(relNode))
-      val isSupported = BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
-      if (!isSupported) {
-        logValidateFailureWithoutThrowable(
-          s"Validation failed for ${this.getClass.toString}" +
-            s"due to native check failure. ")
+      val validateInfo = BackendsApiManager.getValidatorApiInstance
+        .doValidateWithFallBackLog(planNode)
+      if (!validateInfo.isSupported) {
+        val logs = validateInfo.getFallbackInfo()
+        for (i <- 0 until logs.size()) {
+          this.appendValidateLog(logs.get(i))
+        }
+        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
+          s"due to native check failure.")
+        return false
       }
-      isSupported
+      true
     } else {
       true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -74,7 +74,7 @@ case class FallbackBroadcastExchange(session: SparkSession) extends Rule[SparkPl
             if (!isTransformable) {
               logInfo(
                 s"Validation failed for ${this.getClass.toString}" +
-                  s"due to Not supported: FallbackBroadcastExchange.")
+                  s" due to: FallbackBroadcastExchange.")
               TransformHints.tagNotTransformable(bhj)
               TransformHints.tagNotTransformable(exchange)
             }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -72,11 +72,9 @@ case class FallbackBroadcastExchange(session: SparkSession) extends Rule[SparkPl
               }
             }
             if (!isTransformable) {
-              // scalastyle:off println
-              println(
+              logInfo(
                 s"Validation failed for ${this.getClass.toString}" +
                   s"due to Not supported: FallbackBroadcastExchange.")
-              // scalastyle:on println
               TransformHints.tagNotTransformable(bhj)
               TransformHints.tagNotTransformable(exchange)
             }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -72,6 +72,11 @@ case class FallbackBroadcastExchange(session: SparkSession) extends Rule[SparkPl
               }
             }
             if (!isTransformable) {
+              // scalastyle:off println
+              println(
+                s"Validation failed for ${this.getClass.toString}" +
+                  s"due to Not supported: FallbackBroadcastExchange.")
+              // scalastyle:on println
               TransformHints.tagNotTransformable(bhj)
               TransformHints.tagNotTransformable(exchange)
             }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -21,4 +21,9 @@ package io.glutenproject.extension
  * Every Gluten OP should extend this trait.
  */
 trait GlutenPlan {
+  var validateLog: Vector[String] = Vector()
+
+  def appendValidateLog(log: String): Unit = {
+    validateLog = validateLog :+ log
+  }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -138,11 +138,9 @@ case class FallbackMultiCodegens(session: SparkSession) extends Rule[SparkPlan] 
     }
 
   def tagNotTransformable(plan: SparkPlan): SparkPlan = {
-    // scalastyle:off println
-    println(
+    logInfo(
       s"Validation failed for ${this.getClass.toString}" +
         s"due to Not supported: FallbackMultiCodegens.")
-    // scalastyle:on println
     TransformHints.tagNotTransformable(plan)
     plan
   }
@@ -207,11 +205,9 @@ case class FallbackOneRowRelation(session: SparkSession) extends Rule[SparkPlan]
         case _ => false
       }
     if (hasOneRowRelation) {
-      // scalastyle:off println
-      println(
+      logInfo(
         s"Validation failed for ${this.getClass.toString}" +
           s"due to Not supported: FallbackOneRowRelation.")
-      // scalastyle:on println
       plan.foreach(TransformHints.tagNotTransformable)
     }
     plan
@@ -328,11 +324,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
       plan match {
         case plan: BatchScanExec =>
           if (!enableColumnarBatchScan) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar BatchScan not enabled")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             // IF filter expressions aren't empty, we need to transform the inner operators.
@@ -349,11 +343,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: FileSourceScanExec =>
           if (!enableColumnarFileScan) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar FileScan not enabled in FileSourceScanExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             // IF filter expressions aren't empty, we need to transform the inner operators.
@@ -378,11 +370,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         case plan: InMemoryTableScanExec =>
           // ColumnarInMemoryTableScanExec.scala appears to be out-of-date
           //   and need some tests before being enabled.
-          // scalastyle:off println
-          println (
+          logInfo (
             s"Validation failed for ${this.getClass.toString}" +
               s"due to Not supported: InMemoryTableScanExec.")
-          // scalastyle:on println
           TransformHints.tagNotTransformable(plan)
         case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
           if (!enableColumnarHiveTableScan) {
@@ -392,11 +382,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ProjectExec =>
           if (!enableColumnarProject) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar project not enabled")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ProjectExecTransformer(plan.projectList, plan.child)
@@ -410,11 +398,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
             plan.child.isInstanceOf[BatchScanExec]
           // When scanOnly is enabled, filter after scan will be offloaded.
           if ((!scanOnly && !enableColumnarFilter) || (scanOnly && !childIsScan)) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: ScanOnly enabled and plan child is not Scan in FilterExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -426,11 +412,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: HashAggregateExec =>
           if (!enableColumnarHashAgg) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar HashAggregate not enabled in HashAggregateExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -449,19 +433,15 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortAggregateExec =>
           if (!BackendsApiManager.getSettings.replaceSortAggWithHashAgg) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: replaceSortAggWithHashAgg not enabled")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           }
           if (!enableColumnarHashAgg) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar HashAgg not enabled in SortAggregateExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           }
           val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -479,11 +459,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ObjectHashAggregateExec =>
           if (!enableColumnarHashAgg) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar HashAgg not enabled in ObjectHashAggregateExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -502,11 +480,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: UnionExec =>
           if (!enableColumnarUnion) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar Union not enabled in UnionExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = UnionExecTransformer(plan.children)
@@ -517,11 +493,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ExpandExec =>
           if (!enableColumnarExpand) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar Expand not enabled in ExpandExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ExpandExecTransformer(plan.projections,
@@ -533,11 +507,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortExec =>
           if (!enableColumnarSort) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar Sort not enabled in SortExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = SortExecTransformer(
@@ -549,11 +521,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ShuffleExchangeExec =>
           if (!enableColumnarShuffle) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar Shuffle not enabled in ShuffleExchangeExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ColumnarShuffleExchangeExec(
@@ -568,12 +538,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ShuffledHashJoinExec =>
           if (!enableColumnarShuffledHashJoin) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar shufflehashjoin not enabled "
                 + s"in ShuffledHashJoinExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -594,12 +562,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         case plan: BroadcastExchangeExec =>
           // columnar broadcast is enabled only when columnar bhj is enabled.
           if (!enableColumnarBroadcastExchange) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar BroadcastExchange "
                 + s"not enabled in BroadcastExchangeExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ColumnarBroadcastExchangeExec(plan.mode, plan.child)
@@ -616,12 +582,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           //  Currently their doBroadcast() methods just propagate child's broadcast
           //  payloads which is not right in speaking of columnar.
           if (!enableColumnarBroadcastJoin) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar BroadcastJoin "
                 + s"not enabled in BroadcastHashJoinExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(bhj)
           } else {
             val isBhjTransformable: Boolean = {
@@ -649,11 +613,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
             val maybeExchange = buildSidePlan.find {
               case BroadcastExchangeExec(_, _) => true
               case _ =>
-                // scalastyle:off println
-                println(
+                logInfo(
                   s"Validation failed for ${this.getClass.toString}" +
                     s"due to Not supported: not BroadcastExchangeExec at join build side.")
-                // scalastyle:on println
                 false
             }
 
@@ -707,12 +669,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortMergeJoinExec =>
           if (!enableColumnarSortMergeJoin || plan.joinType == FullOuter) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar sortmergejoin "
                 + s"not enabled in enableColumnarSortMergeJoin or is FullOuter join")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = SortMergeJoinExecTransformer(
@@ -727,12 +687,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: WindowExec =>
           if (!enableColumnarWindow) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar window "
                 + s"not enabled in WindowExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = WindowExecTransformer(
@@ -747,12 +705,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: CoalesceExec =>
           if (!enableColumnarCoalesce) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar coalesce "
                 + s"not enabled in CoalesceExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = CoalesceExecTransformer(plan.numPartitions, plan.child)
@@ -763,12 +719,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: GlobalLimitExec =>
           if (!enableColumnarLimit) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar limit "
                 + s"not enabled in GlobalLimitExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
@@ -779,12 +733,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: LocalLimitExec =>
           if (!enableColumnarLimit) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar Limit "
                 + s"not enabled in LocalLimitExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
@@ -795,12 +747,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: GenerateExec =>
           if (!enableColumnarGenerate) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: columnar generate "
                 + s"not enabled in GenerateExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = GenerateExecTransformer(plan.generator, plan.requiredChildOutput,
@@ -820,12 +770,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           TransformHints.tagTransformable(plan)
         case plan: TakeOrderedAndProjectExec =>
           if (!enableTakeOrderedAndProject) {
-            // scalastyle:off println
-            println(
+            logInfo(
               s"Validation failed for ${this.getClass.toString}" +
                 s"due to Not supported: TakeOrderedAndProject "
                 + s"not enabled in TakeOrderedAndProjectExec")
-            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             var tagged = false
@@ -857,15 +805,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
       }
     } catch {
       case e: UnsupportedOperationException =>
-        logWarning(
-          s"Fall back to use row-based operators, error is ${e.getMessage}," +
-            s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
-        // scalastyle:off println
-        println(
+        logInfo(
           s"Validation failed for ${this.getClass.toString}" +
             s"due to Not supported: ${e.getMessage}," +
             s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
-        // scalastyle:on println
         TransformHints.tagNotTransformable(plan)
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -138,6 +138,11 @@ case class FallbackMultiCodegens(session: SparkSession) extends Rule[SparkPlan] 
     }
 
   def tagNotTransformable(plan: SparkPlan): SparkPlan = {
+    // scalastyle:off println
+    println(
+      s"Validation failed for ${this.getClass.toString}" +
+        s"due to Not supported: FallbackMultiCodegens.")
+    // scalastyle:on println
     TransformHints.tagNotTransformable(plan)
     plan
   }
@@ -202,6 +207,11 @@ case class FallbackOneRowRelation(session: SparkSession) extends Rule[SparkPlan]
         case _ => false
       }
     if (hasOneRowRelation) {
+      // scalastyle:off println
+      println(
+        s"Validation failed for ${this.getClass.toString}" +
+          s"due to Not supported: FallbackOneRowRelation.")
+      // scalastyle:on println
       plan.foreach(TransformHints.tagNotTransformable)
     }
     plan
@@ -313,6 +323,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
       plan match {
         case plan: BatchScanExec =>
           if (!enableColumnarBatchScan) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar BatchScan not enabled")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             // IF filter expressions aren't empty, we need to transform the inner operators.
@@ -326,6 +341,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: FileSourceScanExec =>
           if (!enableColumnarFileScan) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar FileScan not enabled in FileSourceScanExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             // IF filter expressions aren't empty, we need to transform the inner operators.
@@ -347,6 +367,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         case plan: InMemoryTableScanExec =>
           // ColumnarInMemoryTableScanExec.scala appears to be out-of-date
           //   and need some tests before being enabled.
+          // scalastyle:off println
+          println (
+            s"Validation failed for ${this.getClass.toString}" +
+              s"due to Not supported: InMemoryTableScanExec.")
+          // scalastyle:on println
           TransformHints.tagNotTransformable(plan)
         case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
           if (!enableColumnarHiveTableScan) {
@@ -356,6 +381,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ProjectExec =>
           if (!enableColumnarProject) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar project not enabled")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ProjectExecTransformer(plan.projectList, plan.child)
@@ -366,6 +396,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
             plan.child.isInstanceOf[BatchScanExec]
           // When scanOnly is enabled, filter after scan will be offloaded.
           if ((!scanOnly && !enableColumnarFilter) || (scanOnly && !childIsScan)) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: ScanOnly enabled and plan child is not Scan in FilterExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -374,6 +409,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: HashAggregateExec =>
           if (!enableColumnarHashAgg) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar HashAggregate not enabled in HashAggregateExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -389,9 +429,19 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortAggregateExec =>
           if (!BackendsApiManager.getSettings.replaceSortAggWithHashAgg) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: replaceSortAggWithHashAgg not enabled")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           }
           if (!enableColumnarHashAgg) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar HashAgg not enabled in SortAggregateExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           }
           val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -406,6 +456,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           TransformHints.tag(plan, transformer.doValidate().toTransformHint)
         case plan: ObjectHashAggregateExec =>
           if (!enableColumnarHashAgg) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar HashAgg not enabled in ObjectHashAggregateExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -421,6 +476,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: UnionExec =>
           if (!enableColumnarUnion) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar Union not enabled in UnionExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = UnionExecTransformer(plan.children)
@@ -428,6 +488,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ExpandExec =>
           if (!enableColumnarExpand) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar Expand not enabled in ExpandExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ExpandExecTransformer(plan.projections,
@@ -436,6 +501,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortExec =>
           if (!enableColumnarSort) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar Sort not enabled in SortExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = SortExecTransformer(
@@ -444,6 +514,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ShuffleExchangeExec =>
           if (!enableColumnarShuffle) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar Shuffle not enabled in ShuffleExchangeExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ColumnarShuffleExchangeExec(
@@ -455,6 +530,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: ShuffledHashJoinExec =>
           if (!enableColumnarShuffledHashJoin) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar shufflehashjoin not enabled "
+                + s"in ShuffledHashJoinExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -472,6 +553,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         case plan: BroadcastExchangeExec =>
           // columnar broadcast is enabled only when columnar bhj is enabled.
           if (!enableColumnarBroadcastExchange) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar BroadcastExchange "
+                + s"not enabled in BroadcastExchangeExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = ColumnarBroadcastExchangeExec(plan.mode, plan.child)
@@ -485,6 +572,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           //  Currently their doBroadcast() methods just propagate child's broadcast
           //  payloads which is not right in speaking of columnar.
           if (!enableColumnarBroadcastJoin) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar BroadcastJoin "
+                + s"not enabled in BroadcastHashJoinExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(bhj)
           } else {
             val isBhjTransformable: Boolean = {
@@ -560,6 +653,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortMergeJoinExec =>
           if (!enableColumnarSortMergeJoin || plan.joinType == FullOuter) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar sortmergejoin "
+                + s"not enabled in enableColumnarSortMergeJoin or is FullOuter join")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = SortMergeJoinExecTransformer(
@@ -574,6 +673,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: WindowExec =>
           if (!enableColumnarWindow) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar window "
+                + s"not enabled in WindowExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = WindowExecTransformer(
@@ -585,6 +690,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: CoalesceExec =>
           if (!enableColumnarCoalesce) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar coalesce "
+                + s"not enabled in CoalesceExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = CoalesceExecTransformer(plan.numPartitions, plan.child)
@@ -592,6 +703,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: GlobalLimitExec =>
           if (!enableColumnarLimit) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar limit "
+                + s"not enabled in GlobalLimitExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
@@ -599,6 +716,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: LocalLimitExec =>
           if (!enableColumnarLimit) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar Limit "
+                + s"not enabled in LocalLimitExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
@@ -606,6 +729,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: GenerateExec =>
           if (!enableColumnarGenerate) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: columnar generate "
+                + s"not enabled in GenerateExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = GenerateExecTransformer(plan.generator, plan.requiredChildOutput,
@@ -619,6 +748,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           TransformHints.tagTransformable(plan)
         case plan: TakeOrderedAndProjectExec =>
           if (!enableTakeOrderedAndProject) {
+            // scalastyle:off println
+            println(
+              s"Validation failed for ${this.getClass.toString}" +
+                s"due to Not supported: TakeOrderedAndProject "
+                + s"not enabled in TakeOrderedAndProjectExec")
+            // scalastyle:on println
             TransformHints.tagNotTransformable(plan)
           } else {
             var tagged = false
@@ -645,6 +780,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         logWarning(
           s"Fall back to use row-based operators, error is ${e.getMessage}," +
             s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
+        // scalastyle:off println
+        println(
+          s"Validation failed for ${this.getClass.toString}" +
+            s"due to Not supported: ${e.getMessage}," +
+            s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
+        // scalastyle:on println
         TransformHints.tagNotTransformable(plan)
     }
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -51,6 +51,8 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
   lazy val completionFuture: scala.concurrent.Future[broadcast.Broadcast[Any]] =
     promise.future
 
+  var validateLog: Vector[String] = Vector()
+
   @transient
   override lazy val relationFuture: java.util.concurrent.Future[broadcast.Broadcast[Any]] = {
     SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
@@ -132,6 +134,8 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
       true
     case _ =>
       // IdentityBroadcastMode not supported. Need to support BroadcastNestedLoopJoin first.
+      validateLog = validateLog :+ "Validation failed for" +
+        " ColumnarBroadcastExchangeExec due to only support HashedRelationBroadcastMode."
       false
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -133,7 +133,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     case _ =>
       // IdentityBroadcastMode not supported. Need to support BroadcastNestedLoopJoin first.
       this.appendValidateLog("Validation failed for" +
-        " ColumnarBroadcastExchangeExec due to only support HashedRelationBroadcastMode.")
+        " ColumnarBroadcastExchangeExec due to: only support HashedRelationBroadcastMode.")
       false
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -51,8 +51,6 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
   lazy val completionFuture: scala.concurrent.Future[broadcast.Broadcast[Any]] =
     promise.future
 
-  var validateLog: Vector[String] = Vector()
-
   @transient
   override lazy val relationFuture: java.util.concurrent.Future[broadcast.Broadcast[Any]] = {
     SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
@@ -134,8 +132,8 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
       true
     case _ =>
       // IdentityBroadcastMode not supported. Need to support BroadcastNestedLoopJoin first.
-      validateLog = validateLog :+ "Validation failed for" +
-        " ColumnarBroadcastExchangeExec due to only support HashedRelationBroadcastMode."
+      this.appendValidateLog("Validation failed for" +
+        " ColumnarBroadcastExchangeExec due to only support HashedRelationBroadcastMode.")
       false
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -46,8 +46,6 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
   private[sql] lazy val readMetrics =
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
 
-  var validateLog: Vector[String] = Vector()
-
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance
@@ -108,8 +106,8 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
   def doValidate(): Boolean = {
     if (!BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child)) {
-      validateLog = validateLog :+ "Validation failed for" +
-        " ColumnarShuffleExchangeExec due to schema check failed."
+      this.appendValidateLog("Validation failed for" +
+        " ColumnarShuffleExchangeExec due to schema check failed.")
       return false
     }
     true

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -107,7 +107,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
     if (!BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child)) {
       this.appendValidateLog("Validation failed for" +
-        " ColumnarShuffleExchangeExec due to schema check failed.")
+        " ColumnarShuffleExchangeExec due to: schema check failed.")
       return false
     }
     true

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -46,6 +46,8 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
   private[sql] lazy val readMetrics =
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
 
+  var validateLog: Vector[String] = Vector()
+
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance
@@ -104,8 +106,13 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 
   def doValidate(): Boolean = {
-    BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
-      outputPartitioning, child)
+    if (!BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
+      outputPartitioning, child)) {
+      validateLog = validateLog :+ "Validation failed for" +
+        " ColumnarShuffleExchangeExec due to schema check failed."
+      return false
+    }
+    true
   }
 
   override def nodeName: String = "ColumnarExchange"

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -100,7 +100,7 @@ case class EvalPythonExecTransformer(
     for (udf <- udfs) {
       if (!PythonUDF.isScalarPythonUDF(udf)) {
         logInfo(
-          s"Validation failed for ${this.getClass.toString} because $udf is not scalar python udf")
+          s"Validation failed for ${this.getClass.toString} due to: $udf is not scalar python udf")
         return false
       }
     }
@@ -124,7 +124,7 @@ case class EvalPythonExecTransformer(
       } catch {
         case e: Throwable =>
           this.appendValidateLog(
-            s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
+            s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
           return false
       }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -123,9 +123,8 @@ case class EvalPythonExecTransformer(
         RelBuilder.makeProjectRel(null, expressionNodes, context, operatorId)
       } catch {
         case e: Throwable =>
-          logValidateFailure(
-            s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}",
-            e)
+          this.appendValidateLog(
+            s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}")
           return false
       }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -99,7 +99,7 @@ case class EvalPythonExecTransformer(
     /// All udfs should be scalar python udf
     for (udf <- udfs) {
       if (!PythonUDF.isScalarPythonUDF(udf)) {
-        logWarning(
+        logInfo(
           s"Validation failed for ${this.getClass.toString} because $udf is not scalar python udf")
         return false
       }

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -20,6 +20,7 @@ package io.glutenproject.vectorized;
 import com.google.protobuf.Any;
 import io.glutenproject.GlutenConfig;
 import io.glutenproject.backendsapi.BackendsApiManager;
+import io.glutenproject.validate.NativePlanValidatorInfo;
 import io.glutenproject.memory.alloc.NativeMemoryAllocators;
 import io.glutenproject.substrait.expression.ExpressionBuilder;
 import io.glutenproject.substrait.expression.StringMapNode;
@@ -52,6 +53,10 @@ public class NativePlanEvaluator {
   // Used to validate the Substrait plan in native compute engine.
   public boolean doValidate(byte[] subPlan) {
     return jniWrapper.nativeDoValidate(subPlan);
+  }
+
+  public NativePlanValidatorInfo doValidateWithFallBackLog(byte[] subPlan) {
+    return jniWrapper.nativeDoValidateWithFallBackLog(subPlan);
   }
 
   private PlanNode buildNativeConfNode(Map<String, String> confs) {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
@@ -17,6 +17,7 @@
 
 package io.glutenproject.vectorized;
 
+import io.glutenproject.validate.NativePlanValidatorInfo;
 import io.glutenproject.init.JniInitialized;
 
 /**
@@ -40,6 +41,7 @@ public class PlanEvaluatorJniWrapper extends JniInitialized {
    */
   native boolean nativeDoValidate(byte[] subPlan);
 
+  native NativePlanValidatorInfo nativeDoValidateWithFallBackLog(byte[] subPlan);
   /**
    * Create a native compute kernel and return a columnar result iterator.
    *

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -916,7 +916,7 @@ object GlutenConfig {
       .checkValue(
         logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
         "Valid values are 'trace', 'debug', 'info', 'warn' and 'error'.")
-      .createWithDefault("INFO")
+      .createWithDefault("DEBUG")
 
   val SOFT_AFFINITY_LOG_LEVEL =
     buildConf("spark.gluten.soft-affinity.logLevel")


### PR DESCRIPTION
## What changes were proposed in this pull request?
In customer workloads, fallbacks often happen but can't find the root cause directly with current fallback logs. 
So in this PR, we will propose 2 changes:
1) add more detailed log about fallback reasons with unified format like "Validation failed for *** due to ***" and "native validation failed due to ***" at native side(refer [PR](https://github.com/oap-project/velox/pull/319))
2) refactor it to make it controllable by “spark.gluten.sql.validate.failure.logLevel”. Log will be printed if it's "DEBUG" as default.


The PR is used to print the fallback reason in stderr/stdout when Gluten user disables AQE and calls df.explain(). In this way user needn't to run the whole query on Gluten, just explain() gluten's plan. Gluten will check each operator if it can offload to Velox, if not a formatted info is dumped to driver's log file. Then we can use a simple python script to summarize the fallback reasons.

Fixes: #2103 
## How was this patch tested?

CI

