### PR TITLE
[VL] Forbid unsupported write using velox

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
@@ -53,4 +53,39 @@ class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
         }
       }
   }
+
+  test("test ctas") {
+    withTable("velox_ctas") {
+      intercept[UnsupportedOperationException] {
+        spark.range(100).toDF("id")
+          .write
+          .format("velox")
+          .saveAsTable("velox_ctas")
+      }
+    }
+  }
+
+  test("test parquet dynamic partition write") {
+    withTempPath { f =>
+      intercept[UnsupportedOperationException] {
+        spark.range(100).selectExpr("id as c1", "id % 7 as p")
+          .write
+          .format("velox")
+          .partitionBy("p")
+          .save(f.getCanonicalPath)
+      }
+    }
+  }
+
+  test("test parquet bucket write") {
+    withTable("bucket") {
+      intercept[UnsupportedOperationException] {
+        spark.range(100).selectExpr("id as c1", "id % 7 as p")
+          .write
+          .format("velox")
+          .bucketBy(7, "p")
+          .saveAsTable("bucket")
+      }
+    }
+  }
 }

--- a/docs/VeloxNotSupport.md
+++ b/docs/VeloxNotSupport.md
@@ -84,10 +84,48 @@ Exception occurs when Velox TableScan is used to read files with unsupported com
 | DWRF        | Y    | Y    | Y    | Y      | Y   | Y   | N    |
 
 
-### Parquet Write.
+### Parquet Write
 
-* Supported configurations: Currently, parquet write only support spark.sql.parquet.compression.codec and parquet.block.size two configurations. Other configurations will not take effect. 
-* Notes: We implemented the insert into command by overriding HiveFileFormat in Vanilla spark. And you need to ensure preferentially load the Gluten jar to overwrite the jar of vanilla spark. Refer to [How to prioritize loading Gluten jars in Spark](https://github.com/oap-project/gluten/blob/main/docs/developers/NewToGluten.md). It should be noted that if the user also modifies the HiveFileFormat, the user's changes may be overwritten.
+We implemented the insert into command by overriding HiveFileFormat in Vanilla spark. And you need to ensure preferentially load the Gluten jar to overwrite the jar of vanilla spark. Refer to [How to prioritize loading Gluten jars in Spark](https://github.com/oap-project/gluten/blob/main/docs/developers/NewToGluten.md). It should be noted that if the user also modifies the HiveFileFormat, the user's changes may be overwritten.
+
+### Velox Parquet Write
+
+#### Configuration (incompatible behavior)
+
+Parquet write only support three configs, other will not take effect.
+
+- compression code:
+  - sql conf: `spark.sql.parquet.compression.codec`
+  - option: `compression.codec`
+- block size
+  - sql conf: `spark.gluten.sql.columnar.parquet.write.blockSize`
+  - option: `parquet.block.size`
+- block rows
+  - sql conf: `spark.gluten.sql.native.parquet.write.blockRows`
+  - option: `parquet.block.rows`
+
+#### Write a partitioned or bucketed table (exception)
+
+Velox does not support dynamic partition write and bucket write, e.g.,
+
+```scala
+spark.range(100).selectExpr("id as c1", "id % 7 as p")
+  .write
+  .format("velox")
+  .partitionBy("p")
+  .save(f.getCanonicalPath)
+```
+
+#### CTAS (exception)
+
+Velox does not create table as select, e.g.,
+
+```scala
+spark.range(100).toDF("id")
+  .write
+  .format("velox")
+  .saveAsTable("velox_ctas")
+```
 
 ### Spill
 

--- a/docs/VeloxNotSupport.md
+++ b/docs/VeloxNotSupport.md
@@ -86,6 +86,8 @@ Exception occurs when Velox TableScan is used to read files with unsupported com
 
 ### Parquet Write
 
+#### Offload hive file format to velox (offload)
+
 We implemented the insert into command by overriding HiveFileFormat in Vanilla spark. And you need to ensure preferentially load the Gluten jar to overwrite the jar of vanilla spark. Refer to [How to prioritize loading Gluten jars in Spark](https://github.com/oap-project/gluten/blob/main/docs/developers/NewToGluten.md). It should be noted that if the user also modifies the HiveFileFormat, the user's changes may be overwritten.
 
 ### Velox Parquet Write


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr does two things:
- Forbid velox write with ctas. It can be supported in Spark3.4
- Forbid velox dynamic partition and bucket write. As mentioned at https://github.com/oap-project/gluten/issues/2042, it would fail if we use dynamic partition write with velox. There is a lot of work need to be done. This pr just throw exception in advance when contains partition or bucket.

## How was this patch tested?

add test
