### PR TITLE
[GLUTEN-2198] [CH] handle different header between upstream and downstream

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -190,7 +190,8 @@ case class CHHashAggregateExecTransformer(
     val groupingList = new util.ArrayList[ExpressionNode]()
     groupingExpressions.foreach(
       expr => {
-        // Rollback 'child.output' to 'output' as child's output may be different with output. See GLUTEN-2198.
+        // Rollback 'child.output' to 'output' as child's output may be different with output.
+        // See GLUTEN-2198.
         val exprNode = ExpressionConverter
           .replaceWithExpressionTransformer(expr, output)
           .doTransform(args)

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -190,10 +190,9 @@ case class CHHashAggregateExecTransformer(
     val groupingList = new util.ArrayList[ExpressionNode]()
     groupingExpressions.foreach(
       expr => {
-        // Use 'child.output' as based Seq[Attribute], the originalInputAttributes
-        // may be different for each backend.
+        // Rollback 'child.output' to 'output' as child's output may be different with output. See GLUTEN-2198.
         val exprNode = ExpressionConverter
-          .replaceWithExpressionTransformer(expr, child.output)
+          .replaceWithExpressionTransformer(expr, output)
           .doTransform(args)
         groupingList.add(exprNode)
       })

--- a/cpp-ch/local-engine/Storages/SourceFromJavaIter.h
+++ b/cpp-ch/local-engine/Storages/SourceFromJavaIter.h
@@ -20,7 +20,8 @@ public:
 
 private:
     DB::Chunk generate() override;
-    void convertNullable(DB::Chunk & chunk);
+    void buildChunk(DB::Block * block, DB::Chunk & chunk);
+    int getPositionByNameForUnion(DB::Block * header, std::string & output_name);
 
     jobject java_iter;
     DB::Block original_header;


### PR DESCRIPTION


## What changes were proposed in this pull request?

This pr handle the case that input block is different with the header and fix the problem that keys may be wrong in aggerator. This two problems are all caused by that columns may be in different order in spark plan betweent upsteam and its downstream.

(Fixes: \#2198)

## How was this patch tested?

This patch was tested by manual tests.