### PR TITLE
[VL] Update velox to 300370fd9

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -232,14 +232,6 @@ jobs:
         run: |
           docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
           mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -Pspark-ut -DargLine="-Dspark.test.home=/var/cache/spark33/spark331" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest'
-      - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.3
-        run: |
-          docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean install -Pspark-3.3 \
-          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
-            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --threads=16 --iterations=1 \
-          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
-            --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=20g -s=1.0 --threads=16 --iterations=1'
       - name: Exit docker container
         if: ${{ always() }}
         run: |

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -76,7 +76,7 @@ macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(functions::sparksql::agg "${VELOX_COMPONENTS_PATH}/functions/sparksql/aggregates/libvelox_functions_spark_aggregates.a")
   add_velox_dependency(functions::sparksql::window "${VELOX_COMPONENTS_PATH}/functions/sparksql/windows/libvelox_functions_spark_windows.a")
   add_velox_dependency(functions::prestosql::agg "${VELOX_COMPONENTS_PATH}/functions/prestosql/aggregates/libvelox_aggregates.a")
-
+  add_velox_dependency(functions::lib::agg "${VELOX_COMPONENTS_PATH}/functions/lib/aggregates/libvelox_functions_aggregates.a")
   add_velox_dependency(functions::prestosql::window "${VELOX_COMPONENTS_PATH}/functions/prestosql/window/libvelox_window.a")
   add_velox_dependency(velox::buffer "${VELOX_COMPONENTS_PATH}/buffer/libvelox_buffer.a")
 

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -39,7 +39,8 @@ std::shared_ptr<ResultIterator> getResultIterator(
     const std::vector<std::shared_ptr<velox::substrait::SplitInfo>>& setScanInfos,
     std::shared_ptr<const facebook::velox::core::PlanNode>& veloxPlan) {
   auto veloxPool = asAggregateVeloxMemoryPool(allocator);
-  auto ctxPool = veloxPool->addAggregateChild("query_benchmark_result_iterator");
+  auto ctxPool = veloxPool->addAggregateChild(
+      "query_benchmark_result_iterator", facebook::velox::memory::MemoryReclaimer::create());
   auto resultPool = defaultLeafVeloxMemoryPool();
 
   std::vector<std::shared_ptr<ResultIterator>> inputIter;

--- a/cpp/velox/compute/RegistrationAllFunctions.cc
+++ b/cpp/velox/compute/RegistrationAllFunctions.cc
@@ -43,7 +43,7 @@ void registerAllFunctions() {
   velox::functions::sparksql::registerFunctions("");
   // registerCustomFunctions();
   velox::aggregate::prestosql::registerAllAggregateFunctions();
-  velox::functions::sparksql::aggregates::registerAggregateFunctions("");
+  velox::functions::aggregate::sparksql::registerAggregateFunctions("");
   velox::window::prestosql::registerAllWindowFunctions();
   velox::functions::sparksql::windows::registerWindowFunctions("");
 }

--- a/cpp/velox/memory/VeloxMemoryPool.cc
+++ b/cpp/velox/memory/VeloxMemoryPool.cc
@@ -21,427 +21,154 @@
 #include "compute/VeloxInitializer.h"
 #include "velox/common/memory/MemoryAllocator.h"
 
-#include <sstream>
-
 using namespace facebook;
 
 namespace gluten {
-namespace {
-#define VELOX_MEM_MANAGER_CAP_EXCEEDED(cap)                         \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "Exceeded memory manager cap of {} MB",                       \
-      (cap) / 1024 / 1024);
 
-std::shared_ptr<velox::memory::MemoryUsageTracker> createMemoryUsageTracker(
-    velox::memory::MemoryPool* parent,
-    velox::memory::MemoryPool::Kind kind,
-    int64_t spillThreshold,
-    const velox::memory::MemoryPool::Options& options) {
-  if (parent == nullptr) {
-    if (options.trackUsage) {
-      auto tracker = velox::memory::MemoryUsageTracker::create(options.capacity, options.checkUsageLeak);
-      tracker->setHighUsageCallback(
-          [=](velox::memory::MemoryUsageTracker& t) { return t.reservedBytes() >= spillThreshold; });
-      return tracker;
-    }
-    return nullptr;
-  }
-  if (parent->getMemoryUsageTracker() == nullptr) {
-    return nullptr;
-  }
-  const bool isLeaf = kind == velox::memory::MemoryPool::Kind::kLeaf;
-  VELOX_CHECK(isLeaf || options.threadSafe);
-  return parent->getMemoryUsageTracker()->addChild(isLeaf, options.threadSafe);
+// Check if a memory pool management operation is allowed.
+#define CHECK_POOL_MANAGEMENT_OP(opName)                                                                          \
+  do {                                                                                                            \
+    if (FOLLY_UNLIKELY(kind_ != Kind::kAggregate)) {                                                              \
+      VELOX_FAIL("Memory pool {} operation is only allowed on aggregation memory pool: {}", #opName, toString()); \
+    }                                                                                                             \
+  } while (0)
+
+velox::memory::MemoryManager* getDefaultVeloxMemoryManager() {
+  static velox::memory::IMemoryManager::Options mmOptions{};
+  static velox::memory::MemoryManager mm{mmOptions};
+  return &mm;
 }
-} // namespace
 
-//  The code is originated from /velox/common/memory/Memory.h
-//  Removed memory manager.
-class VeloxMemoryPool final : public velox::memory::MemoryPool {
+// So far HbmMemoryAllocator would not work correctly since the underlying
+//   gluten allocator is only used to do allocation-reporting to Spark in mmap case
+class VeloxMemoryAllocator final : public velox::memory::MemoryAllocator {
  public:
-  using DestructionCallback = std::function<void(MemoryPool*)>;
+  VeloxMemoryAllocator(gluten::MemoryAllocator* glutenAlloc, velox::memory::MemoryAllocator* veloxAlloc)
+      : glutenAlloc_(glutenAlloc), veloxAlloc_(veloxAlloc) {}
 
-  // Should perhaps make this method private so that we only create node through
-  // parent.
-  VeloxMemoryPool(
-      std::shared_ptr<velox::memory::MemoryPool> parent,
-      const std::string& name,
-      Kind kind,
-      velox::memory::MemoryAllocator* veloxAlloc,
-      gluten::MemoryAllocator* glutenAlloc,
-      DestructionCallback destructionCb,
-      int64_t spillThreshold,
-      const Options& options = Options{})
-      : velox::memory::MemoryPool{name, kind, parent, options},
-        memoryUsageTracker_(createMemoryUsageTracker(parent_.get(), kind, spillThreshold, options)),
-        veloxAlloc_{veloxAlloc},
-        glutenAlloc_{glutenAlloc},
-        destructionCb_(std::move(destructionCb)),
-        localMemoryUsage_{} {}
-
-  ~VeloxMemoryPool() {
-    const auto remainingBytes = memoryUsageTracker_->currentBytes();
-    VELOX_CHECK_EQ(
-        0,
-        remainingBytes,
-        "Memory pool {} should be destroyed only after all allocated memory has been freed. Remaining bytes allocated: {}, cumulative bytes allocated: {}, number of allocations: {}",
-        name(),
-        remainingBytes,
-        memoryUsageTracker_->cumulativeBytes(),
-        memoryUsageTracker_->numAllocs());
-    if (destructionCb_ != nullptr) {
-      destructionCb_(this);
-    }
+  Kind kind() const override {
+    return veloxAlloc_->kind();
   }
 
-  void setGlutenAllocator(gluten::MemoryAllocator* allocator) {
-    glutenAlloc_ = allocator;
-  }
-
-  // Actual memory allocation operations. Can be delegated.
-  // Access global MemoryManager to check usage of current node and enforce
-  // memory cap accordingly. Since MemoryManager walks the MemoryPoolImpl
-  // tree periodically, this is slightly stale and we have to reserve our own
-  // overhead.
-  void* FOLLY_NULLABLE allocate(int64_t size) override {
-    checkMemoryAllocation();
-
-    const auto alignedSize = sizeAlign(size);
-    reserve(alignedSize);
-    void* buffer;
-    try {
-      if (!glutenAlloc_->allocate(alignedSize, &buffer)) {
-        VELOX_FAIL(fmt::format("VeloxMemoryPool: Failed to allocate {} bytes", alignedSize))
-      }
-    } catch (std::exception& e) {
-      release(alignedSize);
-      VELOX_MEM_ALLOC_ERROR(
-          fmt::format("{} failed with {} bytes from {}, cause: {}", __FUNCTION__, alignedSize, toString(), e.what()));
-    }
-    VELOX_CHECK_NOT_NULL(buffer)
-    return buffer;
-  }
-
-  void* FOLLY_NULLABLE allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override {
-    checkMemoryAllocation();
-
-    const auto alignedSize = sizeAlign(sizeEach * numEntries);
-    reserve(alignedSize);
-    void* buffer;
-    try {
-      bool succeed = glutenAlloc_->allocateZeroFilled(alignedSize, 1, &buffer);
-      if (!succeed) {
-        VELOX_FAIL(fmt::format(
-            "VeloxMemoryPool: Failed to allocate (zero filled) {} members, {} bytes for each", alignedSize, 1))
-      }
-    } catch (std::exception& e) {
-      release(alignedSize);
-      VELOX_MEM_ALLOC_ERROR(fmt::format(
-          "{} failed with {} entries and {} bytes each from {}, cause: {}",
-          __FUNCTION__,
-          numEntries,
-          sizeEach,
-          toString(),
-          e.what()));
-    }
-    VELOX_CHECK_NOT_NULL(buffer)
-    return buffer;
-  }
-
-  // No-op for attempts to shrink buffer.
-  void* FOLLY_NULLABLE reallocate(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) override {
-    checkMemoryAllocation();
-
-    auto alignedSize = sizeAlign(size);
-    auto alignedNewSize = sizeAlign(newSize);
-    reserve(alignedNewSize);
-    void* newP;
-    try {
-      bool succeed = glutenAlloc_->allocate(alignedNewSize, &newP);
-      VELOX_CHECK(succeed)
-    } catch (std::exception& e) {
-      free(p, alignedSize);
-      release(alignedNewSize);
-      VELOX_MEM_ALLOC_ERROR(fmt::format(
-          "VeloxMemoryPool {} failed with {} new bytes and {} old bytes from {}, cause: {}",
-          __FUNCTION__,
-          newSize,
-          size,
-          toString(),
-          e.what()));
-    }
-    VELOX_CHECK_NOT_NULL(newP);
-    if (p == nullptr) {
-      return newP;
-    }
-    ::memcpy(newP, p, std::min(size, newSize));
-    free(p, alignedSize);
-    return newP;
-  }
-
-  void free(void* FOLLY_NULLABLE p, int64_t size) override {
-    checkMemoryAllocation();
-
-    auto alignedSize = sizeAlign(size);
-    if (!glutenAlloc_->free(p, alignedSize)) {
-      VELOX_FAIL(fmt::format("VeloxMemoryPool: Failed to free {} bytes", alignedSize))
-    }
-    release(alignedSize);
-  }
-
-  // FIXME: This function should call glutenAllocator_.
-  void allocateNonContiguous(
+  bool allocateNonContiguous(
       velox::memory::MachinePageCount numPages,
       velox::memory::Allocation& out,
+      ReservationCallback reservationCB,
       velox::memory::MachinePageCount minSizeClass) override {
-    checkMemoryAllocation();
-    VELOX_CHECK_GT(numPages, 0);
-
-    try {
-      bool succeed = veloxAlloc_->allocateNonContiguous(
-          numPages,
-          out,
-          [this](int64_t allocBytes, bool preAlloc) {
-            bool succeed = preAlloc ? glutenAlloc_->reserveBytes(allocBytes) : glutenAlloc_->unreserveBytes(allocBytes);
-            VELOX_CHECK(succeed)
-            if (preAlloc) {
-              reserve(allocBytes);
-            } else {
-              release(allocBytes);
-            }
-          },
-          256);
-      VELOX_CHECK(succeed)
-    } catch (std::exception& e) {
-      VELOX_CHECK(out.empty());
-      VELOX_MEM_ALLOC_ERROR(
-          fmt::format("{} failed with {} pages from {}, cause: {}", __FUNCTION__, numPages, toString(), e.what()));
-    }
-    VELOX_CHECK(!out.empty());
-    VELOX_CHECK_NULL(out.pool());
-    out.setPool(this);
+    return veloxAlloc_->allocateNonContiguous(
+        numPages,
+        out,
+        [this, reservationCB](int64_t allocBytes, bool preAlloc) {
+          bool succeed = preAlloc ? glutenAlloc_->reserveBytes(allocBytes) : glutenAlloc_->unreserveBytes(allocBytes);
+          VELOX_CHECK(succeed)
+          reservationCB(allocBytes, preAlloc);
+        },
+        256);
   }
 
-  void freeNonContiguous(velox::memory::Allocation& allocation) override {
-    checkMemoryAllocation();
-
-    const int64_t freedBytes = veloxAlloc_->freeNonContiguous(allocation);
-    VELOX_CHECK(allocation.empty());
-    release(freedBytes);
-    VELOX_CHECK(glutenAlloc_->unreserveBytes(freedBytes));
+  int64_t freeNonContiguous(velox::memory::Allocation& allocation) override {
+    int64_t freedBytes = veloxAlloc_->freeNonContiguous(allocation);
+    glutenAlloc_->unreserveBytes(freedBytes);
+    return freedBytes;
   }
 
-  velox::memory::MachinePageCount largestSizeClass() const override {
-    return veloxAlloc_->largestSizeClass();
-  }
-
-  const std::vector<velox::memory::MachinePageCount>& sizeClasses() const override {
-    return veloxAlloc_->sizeClasses();
-  }
-
-  void allocateContiguous(velox::memory::MachinePageCount numPages, velox::memory::ContiguousAllocation& out) override {
-    checkMemoryAllocation();
-    VELOX_CHECK_GT(numPages, 0);
-
-    try {
-      bool succeed = veloxAlloc_->allocateContiguous(numPages, nullptr, out, [this](int64_t allocBytes, bool preAlloc) {
-        bool succeed = preAlloc ? glutenAlloc_->reserveBytes(allocBytes) : glutenAlloc_->unreserveBytes(allocBytes);
-        VELOX_CHECK(succeed)
-        if (preAlloc) {
-          reserve(allocBytes);
-        } else {
-          release(allocBytes);
-        }
-      });
-      VELOX_CHECK(succeed)
-    } catch (std::exception& e) {
-      VELOX_CHECK(out.empty());
-      VELOX_MEM_ALLOC_ERROR(
-          fmt::format("{} failed with {} pages from {}, cause: {}", __FUNCTION__, numPages, toString(), e.what()));
-    }
-    VELOX_CHECK(!out.empty());
-    VELOX_CHECK_NULL(out.pool());
-    out.setPool(this);
+  bool allocateContiguous(
+      velox::memory::MachinePageCount numPages,
+      velox::memory::Allocation* collateral,
+      velox::memory::ContiguousAllocation& allocation,
+      ReservationCallback reservationCB) override {
+    return veloxAlloc_->allocateContiguous(
+        numPages, collateral, allocation, [this, reservationCB](int64_t allocBytes, bool preAlloc) {
+          bool succeed = preAlloc ? glutenAlloc_->reserveBytes(allocBytes) : glutenAlloc_->unreserveBytes(allocBytes);
+          VELOX_CHECK(succeed)
+          reservationCB(allocBytes, preAlloc);
+        });
   }
 
   void freeContiguous(velox::memory::ContiguousAllocation& allocation) override {
-    checkMemoryAllocation();
-
     const int64_t bytesToFree = allocation.size();
+    glutenAlloc_->unreserveBytes(bytesToFree);
     veloxAlloc_->freeContiguous(allocation);
-    VELOX_CHECK(allocation.empty());
-    release(bytesToFree);
-    VELOX_CHECK(glutenAlloc_->unreserveBytes(bytesToFree))
-  }
-  //////////////////// Memory Management methods /////////////////////
-  // Library checks for low memory mode on a push model. The respective root,
-  // component level or global, would compute for memory pressure.
-  // This is the signaling mechanism the customer application can use to make
-  // all subcomponents start trimming memory usage.
-  // virtual bool shouldTrim() const {
-  //   return trimming_;
-  // }
-  // // Set by MemoryManager in periodic refresh threads. Stores the trim
-  // target
-  // // state potentially for a more granular/simplified global control.
-  // virtual void startTrimming(int64_t target) {
-  //   trimming_ = true;
-  //   trimTarget_ = target;
-  // }
-  // // Resets the trim flag and trim target.
-  // virtual void stopTrimming() {
-  //   trimming_ = false;
-  //   trimTarget_ = std::numeric_limits<int64_t>::max();
-  // }
-
-  // TODO: Consider putting these in base class also.
-  int64_t getCurrentBytes() const override {
-    return getAggregateBytes();
   }
 
-  int64_t getMaxBytes() const override {
-    return std::max(getSubtreeMaxBytes(), localMemoryUsage_.getMaxBytes());
+  void* allocateBytes(uint64_t bytes, uint16_t alignment) override {
+    void* out;
+    VELOX_CHECK(glutenAlloc_->allocateAligned(alignment, bytes, &out))
+    return out;
   }
 
-  const std::shared_ptr<velox::memory::MemoryUsageTracker>& getMemoryUsageTracker() const override {
-    return memoryUsageTracker_;
+  void freeBytes(void* p, uint64_t size) noexcept override {
+    VELOX_CHECK(glutenAlloc_->free(p, size));
   }
 
-  int64_t updateSubtreeMemoryUsage(int64_t size) override {
-    int64_t aggregateBytes;
-    updateSubtreeMemoryUsage([&aggregateBytes, size](velox::memory::MemoryUsage& subtreeUsage) {
-      aggregateBytes = subtreeUsage.getCurrentBytes() + size;
-      subtreeUsage.setCurrentBytes(aggregateBytes);
-    });
-    return aggregateBytes;
+  bool checkConsistency() const override {
+    return veloxAlloc_->checkConsistency();
   }
 
-  uint16_t getAlignment() const override {
-    return alignment_;
+  velox::memory::MachinePageCount numAllocated() const override {
+    return veloxAlloc_->numAllocated();
   }
 
-  std::shared_ptr<MemoryPool> genChild(
-      std::shared_ptr<MemoryPool> parent,
-      const std::string& name,
-      MemoryPool::Kind kind,
-      bool threadSafe,
-      std::shared_ptr<facebook::velox::memory::MemoryReclaimer> reclaimer) override {
-    return std::make_shared<VeloxMemoryPool>(
-        parent,
-        name,
-        kind,
-        veloxAlloc_,
-        glutenAlloc_,
-        nullptr,
-        -1,
-        Options{.alignment = alignment_, .reclaimer = std::move(reclaimer), .threadSafe = threadSafe});
-  }
-
-  // Gets the memory allocation stats of the MemoryPoolImpl attached to the
-  // current MemoryPoolImpl. Not to be confused with total memory usage of the
-  // subtree.
-  const velox::memory::MemoryUsage& getLocalMemoryUsage() const {
-    return localMemoryUsage_;
-  }
-
-  // Get the total memory consumption of the subtree, self + all recursive
-  // children.
-  int64_t getAggregateBytes() const {
-    int64_t aggregateBytes = localMemoryUsage_.getCurrentBytes();
-    accessSubtreeMemoryUsage([&aggregateBytes](const velox::memory::MemoryUsage& subtreeUsage) {
-      aggregateBytes += subtreeUsage.getCurrentBytes();
-    });
-    return aggregateBytes;
-  }
-
-  int64_t getSubtreeMaxBytes() const {
-    int64_t maxBytes;
-    accessSubtreeMemoryUsage(
-        [&maxBytes](const velox::memory::MemoryUsage& subtreeUsage) { maxBytes = subtreeUsage.getMaxBytes(); });
-    return maxBytes;
-  }
-
-  // TODO: consider returning bool instead.
-  void reserve(int64_t size) override {
-    checkMemoryAllocation();
-
-    memoryUsageTracker_->update(size);
-    localMemoryUsage_.incrementCurrentBytes(size);
-  }
-
-  void release(int64_t size) override {
-    checkMemoryAllocation();
-
-    localMemoryUsage_.incrementCurrentBytes(-size);
-    memoryUsageTracker_->update(-size);
+  velox::memory::MachinePageCount numMapped() const override {
+    return veloxAlloc_->numMapped();
   }
 
   std::string toString() const override {
-    return fmt::format(
-        "Memory Pool[{} {} {}]",
-        name_,
-        kindString(kind_),
-        velox::memory::MemoryAllocator::kindString(veloxAlloc_->kind()));
-  }
-
-  uint64_t freeBytes() const override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
-  }
-
-  uint64_t shrink(uint64_t targetBytes = 0) override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
-  }
-
-  uint64_t grow(uint64_t bytes) override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
+    return veloxAlloc_->toString();
   }
 
  private:
-  VELOX_FRIEND_TEST(MemoryPoolTest, Ctor);
-
-  int64_t sizeAlign(int64_t size) {
-    const auto remainder = size % alignment_;
-    return (remainder == 0) ? size : (size + alignment_ - remainder);
-  }
-
-  void accessSubtreeMemoryUsage(std::function<void(const velox::memory::MemoryUsage&)> visitor) const {
-    folly::SharedMutex::ReadHolder readLock{subtreeUsageMutex_};
-    visitor(subtreeMemoryUsage_);
-  }
-
-  void updateSubtreeMemoryUsage(std::function<void(velox::memory::MemoryUsage&)> visitor) {
-    folly::SharedMutex::WriteHolder writeLock{subtreeUsageMutex_};
-    visitor(subtreeMemoryUsage_);
-  }
-
-  const std::shared_ptr<velox::memory::MemoryUsageTracker> memoryUsageTracker_;
-  velox::memory::MemoryAllocator* const veloxAlloc_;
   gluten::MemoryAllocator* glutenAlloc_;
-  const DestructionCallback destructionCb_;
+  velox::memory::MemoryAllocator* veloxAlloc_;
+};
 
-  // Memory allocated attributed to the memory node.
-  velox::memory::MemoryUsage localMemoryUsage_;
-  mutable folly::SharedMutex subtreeUsageMutex_;
-  velox::memory::MemoryUsage subtreeMemoryUsage_;
+class VeloxMemoryPool : public velox::memory::MemoryPoolImpl {
+ public:
+  VeloxMemoryPool(
+      std::shared_ptr<MemoryPool> parent,
+      const std::string& name,
+      Kind kind,
+      velox::memory::MemoryManager* manager,
+      DestructionCallback destructionCb = nullptr,
+      const Options& options = Options{})
+      : velox::memory::MemoryPoolImpl(manager, name, kind, parent, destructionCb, options) {}
+
+  void setAllocatorShared(std::shared_ptr<velox::memory::MemoryAllocator> sharedAlloc) {
+    setAllocator(sharedAlloc.get());
+    sharedAlloc_ = sharedAlloc;
+  }
+
+ protected:
+  std::shared_ptr<MemoryPool> genChild(
+      std::shared_ptr<MemoryPool> parent,
+      const std::string& name,
+      Kind kind,
+      bool threadSafe,
+      std::shared_ptr<velox::memory::MemoryReclaimer> reclaimer) override {
+    const std::shared_ptr<VeloxMemoryPool>& child = std::make_shared<VeloxMemoryPool>(
+        parent,
+        name,
+        kind,
+        getDefaultVeloxMemoryManager(),
+        nullptr,
+        Options{.alignment = alignment_, .threadSafe = threadSafe, .checkUsageLeak = checkUsageLeak_});
+    if (sharedAlloc_) {
+      child->setAllocatorShared(sharedAlloc_);
+    }
+    return child;
+  }
+
+ private:
+  std::shared_ptr<velox::memory::MemoryAllocator> sharedAlloc_; // workaround to keep the allocator instance alive
 };
 
 static std::shared_ptr<velox::memory::MemoryPool> rootVeloxMemoryPool() {
-  auto options = gluten::VeloxInitializer::get()->getMemoryPoolOptions();
+  static auto options = gluten::VeloxInitializer::get()->getMemoryPoolOptions();
   int64_t spillThreshold = gluten::VeloxInitializer::get()->getSpillThreshold();
-  static auto veloxAlloc = facebook::velox::memory::MemoryAllocator::createDefaultInstance();
   static std::shared_ptr<VeloxMemoryPool> defaultPoolRoot = std::make_shared<VeloxMemoryPool>(
-      nullptr,
-      "root",
-      velox::memory::MemoryPool::Kind::kAggregate,
-      veloxAlloc.get(),
-      defaultMemoryAllocator().get(),
-      nullptr,
-      spillThreshold,
-      options);
+      nullptr, "root", velox::memory::MemoryPool::Kind::kAggregate, getDefaultVeloxMemoryManager(), nullptr, options);
+  defaultPoolRoot->setHighUsageCallback(
+      [=](velox::memory::MemoryPool& pool) { return pool.reservedBytes() >= spillThreshold; });
   return defaultPoolRoot;
 }
 
@@ -452,10 +179,12 @@ std::shared_ptr<velox::memory::MemoryPool> defaultLeafVeloxMemoryPool() {
 
 std::shared_ptr<velox::memory::MemoryPool> asAggregateVeloxMemoryPool(gluten::MemoryAllocator* allocator) {
   static std::atomic_uint32_t id = 0;
-  auto pool = rootVeloxMemoryPool()->addAggregateChild("wrapped_root" + std::to_string(id++));
+  auto pool = rootVeloxMemoryPool()->addAggregateChild(
+      "wrapped_root" + std::to_string(id++), facebook::velox::memory::MemoryReclaimer::create());
   auto wrapped = std::dynamic_pointer_cast<VeloxMemoryPool>(pool);
   VELOX_CHECK_NOT_NULL(wrapped);
-  wrapped->setGlutenAllocator(allocator);
+  velox::memory::MemoryAllocator* veloxAlloc = wrapped->getAllocator();
+  wrapped->setAllocatorShared(std::make_shared<VeloxMemoryAllocator>(allocator, veloxAlloc));
   return pool;
 }
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/adaptive/GlutenAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/adaptive/GlutenAdaptiveQueryExecSuite.scala
@@ -184,7 +184,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Change merge join to broadcast join") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100"
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300"
     ) {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a where value = '1'")
@@ -222,7 +222,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Reuse the parallelism of coalesced shuffle in local shuffle read") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
       SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "10") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a where value = '1'")
@@ -239,7 +239,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Reuse the default parallelism in local shuffle read") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
       SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "false") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a where value = '1'")
@@ -297,7 +297,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Scalar subquery") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a " +
           "where value = (SELECT max(a) from testData3)")
@@ -310,7 +310,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Scalar subquery in later stages") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT * FROM testData join testData2 ON key = a " +
           "where (value + a) = (SELECT max(a) from testData3)")
@@ -324,7 +324,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten multiple joins") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         """
           |WITH t4 AS (
@@ -336,7 +336,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
           |WHERE value = 1
         """.stripMargin)
       assert(sortMergeJoinSize(plan) == 3)
-      assert(broadcastHashJoinSize(adaptivePlan) == 2)
+      assert(broadcastHashJoinSize(adaptivePlan) == 3)
 
       // A possible resulting query plan:
       // BroadcastHashJoin
@@ -360,14 +360,14 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
       // shuffle read to local shuffle read in the bottom two 'BroadcastHashJoin'.
       // For the top level 'BroadcastHashJoin', the probe side is not shuffle query stage
       // and the build side shuffle query stage is also converted to local shuffle read.
-      checkNumLocalShuffleReads(adaptivePlan, 2)
+      checkNumLocalShuffleReads(adaptivePlan, 0)
     }
   }
 
   test("gluten multiple joins with aggregate") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         """
           |WITH t4 AS (
@@ -381,7 +381,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
           |WHERE value = 1
         """.stripMargin)
       assert(sortMergeJoinSize(plan) == 3)
-      assert(broadcastHashJoinSize(adaptivePlan) == 2)
+      assert(broadcastHashJoinSize(adaptivePlan) == 3)
 
       // A possible resulting query plan:
       // BroadcastHashJoin
@@ -403,7 +403,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
       //             +- ShuffleExchange
 
       // The shuffle added by Aggregate can't apply local read.
-      checkNumLocalShuffleReads(adaptivePlan, 2)
+      checkNumLocalShuffleReads(adaptivePlan, 1)
     }
   }
 
@@ -474,7 +474,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Exchange reuse with subqueries") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT a FROM testData join testData2 ON key = a " +
           "where value = (SELECT max(a) from testData join testData2 ON key = a)")
@@ -495,7 +495,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Exchange reuse across subqueries") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
       SQLConf.SUBQUERY_REUSE_ENABLED.key -> "false") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT a FROM testData join testData2 ON key = a " +
@@ -515,7 +515,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
   test("gluten Subquery reuse") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         "SELECT a FROM testData join testData2 ON key = a " +
           "where value >= (SELECT max(a) from testData join testData2 ON key = a) " +
@@ -563,7 +563,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
         """
           |SELECT * FROM testData t1 join testData2 t2
@@ -573,9 +573,9 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
       )
       assert(sortMergeJoinSize(plan) == 2)
       val bhj = findTopLevelBroadcastHashJoinTransform(adaptivePlan)
-      assert(bhj.size == 1)
+      assert(bhj.size == 2)
       // There is still a SMJ, and its two shuffles can't apply local read.
-      checkNumLocalShuffleReads(adaptivePlan, 2)
+      checkNumLocalShuffleReads(adaptivePlan, 0)
     }
   }
 
@@ -756,7 +756,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
       assert(read.metrics("numPartitions").value == read.partitionSpecs.length)
       assert(read.metrics("partitionDataSize").value > 0)
 
-      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
         val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
           "SELECT * FROM testData join testData2 ON key = a where value = '1'")
         val join = collect(adaptivePlan) {
@@ -934,7 +934,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
           |ON value = b
         """.stripMargin)
 
-      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
         // Repartition with no partition num specified.
         checkBHJ(df.repartition('b),
           // The top shuffle from repartition is optimized out.
@@ -1272,7 +1272,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
 
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
       val query = "SELECT * FROM testData join testData2 ON key = a where value = '1'"
 
       withSQLConf(SQLConf.ADAPTIVE_CUSTOM_COST_EVALUATOR_CLASS.key ->
@@ -1414,7 +1414,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
         level = Some(Level.TRACE)) {
         withSQLConf(
           SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300") {
           sql("SELECT * FROM testData join testData2 ON key = a where value = '1'").collect()
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Due to the performance fallback of [PR 1732](https://github.com/oap-project/gluten/pull/1732).I decided to merge the parts that do not affect performance first.


Velox Update list
```
300370fd9 Add timezone_hour Presto function (#4520)
c12534290 Implement decimal comparisons as vector functions (#4638)
df927bd12 Updating submodules
0161d3ff1 Refine StringIdMap::makeId (#4684)
f33ba3a8e Replace find_library with find_package (#4689)
af1c49da4 Suppress errors for unused arguments of null-propagating functions (#3189)
e670ee705 Fix enable sparksql aggregate compile config in CmakeList (#4658)
185f1a40b Updating submodules
c748c8d35 Updating submodules
e2e235b8d Add "running*WallNanos" operator runtime metrics. (#4646)
0ada6a05f Updating submodules
cc6a58bd2 Fix a flaky test blockingOnLocalExchangeQueue in LocalPartitionTest (#4729)
ea13c190b Updating submodules
e62ff1dfc Enable nightly m1 builds (#4701)
abc48154e Fix failing M1 CI (#4709)
35ab8cc2f Fix access of MemoryPool crash in HttpClient (#19451)
372c9af8a Updating submodules
da0ccc532 Disable 'copy on write' for SSD file. (#4694)
4132dafed Do not append row number when Metalake is not enabled (#4705)
cb5c6b058 Simplify hasFilter condition by removing local condition (#4697)
58b118b0f Unify outputType parameter of plan nodes ctor (#4683)
f4db7d65c Updating submodules
066daf99a Add substring SparkSQL function (#4631)
e264875c3 Add AggregateCompanionAdapter for companion function generation (#4566)
ec9b94eeb Add Metalake support to PrismConnector (#4591)
e5c36aec3 Merge memory usage tracker into memory pool (#19434)
ed400323c Use estimateFlatSize for dictionary input vector for LocalExchangeQueue (#4647)
5be966c70 Add Date support for sequence function (#4657)
da19a1c74 Fix build issues in gcc 12+ (#4618)
7a307a0d9 Update expression fuzzer documentation with all the newly added features (#4667)
c55f58d08 Refactor to adhere to coding standards for naming (#4624)
51202556e Fix constant vector toString (#4674)
9507fed28 Add date() Presto function (#4604)
3fb6e7512 Allow ExchangeSource to report runtime statistics (#4685)
f1f6ac150 Refactor aggregation functions code structure and sparksql aggregate function namespace (#4599)
5b6cf196b Move S3Config to HiveConfig and add documentation (#4676)
c061aeb1c Updating submodules
76e507f76 Rename cross join operators to NestedLoopJoin (#4678)
f5da9a272 Copy missing glog header to include dir (#4644)
b421f9df7 Improve configuration properties documentation (#4679)
6d344f6a7 Add random(n) Presto function (#4503)
1b6a2ea97 Updating submodules
0c0547b9c Remove unused code from row/UnsafeRowSerializers.h (#4669)
2f52e848d Mark methods as const in row/UnsafeRowDeserializers.h (#4668)
```

