### PR TITLE
[GLUTEN-2095][CH] Fix the incorrect result of  cast(string as binary)

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1167,4 +1167,10 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
 
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
   }
+
+  test("GLUTEN-2095: test cast(string as binary)") {
+    runQueryAndCompare(
+      "select cast(n_nationkey as binary), cast(n_comment as binary) from nation"
+    )(checkOperatorMatch[ProjectExecTransformer])
+  }
 }

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -318,7 +318,11 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "array size function",
       "map size function - legacy",
       "map size function",
-      "map_entries"
+      "map_entries",
+      "misc md5 function",
+      "misc sha1 function",
+      "misc sha2 function",
+      "misc crc32 function"
     )
 
   enableSuite[GlutenDateFunctionsSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?

`cast(xxx as binary)` is implemented to `reinterpretAsStringSpark` function in CH backend, `xxx` here is either StringType or IntegerType. 
When `xxx` is IntegerType, we need output reinterpreted bytes in big-endian order to align with spark. However, when it is  StringType, this step is not necessary.

(Fixes: \#2095)

## How was this patch tested?

unit tests


