### PR TITLE
[GLUTEN-2028][CH] Fix `parseNameStruct` error and refactor code related to `collectStructFieldNames`

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
@@ -17,13 +17,8 @@
 
 package io.glutenproject.vectorized;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import scala.collection.JavaConverters;
-
 import io.glutenproject.execution.BroadCastHashJoinContext;
+import io.glutenproject.expression.ConverterUtils;
 import io.glutenproject.expression.ConverterUtils$;
 import io.glutenproject.substrait.type.TypeNode;
 import io.substrait.proto.NamedStruct;
@@ -31,6 +26,11 @@ import io.substrait.proto.Type;
 
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.Expression;
+import scala.collection.JavaConverters;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class StorageJoinBuilder implements AutoCloseable {
 
@@ -87,12 +87,8 @@ public class StorageJoinBuilder implements AutoCloseable {
     }).collect(Collectors.joining(","));
 
     // create table named struct
-    ArrayList<TypeNode> typeList = new ArrayList<>();
-    ArrayList<String> nameList = new ArrayList<>();
-    for (Attribute attr : output) {
-      typeList.add(converter.getTypeNode(attr.dataType(), attr.nullable()));
-      nameList.add(converter.genColumnNameWithExprId(attr));
-    }
+    ArrayList<TypeNode> typeList = ConverterUtils.collectAttributeTypeNodes(output);
+    ArrayList<String> nameList = ConverterUtils.collectAttributeNamesWithExprId(output);
     Type.Struct.Builder structBuilder = Type.Struct.newBuilder();
     for (TypeNode typeNode : typeList) {
       structBuilder.addTypes(typeNode.toProtobuf());

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -124,7 +124,7 @@ case class CHHashAggregateExecTransformer(
             nameList.add(colName)
             val (dataType, nullable) =
               getIntermediateAggregateResultType(attr, aggregateExpressions)
-            nameList.addAll(RelBuilder.collectStructFieldNamesDFS(dataType))
+            nameList.addAll(ConverterUtils.collectStructFieldNames(dataType))
             typeList.add(ConverterUtils.getTypeNode(dataType, nullable))
           }
           (aggregateResultAttributes, output)

--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/PlanNodesUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/PlanNodesUtil.scala
@@ -17,7 +17,6 @@
 package io.glutenproject.utils
 
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter}
-import io.glutenproject.substrait.`type`.TypeNode
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.ExpressionNode
 import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
@@ -26,8 +25,6 @@ import io.glutenproject.substrait.rel.{LocalFilesBuilder, RelBuilder}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BoundReference, Expression}
 
 import com.google.common.collect.Lists
-
-import java.util
 
 object PlanNodesUtil {
 
@@ -41,12 +38,8 @@ object PlanNodesUtil {
       ConverterUtils.ITERATOR_PREFIX.concat(iteratorIndex.toString))
     context.setIteratorNode(iteratorIndex, inputIter)
 
-    val typeList = new util.ArrayList[TypeNode]()
-    val nameList = new util.ArrayList[String]()
-    for (attr <- output) {
-      typeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
-      nameList.add(ConverterUtils.genColumnNameWithExprId(attr))
-    }
+    val typeList = ConverterUtils.collectAttributeTypeNodes(output)
+    val nameList = ConverterUtils.collectAttributeNamesWithExprId(output)
     val readRel =
       RelBuilder.makeReadRel(typeList, nameList, null, iteratorIndex, context, operatorId)
 

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
@@ -273,11 +273,8 @@ case class ClickHouseAppendDataExec(
   def genInsertPlan(
       substraitContext: SubstraitContext,
       queryOutput: Seq[Attribute]): DllTransformContext = {
-    val typeNodes = ConverterUtils.getTypeNodeFromAttributes(queryOutput)
-    val nameList = new java.util.ArrayList[String]()
-    for (attr <- queryOutput) {
-      nameList.add(ConverterUtils.getShortAttributeName(attr) + "#" + attr.exprId.id)
-    }
+    val typeNodes = ConverterUtils.collectAttributeTypeNodes(queryOutput)
+    val nameList = ConverterUtils.collectAttributeNamesWithExprId(queryOutput)
     val relNode = RelBuilder.makeReadRel(
       typeNodes,
       nameList,

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1110,4 +1110,20 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
       )(checkOperatorMatch[ProjectExecTransformer])
     }
   }
+
+  test("GLUTEN-2028: struct as join key") {
+    val tables = Seq("struct_1", "struct_2")
+    tables.foreach {
+      table =>
+        spark.sql(s"create table $table (info struct<a:int, b:int>) using parquet")
+        spark.sql(s"insert overwrite $table values (named_struct('a', 1, 'b', 2))")
+    }
+    val hints = Seq("BROADCAST(t2)", "SHUFFLE_MERGE(t2), SHUFFLE_HASH(t2)")
+    hints.foreach(
+      hint =>
+        compareResultsAgainstVanillaSpark(
+          s"select /*+ $hint */ t1.info from struct_1 t1 join struct_2 t2 on t1.info = t2.info",
+          true,
+          { _ => }))
+  }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -30,7 +30,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.InSubqueryExec
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -107,52 +106,12 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
     }
   }
 
-  private def normalizeColName(name: String): String = {
-    val caseSensitive = SQLConf.get.caseSensitiveAnalysis
-    if (caseSensitive) name else name.toLowerCase()
-  }
-
-  private def collectAttributesNamesDFS(attributes: Seq[Attribute]): java.util.ArrayList[String] = {
-    val nameList = new java.util.ArrayList[String]()
-    attributes.foreach(
-      attr => {
-        nameList.add(normalizeColName(attr.name))
-        if (BackendsApiManager.getSettings.supportStructType()) {
-          attr.dataType match {
-            case struct: StructType =>
-              val nestedNames = collectDataTypeNamesDFS(struct)
-              nameList.addAll(nestedNames)
-            case _ =>
-          }
-        }
-      }
-    )
-    nameList
-  }
-
-  private def collectDataTypeNamesDFS(dataType: DataType): java.util.ArrayList[String] = {
-    val nameList = new java.util.ArrayList[String]()
-    dataType match {
-      case structType: StructType =>
-        structType.fields.foreach(
-          field => {
-            nameList.add(normalizeColName(field.name))
-            val nestedNames = collectDataTypeNamesDFS(field.dataType)
-            nameList.addAll(nestedNames)
-          }
-        )
-      case _ =>
-    }
-    nameList
-  }
-
   override def doTransform(context: SubstraitContext): TransformContext = {
     val output = outputAttributes()
-    val typeNodes = ConverterUtils.getTypeNodeFromAttributes(output)
+    val typeNodes = ConverterUtils.collectAttributeTypeNodes(output)
+    val nameList = ConverterUtils.collectAttributeNamesWithoutExprId(output)
     val partitionSchemas = getPartitionSchemas
-    val nameList = new java.util.ArrayList[String]()
     val columnTypeNodes = new java.util.ArrayList[ColumnTypeNode]()
-    nameList.addAll(collectAttributesNamesDFS(output))
     for (attr <- output) {
       if (partitionSchemas.exists(_.name.equals(attr.name))) {
         columnTypeNodes.add(new ColumnTypeNode(1))

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -17,11 +17,11 @@
 
 package io.glutenproject.expression
 
+import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.{BasicScanExecTransformer, BatchScanExecTransformer, FileSourceScanExecTransformer, HiveTableScanExecTransformer}
 import io.glutenproject.substrait.`type`._
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.substrait.proto.Type
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -32,6 +32,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util.Locale
+import java.util.{ArrayList => JArrayList, List => JList}
 import scala.collection.JavaConverters._
 
 object ConverterUtils extends Logging {
@@ -76,12 +77,13 @@ object ConverterUtils extends Logging {
     }
   }
 
+  def normalizeColName(name: String): String = {
+    val caseSensitive = SQLConf.get.caseSensitiveAnalysis
+    if (caseSensitive) name else name.toLowerCase(Locale.ROOT)
+  }
+
   def getShortAttributeName(attr: Attribute): String = {
-    val name = if (SQLConf.get.caseSensitiveAnalysis) {
-      attr.name
-    } else {
-      attr.name.toLowerCase(Locale.ROOT)
-    }
+    val name = normalizeColName(attr.name)
     val subIndex = name.indexOf("(")
     if (subIndex != -1) {
       name.substring(0, subIndex)
@@ -90,8 +92,71 @@ object ConverterUtils extends Logging {
     }
   }
 
+  def genColumnNameWithoutExprId(attr: Attribute): String = {
+    getShortAttributeName(attr)
+  }
+
   def genColumnNameWithExprId(attr: Attribute): String = {
-    ConverterUtils.getShortAttributeName(attr) + "#" + attr.exprId.id
+    getShortAttributeName(attr) + "#" + attr.exprId.id
+  }
+
+  def collectAttributeTypeNodes(attributes: JList[Attribute]): JArrayList[TypeNode] = {
+    collectAttributeTypeNodes(attributes.asScala)
+  }
+
+  def collectAttributeTypeNodes(attributes: Seq[Attribute]): JArrayList[TypeNode] = {
+    val typeList = new JArrayList[TypeNode]()
+    attributes.foreach(attr => typeList.add(getTypeNode(attr.dataType, attr.nullable)))
+    typeList
+  }
+
+  def collectAttributeNamesWithExprId(attributes: JList[Attribute]): JArrayList[String] = {
+    collectAttributeNamesWithExprId(attributes.asScala)
+  }
+
+  def collectAttributeNamesWithExprId(attributes: Seq[Attribute]): JArrayList[String] = {
+    collectAttributeNamesDFS(attributes)(genColumnNameWithExprId)
+  }
+
+  // TODO: This is used only by `BasicScanExecTransformer`,
+  //  perhaps we can remove this in the future and use `withExprId` version consistently.
+  def collectAttributeNamesWithoutExprId(attributes: Seq[Attribute]): JArrayList[String] = {
+    collectAttributeNamesDFS(attributes)(genColumnNameWithoutExprId)
+  }
+
+  private def collectAttributeNamesDFS(
+    attributes: Seq[Attribute])(f: Attribute => String): JArrayList[String] = {
+    val nameList = new JArrayList[String]()
+    attributes.foreach(
+      attr => {
+        nameList.add(f(attr))
+        if (BackendsApiManager.getSettings.supportStructType()) {
+          attr.dataType match {
+            case struct: StructType =>
+              val nestedNames = collectStructFieldNames(struct)
+              nameList.addAll(nestedNames)
+            case _ =>
+          }
+        }
+      }
+    )
+    nameList
+  }
+
+  def collectStructFieldNames(dataType: DataType): JArrayList[String] = {
+    val nameList = new JArrayList[String]()
+    dataType match {
+      case structType: StructType =>
+        structType.fields.foreach(
+          field => {
+            nameList.add(normalizeColName(field.name))
+            val nestedNames = collectStructFieldNames(field.dataType)
+            nameList.addAll(nestedNames)
+          }
+        )
+      case _ =>
+    }
+    nameList
   }
 
   def isNullable(nullability: Type.Nullability): Boolean = {
@@ -129,7 +194,7 @@ object ConverterUtils extends Logging {
         (DecimalType(precision, scale), isNullable(decimal.getNullability))
       case Type.KindCase.STRUCT =>
         val struct_ = substraitType.getStruct
-        val fields = new java.util.ArrayList[StructField]
+        val fields = new JArrayList[StructField]
         for (typ <- struct_.getTypesList.asScala) {
           val (field, nullable) = parseFromSubstraitType(typ)
           fields.add(StructField("", field, nullable))
@@ -189,8 +254,8 @@ object ConverterUtils extends Logging {
       case a: ArrayType =>
         TypeBuilder.makeList(nullable, getTypeNode(a.elementType, a.containsNull))
       case s: StructType =>
-        val fieldNodes = new java.util.ArrayList[TypeNode]
-        val fieldNames = new java.util.ArrayList[String]
+        val fieldNodes = new JArrayList[TypeNode]
+        val fieldNames = new JArrayList[String]
         for (structField <- s.fields) {
           fieldNodes.add(getTypeNode(structField.dataType, structField.nullable))
           fieldNames.add(structField.name)
@@ -201,14 +266,6 @@ object ConverterUtils extends Logging {
       case unknown =>
         throw new UnsupportedOperationException(s"Type $unknown not supported.")
     }
-  }
-
-  def getTypeNodeFromAttributes(attributes: Seq[Attribute]): java.util.ArrayList[TypeNode] = {
-    val typeNodes = new java.util.ArrayList[TypeNode]()
-    for (attr <- attributes) {
-      typeNodes.add(getTypeNode(attr.dataType, attr.nullable))
-    }
-    typeNodes
   }
 
   def printBatch(cb: ColumnarBatch): Unit = {


### PR DESCRIPTION

## What changes were proposed in this pull request?

(Fixes: \#2028)

* fix `parseNameStruct` error since there are some places where the schema does not include struct nested fields, e.g. `StorageJoinBuilder`.
* refactor the code related to `collectStructFieldNames`, because the method is implemented in multi places (`RelBuilder` and `BasicScanExecTransformer`), I unify them  in ConverterUtils.

## How was this patch tested?

 unit tests


