### PR TITLE
[CH] Refactor: Recover warning check

### DIFF
--- a/cpp-ch/local-engine/Builder/SerializedPlanBuilder.cpp
+++ b/cpp-ch/local-engine/Builder/SerializedPlanBuilder.cpp
@@ -303,7 +303,7 @@ std::shared_ptr<substrait::Type> SerializedPlanBuilder::buildType(const DB::Data
     else
         throw Exception(ErrorCodes::UNKNOWN_TYPE, "Spark doesn't support converting from {}", ch_type->getName());
 
-    return std::move(res);
+    return res;
 }
 
 void SerializedPlanBuilder::buildType(const DB::DataTypePtr & ch_type, String & substrait_type)

--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -71,7 +71,7 @@ add_library(gluten_clickhouse_backend_libs
         ${jni_sources})
 
 target_link_libraries(gluten_clickhouse_backend_libs PUBLIC
-        substait_source                         # compile options from substait_source  
+        substrait_source                         # compile options from substrait_source
         clickhouse_aggregate_functions
         clickhouse_functions
         gluten_spark_functions

--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -71,7 +71,7 @@ add_library(gluten_clickhouse_backend_libs
         ${jni_sources})
 
 target_link_libraries(gluten_clickhouse_backend_libs PUBLIC
-        substrait_source                         # compile options from substrait_source
+        substrait_source
         clickhouse_aggregate_functions
         clickhouse_functions
         gluten_spark_functions

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -713,7 +713,6 @@ void BackendFinalizerUtil::finalizeGlobally()
 
     auto & global_context = SerializedPlanParser::global_context;
     auto & shared_context = SerializedPlanParser::shared_context;
-    auto * logger = BackendInitializerUtil::logger;
     if (global_context)
     {
         global_context->shutdown();

--- a/cpp-ch/local-engine/Operator/BlockCoalesceOperator.cpp
+++ b/cpp-ch/local-engine/Operator/BlockCoalesceOperator.cpp
@@ -5,7 +5,7 @@ namespace local_engine
 {
 void BlockCoalesceOperator::mergeBlock(DB::Block & block)
 {
-    block_buffer.add(block, 0, block.rows());
+    block_buffer.add(block, 0, static_cast<int>(block.rows()));
 }
 bool BlockCoalesceOperator::isFull()
 {

--- a/cpp-ch/local-engine/Operator/ExpandStep.cpp
+++ b/cpp-ch/local-engine/Operator/ExpandStep.cpp
@@ -36,7 +36,7 @@ ExpandStep::ExpandStep(const DB::DataStream & input_stream_, const ExpandField &
     output_header = getOutputStream().header;
 }
 
-DB::Block ExpandStep::buildOutputHeader(const DB::Block & input_header, const ExpandField & project_set_exprs_)
+DB::Block ExpandStep::buildOutputHeader(const DB::Block & , const ExpandField & project_set_exprs_)
 {
     DB::ColumnsWithTypeAndName cols;
     const auto & types = project_set_exprs_.getTypes();

--- a/cpp-ch/local-engine/Operator/ExpandTransform.cpp
+++ b/cpp-ch/local-engine/Operator/ExpandTransform.cpp
@@ -113,7 +113,7 @@ void ExpandTransform::work()
                 {
                     // Add constant column: gid, gpos, etc.
                     auto col = type->createColumnConst(rows, field);
-                    cols.push_back(std::move(col->convertToFullColumnIfConst()));
+                    cols.push_back(col->convertToFullColumnIfConst());
                 }
             }
         }

--- a/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
@@ -27,7 +27,7 @@ AggregateRelParser::AggregateRelParser(SerializedPlanParser * plan_paser_)
     : RelParser(plan_paser_)
 {}
 
-DB::QueryPlanPtr AggregateRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_)
+DB::QueryPlanPtr AggregateRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & )
 {
     setup(std::move(query_plan), rel);
     LOG_TRACE(logger, "original header is: {}", plan->getCurrentDataStream().header.dumpStructure());

--- a/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -232,8 +232,8 @@ static void writeValue(
 }
 
 SparkRowInfo::SparkRowInfo(
-    const DB::ColumnsWithTypeAndName & cols, const DB::DataTypes & types, const size_t & col_size, const size_t & row_size)
-    : types(types)
+    const DB::ColumnsWithTypeAndName & cols, const DB::DataTypes & dataTypes, const size_t & col_size, const size_t & row_size)
+    : types(dataTypes)
     , num_rows(row_size)
     , num_cols(col_size)
     , null_bitset_width_in_bytes(calculateBitSetWidthInBytes(num_cols))

--- a/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -31,7 +31,7 @@ namespace local_engine
 {
 using namespace DB;
 
-int64_t calculateBitSetWidthInBytes(int32_t num_fields)
+int64_t calculateBitSetWidthInBytes(int64_t num_fields)
 {
     return ((num_fields + 63) / 64) * 8;
 }
@@ -48,7 +48,7 @@ int64_t roundNumberOfBytesToNearestWord(int64_t num_bytes)
 }
 
 
-void bitSet(char * bitmap, int32_t index)
+void bitSet(char * bitmap, size_t index)
 {
     int64_t mask = 1L << (index & 0x3f); // mod 64 and shift
     int64_t word_offset = (index >> 6) * 8;
@@ -58,7 +58,7 @@ void bitSet(char * bitmap, int32_t index)
     memcpy(bitmap + word_offset, &value, sizeof(int64_t));
 }
 
-ALWAYS_INLINE bool isBitSet(const char * bitmap, int32_t index)
+ALWAYS_INLINE bool isBitSet(const char * bitmap, size_t index)
 {
     assert(index >= 0);
     int64_t mask = 1 << (index & 63);

--- a/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/cpp-ch/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -104,7 +104,7 @@ static void writeVariableLengthNonNullableValue(
     const std::vector<int64_t> & offsets,
     std::vector<int64_t> & buffer_cursor)
 {
-    const auto type_without_nullable{std::move(removeNullable(col.type))};
+    const auto type_without_nullable{removeNullable(col.type)};
     const bool use_raw_data = BackingDataLengthCalculator::isDataTypeSupportRawData(type_without_nullable);
     const bool big_endian = BackingDataLengthCalculator::isBigEndianInSparkRow(type_without_nullable);
     VariableLengthDataWriter writer(col.type, buffer_address, offsets, buffer_cursor);
@@ -137,7 +137,7 @@ static void writeVariableLengthNonNullableValue(
         Field field;
         for (size_t i = 0; i < static_cast<size_t>(num_rows); i++)
         {
-            field = std::move((*col.column)[i]);
+            field = (*col.column)[i];
             int64_t offset_and_size = writer.write(i, field, 0);
             memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
         }
@@ -156,7 +156,7 @@ static void writeVariableLengthNullableValue(
     const auto * nullable_column = checkAndGetColumn<ColumnNullable>(*col.column);
     const auto & null_map = nullable_column->getNullMapData();
     const auto & nested_column = nullable_column->getNestedColumn();
-    const auto type_without_nullable{std::move(removeNullable(col.type))};
+    const auto type_without_nullable{removeNullable(col.type)};
     const bool use_raw_data = BackingDataLengthCalculator::isDataTypeSupportRawData(type_without_nullable);
     const bool big_endian = BackingDataLengthCalculator::isBigEndianInSparkRow(type_without_nullable);
     VariableLengthDataWriter writer(col.type, buffer_address, offsets, buffer_cursor);
@@ -193,7 +193,7 @@ static void writeVariableLengthNullableValue(
                 bitSet(buffer_address + offsets[i], col_index);
             else
             {
-                field = std::move(nested_column[i]);
+                field = nested_column[i];
                 int64_t offset_and_size = writer.write(i, field, 0);
                 memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
             }
@@ -211,7 +211,7 @@ static void writeValue(
     const std::vector<int64_t> & offsets,
     std::vector<int64_t> & buffer_cursor)
 {
-    const auto type_without_nullable{std::move(removeNullable(col.type))};
+    const auto type_without_nullable{removeNullable(col.type)};
     const auto is_nullable = isColumnNullable(*col.column);
     if (BackingDataLengthCalculator::isFixedLengthDataType(type_without_nullable))
     {

--- a/cpp-ch/local-engine/Parser/CHColumnToSparkRow.h
+++ b/cpp-ch/local-engine/Parser/CHColumnToSparkRow.h
@@ -8,10 +8,10 @@
 
 namespace local_engine
 {
-int64_t calculateBitSetWidthInBytes(int32_t num_fields);
+int64_t calculateBitSetWidthInBytes(int64_t num_fields);
 int64_t roundNumberOfBytesToNearestWord(int64_t num_bytes);
-void bitSet(char * bitmap, int32_t index);
-bool isBitSet(const char * bitmap, int32_t index);
+void bitSet(char * bitmap, size_t index);
+bool isBitSet(const char * bitmap, size_t index);
 
 class CHColumnToSparkRow;
 class SparkRowToCHColumn;

--- a/cpp-ch/local-engine/Parser/ExpandRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpandRelParser.cpp
@@ -33,7 +33,7 @@ void updateType(DB::DataTypePtr & type, const DB::DataTypePtr & new_type)
 }
 
 DB::QueryPlanPtr
-ExpandRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack)
+ExpandRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> &)
 {
     const auto & expand_rel = rel.expand();
     const auto & header = query_plan->getCurrentDataStream().header;

--- a/cpp-ch/local-engine/Parser/FunctionExecutor.cpp
+++ b/cpp-ch/local-engine/Parser/FunctionExecutor.cpp
@@ -35,17 +35,18 @@ void FunctionExecutor::buildExpression()
 
     Int32 field = 0;
     auto * arguments = scalar_function->mutable_arguments();
-    for (const auto & input_type : input_types)
-    {
-        substrait::FunctionArgument argument;
-        auto * value = argument.mutable_value();
-        auto * selection = value->mutable_selection();
-        auto * direct_reference = selection->mutable_direct_reference();
-        auto * struct_field = direct_reference->mutable_struct_field();
-        struct_field->set_field(field++);
 
-        arguments->Add(std::move(argument));
-    }
+    std::for_each(input_types.cbegin(), input_types.cend(),
+      [&](const auto & ) {
+          substrait::FunctionArgument argument;
+          auto * value = argument.mutable_value();
+          auto * selection = value->mutable_selection();
+          auto * direct_reference = selection->mutable_direct_reference();
+          auto * struct_field = direct_reference->mutable_struct_field();
+          struct_field->set_field(field++);
+
+          arguments->Add(std::move(argument));
+    });
 }
 
 void FunctionExecutor::buildHeader()

--- a/cpp-ch/local-engine/Parser/FunctionParser.cpp
+++ b/cpp-ch/local-engine/Parser/FunctionParser.cpp
@@ -35,12 +35,6 @@ ActionsDAG::NodeRawConstPtrs FunctionParser::parseFunctionArguments(
     const String & ch_func_name,
     ActionsDAGPtr & actions_dag) const
 {
-    auto add_column = [&](const DataTypePtr & type, const Field & field) -> auto
-    {
-        return &actions_dag->addColumn(
-            ColumnWithTypeAndName(type->createColumnConst(1, field), type, plan_parser->getUniqueName(toString(field))));
-    };
-
     ActionsDAG::NodeRawConstPtrs parsed_args;
     const auto & args = substrait_func.arguments();
     parsed_args.reserve(args.size());

--- a/cpp-ch/local-engine/Parser/RelMetric.cpp
+++ b/cpp-ch/local-engine/Parser/RelMetric.cpp
@@ -51,16 +51,16 @@ void RelMetric::serialize(Writer<StringBuffer> & writer, bool) const
 {
     writer.StartObject();
     writer.Key("id");
-    writer.Uint(id);
+    writer.Uint64(id);
     writer.Key("name");
     writer.String(name.c_str());
     RelMetricTimes timeMetrics = getTotalTime();
     writer.Key("time");
-    writer.Uint(timeMetrics.time);
+    writer.Uint64(timeMetrics.time);
     writer.Key("input_wait_time");
-    writer.Uint(timeMetrics.input_wait_elapsed_us);
+    writer.Uint64(timeMetrics.input_wait_elapsed_us);
     writer.Key("output_wait_time");
-    writer.Uint(timeMetrics.output_wait_elapsed_us);
+    writer.Uint64(timeMetrics.output_wait_elapsed_us);
     if (!steps.empty())
     {
         writer.Key("steps");
@@ -80,15 +80,15 @@ void RelMetric::serialize(Writer<StringBuffer> & writer, bool) const
                 writer.Key("name");
                 writer.String(processor->getName().c_str());
                 writer.Key("time");
-                writer.Uint(processor->getElapsedUs());
+                writer.Uint64(processor->getElapsedUs());
                 writer.Key("output_rows");
-                writer.Uint(processor->getProcessorDataStats().output_rows);
+                writer.Uint64(processor->getProcessorDataStats().output_rows);
                 writer.Key("output_bytes");
-                writer.Uint(processor->getProcessorDataStats().output_bytes);
+                writer.Uint64(processor->getProcessorDataStats().output_bytes);
                 writer.Key("input_rows");
-                writer.Uint(processor->getProcessorDataStats().input_rows);
+                writer.Uint64(processor->getProcessorDataStats().input_rows);
                 writer.Key("input_bytes");
-                writer.Uint(processor->getProcessorDataStats().input_bytes);
+                writer.Uint64(processor->getProcessorDataStats().input_bytes);
                 writer.EndObject();
             }
             writer.EndArray();

--- a/cpp-ch/local-engine/Parser/RelMetric.cpp
+++ b/cpp-ch/local-engine/Parser/RelMetric.cpp
@@ -47,7 +47,7 @@ RelMetricTimes RelMetric::getTotalTime() const
     return timeMetrics;
 }
 
-void RelMetric::serialize(Writer<StringBuffer> & writer, bool summary) const
+void RelMetric::serialize(Writer<StringBuffer> & writer, bool) const
 {
     writer.StartObject();
     writer.Key("id");

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1611,7 +1611,7 @@ ActionsDAGPtr SerializedPlanParser::parseJsonTuple(
     std::vector<String> & result_names,
     ActionsDAGPtr actions_dag,
     bool keep_result,
-    bool position)
+    bool)
 {
     if (!actions_dag)
     {

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -220,7 +220,6 @@ std::string getDecimalFunction(const substrait::Type_Decimal & decimal, bool nul
 {
     std::string ch_function_name;
     UInt32 precision = decimal.precision();
-    UInt32 scale = decimal.scale();
 
     if (precision <= DataTypeDecimal32::maxPrecision())
         ch_function_name = "toDecimal32";
@@ -891,7 +890,6 @@ NamesAndTypesList SerializedPlanParser::blockToNameAndTypeList(const Block & hea
 std::string
 SerializedPlanParser::getFunctionName(const std::string & function_signature, const substrait::Expression_ScalarFunction & function)
 {
-    const auto & output_type = function.output_type();
     auto args = function.arguments();
     auto pos = function_signature.find(':');
     auto function_name = function_signature.substr(0, pos);

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -472,7 +472,7 @@ class ASTParser
 {
 public:
     explicit ASTParser(const ContextPtr & _context, std::unordered_map<std::string, std::string> & _function_mapping)
-        : context(_context), function_mapping(_function_mapping){};
+        : context(_context), function_mapping(_function_mapping){}
     ~ASTParser() = default;
 
     ASTPtr parseToAST(const Names & names, const substrait::Expression & rel);

--- a/cpp-ch/local-engine/Parser/SortRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/SortRelParser.cpp
@@ -24,7 +24,6 @@ SortRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, st
     size_t limit = parseLimit(rel_stack_);
     const auto & sort_rel = rel.sort();
     auto sort_descr = parseSortDescription(sort_rel.sorts(), query_plan->getCurrentDataStream().header);
-    const auto & settings = getContext()->getSettingsRef();
     auto sorting_step = std::make_unique<DB::SortingStep>(
         query_plan->getCurrentDataStream(), sort_descr, limit, SortingStep::Settings(*getContext()), false);
     sorting_step->setStepDescription("Sorting step");

--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -35,7 +35,7 @@ jmethodID SparkRowToCHColumn::spark_row_iterator_nextBatch = nullptr;
 ALWAYS_INLINE static void writeRowToColumns(std::vector<MutableColumnPtr> & columns, const SparkRowReader & spark_row_reader)
 {
     auto num_fields = columns.size();
-    const auto & field_types = spark_row_reader.getFieldTypes();
+
     for (size_t i = 0; i < num_fields; i++)
     {
         if (spark_row_reader.supportRawData(i))
@@ -178,7 +178,7 @@ Field VariableLengthDataReader::readArray(const char * buffer, [[maybe_unused]] 
     const auto * array_type = typeid_cast<const DataTypeArray *>(type_without_nullable.get());
     const auto & nested_type = array_type->getNestedType();
     const auto elem_size = BackingDataLengthCalculator::getArrayElementSize(nested_type);
-    const auto len_values = roundNumberOfBytesToNearestWord(elem_size * num_elems);
+
     Array array;
     array.reserve(num_elems);
 

--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -68,7 +68,8 @@ std::unique_ptr<Block> SparkRowToCHColumn::convertSparkRowInfoToCHColumn(const S
         SparkRowReader row_reader(types);
         for (int64_t i = 0; i < num_rows; i++)
         {
-            row_reader.pointTo(spark_row_info.getBufferAddress() + spark_row_info.getOffsets()[i], spark_row_info.getLengths()[i]);
+            row_reader.pointTo(spark_row_info.getBufferAddress() + spark_row_info.getOffsets()[i],
+                               static_cast<int32_t>(spark_row_info.getLengths()[i]));
             writeRowToColumns(mutable_columns, row_reader);
         }
         block->setColumns(std::move(mutable_columns));

--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -40,7 +40,7 @@ ALWAYS_INLINE static void writeRowToColumns(std::vector<MutableColumnPtr> & colu
     {
         if (spark_row_reader.supportRawData(i))
         {
-            const StringRef str_ref{std::move(spark_row_reader.getStringRef(i))};
+            const StringRef str_ref{spark_row_reader.getStringRef(i)};
             if (str_ref.data == nullptr)
                 columns[i]->insertData(nullptr, str_ref.size);
             else if (!spark_row_reader.isBigEndianInSparkRow(i))
@@ -59,12 +59,12 @@ std::unique_ptr<Block> SparkRowToCHColumn::convertSparkRowInfoToCHColumn(const S
     const auto num_rows = spark_row_info.getNumRows();
     if (header.columns())
     {
-        *block = std::move(header.cloneEmpty());
-        MutableColumns mutable_columns{std::move(block->mutateColumns())};
+        *block = header.cloneEmpty();
+        MutableColumns mutable_columns{block->mutateColumns()};
         for (size_t col_i = 0; col_i < header.columns(); ++col_i)
             mutable_columns[col_i]->reserve(num_rows);
 
-        DataTypes types{std::move(header.getDataTypes())};
+        DataTypes types{header.getDataTypes()};
         SparkRowReader row_reader(types);
         for (int64_t i = 0; i < num_rows; i++)
         {
@@ -78,7 +78,7 @@ std::unique_ptr<Block> SparkRowToCHColumn::convertSparkRowInfoToCHColumn(const S
         // This is a special case for count(1)/count(*)
         *block = BlockUtil::buildRowCountBlock(num_rows);
     }
-    return std::move(block);
+    return block;
 }
 
 void SparkRowToCHColumn::appendSparkRowToCHColumn(SparkRowToCHColumnHelper & helper, char * buffer, int32_t length)
@@ -94,7 +94,7 @@ Block * SparkRowToCHColumn::getBlock(SparkRowToCHColumnHelper & helper)
     auto * block = new Block();
     if (helper.header.columns())
     {
-        *block = std::move(helper.header.cloneEmpty());
+        *block = helper.header.cloneEmpty();
         block->setColumns(std::move(helper.mutable_columns));
     }
     else
@@ -120,19 +120,19 @@ VariableLengthDataReader::VariableLengthDataReader(const DataTypePtr & type_)
 Field VariableLengthDataReader::read(const char * buffer, size_t length) const
 {
     if (which.isStringOrFixedString())
-        return std::move(readString(buffer, length));
+        return readString(buffer, length);
 
     if (which.isDecimal128())
-        return std::move(readDecimal(buffer, length));
+        return readDecimal(buffer, length);
 
     if (which.isArray())
-        return std::move(readArray(buffer, length));
+        return readArray(buffer, length);
 
     if (which.isMap())
-        return std::move(readMap(buffer, length));
+        return readMap(buffer, length);
 
     if (which.isTuple())
-        return std::move(readStruct(buffer, length));
+        return readStruct(buffer, length);
 
     throw Exception(ErrorCodes::UNKNOWN_TYPE, "VariableLengthDataReader doesn't support type {}", type->getName());
 }
@@ -153,13 +153,13 @@ Field VariableLengthDataReader::readDecimal(const char * buffer, size_t length) 
 
     auto * decimal128 = reinterpret_cast<Decimal128 *>(buf.data());
     const auto * decimal128_type = typeid_cast<const DataTypeDecimal128 *>(type_without_nullable.get());
-    return std::move(DecimalField<Decimal128>(std::move(*decimal128), decimal128_type->getScale()));
+    return DecimalField<Decimal128>(std::move(*decimal128), decimal128_type->getScale());
 }
 
 Field VariableLengthDataReader::readString(const char * buffer, size_t length) const
 {
     String str(buffer, length);
-    return std::move(Field(std::move(str)));
+    return Field(std::move(str));
 }
 
 Field VariableLengthDataReader::readArray(const char * buffer, [[maybe_unused]] size_t length) const
@@ -189,7 +189,7 @@ Field VariableLengthDataReader::readArray(const char * buffer, [[maybe_unused]] 
         {
             if (isBitSet(buffer + 8, i))
             {
-                array.emplace_back(std::move(Null{}));
+                array.emplace_back(Null{});
             }
             else
             {
@@ -205,7 +205,7 @@ Field VariableLengthDataReader::readArray(const char * buffer, [[maybe_unused]] 
         {
             if (isBitSet(buffer + 8, i))
             {
-                array.emplace_back(std::move(Null{}));
+                array.emplace_back(Null{});
             }
             else
             {
@@ -232,7 +232,7 @@ Field VariableLengthDataReader::readMap(const char * buffer, size_t length) cons
     int64_t key_array_size = 0;
     memcpy(&key_array_size, buffer, 8);
     if (key_array_size == 0 || length == 0)
-        return std::move(Map());
+        return Map();
 
     /// Read UnsafeArrayData of keys
     const auto * map_type = typeid_cast<const DataTypeMap *>(type_without_nullable.get());
@@ -271,7 +271,7 @@ Field VariableLengthDataReader::readStruct(const char * buffer, size_t /*length*
     const auto & field_types = tuple_type->getElements();
     const auto num_fields = field_types.size();
     if (num_fields == 0)
-        return std::move(Tuple());
+        return Tuple();
 
     const auto len_null_bitmap = calculateBitSetWidthInBytes(num_fields);
 
@@ -281,14 +281,14 @@ Field VariableLengthDataReader::readStruct(const char * buffer, size_t /*length*
         const auto & field_type = field_types[i];
         if (isBitSet(buffer, i))
         {
-            tuple[i] = std::move(Null{});
+            tuple[i] = Null{};
             continue;
         }
 
         if (BackingDataLengthCalculator::isFixedLengthDataType(removeNullable(field_type)))
         {
             FixedLengthDataReader reader(field_type);
-            tuple[i] = std::move(reader.read(buffer + len_null_bitmap + i * 8));
+            tuple[i] = reader.read(buffer + len_null_bitmap + i * 8);
         }
         else if (BackingDataLengthCalculator::isVariableLengthDataType(removeNullable(field_type)))
         {
@@ -298,7 +298,7 @@ Field VariableLengthDataReader::readStruct(const char * buffer, size_t /*length*
             const int64_t size = BackingDataLengthCalculator::extractSize(offset_and_size);
 
             VariableLengthDataReader reader(field_type);
-            tuple[i] = std::move(reader.read(buffer + offset, size));
+            tuple[i] = reader.read(buffer + offset, size);
         }
         else
             throw Exception(ErrorCodes::UNKNOWN_TYPE, "VariableLengthDataReader doesn't support type {}", field_type->getName());
@@ -403,7 +403,7 @@ Field FixedLengthDataReader::read(const char * buffer) const
         memcpy(&value, buffer, 4);
 
         const auto * decimal32_type = typeid_cast<const DataTypeDecimal32 *>(type_without_nullable.get());
-        return std::move(DecimalField{value, decimal32_type->getScale()});
+        return DecimalField{value, decimal32_type->getScale()};
     }
 
     if (which.isDecimal64() || which.isDateTime64())
@@ -413,7 +413,7 @@ Field FixedLengthDataReader::read(const char * buffer) const
 
         UInt32 scale = which.isDecimal64() ? typeid_cast<const DataTypeDecimal64 *>(type_without_nullable.get())->getScale()
                                            : typeid_cast<const DataTypeDateTime64 *>(type_without_nullable.get())->getScale();
-        return std::move(DecimalField{value, scale});
+        return DecimalField{value, scale};
     }
     throw Exception(ErrorCodes::UNKNOWN_TYPE, "FixedLengthDataReader doesn't support type {}", type->getName());
 }

--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.h
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.h
@@ -159,14 +159,14 @@ public:
     explicit SparkRowReader(const DataTypes & field_types_)
         : field_types(field_types_)
         , num_fields(field_types.size())
-        , bit_set_width_in_bytes(calculateBitSetWidthInBytes(num_fields))
+        , bit_set_width_in_bytes(static_cast<int32_t>(calculateBitSetWidthInBytes(num_fields)))
         , field_offsets(num_fields)
         , support_raw_datas(num_fields)
         , is_big_endians_in_spark_row(num_fields)
         , fixed_length_data_readers(num_fields)
         , variable_length_data_readers(num_fields)
     {
-        for (auto ordinal = 0; ordinal < num_fields; ++ordinal)
+        for (size_t ordinal = 0; ordinal < num_fields; ++ordinal)
         {
             const auto type_without_nullable = removeNullable(field_types[ordinal]);
             field_offsets[ordinal] = bit_set_width_in_bytes + ordinal * 8L;
@@ -183,13 +183,13 @@ public:
 
     const DataTypes & getFieldTypes() const { return field_types; }
 
-    bool supportRawData(int ordinal) const
+    bool supportRawData(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return support_raw_datas[ordinal];
     }
 
-    bool isBigEndianInSparkRow(int ordinal) const
+    bool isBigEndianInSparkRow(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return is_big_endians_in_spark_row[ordinal];
@@ -207,79 +207,79 @@ public:
         return variable_length_data_readers[ordinal];
     }
 
-    void assertIndexIsValid([[maybe_unused]] int index) const
+    void assertIndexIsValid([[maybe_unused]] size_t index) const
     {
         assert(index >= 0);
         assert(index < num_fields);
     }
 
-    bool isNullAt(int ordinal) const
+    bool isNullAt(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return isBitSet(buffer, ordinal);
     }
 
-    const char * getRawDataForFixedNumber(int ordinal) const
+    const char * getRawDataForFixedNumber(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return reinterpret_cast<const char *>(getFieldOffset(ordinal));
     }
 
-    int8_t getByte(int ordinal) const
+    int8_t getByte(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const int8_t *>(getFieldOffset(ordinal));
     }
 
-    uint8_t getUnsignedByte(int ordinal) const
+    uint8_t getUnsignedByte(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const uint8_t *>(getFieldOffset(ordinal));
     }
 
-    int16_t getShort(int ordinal) const
+    int16_t getShort(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const int16_t *>(getFieldOffset(ordinal));
     }
 
-    uint16_t getUnsignedShort(int ordinal) const
+    uint16_t getUnsignedShort(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const uint16_t *>(getFieldOffset(ordinal));
     }
 
-    int32_t getInt(int ordinal) const
+    int32_t getInt(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const int32_t *>(getFieldOffset(ordinal));
     }
 
-    uint32_t getUnsignedInt(int ordinal) const
+    uint32_t getUnsignedInt(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const uint32_t *>(getFieldOffset(ordinal));
     }
 
-    int64_t getLong(int ordinal) const
+    int64_t getLong(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const int64_t *>(getFieldOffset(ordinal));
     }
 
-    float_t getFloat(int ordinal) const
+    float_t getFloat(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const float_t *>(getFieldOffset(ordinal));
     }
 
-    double_t getDouble(int ordinal) const
+    double_t getDouble(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return *reinterpret_cast<const double_t *>(getFieldOffset(ordinal));
     }
 
-    StringRef getString(int ordinal) const
+    StringRef getString(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         int64_t offset_and_size = getLong(ordinal);
@@ -288,7 +288,7 @@ public:
         return StringRef(reinterpret_cast<const char *>(this->buffer + offset), size);
     }
 
-    int32_t getStringSize(int ordinal) const
+    int32_t getStringSize(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         return static_cast<int32_t>(getLong(ordinal));
@@ -300,7 +300,7 @@ public:
         length = length_;
     }
 
-    StringRef getStringRef(int ordinal) const
+    StringRef getStringRef(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
         if (!support_raw_datas[ordinal])
@@ -327,7 +327,7 @@ public:
                 ErrorCodes::UNKNOWN_TYPE, "SparkRowReader::getStringRef doesn't support type {}", field_types[ordinal]->getName());
     }
 
-    Field getField(int ordinal) const
+    Field getField(size_t ordinal) const
     {
         assertIndexIsValid(ordinal);
 
@@ -352,10 +352,10 @@ public:
     }
 
 private:
-    const char * getFieldOffset(int ordinal) const { return buffer + field_offsets[ordinal]; }
+    const char * getFieldOffset(size_t ordinal) const { return buffer + field_offsets[ordinal]; }
 
     const DataTypes field_types;
-    const int32_t num_fields;
+    const size_t num_fields;
     const int32_t bit_set_width_in_bytes;
     std::vector<int64_t> field_offsets;
     std::vector<bool> support_raw_datas;

--- a/cpp-ch/local-engine/Parser/WindowRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/WindowRelParser.cpp
@@ -63,7 +63,7 @@ WindowRelParser::parse(DB::QueryPlanPtr current_plan_, const substrait::Rel & re
     for (auto & it : window_descriptions)
     {
         auto & win = it.second;
-        ;
+        
         auto window_step = std::make_unique<DB::WindowStep>(current_plan->getCurrentDataStream(), win, win.window_functions);
         window_step->setStepDescription("Window step for window '" + win.window_name + "'");
         steps.emplace_back(window_step.get());

--- a/cpp-ch/local-engine/Parser/WindowRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/WindowRelParser.cpp
@@ -220,7 +220,6 @@ void WindowRelParser::parseBoundType(
     }
     else if (bound.has_current_row())
     {
-        const auto & current_row = bound.current_row();
         bound_type = DB::WindowFrame::BoundaryType::Current;
         offset = 0;
         preceding_direction = is_begin_or_end;

--- a/cpp-ch/local-engine/Parser/WindowRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/WindowRelParser.cpp
@@ -180,7 +180,7 @@ WindowRelParser::parseWindowFrameType(const std::string & function_name, const s
 }
 
 void WindowRelParser::parseBoundType(
-    const std::string & function_name,
+    const std::string & ,
     const substrait::Expression::WindowFunction::Bound & bound,
     bool is_begin_or_end,
     DB::WindowFrame::BoundaryType & bound_type,
@@ -262,7 +262,7 @@ DB::SortDescription WindowRelParser::parsePartitionBy(const google::protobuf::Re
 }
 
 WindowFunctionDescription WindowRelParser::parseWindowFunctionDescription(
-    const substrait::WindowRel & win_rel,
+    const substrait::WindowRel & ,
     const substrait::Expression::WindowFunction & window_function,
     const DB::Names & arg_names,
     const DB::DataTypes & arg_types)

--- a/cpp-ch/local-engine/Shuffle/NativeSplitter.cpp
+++ b/cpp-ch/local-engine/Shuffle/NativeSplitter.cpp
@@ -65,7 +65,6 @@ void NativeSplitter::split(DB::Block & block)
         }
     }
 
-    bool has_active_sender = false;
     for (size_t i = 0; i < options.partition_nums; ++i)
     {
         if (partition_buffer[i]->size() >= options.buffer_size)

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.cpp
@@ -115,7 +115,7 @@ PartitionInfo RangeSelectorBuilder::build(DB::Block & block)
 
 void RangeSelectorBuilder::initSortInformation(Poco::JSON::Array::Ptr orderings)
 {
-    for (size_t i = 0; i < orderings->size(); ++i)
+    for (uint32_t i = 0; i < orderings->size(); ++i)
     {
         auto ordering = orderings->get(i).extract<Poco::JSON::Object::Ptr>();
         auto col_pos = ordering->get("column_ref").convert<DB::Int32>();
@@ -143,7 +143,7 @@ void RangeSelectorBuilder::initSortInformation(Poco::JSON::Array::Ptr orderings)
 void RangeSelectorBuilder::initRangeBlock(Poco::JSON::Array::Ptr range_bounds)
 {
     DB::ColumnsWithTypeAndName columns;
-    for (size_t i = 0; i < sort_field_types.size(); ++i)
+    for (uint32_t i = 0; i < sort_field_types.size(); ++i)
     {
         auto & type_info = sort_field_types[i];
         auto inner_col = type_info.inner_type->createColumn();
@@ -154,7 +154,7 @@ void RangeSelectorBuilder::initRangeBlock(Poco::JSON::Array::Ptr range_bounds)
             col = ColumnNullable::create(std::move(col), DB::ColumnUInt8::create(0, 0));
             data_type = std::make_shared<DB::DataTypeNullable>(data_type);
         }
-        for (size_t r = 0; r < range_bounds->size(); ++r)
+        for (uint32_t r = 0; r < range_bounds->size(); ++r)
         {
             auto row = range_bounds->get(r).extract<Poco::JSON::Array::Ptr>();
             auto field_info = row->get(i).extract<Poco::JSON::Object::Ptr>();

--- a/cpp-ch/local-engine/Shuffle/ShuffleSplitter.cpp
+++ b/cpp-ch/local-engine/Shuffle/ShuffleSplitter.cpp
@@ -138,7 +138,7 @@ void ShuffleSplitter::mergePartitionFiles()
 {
     DB::WriteBufferFromFile data_write_buffer = DB::WriteBufferFromFile(options.data_file);
     std::string buffer;
-    int buffer_size = options.io_buffer_size;
+    size_t buffer_size = options.io_buffer_size;
     buffer.reserve(buffer_size);
     for (size_t i = 0; i < options.partition_nums; ++i)
     {

--- a/cpp-ch/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
+++ b/cpp-ch/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
@@ -14,7 +14,7 @@ void WriteBufferFromJavaOutputStream::nextImpl()
     size_t bytes_write = 0;
     while (offset() - bytes_write > 0)
     {
-        size_t copy_num = std::min(offset() - bytes_write, buffer_size);
+        jint copy_num = static_cast<jint>(std::min(offset() - bytes_write, buffer_size));
         env->SetByteArrayRegion(buffer, 0, copy_num, reinterpret_cast<const jbyte *>(this->working_buffer.begin() + bytes_write));
         safeCallVoidMethod(env, output_stream, output_stream_write, buffer, 0, copy_num);
         bytes_write += copy_num;

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
@@ -50,7 +50,7 @@ protected:
     bool partIsAssignedToBackgroundOperation(const DataPartPtr & part) const override;
     size_t getNumberOfUnfinishedMutations() const override { return 0; }
     std::map<int64_t, MutationCommands> getAlterMutationCommandsForPart(const DataPartPtr & /*part*/) const override { return {}; }
-    void attachRestoredParts(MutableDataPartsVector && /*parts*/) override { throw std::runtime_error("not implement"); };
+    void attachRestoredParts(MutableDataPartsVector && /*parts*/) override { throw std::runtime_error("not implement"); }
 };
 
 }

--- a/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
+++ b/cpp-ch/local-engine/Storages/CustomStorageMergeTree.h
@@ -49,8 +49,8 @@ protected:
     void movePartitionToTable(const StoragePtr & dest_table, const ASTPtr & partition, ContextPtr context) override;
     bool partIsAssignedToBackgroundOperation(const DataPartPtr & part) const override;
     size_t getNumberOfUnfinishedMutations() const override { return 0; }
-    std::map<int64_t, MutationCommands> getAlterMutationCommandsForPart(const DataPartPtr & part) const override { return {}; }
-    void attachRestoredParts(MutableDataPartsVector && parts) override { throw std::runtime_error("not implement"); };
+    std::map<int64_t, MutationCommands> getAlterMutationCommandsForPart(const DataPartPtr & /*part*/) const override { return {}; }
+    void attachRestoredParts(MutableDataPartsVector && /*parts*/) override { throw std::runtime_error("not implement"); };
 };
 
 }

--- a/cpp-ch/local-engine/Storages/Output/ParquetOutputFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/Output/ParquetOutputFormatFile.cpp
@@ -34,7 +34,7 @@ ParquetOutputFormatFile::ParquetOutputFormatFile(
 OutputFormatFile::OutputFormatPtr ParquetOutputFormatFile::createOutputFormat(const DB::Block & header)
 {
     auto res = std::make_shared<OutputFormatFile::OutputFormat>();
-    res->write_buffer = std::move(write_buffer_builder->build(file_uri));
+    res->write_buffer = write_buffer_builder->build(file_uri);
 
     //TODO: align spark parquet config with ch parquet config
     auto format_settings = DB::getFormatSettings(context);

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalSerialization.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelDecimalSerialization.h
@@ -13,60 +13,60 @@ class ExcelDecimalSerialization final : public DB::ISerialization
 {
 public:
     explicit ExcelDecimalSerialization(const SerializationPtr & nested_, UInt32 precision_, UInt32 scale_)
-        : nested_ptr(nested_), precision(precision_), scale(scale_){};
+        : nested_ptr(nested_), precision(precision_), scale(scale_){}
 
     void serializeBinary(const Field &, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeBinary(Field &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeBinary(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeBinary(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeText(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeWholeText(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextEscaped(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextEscaped(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextQuoted(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextQuoted(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextJSON(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextJSON(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextCSV(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
 
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings &) const override;
 

--- a/cpp-ch/local-engine/Storages/Serializations/ExcelSerialization.h
+++ b/cpp-ch/local-engine/Storages/Serializations/ExcelSerialization.h
@@ -21,60 +21,60 @@ using namespace DB;
 class ExcelSerialization final : public DB::ISerialization
 {
 public:
-    explicit ExcelSerialization(const SerializationPtr & nested_, String escape_) : nested_ptr(nested_), escape(escape_){};
+    explicit ExcelSerialization(const SerializationPtr & nested_, String escape_) : nested_ptr(nested_), escape(escape_){}
 
     void serializeBinary(const Field &, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeBinary(Field &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeBinary(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeBinary(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeText(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeWholeText(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextEscaped(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextEscaped(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextQuoted(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextQuoted(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextJSON(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextJSON(IColumn &, ReadBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void serializeTextCSV(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented for excel serialization");
-    };
+    }
     void deserializeTextCSV(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const override;
 
 private:

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -7,10 +7,10 @@ macro(add_headers_and_sources_including_cc prefix common_path)
     add_glob(${prefix}_sources ${common_path}/*.cpp ${common_path}/*.c ${common_path}/*.cc ${common_path}/*.h)
 endmacro()
 
-add_headers_and_sources(substait_source .)
+add_headers_and_sources(substrait_source .)
 add_headers_and_sources_including_cc(ch_parquet arrow)
-add_library(substrait_source ${substait_source_sources})
-target_compile_options(substrait_source PUBLIC -fPIC
+add_library(substrait_source ${substrait_source_sources})
+target_compile_options(substrait_source PRIVATE
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -18,8 +18,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-extra-semi-stmt
     -Wno-extra-semi
     -Wno-unused-result
-    -Wno-unreachable-code-return
-    -Wno-unreachable-code
     -Wno-pessimizing-move
     -Wno-unreachable-code-break
     -Wno-inconsistent-missing-override

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -18,7 +18,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-pessimizing-move
     -Wno-unreachable-code-break
     -Wno-inconsistent-missing-override
-    -Wno-shadow-uncaptured-local
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -22,7 +22,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-unreachable-code-break
     -Wno-inconsistent-missing-override
     -Wno-shadow-uncaptured-local
-    -Wno-suggest-override
     -Wno-unused-member-function
     -Wno-deprecated-this-capture
     -Wno-suggest-destructor-override

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -17,7 +17,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-reserved-identifier
     -Wno-extra-semi-stmt
     -Wno-extra-semi
-    -Wno-unused-result
     -Wno-pessimizing-move
     -Wno-unreachable-code-break
     -Wno-inconsistent-missing-override

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -16,7 +16,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-extra-semi-stmt
     -Wno-extra-semi
     -Wno-pessimizing-move
-    -Wno-unreachable-code-break
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -20,7 +20,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-unreachable-code-break
     -Wno-inconsistent-missing-override
     -Wno-shadow-uncaptured-local
-    -Wno-unused-member-function
     -Wno-deprecated-this-capture
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -13,8 +13,6 @@ add_library(substrait_source ${substait_source_sources})
 target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-shorten-64-to-32
     -Wno-shadow-field-in-constructor
-    -Wno-extra-semi-stmt
-    -Wno-extra-semi
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -11,7 +11,6 @@ add_headers_and_sources(substait_source .)
 add_headers_and_sources_including_cc(ch_parquet arrow)
 add_library(substrait_source ${substait_source_sources})
 target_compile_options(substrait_source PUBLIC -fPIC
-    -Wno-shorten-64-to-32
     -Wno-shadow-field-in-constructor
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(substrait_source ${substait_source_sources})
 target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-shorten-64-to-32
     -Wno-shadow-field-in-constructor
-    -Wno-reserved-identifier
     -Wno-extra-semi-stmt
     -Wno-extra-semi
     -Wno-pessimizing-move

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -15,7 +15,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-shadow-field-in-constructor
     -Wno-extra-semi-stmt
     -Wno-extra-semi
-    -Wno-pessimizing-move
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -22,7 +22,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-unreachable-code
     -Wno-pessimizing-move
     -Wno-unreachable-code-break
-    -Wno-unused-variable
     -Wno-inconsistent-missing-override
     -Wno-shadow-uncaptured-local
     -Wno-suggest-override

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(substrait_source ${substait_source_sources})
 target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-shorten-64-to-32
     -Wno-shadow-field-in-constructor
-    -Wno-return-type
     -Wno-reserved-identifier
     -Wno-extra-semi-stmt
     -Wno-extra-semi

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -19,7 +19,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-extra-semi
     -Wno-unused-result
     -Wno-unreachable-code-return
-    -Wno-unused-parameter
     -Wno-unreachable-code
     -Wno-pessimizing-move
     -Wno-unreachable-code-break

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -17,7 +17,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-extra-semi
     -Wno-pessimizing-move
     -Wno-unreachable-code-break
-    -Wno-inconsistent-missing-override
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -9,8 +9,8 @@ endmacro()
 
 add_headers_and_sources(substait_source .)
 add_headers_and_sources_including_cc(ch_parquet arrow)
-add_library(substait_source ${substait_source_sources})
-target_compile_options(substait_source PUBLIC -fPIC
+add_library(substrait_source ${substait_source_sources})
+target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-shorten-64-to-32
     -Wno-shadow-field-in-constructor
     -Wno-return-type
@@ -33,7 +33,7 @@ target_compile_options(substait_source PUBLIC -fPIC
     -Wno-inconsistent-missing-destructor-override
 )
 
-target_link_libraries(substait_source PUBLIC
+target_link_libraries(substrait_source PUBLIC
     boost::headers_only
     ch_contrib::protobuf
     clickhouse_common_io
@@ -41,7 +41,7 @@ target_link_libraries(substait_source PUBLIC
     substrait
 )
 
-target_include_directories(substait_source SYSTEM BEFORE PUBLIC 
+target_include_directories(substrait_source SYSTEM BEFORE PUBLIC
     ${ARROW_INCLUDE_DIR}
     ${CMAKE_BINARY_DIR}/contrib/arrow-cmake/cpp/src
     ${ClickHouse_SOURCE_DIR}/contrib/arrow-cmake/cpp/src

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -11,7 +11,6 @@ add_headers_and_sources(substait_source .)
 add_headers_and_sources_including_cc(ch_parquet arrow)
 add_library(substrait_source ${substait_source_sources})
 target_compile_options(substrait_source PUBLIC -fPIC
-    -Wno-shadow-field-in-constructor
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/CMakeLists.txt
@@ -19,7 +19,6 @@ target_compile_options(substrait_source PUBLIC -fPIC
     -Wno-unreachable-code-break
     -Wno-inconsistent-missing-override
     -Wno-shadow-uncaptured-local
-    -Wno-deprecated-this-capture
     -Wno-suggest-destructor-override
     -Wno-inconsistent-missing-destructor-override
 )

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.cpp
@@ -32,7 +32,7 @@ namespace local_engine
 FormatFile::InputFormatPtr ExcelTextFormatFile::createInputFormat(const DB::Block & header)
 {
     auto res = std::make_shared<FormatFile::InputFormat>();
-    res->read_buffer = std::move(read_buffer_builder->build(file_info, true));
+    res->read_buffer = read_buffer_builder->build(file_info, true);
 
     DB::FormatSettings format_settings = createFormatSettings();
     size_t max_block_size = file_info.text().max_block_size();

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.cpp
@@ -173,7 +173,7 @@ bool ExcelTextFormatReader::readField(
     const DB::DataTypePtr & type,
     const DB::SerializationPtr & serialization,
     bool is_last_file_column,
-    const String & column_name)
+    const String & )
 {
     preSkipNullValue();
     PeekableReadBufferCheckpoint checkpoint{*buf, false};

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.h
@@ -40,7 +40,7 @@ public:
         DB::Names & input_field_names_,
         String escape_);
 
-    String getName() const { return "ExcelRowInputFormat"; }
+    String getName() const override { return "ExcelRowInputFormat"; }
 
 private:
     String escape;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ExcelTextFormatFile.h
@@ -19,7 +19,7 @@ class ExcelTextFormatFile : public FormatFile
 public:
     explicit ExcelTextFormatFile(
         DB::ContextPtr context_, const substrait::ReadRel::LocalFiles::FileOrFiles & file_info_, ReadBufferBuilderPtr read_buffer_builder_)
-        : FormatFile(context_, file_info_, read_buffer_builder_){};
+        : FormatFile(context_, file_info_, read_buffer_builder_){}
 
     ~ExcelTextFormatFile() override = default;
     FormatFile::InputFormatPtr createInputFormat(const DB::Block & header) override;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/JsonFormatFile.cpp
@@ -13,7 +13,7 @@ JsonFormatFile::JsonFormatFile(DB::ContextPtr context_, const substrait::ReadRel
 FormatFile::InputFormatPtr JsonFormatFile::createInputFormat(const DB::Block & header)
 {
     auto res = std::make_shared<FormatFile::InputFormat>();
-    res->read_buffer = std::move(read_buffer_builder->build(file_info, true));
+    res->read_buffer = read_buffer_builder->build(file_info, true);
 
     Poco::URI file_uri(file_info.uri_file());
     DB::CompressionMethod compression = DB::chooseCompressionMethod(file_uri.getPath(), "auto");

--- a/cpp-ch/local-engine/Storages/SubstraitSource/OrcFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/OrcFormatFile.cpp
@@ -179,7 +179,7 @@ FormatFile::InputFormatPtr OrcFormatFile::createInputFormat(const DB::Block & he
     std::vector<int> total_stripe_indices(total_stripes);
     std::iota(total_stripe_indices.begin(), total_stripe_indices.end(), 0);
 
-    std::vector<int> required_stripe_indices(stripes.size());
+    std::vector<UInt64> required_stripe_indices(stripes.size());
     for (size_t i = 0; i < stripes.size(); ++i)
         required_stripe_indices[i] = stripes[i].index;
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/OrcFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/OrcFormatFile.cpp
@@ -158,7 +158,7 @@ OrcFormatFile::OrcFormatFile(
 FormatFile::InputFormatPtr OrcFormatFile::createInputFormat(const DB::Block & header)
 {
     auto file_format = std::make_shared<FormatFile::InputFormat>();
-    file_format->read_buffer = std::move(read_buffer_builder->build(file_info));
+    file_format->read_buffer = read_buffer_builder->build(file_info);
 
     std::vector<StripeInformation> stripes;
     [[maybe_unused]] UInt64 total_stripes = 0;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.cpp
@@ -87,7 +87,7 @@ arrow::Status innerCreateOrcReader(std::shared_ptr<arrow::io::RandomAccessFile> 
 {
     std::unique_ptr<ArrowInputFile> io_wrapper(new ArrowInputFile(file_));
     orc::ReaderOptions options;
-    ORC_CATCH_NOT_OK(*orc_reader = std::move(orc::createReader(std::move(io_wrapper), options)));
+    ORC_CATCH_NOT_OK(*orc_reader = orc::createReader(std::move(io_wrapper), options));
 
     return arrow::Status::OK();
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.cpp
@@ -58,7 +58,7 @@ namespace local_engine
 {
 uint64_t ArrowInputFile::getLength() const
 {
-    ORC_ASSIGN_OR_THROW(int64_t size, file->GetSize());
+    ORC_ASSIGN_OR_THROW(int64_t size, file->GetSize())
     return static_cast<uint64_t>(size);
 }
 
@@ -69,7 +69,7 @@ uint64_t ArrowInputFile::getNaturalReadSize() const
 
 void ArrowInputFile::read(void * buf, uint64_t length, uint64_t offset)
 {
-    ORC_ASSIGN_OR_THROW(int64_t bytes_read, file->ReadAt(offset, length, buf));
+    ORC_ASSIGN_OR_THROW(int64_t bytes_read, file->ReadAt(offset, length, buf))
 
     if (static_cast<uint64_t>(bytes_read) != length)
     {
@@ -87,7 +87,7 @@ arrow::Status innerCreateOrcReader(std::shared_ptr<arrow::io::RandomAccessFile> 
 {
     std::unique_ptr<ArrowInputFile> io_wrapper(new ArrowInputFile(file_));
     orc::ReaderOptions options;
-    ORC_CATCH_NOT_OK(*orc_reader = orc::createReader(std::move(io_wrapper), options));
+    ORC_CATCH_NOT_OK(*orc_reader = orc::createReader(std::move(io_wrapper), options))
 
     return arrow::Status::OK();
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ParquetFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ParquetFormatFile.cpp
@@ -36,7 +36,7 @@ ParquetFormatFile::ParquetFormatFile(
 FormatFile::InputFormatPtr ParquetFormatFile::createInputFormat(const DB::Block & header)
 {
     auto res = std::make_shared<FormatFile::InputFormat>();
-    res->read_buffer = std::move(read_buffer_builder->build(file_info));
+    res->read_buffer = read_buffer_builder->build(file_info);
 
     std::vector<RowGroupInfomation> required_row_groups;
     [[maybe_unused]] int total_row_groups = 0;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -139,12 +139,12 @@ public:
         size_t hdfs_file_size = hdfs_file_info->mSize;
 
         /// initial_pos maybe in the middle of a row, so we need to find the next row start position.
-        auto get_next_line_pos = [&](hdfsFS fs, hdfsFile fin, size_t initial_pos, size_t file_size) -> size_t
+        auto get_next_line_pos = [&](hdfsFS hdfsFs, hdfsFile file, size_t initial_pos, size_t file_size) -> size_t
         {
             if (initial_pos == 0 || initial_pos == file_size)
                 return initial_pos;
 
-            int seek_ret = hdfsSeek(fs, fin, initial_pos);
+            int seek_ret = hdfsSeek(hdfsFs, file, initial_pos);
             if (seek_ret < 0)
                 throw DB::Exception(DB::ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Fail to seek HDFS file: {}, error: {}", file_path, std::string(hdfsGetLastError()));
 
@@ -153,7 +153,7 @@ public:
 
             auto do_read = [&]() -> int
             {
-                auto n = hdfsRead(fs, fin, buf, buf_size);
+                auto n = hdfsRead(hdfsFs, file, buf, buf_size);
                 if (n < 0)
                     throw DB::Exception(
                         DB::ErrorCodes::CANNOT_READ_FROM_FILE_DESCRIPTOR,
@@ -165,7 +165,7 @@ public:
             };
 
             auto pos = initial_pos;
-            while (1)
+            while (true)
             {
                 auto n = do_read();
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -371,7 +371,7 @@ private:
         DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
             region_name,
             context->getRemoteHostFilter(),
-            context->getGlobalContext()->getSettingsRef().s3_max_redirects,
+            static_cast<unsigned>(context->getGlobalContext()->getSettingsRef().s3_max_redirects),
             false,
             false,
             nullptr,

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -433,7 +433,7 @@ public:
     explicit AzureBlobReadBuffer(DB::ContextPtr context_) : ReadBufferBuilder(context_) { }
     ~AzureBlobReadBuffer() override = default;
 
-    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, bool)
+    std::unique_ptr<DB::ReadBuffer> build(const substrait::ReadRel::LocalFiles::FileOrFiles & file_info, bool) override
     {
         Poco::URI file_uri(file_info.uri_file());
         std::unique_ptr<DB::ReadBuffer> read_buffer;

--- a/cpp-ch/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
@@ -107,7 +107,6 @@ DB::Chunk SubstraitFileSource::generate()
         /// try to read from next file
         file_reader.reset();
     }
-    return {};
 }
 
 bool SubstraitFileSource::tryPrepareReader()

--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
@@ -17,7 +17,7 @@ TextFormatFile::TextFormatFile(
 FormatFile::InputFormatPtr TextFormatFile::createInputFormat(const DB::Block & header)
 {
     auto res = std::make_shared<FormatFile::InputFormat>();
-    res->read_buffer = std::move(read_buffer_builder->build(file_info, true));
+    res->read_buffer = read_buffer_builder->build(file_info, true);
 
     Poco::URI file_uri(file_info.uri_file());
     DB::CompressionMethod compression = DB::chooseCompressionMethod(file_uri.getPath(), "auto");

--- a/cpp-ch/local-engine/jni/jni_common.cpp
+++ b/cpp-ch/local-engine/jni/jni_common.cpp
@@ -59,8 +59,9 @@ jstring charTojstring(JNIEnv * env, const char * pat)
 {
     jclass str_class = (env)->FindClass("Ljava/lang/String;");
     jmethodID ctor_id = (env)->GetMethodID(str_class, "<init>", "([BLjava/lang/String;)V");
-    jbyteArray bytes = (env)->NewByteArray(strlen(pat));
-    (env)->SetByteArrayRegion(bytes, 0, strlen(pat), reinterpret_cast<jbyte *>(const_cast<char *>(pat)));
+    jsize strSize = static_cast<jsize>(strlen(pat));
+    jbyteArray bytes = (env)->NewByteArray(strSize);
+    (env)->SetByteArrayRegion(bytes, 0, strSize, reinterpret_cast<jbyte *>(const_cast<char *>(pat)));
     jstring encoding = (env)->NewStringUTF("UTF-8");
     jstring result = static_cast<jstring>((env)->NewObject(str_class, ctor_id, bytes, encoding));
     env->DeleteLocalRef(bytes);
@@ -71,8 +72,9 @@ jstring charTojstring(JNIEnv * env, const char * pat)
 jbyteArray stringTojbyteArray(JNIEnv * env, const std::string & str)
 {
     const auto * ptr = reinterpret_cast<const jbyte *>(str.c_str());
-    jbyteArray jarray = env->NewByteArray(str.size());
-    env->SetByteArrayRegion(jarray, 0, str.size(), ptr);
+    jsize strSize = static_cast<jsize>(str.size());
+    jbyteArray jarray = env->NewByteArray(strSize);
+    env->SetByteArrayRegion(jarray, 0, strSize, ptr);
     return jarray;
 }
 

--- a/cpp-ch/local-engine/jni/jni_common.h
+++ b/cpp-ch/local-engine/jni/jni_common.h
@@ -60,7 +60,7 @@ jboolean safeCallBooleanMethod(JNIEnv * env, jobject obj, jmethodID method_id, A
 {
     LOCAL_ENGINE_JNI_JMETHOD_START
     auto ret = env->CallBooleanMethod(obj, method_id, args...);
-    LOCAL_ENGINE_JNI_JMETHOD_END(env);
+    LOCAL_ENGINE_JNI_JMETHOD_END(env)
     return ret;
 }
 
@@ -69,7 +69,7 @@ jlong safeCallLongMethod(JNIEnv * env, jobject obj, jmethodID method_id, Args...
 {
     LOCAL_ENGINE_JNI_JMETHOD_START
     auto ret = env->CallLongMethod(obj, method_id, args...);
-    LOCAL_ENGINE_JNI_JMETHOD_END(env);
+    LOCAL_ENGINE_JNI_JMETHOD_END(env)
     return ret;
 }
 
@@ -78,7 +78,7 @@ jint safeCallIntMethod(JNIEnv * env, jobject obj, jmethodID method_id, Args... a
 {
     LOCAL_ENGINE_JNI_JMETHOD_START
     auto ret = env->CallIntMethod(obj, method_id, args...);
-    LOCAL_ENGINE_JNI_JMETHOD_END(env);
+    LOCAL_ENGINE_JNI_JMETHOD_END(env)
     return ret;
 }
 
@@ -87,7 +87,7 @@ void safeCallVoidMethod(JNIEnv * env, jobject obj, jmethodID method_id, Args... 
 {
     LOCAL_ENGINE_JNI_JMETHOD_START
     env->CallVoidMethod(obj, method_id, args...);
-    LOCAL_ENGINE_JNI_JMETHOD_END(env);
+    LOCAL_ENGINE_JNI_JMETHOD_END(env)
 }
 
 template <typename... Args>
@@ -95,7 +95,7 @@ jlong safeCallStaticLongMethod(JNIEnv * env, jclass clazz, jmethodID method_id, 
 {
     LOCAL_ENGINE_JNI_JMETHOD_START
     auto ret = env->CallStaticLongMethod(clazz, method_id, args...);
-    LOCAL_ENGINE_JNI_JMETHOD_END(env);
+    LOCAL_ENGINE_JNI_JMETHOD_END(env)
     return ret;
 }
 }

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -849,7 +849,7 @@ JNIEXPORT void Java_io_glutenproject_vectorized_CHBlockWriterJniWrapper_nativeCl
 }
 
 JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniWrapper_nativeInitFileWriterWrapper(
-    JNIEnv * env, jobject obj, jstring file_uri_)
+    JNIEnv * env, jobject , jstring file_uri_)
 {
     LOCAL_ENGINE_JNI_METHOD_START
     auto file_uri = jstring2string(env, file_uri_);
@@ -859,7 +859,7 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
 }
 
 JNIEXPORT void Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniWrapper_write(
-    JNIEnv * env, jobject obj, jlong instanceId, jlong block_address)
+    JNIEnv * env, jobject , jlong instanceId, jlong block_address)
 {
     LOCAL_ENGINE_JNI_METHOD_START
 
@@ -1057,7 +1057,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_SimpleExpressionEval_nativeNext
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)
 }
 
-JNIEXPORT jlong Java_io_glutenproject_memory_alloc_CHNativeMemoryAllocator_getDefaultAllocator(JNIEnv * env, jclass)
+JNIEXPORT jlong Java_io_glutenproject_memory_alloc_CHNativeMemoryAllocator_getDefaultAllocator(JNIEnv * , jclass)
 {
     return -1;
 }

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -764,7 +764,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHBlockConverterJniWrapper_conv
     for (int i = 0; i < num_columns; i++)
     {
         auto * name = static_cast<jstring>(env->GetObjectArrayElement(names, i));
-        c_names.emplace_back(std::move(jstring2string(env, name)));
+        c_names.emplace_back(jstring2string(env, name));
 
         auto * type = static_cast<jbyteArray>(env->GetObjectArrayElement(types, i));
         auto type_length = env->GetArrayLength(type);

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -39,47 +39,33 @@ static DB::ColumnWithTypeAndName getColumnFromColumnVector(JNIEnv * /*env*/, job
 
 static std::string jstring2string(JNIEnv * env, jstring jStr)
 {
-    try
-    {
-        if (!jStr)
-            return "";
+    if (!jStr)
+        return "";
 
-        jclass string_class = env->GetObjectClass(jStr);
-        jmethodID get_bytes = env->GetMethodID(string_class, "getBytes", "(Ljava/lang/String;)[B");
-        jbyteArray string_jbytes
-            = static_cast<jbyteArray>(local_engine::safeCallObjectMethod(env, jStr, get_bytes, env->NewStringUTF("UTF-8")));
+    jclass string_class = env->GetObjectClass(jStr);
+    jmethodID get_bytes = env->GetMethodID(string_class, "getBytes", "(Ljava/lang/String;)[B");
+    jbyteArray string_jbytes
+        = static_cast<jbyteArray>(local_engine::safeCallObjectMethod(env, jStr, get_bytes, env->NewStringUTF("UTF-8")));
 
-        size_t length = static_cast<size_t>(env->GetArrayLength(string_jbytes));
-        jbyte * p_bytes = env->GetByteArrayElements(string_jbytes, nullptr);
+    size_t length = static_cast<size_t>(env->GetArrayLength(string_jbytes));
+    jbyte * p_bytes = env->GetByteArrayElements(string_jbytes, nullptr);
 
-        std::string ret = std::string(reinterpret_cast<char *>(p_bytes), length);
-        env->ReleaseByteArrayElements(string_jbytes, p_bytes, JNI_ABORT);
+    std::string ret = std::string(reinterpret_cast<char *>(p_bytes), length);
+    env->ReleaseByteArrayElements(string_jbytes, p_bytes, JNI_ABORT);
 
-        env->DeleteLocalRef(string_jbytes);
-        env->DeleteLocalRef(string_class);
-        return ret;
-    }
-    catch (DB::Exception & e)
-    {
-        local_engine::ExceptionUtils::handleException(e);
-    }
+    env->DeleteLocalRef(string_jbytes);
+    env->DeleteLocalRef(string_class);
+    return ret;
 }
 
 static jstring stringTojstring(JNIEnv * env, const char * pat)
 {
-    try
-    {
-        jclass strClass = (env)->FindClass("java/lang/String");
-        jmethodID ctorID = (env)->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
-        jbyteArray bytes = (env)->NewByteArray(strlen(pat));
-        (env)->SetByteArrayRegion(bytes, 0, strlen(pat), reinterpret_cast<const jbyte *>(pat));
-        jstring encoding = (env)->NewStringUTF("UTF-8");
-        return static_cast<jstring>((env)->NewObject(strClass, ctorID, bytes, encoding));
-    }
-    catch (DB::Exception & e)
-    {
-        local_engine::ExceptionUtils::handleException(e);
-    }
+    jclass strClass = (env)->FindClass("java/lang/String");
+    jmethodID ctorID = (env)->GetMethodID(strClass, "<init>", "([BLjava/lang/String;)V");
+    jbyteArray bytes = (env)->NewByteArray(strlen(pat));
+    (env)->SetByteArrayRegion(bytes, 0, strlen(pat), reinterpret_cast<const jbyte *>(pat));
+    jstring encoding = (env)->NewStringUTF("UTF-8");
+    return static_cast<jstring>((env)->NewObject(strClass, ctorID, bytes, encoding));
 }
 
 extern "C" {
@@ -322,7 +308,7 @@ JNIEXPORT jobject Java_io_glutenproject_vectorized_BatchIterator_nativeFetchMetr
     LOG_DEBUG(&Poco::Logger::get("jni"), "{}", metrics_json);
     jobject native_metrics = env->NewObject(native_metrics_class, native_metrics_constructor, stringTojstring(env, metrics_json.c_str()));
     return native_metrics;
-    LOCAL_ENGINE_JNI_METHOD_END(env,)
+    LOCAL_ENGINE_JNI_METHOD_END(env, nullptr)
 }
 
 JNIEXPORT void
@@ -855,7 +841,7 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
     auto file_uri = jstring2string(env, file_uri_);
     auto * writer = local_engine::createFileWriterWrapper(file_uri);
     return reinterpret_cast<jlong>(writer);
-    LOCAL_ENGINE_JNI_METHOD_END(env, )
+    LOCAL_ENGINE_JNI_METHOD_END(env, 0)
 }
 
 JNIEXPORT void Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniWrapper_write(
@@ -901,7 +887,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_StorageJoinBuilder_nativeBuild(
         local_engine::BroadCastJoinBuilder::buildJoin(hash_table_id, input, io_buffer_size, join_key, join_type, struct_string));
     env->ReleaseByteArrayElements(named_struct, struct_address, JNI_ABORT);
     return obj->instance();
-    LOCAL_ENGINE_JNI_METHOD_END(env, )
+    LOCAL_ENGINE_JNI_METHOD_END(env, 0)
 }
 
 JNIEXPORT jlong
@@ -911,7 +897,7 @@ Java_io_glutenproject_vectorized_StorageJoinBuilder_nativeCloneBuildHashTable(JN
     auto * cloned = local_engine::make_wrapper(
         local_engine::SharedPointerWrapper<local_engine::StorageJoinFromReadBuffer>::sharedPtr(instance));
     return cloned->instance();
-    LOCAL_ENGINE_JNI_METHOD_END(env, )
+    LOCAL_ENGINE_JNI_METHOD_END(env, 0)
 }
 
 JNIEXPORT void

--- a/cpp-ch/local-engine/tests/CMakeLists.txt
+++ b/cpp-ch/local-engine/tests/CMakeLists.txt
@@ -37,6 +37,8 @@ if (ENABLE_TESTS)
     target_include_directories(unit_tests_local_engine PRIVATE
         ${GTEST_INCLUDE_DIRS}/include
         ${ClickHouse_SOURCE_DIR}/utils/extern-local_engine)
+    # no-unreachable-code for GTEST_SKIP
+    target_compile_options(unit_tests_local_engine PRIVATE -Wno-unreachable-code)
     target_link_libraries(unit_tests_local_engine PRIVATE gluten_clickhouse_backend_libs _gtest_all clickhouse_parsers loggers)
 else()
     include_directories(benchmark_local_engine SYSTEM PUBLIC

--- a/cpp-ch/local-engine/tests/gtest_spark_row.cpp
+++ b/cpp-ch/local-engine/tests/gtest_spark_row.cpp
@@ -71,7 +71,7 @@ static void assertReadConsistentWithWritten(const SparkRowInfo & spark_row_info,
     /// Check if output of SparkRowReader is consistent with types_and_fields
     {
         auto reader = SparkRowReader(spark_row_info.getDataTypes());
-        reader.pointTo(spark_row_info.getBufferAddress(), spark_row_info.getTotalBytes());
+        reader.pointTo(spark_row_info.getBufferAddress(), static_cast<int32_t>(spark_row_info.getTotalBytes()));
         for (size_t i = 0; i < type_and_fields.size(); ++i)
         {
             EXPECT_TRUE(reader.getField(i) == type_and_fields[i].field);
@@ -296,19 +296,19 @@ TEST(SparkRow, MapTypes)
          []() -> Field
          {
              Map map(2);
-             map[0] = std::move(Tuple{Int32(1), Int32(2)});
-             map[1] = std::move(Tuple{Int32(3), Int32(4)});
+             map[0] = Tuple{Int32(1), Int32(2)};
+             map[1] = Tuple{Int32(3), Int32(4)};
              return std::move(map);
          }()},
         {std::make_shared<DataTypeMap>(std::make_shared<DataTypeInt32>(), map_type),
          []() -> Field
          {
              Map inner_map(2);
-             inner_map[0] = std::move(Tuple{Int32(5), Int32(6)});
-             inner_map[1] = std::move(Tuple{Int32(7), Int32(8)});
+             inner_map[0] = Tuple{Int32(5), Int32(6)};
+             inner_map[1] = Tuple{Int32(7), Int32(8)};
 
              Map map(1);
-             map.back() = std::move(Tuple{Int32(9), std::move(inner_map)});
+             map.back() = Tuple{Int32(9), std::move(inner_map)};
              return std::move(map);
          }()},
     };
@@ -335,15 +335,15 @@ TEST(SparkRow, StructMapTypes)
          []() -> Field
          {
              Map map(1);
-             map[0] = std::move(Tuple{Int32(1), Int32(2)});
-             return std::move(Tuple{std::move(map)});
+             map[0] = Tuple{Int32(1), Int32(2)};
+             return Tuple{std::move(map)};
          }()},
         {std::make_shared<DataTypeMap>(std::make_shared<DataTypeInt32>(), tuple_type),
          []() -> Field
          {
              Tuple inner_tuple{Int32(4)};
              Map map(1);
-             map.back() = std::move(Tuple{Int32(3), std::move(inner_tuple)});
+             map.back() = Tuple{Int32(3), std::move(inner_tuple)};
              return std::move(map);
          }()},
     };
@@ -403,7 +403,7 @@ TEST(SparkRow, ArrayMapTypes)
          []() -> Field
          {
              Map map(1);
-             map[0] = std::move(Tuple{Int32(1), Int32(2)});
+             map[0] = Tuple{Int32(1), Int32(2)};
 
              Array array(1);
              array[0] = std::move(map);


### PR DESCRIPTION
## What changes were proposed in this pull request?

We disabled a lot of warning checks, let's recover it. After this PR,  we still disable the followings at local engine scope 

1. `-Wno-reserved-identifier`:  for jni and generated pb header
2. `-Wno-deprecated`: for generated pb header
3. `-Wno-shadow-field`: see https://github.com/ClickHouse/ClickHouse/pull/50400#issuecomment-1574622119

Please note  disabling `pessimizing-move` may [hurt performance](https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c)
## How was this patch tested?

Using existed UT.
