### PR TITLE
[GLUTEN-2152][CORE] Skip local sort if child output ordering satisfies topk

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -94,7 +94,6 @@ abstract class GlutenClickHouseTPCDSAbstractSuite extends WholeStageTransformerS
     "q18", // inconsistent results
     "q49", // inconsistent results
     "q61", // inconsistent results
-    "q67", // inconsistent results
     "q78", // inconsistent results
     "q83", // decimal error
     "q90" // inconsistent results(decimal)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -94,6 +94,7 @@ abstract class GlutenClickHouseTPCDSAbstractSuite extends WholeStageTransformerS
     "q18", // inconsistent results
     "q49", // inconsistent results
     "q61", // inconsistent results
+    "q67", // inconsistent results
     "q78", // inconsistent results
     "q83", // decimal error
     "q90" // inconsistent results(decimal)


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#2152)

## How was this patch tested?

Pass existed topk test