### PR TITLE
[GLUTEN-2038][VL] Improve parquet write using arrow chunked array

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetFileFormat.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetFileFormat.scala
@@ -61,13 +61,8 @@ class VeloxParquetFileFormat extends GlutenParquetFileFormat
     val conf = ContextUtil.getConfiguration(job)
     val parquetOptions = new ParquetOptions(options, sparkSession.sessionState.conf)
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
-    // pass options to native so that velox can take user-specified conf to write parquet,
-    // i.e., compression and block size.
-    val sparkOptions = new mutable.HashMap[String, String]()
-    sparkOptions.put(SQLConf.PARQUET_COMPRESSION.key, parquetOptions.compressionCodecClassName)
-    options.get(GlutenConfig.PARQUET_BLOCK_SIZE).foreach { blockSize =>
-      sparkOptions.put(GlutenConfig.PARQUET_BLOCK_SIZE, blockSize)
-    }
+    val nativeConf = VeloxParquetFileFormat.nativeConf(
+      options, parquetOptions.compressionCodecClassName)
 
     new OutputWriterFactory {
       override def getFileExtension(context: TaskAttemptContext): String = {
@@ -88,7 +83,7 @@ class VeloxParquetFileFormat extends GlutenParquetFileFormat
         try {
           ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
           instanceId = datasourceJniWrapper.nativeInitDatasource(
-            originPath, cSchema.memoryAddress(), sparkOptions.asJava)
+            originPath, cSchema.memoryAddress(), nativeConf)
         } catch {
           case e: IOException =>
             throw new RuntimeException(e)
@@ -130,4 +125,22 @@ class VeloxParquetFileFormat extends GlutenParquetFileFormat
   override def supportBatch(sparkSession: SparkSession, dataSchema: StructType): Boolean = true
 
   override def shortName(): String = "velox"
+}
+
+object VeloxParquetFileFormat {
+  def nativeConf(
+      options: Map[String, String],
+      compressionCodec: String): java.util.Map[String, String] = {
+    // pass options to native so that velox can take user-specified conf to write parquet,
+    // i.e., compression, block size, block rows.
+    val sparkOptions = new mutable.HashMap[String, String]()
+    sparkOptions.put(SQLConf.PARQUET_COMPRESSION.key, compressionCodec)
+    val blockSize = options.getOrElse(GlutenConfig.PARQUET_BLOCK_SIZE,
+      GlutenConfig.getConf.columnarParquetWriteBlockSize.toString)
+    sparkOptions.put(GlutenConfig.PARQUET_BLOCK_SIZE, blockSize)
+    val blockRows = options.getOrElse(GlutenConfig.PARQUET_BLOCK_ROWS,
+      GlutenConfig.getConf.columnarParquetWriteBlockRows.toString)
+    sparkOptions.put(GlutenConfig.PARQUET_BLOCK_ROWS, blockRows)
+    sparkOptions.asJava
+  }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -91,17 +91,6 @@ class TestOperator extends WholeStageTransformerSuite {
     val df = runQueryAndCompare("select * from temp_test_is_null where col1 is null") { _ => }
     checkLengthAndPlan(df, 2)
   }
-  
-  test("velox parquet write") {
-    withTempDir { dir =>
-      val path = dir.toURI.getPath
-      val df = runQueryAndCompare(
-        "select * from lineitem where l_comment is not null " +
-          "and l_orderkey = 1") { _ => }
-
-      df.write.mode("append").format("velox").save(path)
-    }
-  }
 
   test("is_not_null") {
     val df = runQueryAndCompare(

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
@@ -37,19 +37,21 @@ class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
           case _ => codec
         }
 
-        withTempPath { f =>
-          spark.table("lineitem").write
-            .format("velox")
-            .option("compression", codec)
-            .save(f.getCanonicalPath)
-          val files = f.list()
-          assert(files.nonEmpty, extension)
-          assert(files.exists(_.contains(extension)), extension)
+        TPCHTables.foreach { case (_, df) =>
+          withTempPath { f =>
+            df.write
+              .format("velox")
+              .option("compression", codec)
+              .save(f.getCanonicalPath)
+            val files = f.list()
+            assert(files.nonEmpty, extension)
+            assert(files.exists(_.contains(extension)), extension)
 
-          val parquetDf = spark.read
-            .format("parquet")
-            .load(f.getCanonicalPath)
-          checkAnswer(parquetDf, spark.table("lineitem"))
+            val parquetDf = spark.read
+              .format("parquet")
+              .load(f.getCanonicalPath)
+            checkAnswer(parquetDf, df)
+          }
         }
       }
   }

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -37,6 +37,8 @@ const std::string kSparkBatchSize = "spark.gluten.sql.columnar.maxBatchSize";
 
 const std::string kParquetBlockSize = "parquet.block.size";
 
+const std::string kParquetBlockRows = "parquet.block.rows";
+
 const std::string kParquetCompressionCodec = "spark.sql.parquet.compression.codec";
 
 const std::string kUGIUserName = "spark.gluten.ugi.username";

--- a/cpp/velox/compute/VeloxParquetDatasource.h
+++ b/cpp/velox/compute/VeloxParquetDatasource.h
@@ -29,8 +29,6 @@
 
 #include "memory/ColumnarBatch.h"
 #include "memory/VeloxColumnarBatch.h"
-#include "operators/c2r/ArrowColumnarToRowConverter.h"
-#include "operators/c2r/ColumnarToRow.h"
 #include "operators/writer/Datasource.h"
 
 #include "velox/common/file/FileSystems.h"
@@ -40,7 +38,6 @@
 #include "velox/dwio/common/DataSink.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -60,11 +57,12 @@ class VeloxParquetDatasource final : public Datasource {
   }
 
  private:
+  int64_t maxRowGroupBytes_ = 134217728; // 128MB
+  int64_t maxRowGroupRows_ = 100000000; // 100M
+
   std::string filePath_;
   std::shared_ptr<arrow::Schema> schema_;
-  std::vector<facebook::velox::RowVectorPtr> rowVecs_;
   std::shared_ptr<const facebook::velox::Type> type_;
-  std::shared_ptr<facebook::velox::dwrf::Writer> writer_;
   std::shared_ptr<facebook::velox::parquet::Writer> parquetWriter_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::unique_ptr<facebook::velox::dwio::common::DataSink> sink_;

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/ulysses-you/velox.git
+VELOX_BRANCH=row-group
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/ulysses-you/velox.git
-VELOX_BRANCH=row-group
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 
 #Set on run gluten on HDFS
 ENABLE_HDFS=OFF

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -150,6 +150,12 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableNativeHyperLogLogAggregateFunction: Boolean =
     conf.getConf(COLUMNAR_NATIVE_HYPERLOGLOG_AGGREGATE_ENABLED)
 
+  def columnarParquetWriteBlockSize: Long =
+    conf.getConf(COLUMNAR_PARQUET_WRITE_BLOCK_SIZE)
+
+  def columnarParquetWriteBlockRows: Long =
+    conf.getConf(COLUMNAR_PARQUET_WRITE_BLOCK_ROWS)
+
   def wholeStageFallbackThreshold: Int = conf.getConf(COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD)
 
   def numaBindingInfo: GlutenNumaBindingInfo = {
@@ -238,6 +244,7 @@ object GlutenConfig {
   val SPARK_HIVE_EXEC_ORC_COMPRESS: String = SPARK_PREFIX + HIVE_EXEC_ORC_COMPRESS
   val SPARK_SQL_PARQUET_COMPRESSION_CODEC: String = "spark.sql.parquet.compression.codec"
   val PARQUET_BLOCK_SIZE: String = "parquet.block.size"
+  val PARQUET_BLOCK_ROWS: String = "parquet.block.rows"
   // Hadoop config
   val HADOOP_PREFIX = "spark.hadoop."
 
@@ -746,6 +753,18 @@ object GlutenConfig {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+  val COLUMNAR_PARQUET_WRITE_BLOCK_SIZE =
+    buildConf("spark.gluten.sql.columnar.parquet.write.blockSize")
+      .internal()
+      .longConf
+      .createWithDefault(128 * 1024 * 1024)
+
+  val COLUMNAR_PARQUET_WRITE_BLOCK_ROWS =
+    buildConf("spark.gluten.sql.native.parquet.write.blockRows")
+      .internal()
+      .longConf
+      .createWithDefault(100 * 1000 * 1000)
 
   val COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD =
     buildConf("spark.gluten.sql.columnar.wholeStage.fallback.threshold")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox parquet write would build row groups for each columnar batch, which causes a lot of small row groups. We can cache columnar batch to make a bigger one.

This pr adds a new option `parquet.block.rows` to control the numRows of one row group.

The velox related code change see https://github.com/oap-project/velox/pull/326

(Fixes: \#2038)

## How was this patch tested?
improve test and manually test:

```
spark.range(1000000).write.format("velox").mode("overwrite").option("compression","zstd").save("/opt/parquet/test")

java -cp 'parquet-tools-1.11.1.jar:spark-3.3.1/jars/*' org.apache.parquet.tools.Main meta /opt/parquet/test/part-00000-478ee552-27da-4dc9-9168-6af5303a983d-c000.zstd.parquet

file schema: schema
--------------------------------------------------------------------------------
id:          REQUIRED INT64 R:0 D:0

row group 1: RC:1000000 TS:8297934 OFFSET:4
--------------------------------------------------------------------------------
id:           INT64 ZSTD DO:4 FPO:134785 SZ:1299824/8297934/6.38 VC:1000000 ENC:PLAIN,RLE_DICTIONARY,RLE ST:[min: 0, max: 999999, num_nulls: 0]
```

```
spark.range(1000000).write.format("velox").mode("overwrite").option("compression","zstd").option("parquet.block.size","3000000").save("/opt/parquet/test")

file schema: schema
--------------------------------------------------------------------------------
id:          OPTIONAL INT64 R:0 D:1

row group 1: RC:300000 TS:2697618 OFFSET:4
--------------------------------------------------------------------------------
id:           INT64 ZSTD DO:4 FPO:134785 SZ:588644/2697618/4.58 VC:300000 ENC:RLE,RLE_DICTIONARY,PLAIN ST:[min: 0, max: 299999, num_nulls: 0]

row group 2: RC:300000 TS:2697618 OFFSET:134123
--------------------------------------------------------------------------------
id:           INT64 ZSTD DO:0 FPO:134123 SZ:587996/2697618/4.59 VC:300000 ENC:RLE,RLE_DICTIONARY,PLAIN ST:[min: 300000, max: 599999, num_nulls: 0]

row group 3: RC:300000 TS:2697618 OFFSET:134123
--------------------------------------------------------------------------------
id:           INT64 ZSTD DO:0 FPO:134123 SZ:587986/2697618/4.59 VC:300000 ENC:RLE,RLE_DICTIONARY,PLAIN ST:[min: 600000, max: 899999, num_nulls: 0]

row group 4: RC:100000 TS:1012795 OFFSET:101594
--------------------------------------------------------------------------------
id:           INT64 ZSTD DO:0 FPO:101594 SZ:308849/1012795/3.28 VC:100000 ENC:RLE,RLE_DICTIONARY,PLAIN ST:[min: 900000, max: 999999, num_nulls: 0]
```