### PR TITLE
[GLUTEN-2125][VL] Decouple S3 endpoint/ssl.enabled/path-style-access config from AK/SK

### DIFF
--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -187,11 +187,15 @@ void VeloxInitializer::init(const std::unordered_map<std::string, std::string>& 
     s3Config.insert({
         {"hive.s3.aws-access-key", awsAccessKey},
         {"hive.s3.aws-secret-key", awsSecretKey},
-        {"hive.s3.endpoint", awsEndpoint},
-        {"hive.s3.ssl.enabled", sslEnabled},
-        {"hive.s3.path-style-access", pathStyleAccess},
     });
   }
+
+  s3Config.insert({
+      {"hive.s3.endpoint", awsEndpoint},
+      {"hive.s3.ssl.enabled", sslEnabled},
+      {"hive.s3.path-style-access", pathStyleAccess},
+  });
+
   configurationValues.merge(s3Config);
 #endif
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Decouple S3 endpoint/ssl.enabled/path-style-access config from AK/SK since they are common configs.

(Fixes: \#2125)

## How was this patch tested?

manual tests


