### PR TITLE
[GLUTEN-1434] [VL] Fix shuffle read unalign buffer which origins from netty

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -242,8 +242,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFramePivotSuite]
     // substring issue
     .exclude("pivot with column definition in groupby")
-    // velox int128_t address 16B align issue
-    .exclude("optimized pivot DecimalType")
   enableSuite[GlutenReuseExchangeAndSubquerySuite]
   enableSuite[GlutenSameResultSuite]
   // spill not supported yet.

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1001,8 +1001,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFramePivotSuite]
     // substring issue
     .exclude("pivot with column definition in groupby")
-    // velox int128_t address 16B align issue
-    .exclude("optimized pivot DecimalType")
   enableSuite[GlutenDataFrameRangeSuite]
   enableSuite[GlutenDataFrameSelfJoinSuite]
   enableSuite[GlutenDataFrameSessionWindowingSuite]


### PR DESCRIPTION
For small size ColumnarBatch, this batch will not be compressed, the buffer which origins from netty is aligned, but the actual buffer used in RecordBatch is SliceBuffer(buffer, offset, size), this buffer cannot guarantee align. SIMD instruction `movdqa` required the address 16B aligned, so it will core dump at velox function `copyValuesAndNulls` and left potential coredump. This copy is expensive but essential.

```
BufferReader::DoReadAt(int64_t position, int64_t nbytes) {
return SliceBuffer(buffer_, position, nbytes); // buffer_ is netty buffer
}

```

For most batch which is not tiny batch and compress codec use default lz4, shuffle read will decompress the buffer to an aligned address which meets SIMD instrictions requirement.


Relevant issue: https://github.com/facebookincubator/velox/issues/2388
