### PR TITLE
[VL][CI] Only keep Spark32/Spark33 CI with default version

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -72,16 +72,6 @@ jobs:
           docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           mkdir build && cd build && cmake -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON .. && make -j'
-      - name: Build for Spark 3.2.0
-        run: |
-          docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.0'
-      - name: Build for Spark 3.2.1
-        run: |
-          docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.1'
       - name: Build and run unit test for Spark 3.2.2(other tests)
         run: |
           docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
@@ -135,16 +125,6 @@ jobs:
           docker exec velox-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           mkdir build && cd build && cmake .. && make -j'
-      - name: Build for Spark 3.2.0
-        run: |
-          docker exec velox-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.0'
-      - name: Build for Spark 3.2.1
-        run: |
-          docker exec velox-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.1'
       - name: Build and run unit test for Spark 3.2.2(slow tests)
         run: |
           docker exec velox-ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
@@ -197,11 +177,6 @@ jobs:
           docker exec velox-ubuntu2004-test-spark33-slow-$GITHUB_RUN_ID bash -l -c '
           cd /opt/gluten/cpp && \
           mkdir build && cd build && cmake .. && make -j'
-      - name: Build for Spark 3.3.0
-        run: |
-          docker exec velox-ubuntu2004-test-spark33-slow-$GITHUB_RUN_ID bash -l -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -DskipTests -Dspark33.version=3.3.0'
       - name: Build and Run unit test for Spark 3.3.1(slow tests)
         run: |
           docker exec velox-ubuntu2004-test-spark33-slow-$GITHUB_RUN_ID bash -l -c 'cd /opt/gluten && \
@@ -253,11 +228,6 @@ jobs:
           docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           mkdir build && cd build && cmake .. && make -j'
-      - name: Build for Spark 3.3.0
-        run: |
-          docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c '
-          cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -DskipTests -Dspark33.version=3.3.0'
       - name: Build and Run unit test for Spark 3.3.1(other tests)
         run: |
           docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
@@ -307,7 +277,7 @@ jobs:
         run: |
           docker exec velox-ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests'
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2
         run: |
           docker exec velox-ubuntu2204-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -333,11 +303,11 @@ jobs:
           bash /apache-celeborn-0.2.0-incubating-bin/sbin/stop-worker.sh \
           && bash /apache-celeborn-0.2.0-incubating-bin/sbin/stop-master.sh && rm -rf /apache-celeborn-0.2.0-incubating-bin.tgz \
           && rm -rf /apache-celeborn-0.2.0-incubating-bin && rm -rf /opt/hadoop'
-      - name: Build for Spark 3.3.2
+      - name: Build for Spark 3.3.1
         run: |
           docker exec velox-ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -DskipTests -Dspark33.version=3.3.2'
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -DskipTests'
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.3
         run: |
           docker exec velox-ubuntu2204-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -386,7 +356,7 @@ jobs:
         run: |
           docker exec velox-centos8-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests'
       - name: TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2
         run: |
           docker exec velox-centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -435,7 +405,7 @@ jobs:
         run: |
           docker exec velox-centos7-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2'
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests'
       - name: TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2
         run: |
           docker exec velox-centos7-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
@@ -476,7 +446,7 @@ jobs:
         run: |
           docker exec velox-static-build-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests -Dspark32.version=3.2.2 && \
+          mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -DskipTests && \
           cd /opt/gluten/tools/gluten-it && \
           mvn clean install -Pspark-3.2'
       - name: TPC-H SF1.0 && TPC-DS SF1.0 Parquet local spark3.2 (centos 8)


### PR DESCRIPTION
## What changes were proposed in this pull request?

After this PR, we only keep Spark3.2.2 and Spark3.3.1 in CI.

(Fixes: \#ISSUE-ID)
