### PR TITLE
[UT] Rename "Spark Answer" to "Gluten Answer"

### DIFF
--- a/gluten-core/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
@@ -362,7 +362,7 @@ object GlutenQueryTest extends Assertions {
         s"== Correct Answer - ${expectedAnswer.size} ==" +:
           getRowType(expectedAnswer.headOption) +:
           prepareAnswer(expectedAnswer, isSorted).map(_.toString()),
-        s"== Spark Answer - ${sparkAnswer.size} ==" +:
+        s"== Gluten Answer - ${sparkAnswer.size} ==" +:
           getRowType(sparkAnswer.headOption) +:
           prepareAnswer(sparkAnswer, isSorted).map(_.toString())).mkString("\n")
     }

--- a/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
+++ b/gluten-ut/common/src/test/scala/org/apache/spark/sql/GlutenSQLTestsTrait.scala
@@ -195,7 +195,7 @@ object GlutenQueryTest extends Assertions {
          s"== Correct Answer - ${expectedAnswer.size} ==" +:
            getRowType(expectedAnswer.headOption) +:
            prepareAnswer(expectedAnswer, isSorted).map(_.toString()),
-         s"== Spark Answer - ${sparkAnswer.size} ==" +:
+         s"== Gluten Answer - ${sparkAnswer.size} ==" +:
            getRowType(sparkAnswer.headOption) +:
            prepareAnswer(sparkAnswer, isSorted).map(_.toString())).mkString("\n")}
     """.stripMargin


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a minor fix, Renaming **"Spark Answer"** to **"Gluten Answer"** to avoid confusion.


## How was this patch tested?
Existed UT