### PR TITLE
[GLUTEN-2090][CH] Refactor aggregate function parsing 

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -306,20 +306,22 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         .get(0)
         .getProcessors
         .get(0)
-        .getInputRows == 591677)
+        .getInputRows == 591673)
+
     assert(
       nativeMetricsData.metricsDataList
         .get(4)
         .getSteps
-        .get(0)
+        .get(1)
         .getProcessors
         .get(1)
         .getOutputRows == 4)
+
     assert(
       nativeMetricsData.metricsDataList
         .get(4)
         .getSteps
-        .get(0)
+        .get(1)
         .getProcessors
         .get(0)
         .getOutputRows == 4)

--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -87,11 +87,17 @@ if (ENABLE_LOCAL_UDFS)
     endforeach()
 endif ()
 
+file(GLOB children CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} Parser/*_function_parser)
+foreach(child ${children})
+    add_headers_and_sources(function_parsers ${child})
+endforeach()
+
 # Notice: soures files under Parser/*_udf subdirectories must be built into target ${LOCALENGINE_SHARED_LIB} directly
 #         to make sure all function parsers are registered successly.
 add_library(${LOCALENGINE_SHARED_LIB} SHARED
         local_engine_jni.cpp
         ${local_udfs_sources}
+        ${function_parsers_sources}
         $<TARGET_OBJECTS:clickhouse_malloc>) # why add clickhouse_malloc? check clickhouse PR-8046
 
 target_compile_options(${LOCALENGINE_SHARED_LIB} PUBLIC -fPIC

--- a/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
@@ -1,15 +1,17 @@
 #include "AggregateRelParser.h"
 #include <memory>
 #include <AggregateFunctions/AggregateFunctionIf.h>
-#include <Common/StringUtils/StringUtils.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
+#include <Parser/FunctionParser.h>
+#include <Parser/aggregate_function_parser/CommonAggregateFunctionParser.h>
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/MergingAggregatedStep.h>
+#include <Common/StringUtils/StringUtils.h>
 
 namespace DB
 {
@@ -73,13 +75,17 @@ void AggregateRelParser::setup(DB::QueryPlanPtr query_plan, const substrait::Rel
     {
         AggregateInfo agg_info;
         auto arg = measure.measure().arguments(0).value();
-        auto function_name = parseFunctionName(measure.measure().function_reference(), {});
-        if (!function_name)
+        agg_info.signature_function_name = *parseSignatureFunctionName(measure.measure().function_reference());
+        auto function_parser = FunctionParserFactory::instance().get(agg_info.signature_function_name, getPlanParser());
+        if (!function_parser)
         {
-            throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported aggregate function");
+            throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported aggregate function: {}", agg_info.signature_function_name);
         }
+        /// Put function_parser, parser_func_info and function_name into agg_info for reducing repeated builds.
+        agg_info.function_parser = function_parser;
+        agg_info.parser_func_info = FunctionParser::CommonFunctionInfo(measure);
+        agg_info.function_name = function_parser->getCHFunctionName(agg_info.parser_func_info);
         agg_info.measure = &measure;
-        agg_info.function_name = *function_name;
         aggregates.push_back(agg_info);
     }
 
@@ -103,71 +109,25 @@ void AggregateRelParser::setup(DB::QueryPlanPtr query_plan, const substrait::Rel
     }
 }
 
-// projections for function arguments.
-// 1. add literal columns
-// 2. change argument columns' nullabitlity.
-// 3. if the aggregate expression has filter, add a filter column.
+/// Projections for function arguments.
+/// The projections are built by the function parsers.
 void AggregateRelParser::addPreProjection()
 {
     auto input_header = plan->getCurrentDataStream().header;
-    bool need_projection = false;
     ActionsDAGPtr projection_action = std::make_shared<ActionsDAG>(input_header.getColumnsWithTypeAndName());
+    std::string dag_footprint = projection_action->dumpDAG();
     for (auto & agg_info : aggregates)
     {
-        for (const auto & arg : agg_info.measure->measure().arguments())
+        auto arg_nodes = agg_info.function_parser->parseFunctionArguments(agg_info.parser_func_info, projection_action);
+        for (auto & arg_node : arg_nodes)
         {
-            String arg_column_name;
-            DB::DataTypePtr arg_column_type = nullptr;
-            auto arg_value = arg.value();
-            if (arg_value.has_selection())
-            {
-                const auto & col = input_header.getByPosition(arg_value.selection().direct_reference().struct_field().field());
-                arg_column_name = col.name;
-                arg_column_type = col.type;
-            }
-            else if (arg_value.has_literal())
-            {
-                const auto * node = parseArgument(projection_action, arg_value);
-                projection_action->addOrReplaceInOutputs(*node);
-                arg_column_name = node->result_name;
-                arg_column_type = node->result_type;
-                need_projection = true;
-            }
-            else
-            {
-                throw Exception(DB::ErrorCodes::UNKNOWN_TYPE, "Unsupported aggregate argument: {}", arg_value.DebugString());
-            }
-
-            // If the aggregate result is required to be nullable, make all inputs be nullable at the first stage.
-            auto required_output_which_type = WhichDataType(parseType(agg_info.measure->measure().output_type()));
-            if (required_output_which_type.isNullable()
-                && agg_info.measure->measure().phase() == substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE
-                && !projection_action->findInOutputs(arg_column_name).result_type->isNullable())
-            {
-                ActionsDAG::NodeRawConstPtrs args;
-                agg_info.has_mismatch_nullablity = true;
-                args.emplace_back(&projection_action->findInOutputs(arg_column_name));
-                const auto * node = buildFunctionNode(projection_action, "toNullable", args);
-                projection_action->addOrReplaceInOutputs(*node);
-                arg_column_name = node->result_name;
-                arg_column_type = node->result_type;
-                need_projection = true;
-            }
-            agg_info.arg_column_names.emplace_back(arg_column_name);
-            agg_info.arg_column_types.emplace_back(arg_column_type);
+            agg_info.arg_column_names.emplace_back(arg_node->result_name);
+            agg_info.arg_column_types.emplace_back(arg_node->result_type);
+            projection_action->addOrReplaceInOutputs(*arg_node);
         }
-
-        if (agg_info.measure->has_filter())
-        {
-            // With `If` combinator, the function take one more argument which refers to the condition.
-            const auto * action_node = parseExpression(projection_action, agg_info.measure->filter());
-            agg_info.filter_column_name = action_node->result_name;
-            agg_info.arg_column_names.emplace_back(agg_info.filter_column_name);
-            agg_info.arg_column_types.emplace_back(action_node->result_type);
-            need_projection = true;
-        }
+        agg_info.params = agg_info.function_parser->parseFunctionParameters(agg_info.parser_func_info);
     }
-    if (need_projection)
+    if (projection_action->dumpDAG() != dag_footprint)
     {
         auto projection_step = std::make_unique<DB::ExpressionStep>(plan->getCurrentDataStream(), projection_action);
         projection_step->setStepDescription("Projection before aggregate");
@@ -194,70 +154,12 @@ void AggregateRelParser::buildAggregateDescriptions(AggregateDescriptions & desc
         const auto & measure = agg_info.measure->measure();
         description.column_name = build_result_column_name(agg_info.function_name, agg_info.arg_column_names, measure.phase());
         description.argument_names = agg_info.arg_column_names;
-        // The suffix of "PartialMerge" is used in AggregateFunctionCombinatorPartialMerge
-        const auto * partial_merge_suffix = "PartialMerge";
-        auto function_name = agg_info.function_name;
-        auto arg_column_types = agg_info.arg_column_types;
-        if (measure.phase() != substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE)
-        {
-            if (agg_info.arg_column_types.size() != 1)
-            {
-                throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Only support one argument aggregate function in phase {}", measure.phase());
-            }
-            // Add a check here for safty.
-            if (!agg_info.filter_column_name.empty())
-            {
-                throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Unspport apply filter in phase {}", measure.phase());
-            }
-
-            const auto * agg_function_data = DB::checkAndGetDataType<DB::DataTypeAggregateFunction>(agg_info.arg_column_types[0].get());
-            if (!agg_function_data)
-            {
-                // FIXME. This is should be fixed. It's the case that count(distinct(xxx)) with other aggregate functions.
-                // Gluten breaks the rule that intermediate result should have a special format name here.
-                if (measure.phase() != substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE)
-                {
-                    LOG_INFO(logger, "Intermediate aggregate function data is expected in phase {} for {}", measure.phase(), function_name);
-                    auto arg_type = DB::removeNullable(agg_info.arg_column_types[0]);
-                    if (auto * tupe_type = typeid_cast<const DB::DataTypeTuple*>(arg_type.get()))
-                    {
-                        arg_column_types = tupe_type->getElements();
-                    }
-                    auto agg_function = getAggregateFunction(function_name, arg_column_types);
-                    auto agg_intermediate_result_type = agg_function->getStateType();
-                    arg_column_types = {agg_intermediate_result_type};
-                }
-            }
-            else
-            {
-                // Special case for handling the intermedidate result from aggregate functions with filter.
-                // It's safe to use AggregateFunctionxxx to parse intermediate result from AggregateFunctionxxxIf,
-                // since they have the same binary representation
-                // reproduce this case by
-                //  select 
-                //    count(a),count(b), count(1), count(distinct(a)), count(distinct(b)) 
-                //  from values (1, null), (2,2) as data(a,b)
-                // with `first_value` enable
-                if (measure.phase() != substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE)
-                {
-                    if (endsWith(agg_function_data->getFunction()->getName(), "If")
-                        && function_name != agg_function_data->getFunction()->getName())
-                    {
-                        auto original_args_types = agg_function_data->getArgumentsDataTypes();
-                        arg_column_types = DataTypes(original_args_types.begin(), std::prev(original_args_types.end()));
-                        auto agg_function = getAggregateFunction(function_name, arg_column_types);
-                        arg_column_types = {agg_function->getStateType()};
-                    }
-                }
-            }
-            function_name = function_name + partial_merge_suffix;
-        }
-        else if (!agg_info.filter_column_name.empty())
-        {
-            // Apply `If` aggregate function combinator on the original aggregate function.
-            function_name += "If";
-        }
-        description.function = getAggregateFunction(function_name, arg_column_types);
+        // May apply `PartialMerge` and `If` on the original function.
+        auto [combinator_function_name, combinator_function_arg_types]
+            = typeid_cast<BaseAggregateFunctionParser *>(agg_info.function_parser.get())
+                  ->tryApplyCHCombinator(agg_info.parser_func_info, agg_info.function_name, agg_info.arg_column_types);
+        DB::AggregateFunctionProperties properties;
+        description.function = getAggregateFunction(combinator_function_name, combinator_function_arg_types, properties, agg_info.params);
         descriptions.emplace_back(description);
     }
 }
@@ -331,87 +233,23 @@ void AggregateRelParser::addAggregatingStep()
 // Only be called in final stage.
 void AggregateRelParser::addPostProjection()
 {
-    addPostProjectionForAggregatingResult();   
-    addPostProjectionForTypeMismatch();
-}
-
-// Handle special cases for aggregate result.
-void AggregateRelParser::addPostProjectionForAggregatingResult()
-{
     auto input_header = plan->getCurrentDataStream().header;
-    auto current_cols = plan->getCurrentDataStream().header.getColumnsWithTypeAndName();
-    ActionsDAGPtr projection_action = std::make_shared<ActionsDAG>(input_header.getColumnsWithTypeAndName());
-
-    auto build_function_node = [&](ActionsDAGPtr action_dag,
-                                   const String & function_name,
-                                   const String & result_name,
-                                   const DB::ActionsDAG::NodeRawConstPtrs & args)
-    {
-        auto function_builder = DB::FunctionFactory::instance().get(function_name, getContext());
-        return &action_dag->addFunction(function_builder, args, result_name);
-    };
-
-    bool need_projection = false;
+    ActionsDAGPtr project_actions_dag = std::make_shared<ActionsDAG>(input_header.getColumnsWithTypeAndName());
+    auto dag_footprint = project_actions_dag->dumpDAG();
     for (const auto & agg_info : aggregates)
     {
-        // groupArray is used to implement collect_list in spark. But there is a difference between them.
-        // If all elements are null, collect_list will return [], but groupArray will return null. And clickhosue
-        // has backward compatibility issue, we cannot modify the inner implementation of groupArray
-        if (agg_info.function_name == "groupArray" || agg_info.function_name == "groupUniqArray")
-        {
-            auto pos = agg_info.measure->measure().arguments(0).value().selection().direct_reference().struct_field().field();
-            if (current_cols[pos].type->isNullable())
-            {
-                ActionsDAG::NodeRawConstPtrs args;
-                args.push_back(&projection_action->findInOutputs(agg_info.arg_column_names[0]));
-                auto nested_type = typeid_cast<const DB::DataTypeNullable *>(current_cols[pos].type.get())->getNestedType();
-                DB::Field empty_field = nested_type->getDefault();
-                const auto * default_value_node = &projection_action->addColumn(
-                    ColumnWithTypeAndName(nested_type->createColumnConst(1, empty_field), nested_type, getUniqueName("[]")));
-                args.push_back(default_value_node);
-                const auto * if_null_node = build_function_node(projection_action, "ifNull", current_cols[pos].name, args);
-                projection_action->addOrReplaceInOutputs(*if_null_node);
-                need_projection = true;
-            }
-        }
-    }
-
-    if (need_projection)
-    {
-        auto projection_step = std::make_unique<DB::ExpressionStep>(plan->getCurrentDataStream(), projection_action);
-        projection_step->setStepDescription("Post-projection For Special Aggregate Functions");
-        steps.emplace_back(projection_step.get());
-        plan->addStep(std::move(projection_step));
-    }
-}
-
-void AggregateRelParser::addPostProjectionForTypeMismatch()
-{
-    auto current_cols = plan->getCurrentDataStream().header.getColumnsWithTypeAndName();
-    auto target_cols = current_cols;
-    bool need_convert = false;
-    for (const auto & agg_info : aggregates)
-    {
-        // For final stage, the argument refers to a intermediate resutl.
+        /// For final stage, the aggregate function's input is only one intermediate result columns.
+        /// The final result columm's position is the same as the intermediate result column's position.
         auto pos = agg_info.measure->measure().arguments(0).value().selection().direct_reference().struct_field().field();
-        auto output_type = parseType(agg_info.measure->measure().output_type());
-        if (!output_type->equals(*current_cols[pos].type))
-        {
-            target_cols[pos].type = output_type;
-            target_cols[pos].column = output_type->createColumn();
-            need_convert = true;
-        }
+        const auto * agg_result_node = project_actions_dag->getInputs()[pos];
+        agg_info.function_parser->convertNodeTypeIfNeeded(agg_info.parser_func_info, agg_result_node, project_actions_dag);
     }
-    if (need_convert)
+    if (project_actions_dag->dumpDAG() != dag_footprint)
     {
-        ActionsDAGPtr convert_action = ActionsDAG::makeConvertingActions(current_cols, target_cols, DB::ActionsDAG::MatchColumnsMode::Position);
-        if (convert_action)
-        {
-            QueryPlanStepPtr convert_step = std::make_unique<ExpressionStep>(plan->getCurrentDataStream(), convert_action);
-            convert_step->setStepDescription("Post-projection For Type Mismatch");
-            steps.emplace_back(convert_step.get());
-            plan->addStep(std::move(convert_step));
-        }
+        QueryPlanStepPtr convert_step = std::make_unique<ExpressionStep>(plan->getCurrentDataStream(), project_actions_dag);
+        convert_step->setStepDescription("Post-projection for aggregate");
+        steps.emplace_back(convert_step.get());
+        plan->addStep(std::move(convert_step));
     }
 }
 
@@ -420,5 +258,4 @@ void registerAggregateParser(RelParserFactory & factory)
     auto builder = [](SerializedPlanParser * plan_parser) { return std::make_shared<AggregateRelParser>(plan_parser); };
     factory.registerBuilder(substrait::Rel::RelTypeCase::kAggregate, builder);
 }
-
 }

--- a/cpp-ch/local-engine/Parser/AggregateRelParser.h
+++ b/cpp-ch/local-engine/Parser/AggregateRelParser.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Parser/FunctionParser.h>
 #include <Parser/RelParser.h>
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
@@ -18,9 +19,15 @@ private:
         const substrait::AggregateRel::Measure * measure = nullptr;
         Strings arg_column_names;
         DB::DataTypes arg_column_types;
+        Array params;
+        String signature_function_name;
         String function_name;
-        bool has_mismatch_nullablity = false;
-        String filter_column_name;
+        // If no combinator be applied on it, same as function_name
+        String combinator_function_name;
+        // For avoiding repeated builds.
+        FunctionParser::CommonFunctionInfo parser_func_info;
+        // For avoiding repeated builds.
+        FunctionParserPtr function_parser;
     };
 
     Poco::Logger * logger = &Poco::Logger::get("AggregateRelParser");
@@ -38,8 +45,6 @@ private:
     void addMergingAggregatedStep();
     void addAggregatingStep();
     void addPostProjection();
-    void addPostProjectionForAggregatingResult();
-    void addPostProjectionForTypeMismatch();
 
     void buildAggregateDescriptions(AggregateDescriptions & descriptions);
 };

--- a/cpp-ch/local-engine/Parser/FunctionParser.cpp
+++ b/cpp-ch/local-engine/Parser/FunctionParser.cpp
@@ -11,6 +11,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_FUNCTION;
+    extern const int NOT_IMPLEMENTED;
 }
 }
 
@@ -20,7 +21,17 @@ using namespace DB;
 
 String FunctionParser::getCHFunctionName(const substrait::Expression_ScalarFunction & substrait_func) const
 {
-    auto func_signature = plan_parser->function_mapping.at(std::to_string(substrait_func.function_reference()));
+    return getCHFunctionName(CommonFunctionInfo(substrait_func));
+}
+
+String FunctionParser::getCHFunctionName(const DB::DataTypes &) const
+{
+    throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implemented");
+}
+
+String FunctionParser::getCHFunctionName(const CommonFunctionInfo & func_info) const
+{
+    auto func_signature = plan_parser->function_mapping.at(std::to_string(func_info.function_ref));
     auto pos = func_signature.find(':');
     auto func_name = func_signature.substr(0, pos);
 
@@ -35,12 +46,24 @@ ActionsDAG::NodeRawConstPtrs FunctionParser::parseFunctionArguments(
     const String & ch_func_name,
     ActionsDAGPtr & actions_dag) const
 {
+    return parseFunctionArguments(CommonFunctionInfo(substrait_func), ch_func_name, actions_dag);
+}
+
+DB::ActionsDAG::NodeRawConstPtrs FunctionParser::parseFunctionArguments(
+    const CommonFunctionInfo & func_info, const String & ch_func_name, DB::ActionsDAGPtr & actions_dag) const
+{
     ActionsDAG::NodeRawConstPtrs parsed_args;
-    const auto & args = substrait_func.arguments();
+    const auto & args = func_info.arguments;
     parsed_args.reserve(args.size());
     for (const auto & arg : args)
         plan_parser->parseFunctionArgument(actions_dag, parsed_args, ch_func_name, arg);
     return parsed_args;
+}
+
+DB::ActionsDAG::NodeRawConstPtrs FunctionParser::parseFunctionArguments(
+    const CommonFunctionInfo & func_info, DB::ActionsDAGPtr & actions_dag) const
+{
+    return parseFunctionArguments(func_info, getCHFunctionName(func_info), actions_dag);
 }
 
 const ActionsDAG::Node * FunctionParser::parse(
@@ -53,10 +76,25 @@ const ActionsDAG::Node * FunctionParser::parse(
     return convertNodeTypeIfNeeded(substrait_func, func_node, actions_dag);
 }
 
+const DB::ActionsDAG::Node * FunctionParser::parse(
+    const CommonFunctionInfo & func_info, ActionsDAGPtr & actions_dag) const
+{
+    auto ch_func_name = getCHFunctionName(func_info);
+    auto parsed_args = parseFunctionArguments(func_info, ch_func_name, actions_dag);
+    const auto * func_node = toFunctionNode(actions_dag, ch_func_name, parsed_args);
+    return convertNodeTypeIfNeeded(func_info, func_node, actions_dag);
+}
+
 const ActionsDAG::Node * FunctionParser::convertNodeTypeIfNeeded(
     const substrait::Expression_ScalarFunction & substrait_func, const ActionsDAG::Node * func_node, ActionsDAGPtr & actions_dag) const
 {
-    const auto & output_type = substrait_func.output_type();
+    return convertNodeTypeIfNeeded(CommonFunctionInfo(substrait_func), func_node, actions_dag);
+}
+
+const DB::ActionsDAG::Node * FunctionParser::convertNodeTypeIfNeeded(
+    const CommonFunctionInfo & func_info, const DB::ActionsDAG::Node * func_node, DB::ActionsDAGPtr & actions_dag) const
+{
+    const auto & output_type = func_info.output_type;
     if (!isTypeMatched(output_type, func_node->result_type))
         return ActionsDAGUtil::convertNodeType(
             actions_dag, func_node, SerializedPlanParser::parseType(output_type)->getName(), func_node->result_name);
@@ -70,12 +108,13 @@ void FunctionParserFactory::registerFunctionParser(const String & name, Value va
         throw Exception(ErrorCodes::LOGICAL_ERROR, "FunctionParserFactory: function parser name '{}' is not unique", name);
 }
 
-
 FunctionParserPtr FunctionParserFactory::get(const String & name, SerializedPlanParser * plan_parser)
 {
     auto res = tryGet(name, plan_parser);
     if (!res)
+    {
         throw Exception(ErrorCodes::UNKNOWN_FUNCTION, "Unknown function parser {}", name);
+    }
 
     return res;
 }

--- a/cpp-ch/local-engine/Parser/FunctionParser.h
+++ b/cpp-ch/local-engine/Parser/FunctionParser.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <substrait/algebra.pb.h>
-#include <boost/noncopyable.hpp>
-
-#include <base/types.h>
-#include <Common/IFactoryWithAliases.h>
+#include <Core/Field.h>
+#include <DataTypes/IDataType.h>
+#include <Functions/FunctionFactory.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Parser/SerializedPlanParser.h>
+#include <base/types.h>
+#include <boost/noncopyable.hpp>
+#include <substrait/algebra.pb.h>
+#include <Common/IFactoryWithAliases.h>
 
 namespace local_engine
 {
@@ -16,17 +18,116 @@ class SerializedPlanParser;
 class FunctionParser
 {
 public:
+    /// Manage scalar, aggregate and window functions by FunctionParser.
+    /// Usally we need to make pre-projections and a post-projection for functions.
+
+    /// CommonFunctionInfo is commmon representation for different function types, 
+    struct CommonFunctionInfo
+    {
+        /// basic common function informations
+        using Arguments = google::protobuf::RepeatedPtrField<substrait::FunctionArgument>;
+        using SortFields = google::protobuf::RepeatedPtrField<substrait::SortField>;
+        DB::Int32 function_ref;
+        Arguments arguments;
+        substrait::Type output_type;
+    
+        /// Following is for aggregate and window functions.
+        substrait::AggregationPhase phase;
+        SortFields sort_fields;
+        // only be used in aggregate functions at present.
+        substrait::Expression filter;
+        bool is_in_window = false;
+        bool is_aggregate_function = false;
+        bool has_filter = false;
+
+        CommonFunctionInfo()
+        {
+            function_ref = -1;
+        }
+
+        CommonFunctionInfo(const substrait::Expression_ScalarFunction & substrait_func)
+            : function_ref(substrait_func.function_reference())
+            , arguments(substrait_func.arguments())
+            , output_type(substrait_func.output_type())
+        {
+        }
+
+        CommonFunctionInfo(const substrait::WindowRel::Measure & win_measure)
+            : function_ref(win_measure.measure().function_reference())
+            , arguments(win_measure.measure().arguments())
+            , output_type(win_measure.measure().output_type())
+            , phase(win_measure.measure().phase())
+            , sort_fields(win_measure.measure().sorts())
+        {
+            is_in_window = true;
+            is_aggregate_function = true;
+        }
+
+        CommonFunctionInfo(const substrait::AggregateRel::Measure & agg_measure)
+            : function_ref(agg_measure.measure().function_reference())
+            , arguments(agg_measure.measure().arguments())
+            , output_type(agg_measure.measure().output_type())
+            , phase(agg_measure.measure().phase())
+            , sort_fields(agg_measure.measure().sorts())
+            , filter(agg_measure.filter())
+        {
+            has_filter = agg_measure.has_filter();
+            is_aggregate_function = true;
+        }
+    };
     explicit FunctionParser(SerializedPlanParser * plan_parser_) : plan_parser(plan_parser_) { }
 
     virtual ~FunctionParser() = default;
 
     virtual String getName() const = 0;
 
-    /// Input: substrait_func, action_dag
-    /// Output: actions_dag, required_columns, and result_node
+    /// This is a convenient interface for scalar functions, and should not be used for aggregate functions.
+    /// It usally take following actions:
+    /// - add const columns for literal arguments into actions_dag.
+    /// - make pre-projections for input arguments. e.g. type conversion.
+    /// - make a post-projection for the function result. e.g. type conversion.
     virtual const DB::ActionsDAG::Node * parse(
         const substrait::Expression_ScalarFunction & substrait_func,
         DB::ActionsDAGPtr & actions_dag) const;
+    /// We recomment to implement this in the subclass instead of the previous one.
+    /// The previous one is mainly for backward compatibility.
+    virtual const DB::ActionsDAG::Node * parse(
+        const CommonFunctionInfo & func_info,
+        DB::ActionsDAGPtr & actions_dag) const;
+
+    /// In some special cases, different arguments size or different arguments types may refer to different
+    /// CH function implementation.
+    virtual String getCHFunctionName(const CommonFunctionInfo & func_info) const;
+    /// In most cases, arguments size and types are enough to determine the CH function implementation.
+    /// This is only be used in SerializedPlanParser::parseNameStructure.
+    virtual String getCHFunctionName(const DB::DataTypes & args) const;
+
+    /// Do some preprojections for the function arguments, and return the necessary arguments for the CH function.
+    virtual DB::ActionsDAG::NodeRawConstPtrs parseFunctionArguments(
+        const CommonFunctionInfo & func_info,
+        const String & ch_func_name,
+        DB::ActionsDAGPtr & actions_dag) const;
+    DB::ActionsDAG::NodeRawConstPtrs parseFunctionArguments(
+        const CommonFunctionInfo & func_info,
+        DB::ActionsDAGPtr & actions_dag) const;
+
+    /// Make a postprojection for the function result.
+    virtual const DB::ActionsDAG::Node * convertNodeTypeIfNeeded(
+        const CommonFunctionInfo & func_info,
+        const DB::ActionsDAG::Node * func_node,
+        DB::ActionsDAGPtr & actions_dag) const;
+
+    /// Parameters are only used in aggregate functions at present. e.g. percentiles(0.5)(x).
+    /// 0.5 is the parameter of percentiles function.
+    virtual DB::Array parseFunctionParameters(const CommonFunctionInfo & /*func_info*/) const
+    {
+        return DB::Array();
+    }
+    /// Return the default parameters of the function. It's useful for creating a default function instance.
+    virtual DB::Array getDefaultFunctionParameters() const
+    {
+        return DB::Array();
+    }
 
 protected:
     virtual String getCHFunctionName(const substrait::Expression_ScalarFunction & substrait_func) const;
@@ -55,6 +156,20 @@ protected:
     {
         return plan_parser->toFunctionNode(action_dag, func_name, args);
     }
+    
+    const DB::ActionsDAG::Node *
+    toFunctionNode(DB::ActionsDAGPtr & action_dag, const String & func_name, const String & result_name, const DB::ActionsDAG::NodeRawConstPtrs & args) const
+    {
+        auto function_builder = DB::FunctionFactory::instance().get(func_name, getContext());
+        return &action_dag->addFunction(function_builder, args, result_name);
+    }
+
+    const DB::ActionsDAG::Node * parseExpression(DB::ActionsDAGPtr actions_dag, const substrait::Expression & rel) const
+    {
+        return plan_parser->parseExpression(actions_dag, rel);
+    }
+
+    std::pair<DataTypePtr, Field> parseLiteral(const substrait::Expression_Literal & literal) const { return plan_parser->parseLiteral(literal); }
 
     SerializedPlanParser * plan_parser;
 };
@@ -80,7 +195,6 @@ public:
         // std::cout << "register function parser with name:" << Parser::name << std::endl;
         auto creator
             = [](SerializedPlanParser * plan_parser) -> std::shared_ptr<FunctionParser> { return std::make_shared<Parser>(plan_parser); };
-
         registerFunctionParser(Parser::name, creator);
     }
 

--- a/cpp-ch/local-engine/Parser/RelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParser.cpp
@@ -16,7 +16,7 @@ namespace ErrorCodes
 namespace local_engine
 {
 AggregateFunctionPtr RelParser::getAggregateFunction(
-    DB::String & name, DB::DataTypes arg_types, DB::AggregateFunctionProperties & properties, const DB::Array & parameters)
+    const DB::String & name, DB::DataTypes arg_types, DB::AggregateFunctionProperties & properties, const DB::Array & parameters)
 {
     auto & factory = AggregateFunctionFactory::instance();
     return factory.get(name, arg_types, parameters, properties);

--- a/cpp-ch/local-engine/Parser/RelParser.h
+++ b/cpp-ch/local-engine/Parser/RelParser.h
@@ -30,11 +30,15 @@ public:
     }
 
     static AggregateFunctionPtr getAggregateFunction(
-        DB::String & name, DB::DataTypes arg_types, DB::AggregateFunctionProperties & properties, const DB::Array & parameters = {});
+        const DB::String & name,
+        DB::DataTypes arg_types,
+        DB::AggregateFunctionProperties & properties,
+        const DB::Array & parameters = {});
 
     static DB::DataTypePtr parseType(const substrait::Type & type) { return SerializedPlanParser::parseType(type); }
 
 protected:
+    inline SerializedPlanParser * getPlanParser() { return plan_parser; }
     inline ContextPtr getContext() { return plan_parser->context; }
 
     inline String getUniqueName(const std::string & name) { return plan_parser->getUniqueName(name); }
@@ -62,13 +66,6 @@ protected:
     buildFunctionNode(ActionsDAGPtr action_dag, const String & function, const DB::ActionsDAG::NodeRawConstPtrs & args)
     {
         return plan_parser->toFunctionNode(action_dag, function, args);
-    }
-
-    DB::AggregateFunctionPtr getAggregateFunction(const std::string & name, DB::DataTypes arg_types)
-    {
-        auto & factory = DB::AggregateFunctionFactory::instance();
-        DB::AggregateFunctionProperties properties;
-        return factory.get(name, arg_types, DB::Array{}, properties);
     }
 
 private:

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -156,42 +156,6 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS
        // null related functions
        {"coalesce", "coalesce"},
 
-       // aggregate functions
-       {"count", "count"},
-       {"avg", "avg"},
-       {"sum", "sum"},
-       {"min", "min"},
-       {"max", "max"},
-       {"collect_list", "groupArray"},
-       {"collect_set", "groupUniqArray"},
-       {"first", "first_value_respect_nulls"},
-       {"first_ignore_null", "first_value"},
-       {"last_ignore_null", "last_value"},
-       {"last", "last_value_respect_nulls"},
-
-       // window functions
-       {"lead", "lead"},
-       {"lag", "lag"},
-       {"dense_rank", "dense_rank"},
-       {"rank", "rank"},
-       {"row_number", "row_number"},
-       {"ntile", "ntile"},
-       {"percent_rank", "percent_rank"},
-       {"cume_dist", "cume_dist"},
-
-       // In Spark, stddev is the alias for stddev_samp.
-       {"stddev", "stddev_samp"},
-       {"stddev_samp", "stddev_samp"},
-       {"stddev_pop", "stddev_pop"},
-       {"bit_and", "groupBitAnd"},
-       {"bit_or", "groupBitOr"},
-       {"bit_xor", "groupBitXor"},
-       {"covar_pop", "covarPop"},
-       {"covar_samp", "covarSamp"},
-       {"var_samp", "varSamp"},
-       {"var_pop", "varPop"},
-       {"corr", "corr"},
-
        // date or datetime functions
        {"from_unixtime", "fromUnixTimestampInJodaSyntax"},
        {"date_add", "addDays"},
@@ -387,35 +351,6 @@ private:
 
     static std::pair<DataTypePtr, Field> parseLiteral(const substrait::Expression_Literal & literal);
     void wrapNullable(std::vector<String> columns, ActionsDAGPtr actionsDag, std::map<std::string, std::string> & nullable_measure_names);
-
-    static Aggregator::Params getAggregateParam(const Names & keys, const AggregateDescriptions & aggregates, const ContextPtr & context_)
-    {
-        const Settings & settings = context_->getSettingsRef();
-        return Aggregator::Params(
-            keys,
-            aggregates,
-            false,
-            settings.max_rows_to_group_by,
-            settings.group_by_overflow_mode,
-            settings.group_by_two_level_threshold,
-            settings.group_by_two_level_threshold_bytes,
-            settings.max_bytes_before_external_group_by,
-            settings.empty_result_for_aggregation_by_empty_set,
-            context_->getTempDataOnDisk(),
-            settings.max_threads,
-            settings.min_free_disk_space_for_temporary_data,
-            true,
-            3,
-            settings.max_block_size,
-            false,
-            false);
-    }
-
-    static Aggregator::Params getMergedAggregateParam(const Names & keys, const AggregateDescriptions & aggregates)
-    {
-        Settings settings;
-        return Aggregator::Params(keys, aggregates, false, settings.max_threads, settings.max_block_size);
-    }
 
     IQueryPlanStep * addRemoveNullableStep(QueryPlan & plan, std::vector<String> columns);
 

--- a/cpp-ch/local-engine/Parser/WindowRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/WindowRelParser.cpp
@@ -42,10 +42,11 @@ WindowRelParser::WindowRelParser(SerializedPlanParser * plan_paser_) : RelParser
 DB::QueryPlanPtr
 WindowRelParser::parse(DB::QueryPlanPtr current_plan_, const substrait::Rel & rel, std::list<const substrait::Rel *> & /*rel_stack_*/)
 {
-    // rel_stack = rel_stack_;
     const auto & win_rel_pb = rel.window();
     current_plan = std::move(current_plan_);
-    auto expected_header = current_plan->getCurrentDataStream().header;
+    input_header = current_plan->getCurrentDataStream().header;
+    // The output header is : original columns ++ window columns
+    output_header = input_header;
     for (const auto & measure : win_rel_pb.measures())
     {
         const auto & win_function = measure.measure();
@@ -53,11 +54,13 @@ WindowRelParser::parse(DB::QueryPlanPtr current_plan_, const substrait::Rel & re
         named_col.name = win_function.column_name();
         named_col.type = parseType(win_function.output_type());
         named_col.column = named_col.type->createColumn();
-        expected_header.insert(named_col);
+        output_header.insert(named_col);
     }
-    tryAddProjectionBeforeWindow(*current_plan, win_rel_pb);
 
-    auto window_descriptions = parseWindowDescriptions(win_rel_pb);
+    initWindowsInfos(win_rel_pb);
+    tryAddProjectionBeforeWindow();
+
+    auto window_descriptions = parseWindowDescriptions();
 
     /// In spark plan, there is already a sort step before each window, so we don't need to add sort steps here.
     for (auto & it : window_descriptions)
@@ -70,32 +73,22 @@ WindowRelParser::parse(DB::QueryPlanPtr current_plan_, const substrait::Rel & re
         current_plan->addStep(std::move(window_step));
     }
 
-
-    auto current_header = current_plan->getCurrentDataStream().header;
-    if (!DB::blocksHaveEqualStructure(expected_header, current_header))
-    {
-        ActionsDAGPtr convert_action = ActionsDAG::makeConvertingActions(
-            current_header.getColumnsWithTypeAndName(),
-            expected_header.getColumnsWithTypeAndName(),
-            DB::ActionsDAG::MatchColumnsMode::Name);
-        QueryPlanStepPtr convert_step = std::make_unique<DB::ExpressionStep>(current_plan->getCurrentDataStream(), convert_action);
-        convert_step->setStepDescription("Convert window Output");
-        steps.emplace_back(convert_step.get());
-        current_plan->addStep(std::move(convert_step));
-    }
+    tryAddProjectionAfterWindow();
 
     return std::move(current_plan);
 }
+
 DB::WindowDescription
-WindowRelParser::parseWindowDescrption(const substrait::WindowRel & win_rel, const substrait::Expression::WindowFunction & win_function)
+WindowRelParser::parseWindowDescription(const WindowInfo & win_info)
 {
     DB::WindowDescription win_descr;
-    win_descr.frame = parseWindowFrame(win_function);
-    win_descr.partition_by = parsePartitionBy(win_rel.partition_expressions());
-    win_descr.order_by = SortRelParser::parseSortDescription(win_rel.sorts(), current_plan->getCurrentDataStream().header);
+    win_descr.frame = parseWindowFrame(win_info);
+    win_descr.partition_by = parsePartitionBy(win_info.partition_exprs);
+    win_descr.order_by = SortRelParser::parseSortDescription(win_info.sort_fields, current_plan->getCurrentDataStream().header);
     win_descr.full_sort_description = win_descr.partition_by;
     win_descr.full_sort_description.insert(win_descr.full_sort_description.end(), win_descr.order_by.begin(), win_descr.order_by.end());
 
+    // window_name is used to identify the window description
     DB::WriteBufferFromOwnString ss;
     ss << "partition by " << DB::dumpSortDescription(win_descr.partition_by);
     ss << " order by " << DB::dumpSortDescription(win_descr.order_by);
@@ -104,42 +97,48 @@ WindowRelParser::parseWindowDescrption(const substrait::WindowRel & win_rel, con
     return win_descr;
 }
 
-std::unordered_map<DB::String, WindowDescription> WindowRelParser::parseWindowDescriptions(const substrait::WindowRel & win_rel)
+/// In CH, it put all functions into one window description if they have the same partition expressions and sort fields.
+std::unordered_map<DB::String, WindowDescription> WindowRelParser::parseWindowDescriptions()
 {
     std::unordered_map<DB::String, WindowDescription> window_descriptions;
-    for (int i = 0; i < win_rel.measures_size(); ++i)
+    for (size_t i = 0; i < win_infos.size(); ++i)
     {
-        const auto & measure = win_rel.measures(i);
+        auto & win_info = win_infos[i];
+        const auto & measure = *win_info.measure;
         const auto & win_function = measure.measure();
-        auto win_descr = parseWindowDescrption(win_rel, win_function);
+        auto win_description = parseWindowDescription(win_info);
+
+        /// Check whether there is already a window description with the same name
+        /// if the partition expressions and sort fields are the same, the window functtions belong
+        /// to the same window description.
         WindowDescription * description = nullptr;
-        const auto win_it = window_descriptions.find(win_descr.window_name);
+        const auto win_it = window_descriptions.find(win_description.window_name);
         if (win_it != window_descriptions.end())
             description = &win_it->second;
         else
         {
-            window_descriptions[win_descr.window_name] = win_descr;
-            description = &window_descriptions[win_descr.window_name];
+            window_descriptions[win_description.window_name] = win_description;
+            description = &window_descriptions[win_description.window_name];
         }
-        auto win_func = parseWindowFunctionDescription(win_rel, win_function, measures_arg_names[i], measures_arg_types[i]);
+
+        auto win_func = parseWindowFunctionDescription(
+            win_info.function_name, win_function, win_info.arg_column_names, win_info.arg_column_types, win_info.params);
         description->window_functions.emplace_back(win_func);
     }
     return window_descriptions;
 }
 
-DB::WindowFrame WindowRelParser::parseWindowFrame(const substrait::Expression::WindowFunction & window_function)
+DB::WindowFrame WindowRelParser::parseWindowFrame(const WindowInfo & win_info)
 {
-    auto function_name = parseSignatureFunctionName(window_function.function_reference());
-    if (!function_name)
-        function_name = "";
     DB::WindowFrame win_frame;
-    win_frame.type = parseWindowFrameType(*function_name, window_function);
-    parseBoundType(
-        *function_name, window_function.lower_bound(), true, win_frame.begin_type, win_frame.begin_offset, win_frame.begin_preceding);
-    parseBoundType(*function_name, window_function.upper_bound(), false, win_frame.end_type, win_frame.end_offset, win_frame.end_preceding);
+    const auto & signature_function_name = win_info.signature_function_name;
+    const auto & window_function = win_info.measure->measure();
+    win_frame.type = parseWindowFrameType(signature_function_name, window_function);
+    parseBoundType(window_function.lower_bound(), true, win_frame.begin_type, win_frame.begin_offset, win_frame.begin_preceding);
+    parseBoundType(window_function.upper_bound(), false, win_frame.end_type, win_frame.end_offset, win_frame.end_preceding);
 
     // special cases
-    if (*function_name == "lead" || *function_name == "lag")
+    if (signature_function_name == "lead" || signature_function_name == "lag")
     {
         win_frame.begin_preceding = true;
         win_frame.end_preceding = false;
@@ -180,7 +179,6 @@ WindowRelParser::parseWindowFrameType(const std::string & function_name, const s
 }
 
 void WindowRelParser::parseBoundType(
-    const std::string & ,
     const substrait::Expression::WindowFunction::Bound & bound,
     bool is_begin_or_end,
     DB::WindowFrame::BoundaryType & bound_type,
@@ -242,7 +240,6 @@ void WindowRelParser::parseBoundType(
     }
 }
 
-
 DB::SortDescription WindowRelParser::parsePartitionBy(const google::protobuf::RepeatedPtrField<substrait::Expression> & expressions)
 {
     DB::Block header = current_plan->getCurrentDataStream().header;
@@ -261,146 +258,105 @@ DB::SortDescription WindowRelParser::parsePartitionBy(const google::protobuf::Re
 }
 
 WindowFunctionDescription WindowRelParser::parseWindowFunctionDescription(
-    const substrait::WindowRel & ,
+    const String & ch_function_name,
     const substrait::Expression::WindowFunction & window_function,
     const DB::Names & arg_names,
-    const DB::DataTypes & arg_types)
+    const DB::DataTypes & arg_types,
+    const DB::Array & params)
 {
-    auto header = current_plan->getCurrentDataStream().header;
     WindowFunctionDescription description;
     description.column_name = window_function.column_name();
     description.function_node = nullptr;
-
-    auto function_name = parseFunctionName(window_function.function_reference(), {});
-    if (!function_name)
-        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Not found function for reference: {}", window_function.function_reference());
     DB::AggregateFunctionProperties agg_function_props;
-    // Special transform for lead/lag
-    if (*function_name == "lead" || *function_name == "lag")
-    {
-        if (*function_name == "lead")
-            function_name = "leadInFrame";
-        else
-            function_name = "lagInFrame";
-        auto agg_function_ptr = getAggregateFunction(*function_name, arg_types, agg_function_props);
+    auto agg_function_ptr = RelParser::getAggregateFunction(ch_function_name, arg_types, agg_function_props, params);
 
-        description.argument_names = arg_names;
-        description.argument_types = arg_types;
-        description.aggregate_function = agg_function_ptr;
-    }
-    else
-    {
-        auto agg_function_ptr = getAggregateFunction(*function_name, arg_types, agg_function_props);
-
-        description.argument_names = arg_names;
-        description.argument_types = arg_types;
-        description.aggregate_function = agg_function_ptr;
-    }
-
+    description.argument_names = arg_names;
+    description.argument_types = arg_types;
+    description.aggregate_function = agg_function_ptr;
     return description;
 }
 
-void WindowRelParser::tryAddProjectionBeforeWindow(QueryPlan & plan, const substrait::WindowRel & win_rel)
+void WindowRelParser::initWindowsInfos(const substrait::WindowRel & win_rel)
 {
-    auto header = plan.getCurrentDataStream().header;
-    ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(header.getColumnsWithTypeAndName());
-    bool need_project = false;
+    win_infos.reserve(win_rel.measures_size());
     for (const auto & measure : win_rel.measures())
     {
-        DB::Names names;
-        DB::DataTypes types;
-        auto function_name = parseSignatureFunctionName(measure.measure().function_reference());
-        if (function_name && (*function_name == "lead" || *function_name == "lag"))
-        {
-            const auto & arg0 = measure.measure().arguments(0).value();
-            auto arg1 = measure.measure().arguments(1).value();
-            /// The 3rd arg is default value
-            /// when it is set to null, the 1st arg must be nullable
-            const auto & arg2 = measure.measure().arguments(2).value();
-            const auto & col = header.getByPosition(arg0.selection().direct_reference().struct_field().field());
-            const DB::ActionsDAG::Node * node = nullptr;
-
-            if (arg2.has_literal() && arg2.literal().has_null() && !col.type->isNullable())
-            {
-                node = ActionsDAGUtil::convertNodeType(
-                    actions_dag, &actions_dag->findInOutputs(col.name), makeNullable(col.type)->getName(), col.name);
-                actions_dag->addOrReplaceInOutputs(*node);
-                names.emplace_back(node->result_name);
-                types.emplace_back(node->result_type);
-            }
-            else
-            {
-                names.emplace_back(col.name);
-                types.emplace_back(col.type);
-            }
-
-            // lag's offset is negative
-            if (*function_name == "lag")
-            {
-                auto literal_result = parseLiteral(arg1.literal());
-                assert(literal_result.second.safeGet<DB::Int32>() < 0);
-                auto real_field = 0 - literal_result.second.safeGet<DB::Int32>();
-                node = &actions_dag->addColumn(ColumnWithTypeAndName(
-                    literal_result.first->createColumnConst(1, real_field), literal_result.first, getUniqueName(toString(real_field))));
-            }
-            else
-            {
-                node = parseArgument(actions_dag, arg1);
-            }
-            node = ActionsDAGUtil::convertNodeType(actions_dag, node, DataTypeInt64().getName());
-            actions_dag->addOrReplaceInOutputs(*node);
-            names.emplace_back(node->result_name);
-            types.emplace_back(node->result_type);
-
-            if (arg2.has_literal() && !arg2.literal().has_null())
-            {
-                node = parseArgument(actions_dag, arg2);
-                actions_dag->addOrReplaceInOutputs(*node);
-                names.emplace_back(node->result_name);
-                types.emplace_back(node->result_type);
-            }
-            need_project = true;
-        }
-        else
-        {
-            for (int i = 0, n = measure.measure().arguments().size(); i < n; ++i)
-            {
-                const auto & arg = measure.measure().arguments(i).value();
-                if (arg.has_selection())
-                {
-                    const auto & col = header.getByPosition(arg.selection().direct_reference().struct_field().field());
-                    names.push_back(col.name);
-                    types.emplace_back(col.type);
-                }
-                else if (arg.has_literal())
-                {
-                    // for example, sum(2) over(...), we need to add new const column for 2, otherwise
-                    // an exception of not found column(2) will throw.
-                    const auto * node = parseArgument(actions_dag, arg);
-                    names.push_back(node->result_name);
-                    types.emplace_back(node->result_type);
-                    actions_dag->addOrReplaceInOutputs(*node);
-                    need_project = true;
-                }
-                else
-                {
-                    // There should be a projections ahead to eliminate complex expressions.
-                    throw Exception(ErrorCodes::UNKNOWN_TYPE, "unsupported aggregate argument type {}.", arg.DebugString());
-                }
-            }
-        }
-        measures_arg_names.emplace_back(std::move(names));
-        measures_arg_types.emplace_back(std::move(types));
-    }
-    if (need_project)
-    {
-        auto project_step = std::make_unique<ExpressionStep>(plan.getCurrentDataStream(), actions_dag);
-        project_step->setStepDescription("Add projections before aggregation");
-        steps.emplace_back(project_step.get());
-        plan.addStep(std::move(project_step));
+        WindowInfo win_info;
+        win_info.result_column_name = measure.measure().column_name();
+        win_info.measure = &measure;
+        win_info.signature_function_name = *parseSignatureFunctionName(measure.measure().function_reference());
+        win_info.parser_func_info = FunctionParser::CommonFunctionInfo(measure);
+        win_info.function_parser = FunctionParserFactory::instance().get(win_info.signature_function_name, getPlanParser());
+        win_info.function_name = win_info.function_parser->getCHFunctionName(win_info.parser_func_info);
+        win_info.partition_exprs = win_rel.partition_expressions();
+        win_info.sort_fields = win_rel.sorts();
+        win_infos.emplace_back(win_info);
     }
 }
 
+void WindowRelParser::tryAddProjectionBeforeWindow()
+{
+    auto header = current_plan->getCurrentDataStream().header;
+    ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(header.getColumnsWithTypeAndName());
+    auto dag_footprint = actions_dag->dumpDAG();
+
+    for (auto & win_info : win_infos )
+    {
+        auto arg_nodes = win_info.function_parser->parseFunctionArguments(win_info.parser_func_info, actions_dag);
+        for (auto & arg_node : arg_nodes)
+        {
+            win_info.arg_column_names.emplace_back(arg_node->result_name);
+            win_info.arg_column_types.emplace_back(arg_node->result_type);
+            actions_dag->addOrReplaceInOutputs(*arg_node);
+        } 
+        win_info.params = win_info.function_parser->parseFunctionParameters(win_info.parser_func_info);       
+    }
+
+    if (actions_dag->dumpDAG() != dag_footprint)
+    {
+        auto project_step = std::make_unique<ExpressionStep>(current_plan->getCurrentDataStream(), actions_dag);
+        project_step->setStepDescription("Add projections before window");
+        steps.emplace_back(project_step.get());
+        current_plan->addStep(std::move(project_step));
+    }
+}
+
+void WindowRelParser::tryAddProjectionAfterWindow()
+{
+    // The final result header is : original header ++ [window aggregate columns]
+    auto header = current_plan->getCurrentDataStream().header;
+    ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(header.getColumnsWithTypeAndName());
+    auto dag_footprint = actions_dag->dumpDAG();
+
+    for (size_t i = 0; i < win_infos.size(); ++i)
+    {
+        auto & win_info = win_infos[i];
+        const auto * win_result_node = &actions_dag->findInOutputs(win_info.result_column_name);
+        win_info.function_parser->convertNodeTypeIfNeeded(win_info.parser_func_info, win_result_node, actions_dag);
+    }
+
+    if (actions_dag->dumpDAG() != dag_footprint)
+    {
+        auto project_step = std::make_unique<ExpressionStep>(current_plan->getCurrentDataStream(), actions_dag);
+        project_step->setStepDescription("Add projections for window result");
+        steps.emplace_back(project_step.get());
+        current_plan->addStep(std::move(project_step));
+    }
+
+    // This projeciton will remove the const columns from the window function arguments
+    auto current_header = current_plan->getCurrentDataStream().header;
+    if (!DB::blocksHaveEqualStructure(output_header, current_header))
+    {
+        ActionsDAGPtr convert_action = ActionsDAG::makeConvertingActions(
+            current_header.getColumnsWithTypeAndName(),
+            output_header.getColumnsWithTypeAndName(),
+            DB::ActionsDAG::MatchColumnsMode::Name);
+        QueryPlanStepPtr convert_step = std::make_unique<DB::ExpressionStep>(current_plan->getCurrentDataStream(), convert_action);
+        convert_step->setStepDescription("Convert window Output");
+        steps.emplace_back(convert_step.get());
+        current_plan->addStep(std::move(convert_step));
+    }
+}
 
 void registerWindowRelParser(RelParserFactory & factory)
 {

--- a/cpp-ch/local-engine/Parser/WindowRelParser.h
+++ b/cpp-ch/local-engine/Parser/WindowRelParser.h
@@ -4,10 +4,13 @@
 #include <Core/SortDescription.h>
 #include <DataTypes/IDataType.h>
 #include <Interpreters/WindowDescription.h>
+#include <Parser/FunctionParser.h>
 #include <Parser/RelParser.h>
+#include <Parser/aggregate_function_parser/CommonAggregateFunctionParser.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Poco/Logger.h>
 #include <Common/logger_useful.h>
+
 namespace local_engine
 {
 class WindowRelParser : public RelParser
@@ -19,25 +22,43 @@ public:
     parse(DB::QueryPlanPtr current_plan_, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_) override;
 
 private:
+    struct WindowInfo
+    {
+        const substrait::WindowRel::Measure * measure = nullptr;
+        String result_column_name;
+        Strings arg_column_names;
+        DB::DataTypes arg_column_types;
+        DB::Array params;
+        String signature_function_name;
+        // function name in CH
+        String function_name;
+        // For avoiding repeated builds.
+        FunctionParser::CommonFunctionInfo parser_func_info;
+        // For avoiding repeated builds.
+        FunctionParserPtr function_parser;
+
+        google::protobuf::RepeatedPtrField<substrait::Expression> partition_exprs;
+        google::protobuf::RepeatedPtrField<substrait::SortField> sort_fields;
+
+    };
     DB::QueryPlanPtr current_plan;
-    // std::list<const substrait::Rel *> * rel_stack;
+    DB::Block input_header;
+    // The final output schema.
+    DB::Block output_header;
     Poco::Logger * logger = &Poco::Logger::get("WindowRelParser");
-    // for constructing aggregate function argument names
-    std::vector<DB::Names> measures_arg_names;
-    std::vector<DB::DataTypes> measures_arg_types;
+    std::vector<WindowInfo> win_infos;
 
     /// There will be window descrptions generated for different window frame type;
-    std::unordered_map<DB::String, WindowDescription> parseWindowDescriptions(const substrait::WindowRel & win_rel);
+    std::unordered_map<DB::String, WindowDescription> parseWindowDescriptions();
 
     // Build a window description in CH with respect to a window function, since the same
     // function may have different window frame in CH and spark.
     DB::WindowDescription
-    parseWindowDescrption(const substrait::WindowRel & win_rel, const substrait::Expression::WindowFunction & win_function);
-    DB::WindowFrame parseWindowFrame(const substrait::Expression::WindowFunction & window_function);
+    parseWindowDescription(const WindowInfo & win_info);
+    DB::WindowFrame parseWindowFrame(const WindowInfo & win_info);
     DB::WindowFrame::FrameType
     parseWindowFrameType(const std::string & function_name, const substrait::Expression::WindowFunction & window_function);
     static void parseBoundType(
-        const std::string & function_name,
         const substrait::Expression::WindowFunction::Bound & bound,
         bool is_begin_or_end,
         DB::WindowFrame::BoundaryType & bound_type,
@@ -45,12 +66,15 @@ private:
         bool & preceding);
     DB::SortDescription parsePartitionBy(const google::protobuf::RepeatedPtrField<substrait::Expression> & expressions);
     DB::WindowFunctionDescription parseWindowFunctionDescription(
-        const substrait::WindowRel & win_rel,
+        const String & ch_function_name,
         const substrait::Expression::WindowFunction & window_function,
         const DB::Names & arg_names,
-        const DB::DataTypes & arg_types);
+        const DB::DataTypes & arg_types,
+        const DB::Array & params);
 
-    void tryAddProjectionBeforeWindow(QueryPlan & plan, const substrait::WindowRel & win_rel);
+    void initWindowsInfos(const substrait::WindowRel & win_rel);
+    void tryAddProjectionBeforeWindow();
+    void tryAddProjectionAfterWindow();
 };
 
 

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.cpp
@@ -1,0 +1,9 @@
+#include "CollectListParser.h"
+#include <DataTypes/DataTypeNullable.h>
+#include <Interpreters/ActionsDAG.h>
+
+namespace local_engine
+{
+FunctionParserRegister<CollectListParser> register_collect_list;
+FunctionParserRegister<CollectSetParser> register_collect_set;
+}

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.h
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CollectListParser.h
@@ -1,0 +1,79 @@
+#pragma once
+#include "CommonAggregateFunctionParser.h"
+#include <DataTypes/DataTypeNullable.h>
+#include <Interpreters/ActionsDAG.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+}
+
+namespace local_engine
+{
+// groupArray is used to implement collect_list in spark. But there is a difference between them.
+// If all elements are null, collect_list will return [], but groupArray will return null. And clickhosue
+// has backward compatibility issue, we cannot modify the inner implementation of groupArray
+class CollectFunctionParser : public BaseAggregateFunctionParser
+{
+public:
+    explicit CollectFunctionParser(SerializedPlanParser * plan_parser_) : BaseAggregateFunctionParser(plan_parser_) { }
+    ~CollectFunctionParser() override = default;
+    virtual String getName() const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implement");
+    }
+
+    virtual String getCHFunctionName(const CommonFunctionInfo &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implement");
+    }
+
+    virtual String getCHFunctionName(const DB::DataTypes &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not implement");
+    }
+    const DB::ActionsDAG::Node * convertNodeTypeIfNeeded(
+        const CommonFunctionInfo &, const DB::ActionsDAG::Node * func_node, DB::ActionsDAGPtr & actions_dag) const override
+    {
+        const DB::ActionsDAG::Node * ret_node = func_node;
+        if (func_node->result_type->isNullable())
+        {
+            DB::ActionsDAG::NodeRawConstPtrs args = {func_node};
+            auto nested_type = typeid_cast<const DB::DataTypeNullable *>(func_node->result_type.get())->getNestedType();
+            DB::Field empty_field = nested_type->getDefault();
+            const auto * default_value_node = &actions_dag->addColumn(
+                ColumnWithTypeAndName(nested_type->createColumnConst(1, empty_field), nested_type, getUniqueName("[]")));
+            args.push_back(default_value_node);
+            const auto * if_null_node = toFunctionNode(actions_dag, "ifNull", func_node->result_name, args);
+            actions_dag->addOrReplaceInOutputs(*if_null_node);
+            ret_node = if_null_node;
+        }
+        return ret_node;
+    }
+};
+
+class CollectListParser : public CollectFunctionParser
+{
+public:
+    explicit CollectListParser(SerializedPlanParser * plan_parser_) : CollectFunctionParser(plan_parser_) { }
+    ~CollectListParser() override = default;
+    static constexpr auto name = "collect_list";
+    String getName() const override { return name; }
+    String getCHFunctionName(const CommonFunctionInfo &) const override { return "groupArray"; }
+    String getCHFunctionName(const DB::DataTypes &) const override { return "groupArray"; }
+};
+
+class CollectSetParser : public CollectFunctionParser
+{
+public:
+    explicit CollectSetParser(SerializedPlanParser * plan_parser_) : CollectFunctionParser(plan_parser_) { }
+    ~CollectSetParser() override = default;
+    static constexpr auto name = "collect_set";
+    String getName() const override { return name; }
+    String getCHFunctionName(const CommonFunctionInfo &) const override { return "groupUniqArray"; }
+    String getCHFunctionName(const DB::DataTypes &) const override { return "groupUniqArray"; }
+};
+}

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.cpp
@@ -1,0 +1,198 @@
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <DataTypes/DataTypeAggregateFunction.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <Parser/SerializedPlanParser.h>
+#include <Parser/aggregate_function_parser/CommonAggregateFunctionParser.h>
+#include <Common/CHUtil.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int UNKNOWN_TYPE;
+    extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_FUNCTION;
+}
+}
+
+namespace local_engine
+{
+
+DB::ActionsDAG::NodeRawConstPtrs BaseAggregateFunctionParser::parseFunctionArguments(
+    const CommonFunctionInfo & func_info, const String &, DB::ActionsDAGPtr & actions_dag) const
+{
+    DB::ActionsDAG::NodeRawConstPtrs collected_args;
+    const auto & inputs = actions_dag->getInputs();
+    for (const auto & arg : func_info.arguments)
+    {
+        auto arg_value = arg.value();
+        const DB::ActionsDAG::Node * arg_node = nullptr;
+        if (arg_value.has_selection())
+        {
+            auto col_pos = arg_value.selection().direct_reference().struct_field().field();
+            arg_node = inputs[col_pos];
+        }
+        else if (arg_value.has_literal())
+        {
+            const auto * node = parseExpression(actions_dag, arg_value);
+            actions_dag->addOrReplaceInOutputs(*node);
+            arg_node = node;
+        }
+        else
+        {
+            // For aggregate function, the only supported argument type is selection or literal.
+            throw Exception(DB::ErrorCodes::UNKNOWN_TYPE, "Unsupported argument type: {}", arg.DebugString());
+        }
+
+        // If the aggregate result is required to be nullable, make all inputs be nullable at the first stage.
+        auto required_output_type = DB::WhichDataType(SerializedPlanParser::parseType(func_info.output_type));
+        if (required_output_type.isNullable()
+            && func_info.phase == substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE
+            && !arg_node->result_type->isNullable())
+        {
+            ActionsDAG::NodeRawConstPtrs args;
+            args.emplace_back(arg_node);
+            const auto * node = toFunctionNode(actions_dag, "toNullable", args);
+            actions_dag->addOrReplaceInOutputs(*node);
+            arg_node = node;
+        }
+
+        collected_args.push_back(arg_node);
+    }
+    if (func_info.has_filter)
+    {
+        // With `If` combinator, the function take one more argument which refers to the condition.
+        const auto * action_node = parseExpression(actions_dag, func_info.filter);
+        collected_args.emplace_back(action_node);
+    }
+    return collected_args;
+}
+
+const DB::ActionsDAG::Node * BaseAggregateFunctionParser::convertNodeTypeIfNeeded(
+    const CommonFunctionInfo & func_info, const DB::ActionsDAG::Node * func_node, DB::ActionsDAGPtr & actions_dag) const
+{
+    auto ret_node = func_node;
+    auto output_type = SerializedPlanParser::parseType(func_info.output_type);
+    if (!output_type->equals(*func_node->result_type))
+    {
+        ret_node = ActionsDAGUtil::convertNodeType(actions_dag, func_node, output_type->getName(), func_node->result_name);
+        actions_dag->addOrReplaceInOutputs(*ret_node);
+    }
+    return ret_node;
+}
+
+std::pair<String, DB::DataTypes> BaseAggregateFunctionParser::tryApplyCHCombinator(
+    const CommonFunctionInfo & func_info, const String & ch_func_name, const DB::DataTypes & arg_column_types) const
+{
+    auto get_aggregate_function = [](const String & name, const DB::DataTypes & arg_types) -> DB::AggregateFunctionPtr
+    {
+        DB::AggregateFunctionProperties properties;
+        auto func = DB::AggregateFunctionFactory::instance().get(name, arg_types, DB::Array{}, properties);
+        if (!func)
+        {
+            throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unknown aggregate function {}", name);
+        }
+        return func;
+    };
+    String combinator_function_name = ch_func_name;
+    DB::DataTypes combinator_arg_column_types = arg_column_types;
+    if (func_info.phase != substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE)
+    {
+        if (arg_column_types.size() != 1)
+        {
+            throw Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Only support one argument aggregate function in phase {}", func_info.phase);
+        }
+        // Add a check here for safty.
+        if (func_info.has_filter)
+        {
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Unspport apply filter in phase {}", func_info.phase);
+        }
+
+        const auto * agg_function_data = DB::checkAndGetDataType<DB::DataTypeAggregateFunction>(arg_column_types[0].get());
+        if (!agg_function_data)
+        {
+            // FIXME. This is should be fixed. It's the case that count(distinct(xxx)) with other aggregate functions.
+            // Gluten breaks the rule that intermediate result should have a special format name here.
+            LOG_INFO(logger, "Intermediate aggregate function data is expected in phase {} for {}", func_info.phase, ch_func_name);
+            auto arg_type = DB::removeNullable(arg_column_types[0]);
+            if (auto * tupe_type = typeid_cast<const DB::DataTypeTuple *>(arg_type.get()))
+            {
+                combinator_arg_column_types = tupe_type->getElements();
+            }
+            auto agg_function = get_aggregate_function(ch_func_name, arg_column_types);
+            auto agg_intermediate_result_type = agg_function->getStateType();
+            combinator_arg_column_types = {agg_intermediate_result_type};
+        }
+        else
+        {
+            // Special case for handling the intermedidate result from aggregate functions with filter.
+            // It's safe to use AggregateFunctionxxx to parse intermediate result from AggregateFunctionxxxIf,
+            // since they have the same binary representation
+            // reproduce this case by
+            //  select
+            //    count(a),count(b), count(1), count(distinct(a)), count(distinct(b))
+            //  from values (1, null), (2,2) as data(a,b)
+            // with `first_value` enable
+            if (endsWith(agg_function_data->getFunction()->getName(), "If") && ch_func_name != agg_function_data->getFunction()->getName())
+            {
+                auto original_args_types = agg_function_data->getArgumentsDataTypes();
+                combinator_arg_column_types = DataTypes(original_args_types.begin(), std::prev(original_args_types.end()));
+                auto agg_function = get_aggregate_function(ch_func_name, combinator_arg_column_types);
+                combinator_arg_column_types = {agg_function->getStateType()};
+            }
+        }
+        combinator_function_name += "PartialMerge";
+    }
+    else if (func_info.has_filter)
+    {
+        // Apply `If` aggregate function combinator on the original aggregate function.
+        combinator_function_name += "If";
+    }
+    return {combinator_function_name, combinator_arg_column_types};
+}
+
+#define REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(cls_name, substait_name, ch_name) \
+    class AggregateFunctionParser##cls_name : public BaseAggregateFunctionParser \
+    { \
+    public: \
+        AggregateFunctionParser##cls_name(SerializedPlanParser * plan_parser_) : BaseAggregateFunctionParser(plan_parser_) \
+        { \
+        } \
+        ~AggregateFunctionParser##cls_name() override = default; \
+        String getName() const override { return  #substait_name; } \
+        static constexpr auto name = #substait_name; \
+        String getCHFunctionName(const CommonFunctionInfo &) const override { return #ch_name; } \
+        String getCHFunctionName(const DB::DataTypes &) const override { return #ch_name; } \
+    }; \
+    static const FunctionParserRegister<AggregateFunctionParser##cls_name> register_##cls_name = FunctionParserRegister<AggregateFunctionParser##cls_name>();
+
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Count, count, count)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Sum, sum, sum)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Avg, avg, avg)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Min, min, min)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Max, max, max)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(StdDev, stddev, stddev_samp)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(StdDevSamp, stddev_samp, stddev_samp)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(StdDevPop, stddev_pop, stddev_pop)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(BitAnd, bit_and, groupBitAnd)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(BitOr, bit_or, groupBitOr)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(BitXor, bit_xor, groupBitXor)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(CovarPop, covar_pop, covarPop)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(CovarSamp, covar_samp, covarSamp)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(VarSamp, var_samp, varSamp)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(VarPop, var_pop, varPop)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Corr, corr, corr)
+
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(First, first, first_value_respect_nulls)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(FirstIgnoreNull, first_ignore_null, first_value)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Last, last, last_value_respect_nulls)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(LastIgnoreNull, last_ignore_null, last_value)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(DenseRank, dense_rank, dense_rank)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Rank, rank, rank)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(RowNumber, row_number, row_number)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Ntile, ntile, ntile)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(PercentRank, percent_rank, percent_rank)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(CumeDist, cume_dist, cume_dist)
+}

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.h
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <utility>
+#include <DataTypes/IDataType.h>
+#include <Parser/FunctionParser.h>
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
+
+namespace local_engine
+{
+class BaseAggregateFunctionParser: public FunctionParser
+{
+public:
+    explicit BaseAggregateFunctionParser(SerializedPlanParser * plan_parser_) : FunctionParser(plan_parser_) { }
+    virtual ~BaseAggregateFunctionParser() override = default;
+
+    virtual String getName() const override { return "BaseAggregateFunctionParser"; }
+
+    virtual DB::ActionsDAG::NodeRawConstPtrs parseFunctionArguments(
+        const CommonFunctionInfo & func_info,
+        const String & ch_func_name,
+        DB::ActionsDAGPtr & actions_dag) const override;
+
+    virtual const DB::ActionsDAG::Node * convertNodeTypeIfNeeded(
+        const CommonFunctionInfo & func_info,
+        const DB::ActionsDAG::Node * func_node,
+        DB::ActionsDAGPtr & actions_dag) const override;
+
+    // `PartialMerge` is applied on the merging stages.
+    // `If` is applied when the aggreate function has a filter. This should only happen on the 1st stage.
+    // If no combinator is applied, return (ch_func_name,arg_column_types)
+    virtual std::pair<String, DB::DataTypes>
+    tryApplyCHCombinator(const CommonFunctionInfo & func_info, const String & ch_func_name, const DB::DataTypes & arg_column_types) const;
+
+protected:
+    Poco::Logger * logger = &Poco::Logger::get("BaseAggregateFunctionParser");
+};
+
+}   // namespace local_engine

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/LeadLagParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/LeadLagParser.cpp
@@ -1,0 +1,100 @@
+#include "LeadLagParser.h"
+#include <Columns/ColumnNullable.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Common/CHUtil.h>
+
+namespace local_engine
+{
+DB::ActionsDAG::NodeRawConstPtrs
+LeadParser::parseFunctionArguments(const CommonFunctionInfo & func_info, const String & /*ch_func_name*/, DB::ActionsDAGPtr & actions_dag) const
+{
+    DB::ActionsDAG::NodeRawConstPtrs args;
+    const auto & arg0 = func_info.arguments[0].value();
+    const auto & arg1 = func_info.arguments[1].value();
+    /// The 3rd arg is default value
+    /// when it is set to null, the 1st arg must be nullable
+    const auto & arg2 = func_info.arguments[2].value();
+    const auto * arg0_col = actions_dag->getInputs()[arg0.selection().direct_reference().struct_field().field()];
+    auto arg0_col_name = arg0_col->result_name;
+    auto arg0_col_type= arg0_col->result_type;
+    const DB::ActionsDAG::Node * node = nullptr;
+    if (arg2.has_literal() && arg2.literal().has_null() && !arg0_col_type->isNullable())
+    {
+        node = ActionsDAGUtil::convertNodeType(
+            actions_dag,
+            &actions_dag->findInOutputs(arg0_col_name),
+            DB::makeNullable(arg0_col_type)->getName(),
+            arg0_col_name);
+        actions_dag->addOrReplaceInOutputs(*node);
+        args.push_back(node);
+    }
+    else
+    {
+        args.push_back(arg0_col);
+    }
+
+    node = parseExpression(actions_dag, arg1);
+    node = ActionsDAGUtil::convertNodeType(actions_dag, node, DB::DataTypeInt64().getName());
+    actions_dag->addOrReplaceInOutputs(*node);
+    args.push_back(node);
+
+    if (arg2.has_literal() && !arg2.literal().has_null())
+    {
+        node = parseExpression(actions_dag, arg2);
+        actions_dag->addOrReplaceInOutputs(*node);
+        args.push_back(node);
+    }    
+    return args;
+}
+FunctionParserRegister<LeadParser> lead_register;
+
+DB::ActionsDAG::NodeRawConstPtrs
+LagParser::parseFunctionArguments(const CommonFunctionInfo & func_info, const String & /*ch_func_name*/, DB::ActionsDAGPtr & actions_dag) const
+{
+    DB::ActionsDAG::NodeRawConstPtrs args;
+    const auto & arg0 = func_info.arguments[0].value();
+    const auto & arg1 = func_info.arguments[1].value();
+    /// The 3rd arg is default value
+    /// when it is set to null, the 1st arg must be nullable
+    const auto & arg2 = func_info.arguments[2].value();
+    const auto * arg0_col = actions_dag->getInputs()[arg0.selection().direct_reference().struct_field().field()];
+    auto arg0_col_name = arg0_col->result_name;
+    auto arg0_col_type = arg0_col->result_type;
+    const DB::ActionsDAG::Node * node = nullptr;
+    if (arg2.has_literal() && arg2.literal().has_null() && !arg0_col->result_type->isNullable())
+    {
+        node = ActionsDAGUtil::convertNodeType(
+            actions_dag,
+            &actions_dag->findInOutputs(arg0_col_name),
+            DB::makeNullable(arg0_col_type)->getName(),
+            arg0_col_name);
+        actions_dag->addOrReplaceInOutputs(*node);
+        args.push_back(node);
+    }
+    else
+    {
+        args.push_back(arg0_col);
+    }
+
+    // lag's offset is negative
+    auto literal_result = parseLiteral(arg1.literal());
+    assert(literal_result.second.safeGet<DB::Int32>() < 0);
+    auto real_field = 0 - literal_result.second.safeGet<DB::Int32>();
+    node = &actions_dag->addColumn(ColumnWithTypeAndName(
+        literal_result.first->createColumnConst(1, real_field), literal_result.first, getUniqueName(toString(real_field))));
+    node = ActionsDAGUtil::convertNodeType(actions_dag, node, DB::DataTypeInt64().getName());
+    actions_dag->addOrReplaceInOutputs(*node);
+    args.push_back(node);
+
+    if (arg2.has_literal() && !arg2.literal().has_null())
+    {
+        node = parseExpression(actions_dag, arg2);
+        actions_dag->addOrReplaceInOutputs(*node);
+        args.push_back(node);
+    }
+    return args;
+}
+FunctionParserRegister<LagParser> lag_register;
+}

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/LeadLagParser.h
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/LeadLagParser.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "CommonAggregateFunctionParser.h"
+
+namespace local_engine
+{
+class LeadParser : public BaseAggregateFunctionParser
+{
+public:
+    explicit LeadParser(SerializedPlanParser * plan_parser_) : BaseAggregateFunctionParser(plan_parser_) { }
+    ~LeadParser() override = default;
+    static constexpr auto name = "lead";
+    String getName() const override { return name; }
+    String getCHFunctionName(const CommonFunctionInfo &) const override { return "leadInFrame"; }
+    String getCHFunctionName(const DB::DataTypes &) const override { return "leadInFrame"; }
+    DB::ActionsDAG::NodeRawConstPtrs parseFunctionArguments(
+        const CommonFunctionInfo & func_info, const String & ch_func_name, DB::ActionsDAGPtr & actions_dag) const override;
+};
+
+class LagParser : public BaseAggregateFunctionParser
+{
+public:
+    explicit LagParser(SerializedPlanParser * plan_parser_) : BaseAggregateFunctionParser(plan_parser_) { }
+    ~LagParser() override = default;
+    static constexpr auto name = "lag";
+    String getName() const override { return name; }
+    String getCHFunctionName(const CommonFunctionInfo &) const override { return "lagInFrame"; }
+    String getCHFunctionName(const DB::DataTypes &) const override { return "lagInFrame"; }
+    DB::ActionsDAG::NodeRawConstPtrs parseFunctionArguments(
+        const CommonFunctionInfo & func_info, const String & ch_func_name, DB::ActionsDAGPtr & actions_dag) const override;
+};
+}

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -438,9 +438,6 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude(
       "reuse window partitionBy",
       "reuse window orderBy",
-      "collect_list in ascending ordered window",
-      "collect_list in descending ordered window",
-      "collect_set in window",
       "lead/lag with ignoreNulls",
       "Window spill with less than the inMemoryThreshold",
       "Window spill with more than the inMemoryThreshold and spillThreshold",

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameAsOfJoinSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameAsOfJoinSuite.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql
 
 class GlutenDataFrameAsOfJoinSuite extends DataFrameAsOfJoinSuite with GlutenSQLTestsBaseTrait {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes:  #2090

1. aggregate functions are used both in `window` and `aggregate` steps. The usage is common. We need codes could be shared among both steps, keep the aggregate function behavior consistent and reduce duplication of codes.
2. Implement aggregate function parsers and manage them by already existing `FunctionParserFactory`. We make some adjustment to the `FunctionParser` to support aggregate functions.


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

