### PR TITLE
Revert "[VL] fix the crash problem caused by SIMD instructions execution"

### DIFF
--- a/cpp/core/memory/HbwAllocator.h
+++ b/cpp/core/memory/HbwAllocator.h
@@ -41,10 +41,6 @@ class HbwMemoryAllocator final : public MemoryAllocator {
 
   bool unreserveBytes(int64_t size) override;
 
-  std::string toString() const override {
-    return "HbwMemoryAllocator";
-  }
-
   int64_t getBytes() const override;
 
  private:

--- a/cpp/core/memory/MemoryAllocator.cc
+++ b/cpp/core/memory/MemoryAllocator.cc
@@ -113,12 +113,6 @@ int64_t ListenableMemoryAllocator::getBytes() const {
   return bytes_;
 }
 
-std::string ListenableMemoryAllocator::toString() const {
-  std::string str = "ListenableMemoryAllocator delegate:";
-  str += delegated_->toString();
-  return str;
-}
-
 bool StdMemoryAllocator::allocate(int64_t size, void** out) {
   *out = std::malloc(size);
   bytes_ += size;
@@ -176,10 +170,6 @@ bool StdMemoryAllocator::unreserveBytes(int64_t size) {
 
 int64_t StdMemoryAllocator::getBytes() const {
   return bytes_;
-}
-
-std::string StdMemoryAllocator::toString() const {
-  return "StdMemoryAllocator";
 }
 
 std::shared_ptr<MemoryAllocator> defaultMemoryAllocator() {

--- a/cpp/core/memory/MemoryAllocator.h
+++ b/cpp/core/memory/MemoryAllocator.h
@@ -21,7 +21,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
-#include <string>
 #include <utility>
 
 #include "arrow/memory_pool.h"
@@ -45,8 +44,6 @@ class MemoryAllocator {
   virtual bool unreserveBytes(int64_t size) = 0;
 
   virtual int64_t getBytes() const = 0;
-
-  virtual std::string toString() const = 0;
 };
 
 class AllocationListener {
@@ -84,8 +81,6 @@ class ListenableMemoryAllocator final : public MemoryAllocator {
 
   int64_t getBytes() const override;
 
-  std::string toString() const override;
-
  private:
   MemoryAllocator* delegated_;
   std::shared_ptr<AllocationListener> listener_;
@@ -111,8 +106,6 @@ class StdMemoryAllocator final : public MemoryAllocator {
   bool unreserveBytes(int64_t size) override;
 
   int64_t getBytes() const override;
-
-  std::string toString() const override;
 
  private:
   std::atomic_int64_t bytes_{0};


### PR DESCRIPTION
Reverts oap-project/gluten#1990

@zuochunwei This causes 2% performance regression on a daily TPC-H job. Let's revert and investigate.

Thanks @rui-mo for doing the benchmark.