### PR TITLE
[CORE] Auto generate libhdfs3 conf file from spark hadoop configuration

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkUtil.scala
@@ -16,6 +16,9 @@
  */
 package org.apache.spark.util
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.SparkSession
@@ -48,5 +51,9 @@ object SparkUtil extends Logging {
         None
       }
     }.filter(!_.isEmpty).map(_.get).toList
+  }
+
+  def newConfiguration(conf: SparkConf): Configuration = {
+    SparkHadoopUtil.get.newConfiguration(conf)
   }
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -336,6 +336,8 @@ object GlutenConfig {
   // Tokens of current user, split by `\0`
   val GLUTEN_UGI_TOKENS = "spark.gluten.ugi.tokens"
 
+  val AUTO_GENERATE_LIBHDFS3_CONF_KEY = "spark.gluten.generate.libhdfs3.conf.auto"
+
   var ins: GlutenConfig = _
 
   def getConf: GlutenConfig = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Automatically generate libhdfs3 configuration file from spark hadoop configuration.

After this pr, we only need to add the following configuration when using hdfs, and the libhdfs3 configuration file will be automatically generated in the executor work dir.

```
spark.executorEnv.LIBHDFS3_CONF=hadoop-test.xml;
spark.gluten.generate.libhdfs3.conf.auto=true
```
​
## How was this patch tested?

successfully read hive table of hdfs path and the hadoop-test.xml file is generated in the executor work dir

```
23/06/29 13:03:11 INFO GlutenExecutorPlugin: Writing Hadoop configuration to hadoop-test.xml
```

