### PR TITLE
[GLUTEN-2139][CORE] Inject fallback reason to plan tag

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
@@ -36,7 +36,7 @@ case class CHFilterExecTransformer(condition: Expression, child: SparkPlan)
   extends FilterExecTransformerBase(condition, child)
   with TransformSupport {
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val leftCondition = getLeftCondition
     if (leftCondition == null) {
       // All the filters can be pushed down and the computing of this Filter

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.GlutenConfig
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.RelBuilder
@@ -35,39 +36,29 @@ case class CHFilterExecTransformer(condition: Expression, child: SparkPlan)
   extends FilterExecTransformerBase(condition, child)
   with TransformSupport {
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     val leftCondition = getLeftCondition
     if (leftCondition == null) {
       // All the filters can be pushed down and the computing of this Filter
       // is not needed.
-      return true
+      return ok()
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     val relNode =
-      try {
-        getRelNode(
-          substraitContext,
-          leftCondition,
-          child.output,
-          operatorId,
-          null,
-          validation = true)
-      } catch {
-        case e: Throwable =>
-          logValidateFailure(
-            s"Validation failed for ${this.getClass.toString} due to ${e.getMessage}",
-            e)
-          return false
-      }
+      getRelNode(substraitContext, leftCondition, child.output, operatorId, null, validation = true)
     val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val validator = new CHNativeExpressionEvaluator()
-      validator.doValidate(planNode.toProtobuf.toByteArray)
+      if (validator.doValidate(planNode.toProtobuf.toByteArray)) {
+        ok()
+      } else {
+        notOk("native check failure")
+      }
     } else {
-      true
+      ok()
     }
   }
 

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
@@ -81,7 +81,7 @@ case class CHBroadcastHashJoinExecTransformer(
       newRight: SparkPlan): CHBroadcastHashJoinExecTransformer =
     copy(left = newLeft, right = newRight)
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val shouldFallback =
       CHJoinValidateUtil.shouldFallback(joinType, left.outputSet, right.outputSet, condition)
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -141,7 +141,7 @@ abstract class FilterExecTransformerBase(val cond: Expression,
     }
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     if (cond == null) {
       // The computing of this Filter is not needed.
       return ok()
@@ -229,7 +229,7 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
 
   override def supportsColumnar: Boolean = GlutenConfig.getConf.enableColumnarIterator
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     val operatorId = substraitContext.nextOperatorId(this.nodeName)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -22,7 +22,7 @@ import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter, ExpressionTransformer}
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import io.glutenproject.extension.columnar.TransformHints
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.SubstraitContext
@@ -47,7 +47,6 @@ import scala.collection.JavaConverters._
 abstract class FilterExecTransformerBase(val cond: Expression,
                                          val input: SparkPlan) extends UnaryExecNode
   with TransformSupport
-  with GlutenPlan
   with PredicateHelper
   with AliasAwareOutputPartitioning
   with Logging {
@@ -142,31 +141,21 @@ abstract class FilterExecTransformerBase(val cond: Expression,
     }
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     if (cond == null) {
       // The computing of this Filter is not needed.
-      return true
+      return ok()
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
-    val relNode = try {
-      getRelNode(
-        substraitContext, cond, child.output, operatorId, null, validation = true)
-    } catch {
-      case e: Throwable =>
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: ${e.getMessage}")
-        return false
-    }
-
+    val relNode = getRelNode(
+      substraitContext, cond, child.output, operatorId, null, validation = true)
     // For now arrow backend only support scan + filter pattern
     if (BackendsApiManager.getSettings.fallbackFilterWithoutConjunctiveScan()) {
       if (!(child.isInstanceOf[DataSourceScanExec] ||
         child.isInstanceOf[DataSourceV2ScanExecBase])) {
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: {child is not DataSourceScanExec or DataSourceV2ScanExecBase}")
-        return false
+        return notOk("child is not DataSourceScanExec or DataSourceV2ScanExecBase")
       }
     }
 
@@ -175,18 +164,9 @@ abstract class FilterExecTransformerBase(val cond: Expression,
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
-      if (!validateInfo.isSupported) {
-        val fallbackInfo = validateInfo.getFallbackInfo()
-        for (i <- 0 until fallbackInfo.size()) {
-          this.appendValidateLog(fallbackInfo.get(i))
-        }
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: native check failure.")
-        return false
-      }
-      true
+      nativeValidationResult(validateInfo)
     } else {
-      true
+      ok()
     }
   }
 
@@ -237,7 +217,6 @@ abstract class FilterExecTransformerBase(val cond: Expression,
 case class ProjectExecTransformer(projectList: Seq[NamedExpression],
                                   child: SparkPlan) extends UnaryExecNode
   with TransformSupport
-  with GlutenPlan
   with PredicateHelper
   with AliasAwareOutputPartitioning
   with Logging {
@@ -250,36 +229,20 @@ case class ProjectExecTransformer(projectList: Seq[NamedExpression],
 
   override def supportsColumnar: Boolean = GlutenConfig.getConf.enableColumnarIterator
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
-    val relNode = try {
-      getRelNode(
-        substraitContext, projectList, child.output, operatorId, null, validation = true)
-    } catch {
-      case e: Throwable =>
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: ${e.getMessage}")
-        return false
-    }
+    val relNode = getRelNode(
+      substraitContext, projectList, child.output, operatorId, null, validation = true)
     // Then, validate the generated plan in native engine.
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
-      if (!validateInfo.isSupported) {
-        val fallbackInfo = validateInfo.getFallbackInfo()
-        for (i <- 0 until fallbackInfo.size() ) {
-          this.appendValidateLog(fallbackInfo.get(i))
-        }
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: native check failure.")
-        return false
-      }
-      true
+      nativeValidationResult(validateInfo)
     } else {
-      true
+      ok()
     }
   }
 
@@ -443,13 +406,11 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = columnarInputRDD
 
-  def doValidate(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)) {
-      this.appendValidateLog("Validation failed for" +
-        " UnionExecTransformer due to: schema check failed.")
-      return false
+      return notOk(s"schema check failed, $schema")
     }
-    true
+    ok()
   }
 }
 
@@ -559,7 +520,8 @@ object FilterHandler {
               .transformDynamicPruningExpr(
                 batchScan.runtimeFilters,
                 reuseSubquery))
-            TransformHints.tagNotTransformable(newSource)
+            TransformHints.tagNotTransformable(newSource,
+              "The scan in BatchScanExec is not a FileScan")
             newSource
           }
       }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -78,7 +78,7 @@ trait BasicScanExecTransformer extends TransformSupport {
     )
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val fileFormat = ConverterUtils.getFileFormat(this)
     if (!BackendsApiManager.getTransformerApiInstance
       .supportsReadFileFormat(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter}
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.`type`.ColumnTypeNode
 import io.glutenproject.substrait.plan.PlanBuilder
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.InSubqueryExec
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
+trait BasicScanExecTransformer extends TransformSupport {
 
   // The key of merge schema option in Parquet reader.
   protected val mergeSchemaOptionKey = "mergeschema"
@@ -78,42 +78,23 @@ trait BasicScanExecTransformer extends TransformSupport with GlutenPlan {
     )
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     val fileFormat = ConverterUtils.getFileFormat(this)
     if (!BackendsApiManager.getTransformerApiInstance
       .supportsReadFileFormat(
         fileFormat, schema.fields, getPartitionSchemas.nonEmpty, getInputFilePaths)) {
-      this.appendValidateLog(
-        s"Validation failed for ${this.getClass.toString} due to: {$fileFormat}")
-      return false
+      return notOk(s"does not support fileFormat: $fileFormat")
     }
 
     val substraitContext = new SubstraitContext
-    val relNode = try {
-      doTransform(substraitContext).root
-    } catch {
-      case e: Throwable =>
-        this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
-        return false
-    }
-
+    val relNode = doTransform(substraitContext).root
     if (GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
-      if (!validateInfo.isSupported) {
-        val fallbackInfo = validateInfo.getFallbackInfo()
-        for (i <- 0 until fallbackInfo.size()) {
-          this.appendValidateLog(fallbackInfo.get(i))
-        }
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: native check failure.")
-        return false
-      }
-      true
+      nativeValidationResult(validateInfo)
     } else {
-      true
+      ok()
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -47,7 +47,7 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
       throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     scan match {
       case parquetScan: ParquetScan if parquetScan.options.containsKey(mergeSchemaOptionKey) &&
         parquetScan.options.get(mergeSchemaOptionKey) == "true" =>

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -20,6 +20,7 @@ package io.glutenproject.execution
 import java.util.Objects
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -46,13 +47,11 @@ class BatchScanExecTransformer(output: Seq[AttributeReference], @transient scan:
       throw new UnsupportedOperationException(s"${scan.getClass.toString} is not supported")
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     scan match {
       case parquetScan: ParquetScan if parquetScan.options.containsKey(mergeSchemaOptionKey) &&
         parquetScan.options.get(mergeSchemaOptionKey) == "true" =>
-        logValidateFailure(s"Validation failed for ${this.getClass.toString} due to: ",
-          new UnsupportedOperationException(s"$mergeSchemaOptionKey is not supported."))
-        return false
+        return notOk(s"option $mergeSchemaOptionKey is not supported")
       case _ =>
     }
     super.doValidateInternal()

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -17,7 +17,6 @@
 
 package io.glutenproject.execution
 
-import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
 import io.glutenproject.substrait.SubstraitContext
 import org.apache.spark.{Partition, SparkContext, TaskContext}
@@ -29,7 +28,7 @@ import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
-  extends UnaryExecNode with TransformSupport with GlutenPlan {
+  extends UnaryExecNode with TransformSupport {
 
   override def supportsColumnar: Boolean = true
 
@@ -53,8 +52,6 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
     case _ =>
       this
   }
-
-  override def doValidateInternal(): Boolean = false
 
   override def doTransform(context: SubstraitContext): TransformContext = {
     throw new UnsupportedOperationException(s"This operator doesn't support doTransform.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -208,7 +208,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
     }
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportExpandExec()) {
       return notOk("backend does not support expand")
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -122,7 +122,7 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     this
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
     if (bucketedScan) {
       throw new UnsupportedOperationException("bucketed scan is not supported")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.HashMap
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
@@ -121,18 +122,14 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
     this
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
     if (bucketedScan) {
-      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to: ",
-        new UnsupportedOperationException("bucketed scan is not supported"))
-      return false
+      throw new UnsupportedOperationException("bucketed scan is not supported")
     }
     if (relation.options.exists(option =>
       option._1 == mergeSchemaOptionKey && option._2 == "true")) {
-      logValidateFailure(s"Validation failed for ${this.getClass.toString} due to: ",
-        new UnsupportedOperationException(s"$mergeSchemaOptionKey is not supported."))
-      return false
+      throw new UnsupportedOperationException(s"option $mergeSchemaOptionKey is not supported.")
     }
     super.doValidateInternal()
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -88,7 +88,7 @@ case class GenerateExecTransformer(
 
   override def supportsColumnar: Boolean = true
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     if (BackendsApiManager.veloxBackend) {
       return notOk("Velox backend does not support")
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -136,7 +136,7 @@ abstract class HashAggregateExecBaseTransformer(
     }
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
     val aggParams = new AggregationParams

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -22,7 +22,7 @@ import com.google.protobuf.Any
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
@@ -55,7 +55,7 @@ abstract class HashAggregateExecBaseTransformer(
                                      initialInputBufferOffset: Int,
                                      resultExpressions: Seq[NamedExpression],
                                      child: SparkPlan)
-  extends BaseAggregateExec with TransformSupport with GlutenPlan {
+  extends BaseAggregateExec with TransformSupport {
 
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
@@ -132,50 +132,31 @@ abstract class HashAggregateExecBaseTransformer(
       case d: DecimalType => true
       case a: ArrayType => true
       case n: NullType => true
-      case other => this.appendValidateLog(
-        s"Validation failed for ${this.getClass.toString}" +
-          s" due to: {data type ${dataType}}");
-        false
+      case other => false
     }
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
     val aggParams = new AggregationParams
-    val relNode = {
-      try {
-        getAggRel(substraitContext, operatorId, aggParams, null, validation = true)
-      } catch {
-        case e: Throwable =>
-          this.appendValidateLog(
-            s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
-          return false
-      }
-    }
+    val relNode = getAggRel(substraitContext, operatorId, aggParams, null, validation = true)
     if (aggregateAttributes.exists(attr => !checkType(attr.dataType))) {
-      return false
+      return notOk("does not support data type in aggregation expression," +
+        s"${aggregateAttributes.map(_.dataType)}")
     }
     if (groupingExpressions.exists(attr => !checkType(attr.dataType))) {
-      return false
+      return notOk("does not support data type in group expression," +
+        s"${groupingExpressions.map(_.dataType)}")
     }
     val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
-      if (!validateInfo.isSupported) {
-        val fallbackInfo = validateInfo.getFallbackInfo()
-        for (i <- 0 until fallbackInfo.size()) {
-          this.appendValidateLog(fallbackInfo.get(i))
-        }
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: native check failure.")
-        return false
-      }
-      true
+      nativeValidationResult(validateInfo)
     } else {
-      true
+      ok()
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -222,7 +222,7 @@ trait HashJoinLikeExecTransformer
       this
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -85,7 +85,7 @@ case class LimitTransformer(child: SparkPlan,
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genLimitTransformerMetricsUpdater(metrics)
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val context = new SubstraitContext
     val operatorId = context.nextOperatorId(this.nodeName)
     val relNode = getRelNode(context, operatorId, offset, count, child.output, null, true)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -244,7 +244,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     }
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportSortExec()) {
       return notOk("backend does not sort")
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -26,7 +26,7 @@ import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
@@ -47,7 +47,7 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
                                global: Boolean,
                                child: SparkPlan,
                                testSpillFrequency: Int = 0)
-  extends UnaryExecNode with TransformSupport with GlutenPlan {
+  extends UnaryExecNode with TransformSupport {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
@@ -244,42 +244,23 @@ case class SortExecTransformer(sortOrder: Seq[SortOrder],
     }
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportSortExec()) {
-      this.appendValidateLog(
-        s"Validation failed for ${this.getClass.toString}" +
-          s" due to: {SortExec}. ")
-      return false
+      return notOk("backend does not sort")
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
 
-    val relNode = try {
-      getRelNode(
-        substraitContext, sortOrder, child.output, operatorId, null, validation = true)
-    } catch {
-      case e: Throwable =>
-        this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
-        return false
-    }
+    val relNode = getRelNode(
+      substraitContext, sortOrder, child.output, operatorId, null, validation = true)
 
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
-      if (!validateInfo.isSupported) {
-        val fallbackInfo = validateInfo.getFallbackInfo()
-        for (i <- 0 until fallbackInfo.size()) {
-          this.appendValidateLog(fallbackInfo.get(i))
-        }
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: native check failure.")
-        return false
-      }
-      true
+      nativeValidationResult(validateInfo)
     } else {
-      true
+      ok()
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -25,7 +25,7 @@ import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.{JoinParams, SubstraitContext}
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.GlutenConfig
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.substrait.proto.JoinRel
 import org.apache.spark.rdd.RDD
@@ -51,7 +51,7 @@ case class SortMergeJoinExecTransformer(
                                          right: SparkPlan,
                                          isSkewJoin: Boolean = false,
                                          projectList: Seq[NamedExpression] = null)
-  extends BinaryExecNode with TransformSupport with GlutenPlan {
+  extends BinaryExecNode with TransformSupport {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
@@ -252,50 +252,31 @@ case class SortMergeJoinExecTransformer(
       JoinRel.JoinType.UNRECOGNIZED
   }
 
-  override def doValidateInternal(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {
-      this.appendValidateLog(
-        s"Validation failed for ${this.getClass.toString}" +
-          s" due to: {Join type ${joinType}}")
-      return false
+      return notOk(s"does not support join type $joinType, substrait: $substraitJoinType")
     }
-    val relNode = try {
-      JoinUtils.createJoinRel(
-        streamedKeys,
-        bufferedKeys,
-        condition,
-        substraitJoinType,
-        false,
-        joinType,
-        genJoinParametersBuilder(),
-        null, null, streamedPlan.output,
-        bufferedPlan.output,
-        substraitContext, substraitContext.nextOperatorId(this.nodeName), validation = true)
-    } catch {
-      case e: Throwable =>
-        this.appendValidateLog(
-          s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
-        return false
-    }
+    val relNode = JoinUtils.createJoinRel(
+      streamedKeys,
+      bufferedKeys,
+      condition,
+      substraitJoinType,
+      false,
+      joinType,
+      genJoinParametersBuilder(),
+      null, null, streamedPlan.output,
+      bufferedPlan.output,
+      substraitContext, substraitContext.nextOperatorId(this.nodeName), validation = true)
     // Then, validate the generated plan in native engine.
     if (GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
       val validateInfo = BackendsApiManager.getValidatorApiInstance
         .doValidateWithFallBackLog(planNode)
-      if (!validateInfo.isSupported) {
-        val fallbackInfo = validateInfo.getFallbackInfo()
-        for (i <- 0 until fallbackInfo.size()) {
-          this.appendValidateLog(fallbackInfo.get(i))
-        }
-        this.appendValidateLog(s"Validation failed for ${this.getClass.toString}" +
-          s" due to: native check failure.")
-        return false
-      }
-      true
+      nativeValidationResult(validateInfo)
     } else {
-      true
+      ok()
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -252,7 +252,7 @@ case class SortMergeJoinExecTransformer(
       JoinRel.JoinType.UNRECOGNIZED
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     if (substraitJoinType == JoinRel.JoinType.UNRECOGNIZED) {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -26,7 +26,6 @@ import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
 import io.glutenproject.substrait.rel.RelNode
-import io.glutenproject.test.TestStats
 import io.glutenproject.utils.{LogLevelUtil, SubstraitPlanPrinterUtil}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -50,42 +49,7 @@ case class WholestageTransformContext(
     root: PlanNode,
     substraitContext: SubstraitContext = null)
 
-trait TransformSupport extends SparkPlan with LogLevelUtil {
-
-  lazy val validateFailureLogLevel = GlutenConfig.getConf.validateFailureLogLevel
-  lazy val printStackOnValidateFailure = GlutenConfig.getConf.printStackOnValidateFailure
-
-  /**
-   * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
-   */
-  final def doValidate(): Boolean = {
-    try {
-      TransformerState.enterValidation
-      val res = doValidateInternal
-
-      if (!res) {
-        TestStats.addFallBackClassName(this.getClass.toString)
-      }
-
-      res
-    } finally {
-      TransformerState.finishValidation
-    }
-  }
-
-  def doValidateInternal(): Boolean = false
-
-  def logValidateFailure(msg: => String, e: Throwable): Unit = {
-    if (printStackOnValidateFailure) {
-      logOnLevel(validateFailureLogLevel, msg, e)
-    } else {
-      logOnLevel(validateFailureLogLevel, msg)
-    }
-  }
-//  def logValidateFailureWithoutThrowable(msg: => String): Unit = {
-//      logOnLevel(validateFailureLogLevel, msg)
-//  }
-
+trait TransformSupport extends GlutenPlan {
   /**
    * Returns all the RDDs of ColumnarBatch which generates the input rows.
    *
@@ -116,7 +80,7 @@ trait TransformSupport extends SparkPlan with LogLevelUtil {
 }
 
 case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
-  extends UnaryExecNode with TransformSupport with GlutenPlan with LogLevelUtil {
+  extends UnaryExecNode with TransformSupport {
 
   // For WholeStageCodegen-like operator, only pipeline time will be handled in graph plotting.
   // See SparkPlanGraph.scala:205 for reference.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -19,11 +19,12 @@ package io.glutenproject.execution
 
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
+
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
-import io.glutenproject.extension.{GlutenPlan, ValidationResult}
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.expression.{ExpressionNode, WindowFunctionNode}
@@ -32,6 +33,7 @@ import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.BindReferencesUtil
 import io.substrait.proto.SortField
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -41,13 +43,12 @@ import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util
-import scala.collection.JavaConverters._
 
 case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
                                  partitionSpec: Seq[Expression],
                                  orderSpec: Seq[SortOrder],
                                  child: SparkPlan)
-    extends WindowExecBase with TransformSupport with GlutenPlan {
+    extends WindowExecBase with TransformSupport {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
@@ -172,7 +173,7 @@ case class WindowExecTransformer(windowExpression: Seq[NamedExpression],
     }
   }
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportWindowExec(windowExpression)) {
       return notOk(s"unsupport window expression ${windowExpression.mkString(", ")}")
     }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -17,13 +17,77 @@
 
 package io.glutenproject.extension
 
+import scala.collection.JavaConverters._
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.expression.TransformerState
+import io.glutenproject.test.TestStats
+import io.glutenproject.utils.LogLevelUtil
+import io.glutenproject.validate.NativePlanValidatorInfo
+import org.apache.spark.sql.execution.SparkPlan
+
+case class ValidationResult(
+    validated: Boolean,
+    reason: Option[String])
+
+object ValidationResult {
+  def ok: ValidationResult = ValidationResult(validated = true, None)
+  def notOk(reason: String): ValidationResult = ValidationResult(validated = false, Some(reason))
+}
+
 /**
  * Every Gluten OP should extend this trait.
  */
-trait GlutenPlan {
-  var validateLog: Vector[String] = Vector()
+trait GlutenPlan extends SparkPlan with LogLevelUtil {
 
-  def appendValidateLog(log: String): Unit = {
-    validateLog = validateLog :+ log
+  private lazy val validateFailureLogLevel = glutenConf.validateFailureLogLevel
+  private lazy val printStackOnValidateFailure = glutenConf.printStackOnValidateFailure
+
+  def glutenConf: GlutenConfig = GlutenConfig.getConf
+
+  /**
+   * Validate whether this SparkPlan supports to be transformed into substrait node in Native Code.
+   */
+  final def doValidate(): ValidationResult = {
+    try {
+      TransformerState.enterValidation
+      val res = doValidateInternal()
+      if (!res.validated) {
+        TestStats.addFallBackClassName(this.getClass.toString)
+
+        // the reason must be set if failed to validate
+        assert(res.reason.isDefined)
+      }
+      res
+    } catch {
+      case e: Throwable =>
+        logValidateFailure(s"Validation failed with exception for plan: $nodeName, due to:", e)
+        notOk(e.getMessage)
+    } finally {
+      TransformerState.finishValidation
+    }
+  }
+
+  def doValidateInternal(): ValidationResult =
+    ValidationResult.notOk(s"$nodeName does not override doValidateInternal")
+
+  def logValidateFailure(msg: => String, e: Throwable): Unit = {
+    if (printStackOnValidateFailure) {
+      logOnLevel(validateFailureLogLevel, msg, e)
+    } else {
+      logOnLevel(validateFailureLogLevel, msg)
+    }
+  }
+
+  protected def ok(): ValidationResult = ValidationResult.ok
+  protected def notOk(reason: String): ValidationResult = ValidationResult.notOk(reason)
+  protected def nativeValidationResult(info: NativePlanValidatorInfo): ValidationResult = {
+    if (info.isSupported) {
+      ok()
+    } else {
+      val fallbackInfo = info.getFallbackInfo.asScala
+        .mkString("native check failure:", ", ", "")
+      notOk(fallbackInfo)
+    }
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -111,6 +111,10 @@ object TransformHints {
     }
     plan.getTagValue(TAG).getOrElse(throw new IllegalStateException())
   }
+
+  def getHintOption(plan: SparkPlan): Option[TransformHint] = {
+    plan.getTagValue(TAG)
+  }
 }
 
 // Holds rules which have higher privilege to tag (not) transformable before AddTransformHintRule.

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -20,7 +20,9 @@ package io.glutenproject.extension.columnar
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.utils.PhysicalPlanSelector
+
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -53,7 +55,7 @@ trait TransformHint {
 }
 
 case class TRANSFORM_SUPPORTED() extends TransformHint
-case class TRANSFORM_UNSUPPORTED() extends TransformHint
+case class TRANSFORM_UNSUPPORTED(reason: Option[String]) extends TransformHint
 
 object TransformHints {
   val TAG: TreeNodeTag[TransformHint] =
@@ -93,8 +95,14 @@ object TransformHints {
     tag(plan, TRANSFORM_SUPPORTED())
   }
 
-  def tagNotTransformable(plan: SparkPlan): Unit = {
-    tag(plan, TRANSFORM_UNSUPPORTED())
+  def tagNotTransformable(plan: SparkPlan, validationResult: ValidationResult): Unit = {
+    if (!validationResult.validated) {
+      tag(plan, TRANSFORM_UNSUPPORTED(validationResult.reason))
+    }
+  }
+
+  def tagNotTransformable(plan: SparkPlan, reason: String): Unit = {
+    tag(plan, TRANSFORM_UNSUPPORTED(Some(reason)))
   }
 
   def getHint(plan: SparkPlan): TransformHint = {
@@ -115,7 +123,7 @@ object TagBeforeTransformHits {
 case class FallbackOnANSIMode(session: SparkSession) extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = PhysicalPlanSelector.maybe(session, plan) {
     if (GlutenConfig.getConf.enableAnsiMode) {
-      plan.foreach(TransformHints.tagNotTransformable)
+      plan.foreach(TransformHints.tagNotTransformable(_, "does not support ansi mode"))
     }
     plan
   }
@@ -138,10 +146,7 @@ case class FallbackMultiCodegens(session: SparkSession) extends Rule[SparkPlan] 
     }
 
   def tagNotTransformable(plan: SparkPlan): SparkPlan = {
-    logInfo(
-      s"Validation failed for ${this.getClass.toString}" +
-        s" due to: FallbackMultiCodegens.")
-    TransformHints.tagNotTransformable(plan)
+    TransformHints.tagNotTransformable(plan, "fallback multi codegens")
     plan
   }
 
@@ -205,10 +210,7 @@ case class FallbackOneRowRelation(session: SparkSession) extends Rule[SparkPlan]
         case _ => false
       }
     if (hasOneRowRelation) {
-      logInfo(
-        s"Validation failed for ${this.getClass.toString}" +
-          s" due to: FallbackOneRowRelation.")
-      plan.foreach(TransformHints.tagNotTransformable)
+      plan.foreach(TransformHints.tagNotTransformable(_, "fallback one row plan"))
     }
     plan
   }
@@ -246,11 +248,14 @@ case class FallbackEmptySchemaRelation() extends Rule[SparkPlan] {
         if (p.children.exists(_.output.isEmpty)) {
           // Some backends are not eligible to offload plan with zero-column input.
           // If any child have empty output, mark the plan and that child as UNSUPPORTED.
-          logWarning(s"May fallback ${p.getClass.toString} and its children because" +
-            s" at least one of its children has empty output.")
-          TransformHints.tagNotTransformable(p)
-          p.children.foreach(child =>
-            if (child.output.isEmpty) TransformHints.tagNotTransformable(child))
+          TransformHints.tagNotTransformable(p,
+            "at least one of its children has empty output")
+          p.children.foreach { child =>
+            if (child.output.isEmpty) {
+              TransformHints.tagNotTransformable(child,
+                "at least one of its children has empty output")
+            }
+          }
         }
       }
       p
@@ -293,7 +298,6 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
   val enableTakeOrderedAndProject: Boolean =
     !scanOnly && columnarConf.enableTakeOrderedAndProject &&
       enableColumnarSort && enableColumnarLimit && enableColumnarShuffle && enableColumnarProject
-  val printValidateLogEnabled: Boolean = columnarConf.validateFailureLogLevel == "DEBUG"
 
   def apply(plan: SparkPlan): SparkPlan = {
     addTransformableTags(plan)
@@ -305,13 +309,6 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
   private def addTransformableTags(plan: SparkPlan): SparkPlan = {
     addTransformableTag(plan)
     plan.withNewChildren(plan.children.map(addTransformableTags))
-  }
-  private def printValidateLog(validateLog: Vector[String]): Unit = {
-    for (elem <- validateLog) {logInfo(elem)}
-  }
-
-  private def printValidateLog(className: String, message: String): Unit = {
-    logInfo("Validation failed for " + className + " due to: " + message)
   }
 
   private def addTransformableTag(plan: SparkPlan): Unit = {
@@ -327,8 +324,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
       plan match {
         case plan: BatchScanExec =>
           if (!enableColumnarBatchScan) {
-            printValidateLog(this.getClass.toString, "columnar BatchScan not enabled")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan, "columnar BatchScan is disabled")
           } else {
             // IF filter expressions aren't empty, we need to transform the inner operators.
             if (plan.runtimeFilters.nonEmpty) {
@@ -337,16 +333,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               val transformer = new BatchScanExecTransformer(plan.output, plan.scan,
                 plan.runtimeFilters)
               TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-              if(printValidateLogEnabled) {
-                printValidateLog(transformer.validateLog)
-              }
             }
           }
         case plan: FileSourceScanExec =>
           if (!enableColumnarFileScan) {
-            printValidateLog(this.getClass.toString, "columnar FileScan" +
-              " not enabled in FileSourceScanExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar FileScan is not enabled in FileSourceScanExec")
           } else {
             // IF filter expressions aren't empty, we need to transform the inner operators.
             if (plan.partitionFilters.nonEmpty) {
@@ -362,54 +354,41 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 plan.tableIdentifier,
                 plan.disableBucketedScan)
               TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-              if (printValidateLogEnabled) {
-                printValidateLog(transformer.validateLog)
-              }
             }
           }
         case plan: InMemoryTableScanExec =>
           // ColumnarInMemoryTableScanExec.scala appears to be out-of-date
           //   and need some tests before being enabled.
-          printValidateLog(this.getClass.toString, "InMemoryTableScanExec not supported")
-          TransformHints.tagNotTransformable(plan)
+          TransformHints.tagNotTransformable(plan, "InMemoryTableScanExec is not supported")
         case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
           if (!enableColumnarHiveTableScan) {
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan, "columnar hive table scan is disabled")
           } else {
             TransformHints.tag(plan, HiveTableScanExecTransformer.validate(plan).toTransformHint)
           }
         case plan: ProjectExec =>
           if (!enableColumnarProject) {
-            printValidateLog(this.getClass.toString, "columnar project not enabled")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan, "columnar project is disabled")
           } else {
             val transformer = ProjectExecTransformer(plan.projectList, plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: FilterExec =>
           val childIsScan = plan.child.isInstanceOf[FileSourceScanExec] ||
             plan.child.isInstanceOf[BatchScanExec]
           // When scanOnly is enabled, filter after scan will be offloaded.
           if ((!scanOnly && !enableColumnarFilter) || (scanOnly && !childIsScan)) {
-            printValidateLog(this.getClass.toString,
+            TransformHints.tagNotTransformable(plan,
               "ScanOnly enabled and plan child is not Scan in FilterExec")
-            TransformHints.tagNotTransformable(plan)
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genFilterExecTransformer(plan.condition, plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: HashAggregateExec =>
           if (!enableColumnarHashAgg) {
-            printValidateLog(this.getClass.toString,
-              "columnar HashAggregate not enabled in HashAggregateExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar HashAggregate is not enabled in HashAggregateExec")
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
@@ -421,20 +400,14 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 plan.resultExpressions,
                 plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: SortAggregateExec =>
           if (!BackendsApiManager.getSettings.replaceSortAggWithHashAgg) {
-            printValidateLog(this.getClass.toString,
-              "replaceSortAggWithHashAgg not enabled")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan, "replaceSortAggWithHashAgg is not enabled")
           }
           if (!enableColumnarHashAgg) {
-            printValidateLog(this.getClass.toString,
-              "columnar HashAgg not enabled in SortAggregateExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar HashAgg is not enabled in SortAggregateExec")
           }
           val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
@@ -446,14 +419,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 plan.resultExpressions,
                 plan.child)
           TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-          if (printValidateLogEnabled) {
-            printValidateLog(transformer.validateLog)
-          }
         case plan: ObjectHashAggregateExec =>
           if (!enableColumnarHashAgg) {
-            printValidateLog(this.getClass.toString,
-              "columnar HashAgg not enabled in ObjectHashAggregateExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar HashAgg is not enabled in ObjectHashAggregateExec")
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
@@ -465,53 +434,37 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 plan.resultExpressions,
                 plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: UnionExec =>
           if (!enableColumnarUnion) {
-            printValidateLog(this.getClass.toString,
-              "columnar Union not enabled in UnionExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar Union is not enabled in UnionExec")
           } else {
             val transformer = UnionExecTransformer(plan.children)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: ExpandExec =>
           if (!enableColumnarExpand) {
-            printValidateLog(this.getClass.toString,
-              "columnar Expand not enabled in ExpandExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar Expand is not enabled in ExpandExec")
           } else {
             val transformer = ExpandExecTransformer(plan.projections,
               plan.output, plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: SortExec =>
           if (!enableColumnarSort) {
-            printValidateLog(this.getClass.toString,
-              "columnar Sort not enabled in SortExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar Sort is not enabled in SortExec")
           } else {
             val transformer = SortExecTransformer(
               plan.sortOrder, plan.global, plan.child, plan.testSpillFrequency)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: ShuffleExchangeExec =>
           if (!enableColumnarShuffle) {
-            printValidateLog(this.getClass.toString,
-              "columnar Shuffle not enabled in ShuffleExchangeExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar Shuffle is not enabled in ShuffleExchangeExec")
           } else {
             val transformer = ColumnarShuffleExchangeExec(
               plan.outputPartitioning,
@@ -519,15 +472,11 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan.shuffleOrigin,
               plan.child.output)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: ShuffledHashJoinExec =>
           if (!enableColumnarShuffledHashJoin) {
-            printValidateLog(this.getClass.toString,
-              "columnar shufflehashjoin not enabled in ShuffledHashJoinExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar shufflehashjoin is not enabled in ShuffledHashJoinExec")
           } else {
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genShuffledHashJoinExecTransformer(
@@ -540,22 +489,15 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 plan.right,
                 plan.isSkewJoin)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: BroadcastExchangeExec =>
           // columnar broadcast is enabled only when columnar bhj is enabled.
           if (!enableColumnarBroadcastExchange) {
-            printValidateLog(this.getClass.toString,
-              "columnar BroadcastExchange not enabled in BroadcastExchangeExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar BroadcastExchange is not enabled in BroadcastExchangeExec")
           } else {
             val transformer = ColumnarBroadcastExchangeExec(plan.mode, plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case bhj: BroadcastHashJoinExec =>
           // FIXME Hongze: In following codes we perform a lot of if-else conditions to
@@ -565,11 +507,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           //  Currently their doBroadcast() methods just propagate child's broadcast
           //  payloads which is not right in speaking of columnar.
           if (!enableColumnarBroadcastJoin) {
-            printValidateLog(this.getClass.toString,
-              "columnar BroadcastJoin not enabled in BroadcastHashJoinExec")
-            TransformHints.tagNotTransformable(bhj)
+            TransformHints.tagNotTransformable(bhj,
+              "columnar BroadcastJoin is not enabled in BroadcastHashJoinExec")
           } else {
-            val isBhjTransformable: Boolean = {
+            val isBhjTransformable: ValidationResult = {
               val transformer = BackendsApiManager.getSparkPlanExecApiInstance
                 .genBroadcastHashJoinExecTransformer(
                   bhj.leftKeys,
@@ -580,11 +521,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                   bhj.left,
                   bhj.right,
                   isNullAwareAntiJoin = bhj.isNullAwareAntiJoin)
-              val isSupported = transformer.doValidate()
-              if (printValidateLogEnabled) {
-                printValidateLog(transformer.validateLog)
-              }
-              isSupported
+              transformer.doValidate()
             }
             val buildSidePlan = bhj.buildSide match {
               case BuildLeft => bhj.left
@@ -593,18 +530,13 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
 
             val maybeExchange = buildSidePlan.find {
               case BroadcastExchangeExec(_, _) => true
-              case _ =>
-                printValidateLog(this.getClass.toString,
-                  "not BroadcastExchangeExec at join build side.")
-                false
+              case _ => false
             }
 
             maybeExchange match {
               case Some(exchange@BroadcastExchangeExec(mode, child)) =>
                 TransformHints.tag(bhj, isBhjTransformable.toTransformHint)
-                if (!isBhjTransformable) {
-                  TransformHints.tagNotTransformable(exchange)
-                }
+                TransformHints.tagNotTransformable(exchange, isBhjTransformable)
               case None =>
                 // we are in AQE, find the hidden exchange
                 // FIXME did we consider the case that AQE: OFF && Reuse: ON ?
@@ -636,9 +568,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
                 // to conform to the underlying exchange's type, columnar or vanilla
                 exchange match {
                   case BroadcastExchangeExec(mode, child) =>
-                    TransformHints.tagNotTransformable(bhj)
+                    TransformHints.tagNotTransformable(bhj,
+                      "it's a materialized broadcast exchange or reused broadcast exchange")
                   case ColumnarBroadcastExchangeExec(mode, child) =>
-                    if (!isBhjTransformable) {
+                    if (!isBhjTransformable.validated) {
                       throw new IllegalStateException(s"BroadcastExchange has already been" +
                         s" transformed to columnar version but BHJ is determined as" +
                         s" non-transformable: ${bhj.toString()}")
@@ -649,10 +582,8 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: SortMergeJoinExec =>
           if (!enableColumnarSortMergeJoin || plan.joinType == FullOuter) {
-            printValidateLog(this.getClass.toString,
-              "columnar sortmergejoin not enabled" +
-                " in enableColumnarSortMergeJoin or is FullOuter join")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar sort merge join is not enabled or join type is FullOuter")
           } else {
             val transformer = SortMergeJoinExecTransformer(
               plan.leftKeys,
@@ -666,9 +597,8 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           }
         case plan: WindowExec =>
           if (!enableColumnarWindow) {
-            printValidateLog(this.getClass.toString,
-              "columnar window not enabled in WindowExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar window is not enabled in WindowExec")
           } else {
             val transformer = WindowExecTransformer(
               plan.windowExpression,
@@ -676,93 +606,60 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan.orderSpec,
               plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: CoalesceExec =>
           if (!enableColumnarCoalesce) {
-            printValidateLog(this.getClass.toString,
-              "columnar coalesce not enabled in CoalesceExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar coalesce is not enabled in CoalesceExec")
           } else {
             val transformer = CoalesceExecTransformer(plan.numPartitions, plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: GlobalLimitExec =>
           if (!enableColumnarLimit) {
-            printValidateLog(this.getClass.toString,
-              "columnar limit not enabled in GlobalLimitExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar limit is not enabled in GlobalLimitExec")
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: LocalLimitExec =>
           if (!enableColumnarLimit) {
-            printValidateLog(this.getClass.toString,
-              "columnar limit not enabled in LocalLimitExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar limit is not enabled in GlobalLimitExec")
           } else {
             val transformer = LimitTransformer(plan.child, 0L, plan.limit)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: GenerateExec =>
           if (!enableColumnarGenerate) {
-            printValidateLog(this.getClass.toString,
-              "columnar generate not enabled in GenerateExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar generate is not enabled in GenerateExec")
           } else {
             val transformer = GenerateExecTransformer(plan.generator, plan.requiredChildOutput,
               plan.outer, plan.generatorOutput, plan.child)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-            if (printValidateLogEnabled) {
-              printValidateLog(transformer.validateLog)
-            }
           }
         case plan: EvalPythonExec =>
           val transformer = EvalPythonExecTransformer(plan.udfs, plan.resultAttrs, plan.child)
           TransformHints.tag(plan, transformer.doValidate().toTransformHint)
-          if (printValidateLogEnabled) {
-            printValidateLog(transformer.validateLog)
-          }
         case _: AQEShuffleReadExec =>
           TransformHints.tagTransformable(plan)
         case plan: TakeOrderedAndProjectExec =>
           if (!enableTakeOrderedAndProject) {
-            printValidateLog(this.getClass.toString,
-              "TakeOrderedAndProject not enabled in TakeOrderedAndProjectExec")
-            TransformHints.tagNotTransformable(plan)
+            TransformHints.tagNotTransformable(plan,
+              "columnar topK is not enabled in TakeOrderedAndProjectExec")
           } else {
-            var tagged = false
+            var tagged: ValidationResult = null
             val limitPlan = LimitTransformer(plan.child, 0, plan.limit)
             tagged = limitPlan.doValidate()
-            if (printValidateLogEnabled) {
-              printValidateLog(limitPlan.validateLog)
-            }
-            if (tagged) {
+            if (tagged.validated) {
               val sortPlan = SortExecTransformer(plan.sortOrder, false, plan.child)
               tagged = sortPlan.doValidate()
-              if (printValidateLogEnabled) {
-                printValidateLog(sortPlan.validateLog)
-              }
             }
-
-            if (tagged) {
+            if (tagged.validated) {
               val projectPlan = ProjectExecTransformer(plan.projectList, plan.child)
               tagged = projectPlan.doValidate()
-              if (printValidateLogEnabled) {
-                printValidateLog(projectPlan.validateLog)
-              }
             }
             TransformHints.tag(plan, tagged.toTransformHint)
           }
@@ -772,18 +669,18 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
       }
     } catch {
       case e: UnsupportedOperationException =>
-        printValidateLog(this.getClass.toString, "${e.getMessage}," +
-          s"original sparkplan is ${plan.getClass}(${plan.children.toList.map(_.getClass)})")
-        TransformHints.tagNotTransformable(plan)
+        TransformHints.tagNotTransformable(plan,
+          s"${e.getMessage}, original sparkplan is " +
+            s"${plan.getClass}(${plan.children.toList.map(_.getClass)})")
     }
   }
 
-  implicit class EncodeTransformableTagImplicits(transformable: Boolean) {
+  implicit class EncodeTransformableTagImplicits(validationResult: ValidationResult) {
     def toTransformHint: TransformHint = {
-      if (transformable) {
+      if (validationResult.validated) {
         TRANSFORM_SUPPORTED()
       } else {
-        TRANSFORM_UNSUPPORTED()
+        TRANSFORM_UNSUPPORTED(validationResult.reason)
       }
     }
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import org.apache.spark.{SparkException, broadcast}
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
@@ -127,14 +127,12 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     ColumnarBroadcastExchangeExec(mode.canonicalized, child.canonicalized)
   }
 
-  def doValidate(): Boolean = mode match {
+  override def doValidateInternal(): ValidationResult = mode match {
     case _: HashedRelationBroadcastMode =>
-      true
+      ok()
     case _ =>
       // IdentityBroadcastMode not supported. Need to support BroadcastNestedLoopJoin first.
-      this.appendValidateLog("Validation failed for" +
-        " ColumnarBroadcastExchangeExec due to: only support HashedRelationBroadcastMode.")
-      false
+      notOk("only support HashedRelationBroadcastMode")
   }
 
   override def doPrepare(): Unit = {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -127,7 +127,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
     ColumnarBroadcastExchangeExec(mode.canonicalized, child.canonicalized)
   }
 
-  override def doValidateInternal(): ValidationResult = mode match {
+  override protected def doValidateInternal(): ValidationResult = mode match {
     case _: HashedRelationBroadcastMode =>
       ok()
     case _ =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.ValidationResult
+
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
@@ -39,7 +41,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
                                        child: SparkPlan,
                                        shuffleOrigin: ShuffleOrigin = ENSURE_REQUIREMENTS,
                                        projectOutputAttributes: Seq[Attribute])
-  extends ShuffleExchangeLike with GlutenPlan{
+  extends ShuffleExchangeLike with GlutenPlan {
   private[sql] lazy val writeMetrics =
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
 
@@ -100,14 +102,12 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
 
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 
-  def doValidate(): Boolean = {
+  override def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child)) {
-      this.appendValidateLog("Validation failed for" +
-        " ColumnarShuffleExchangeExec due to: schema check failed.")
-      return false
+      return notOk("schema check failed")
     }
-    true
+    ok()
   }
 
   override def nodeName: String = "ColumnarExchange"

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -102,7 +102,7 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
 
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child)) {
       return notOk("schema check failed")

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.columnar.{TRANSFORM_UNSUPPORTED, TransformHints}
+import io.glutenproject.utils.LogLevelUtil
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * This rule is used to collect all fallback reason.
+ * 1. print fallback reason for each plan node
+ * 2. TODO: post all fallback reason using one event
+ */
+case class GlutenFallbackReporter(
+    glutenConfig: GlutenConfig,
+    spark: SparkSession) extends Rule[SparkPlan] with LogLevelUtil {
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!glutenConfig.enableFallbackReport) {
+      return plan
+    }
+    printFallbackReason(plan)
+    plan
+  }
+
+  private def printFallbackReason(plan: SparkPlan): Unit = {
+    val validateFailureLogLevel = glutenConfig.validateFailureLogLevel
+    plan.foreach {
+      case _: GlutenPlan => // ignore
+      case plan: SparkPlan =>
+        TransformHints.getHint(plan) match {
+          case TRANSFORM_UNSUPPORTED(reason) =>
+            logOnLevel(validateFailureLogLevel,
+              s"Validation failed for plan: ${plan.nodeName}, due to: $reason.")
+          case _ =>
+        }
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -46,10 +46,11 @@ case class GlutenFallbackReporter(
     plan.foreach {
       case _: GlutenPlan => // ignore
       case plan: SparkPlan =>
-        TransformHints.getHint(plan) match {
-          case TRANSFORM_UNSUPPORTED(reason) =>
+        // some SparkPlan do not have hint, e.g., `ColumnarAQEShuffleRead`
+        TransformHints.getHintOption(plan) match {
+          case Some(TRANSFORM_UNSUPPORTED(reason)) =>
             logOnLevel(validateFailureLogLevel,
-              s"Validation failed for plan: ${plan.nodeName}, due to: $reason.")
+              s"Validation failed for plan: ${plan.nodeName}, due to: ${reason.getOrElse("")}.")
           case _ =>
         }
     }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -92,7 +92,7 @@ case class EvalPythonExecTransformer(
 
   override def supportsColumnar: Boolean = true
 
-  override def doValidateInternal(): ValidationResult = {
+  override protected def doValidateInternal(): ValidationResult = {
     // All udfs should be scalar python udf
     for (udf <- udfs) {
       if (!PythonUDF.isScalarPythonUDF(udf)) {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -21,7 +21,7 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.TransformContext
 import io.glutenproject.execution.TransformSupport
 import io.glutenproject.expression._
-import io.glutenproject.extension.GlutenPlan
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.`type`._
 import io.glutenproject.substrait.SubstraitContext
@@ -29,7 +29,6 @@ import io.glutenproject.substrait.expression._
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel._
-
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -38,7 +37,6 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.EvalPythonExec
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
 import com.google.common.collect.Lists
 import com.google.protobuf.Any
 
@@ -49,8 +47,7 @@ case class EvalPythonExecTransformer(
     resultAttrs: Seq[Attribute],
     child: SparkPlan)
   extends EvalPythonExec
-  with TransformSupport
-  with GlutenPlan {
+  with TransformSupport {
 
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genFilterTransformerMetricsUpdater(metrics)
@@ -95,13 +92,11 @@ case class EvalPythonExecTransformer(
 
   override def supportsColumnar: Boolean = true
 
-  override def doValidateInternal(): Boolean = {
-    /// All udfs should be scalar python udf
+  override def doValidateInternal(): ValidationResult = {
+    // All udfs should be scalar python udf
     for (udf <- udfs) {
       if (!PythonUDF.isScalarPythonUDF(udf)) {
-        logInfo(
-          s"Validation failed for ${this.getClass.toString} due to: $udf is not scalar python udf")
-        return false
+        return notOk(s"$udf is not scalar python udf")
       }
     }
 
@@ -118,21 +113,16 @@ case class EvalPythonExecTransformer(
           ExpressionConverter.replaceWithExpressionTransformer(udf, child.output).doTransform(args))
       })
 
-    val relNode =
-      try {
-        RelBuilder.makeProjectRel(null, expressionNodes, context, operatorId)
-      } catch {
-        case e: Throwable =>
-          this.appendValidateLog(
-            s"Validation failed for ${this.getClass.toString} due to: ${e.getMessage}")
-          return false
-      }
-
+    val relNode = RelBuilder.makeProjectRel(null, expressionNodes, context, operatorId)
     if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(context, Lists.newArrayList(relNode))
-      BackendsApiManager.getValidatorApiInstance.doValidate(planNode)
+      if (BackendsApiManager.getValidatorApiInstance.doValidate(planNode)) {
+        ok()
+      } else {
+        notOk(s"substrait plan check failure, $planNode")
+      }
     } else {
-      true
+      ok()
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.{BasicScanExecTransformer, TransformContext}
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.SubstraitContext
@@ -237,15 +238,19 @@ object HiveTableScanExecTransformer {
     plan.isInstanceOf[HiveTableScanExec]
   }
 
-  def validate(plan: SparkPlan): Boolean = {
+  def validate(plan: SparkPlan): ValidationResult = {
     plan match {
       case hiveTableScan: HiveTableScanExec =>
         val hiveTableScanTransformer = new HiveTableScanExecTransformer(
           hiveTableScan.requestedAttributes,
           hiveTableScan.relation,
           hiveTableScan.partitionPruningPred)(hiveTableScan.session)
-        hiveTableScanTransformer.scan.isDefined && hiveTableScanTransformer.doValidate()
-      case _ => false
+          if (hiveTableScanTransformer.scan.isDefined) {
+            hiveTableScanTransformer.doValidate()
+          } else {
+            ValidationResult.notOk("Hive scan is not defined")
+          }
+      case _ => ValidationResult.notOk("Is not a Hive scan")
     }
   }
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -34,7 +34,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.dataFilters,
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan)
-      if (transformer.doValidate()) {
+      if (transformer.doValidate().validated) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -34,7 +34,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.dataFilters,
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan)
-      if (transformer.doValidate()) {
+      if (transformer.doValidate().validated) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -35,7 +35,7 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait {
       }
       assert(testAppender.loggingEvents.exists(_.getMessage.getFormattedMessage.contains(
         "Validation failed for plan: Scan parquet default.t, " +
-          "due to: Some(columnar FileScan is not enabled in FileSourceScanExec)")))
+          "due to: columnar FileScan is not enabled in FileSourceScanExec")))
     }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.gluten
+
+import io.glutenproject.GlutenConfig
+import org.apache.spark.sql.GlutenSQLTestsTrait
+
+class GlutenFallbackSuite extends GlutenSQLTestsTrait {
+
+  test("test fallback logging") {
+    val testAppender = new LogAppender("fallback reason")
+    withLogAppender(testAppender) {
+      withSQLConf(
+        GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key -> "true",
+        GlutenConfig.VALIDATE_FAILURE_LOG_LEVEL.key -> "info") {
+        withTable("t") {
+          spark.range(10).write.format("parquet").saveAsTable("t")
+          sql("SELECT * FROM t").collect()
+        }
+      }
+      assert(testAppender.loggingEvents.exists(_.getMessage.getFormattedMessage.contains(
+        "Validation failed for plan: Scan parquet default.t, " +
+          "due to: Some(columnar FileScan is not enabled in FileSourceScanExec)")))
+    }
+  }
+}

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -919,7 +919,7 @@ object GlutenConfig {
       .checkValue(
         logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
         "Valid values are 'trace', 'debug', 'info', 'warn' and 'error'.")
-      .createWithDefault("DEBUG")
+      .createWithDefault("INFO")
 
   val SOFT_AFFINITY_LOG_LEVEL =
     buildConf("spark.gluten.soft-affinity.logLevel")

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -220,6 +220,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def printStackOnValidateFailure: Boolean =
     conf.getConf(VALIDATE_FAILURE_PRINT_STACK_ENABLED)
 
+  def enableFallbackReport: Boolean = conf.getConf(FALLBACK_REPORTER_ENABLED)
+
   def debug: Boolean = conf.getConf(DEBUG_LEVEL_ENABLED)
   def taskStageId: Int = conf.getConf(BENCHMARK_TASK_STAGEID)
   def taskPartitionId: Int = conf.getConf(BENCHMARK_TASK_PARTITIONID)
@@ -982,4 +984,10 @@ object GlutenConfig {
       .doc("A class for the extended expressions transformer.")
       .stringConf
       .createWithDefaultString("")
+
+  val FALLBACK_REPORTER_ENABLED =
+    buildConf("spark.gluten.sql.columnar.fallbackReporter")
+      .doc("When true, enable fallback reporter rule to print fallback reason")
+      .booleanConf
+      .createWithDefault(true)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr resolves the steps (1, 2, 2.5) in #2139 

The mian change is:
1. make `TransformSupport` inherit `GlutenPlan` and pull out validate related code to `GlutenPlan`.
2. change the `doValidateInternal` result type from `boolean` to `ValidationResult `, `ValidationResult` holds a string type reason.
3. centralize `Throwable` catching and logging to `doValidate`
4. add a new rule `GlutenFallbackReporter` to collect unsupport transform tag and print fallback reason. (post event will do in a seperate pr)

Note, This pr assumes that:
- if a vanilla SparkPlan can be offloaded, then Gluten make a new `TransformSupport`
- if a plan is produced by Gluten, then it should inherit `GlutenPlan`
- every vanilla SparkPlan should contains transform hint

(Fixes: \#2139)

## How was this patch tested?
Pass CI and add test

An example:
```
create table t (c1 int) using parquet;

set spark.gluten.sql.validate.failure.logLevel=warn;
set spark.gluten.sql.columnar.filescan=false;

select * from t;

23/07/03 20:22:54 WARN GlutenFallbackReporter: Validation failed for plan: Scan parquet default.t, due to: columnar FileScan is not enabled in FileSourceScanExec.

```