### PR TITLE
[GLUTEN-1434][CORE][FOLLOWUP] Remove isAdaptiveContextOrTopParentExchange check

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -29,12 +29,12 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util.concurrent.atomic.AtomicInteger
 
-case class TakeOrderedAndProjectExecTransformer(limit: Int,
-                                                sortOrder: Seq[SortOrder],
-                                                projectList: Seq[NamedExpression],
-                                                child: SparkPlan,
-                                                isAdaptiveContextOrTopParentExchange: Boolean)
-    extends UnaryExecNode with GlutenPlan {
+case class TakeOrderedAndProjectExecTransformer(
+    limit: Int,
+    sortOrder: Seq[SortOrder],
+    projectList: Seq[NamedExpression],
+    child: SparkPlan)
+  extends UnaryExecNode with GlutenPlan {
   override def outputPartitioning: Partitioning = SinglePartition
   override def outputOrdering: Seq[SortOrder] = sortOrder
   override def supportsColumnar: Boolean = true
@@ -96,8 +96,7 @@ case class TakeOrderedAndProjectExecTransformer(limit: Int,
           transformStageCounter.incrementAndGet())
         val shuffleExec = ShuffleExchangeExec(SinglePartition, limitStagePlan)
         val transformedShuffleExec = ColumnarShuffleUtil.genColumnarShuffleExchange(
-          shuffleExec, limitStagePlan, isAdaptiveContextOrTopParentExchange,
-          shuffleExec.child.output)
+          shuffleExec, limitStagePlan, shuffleExec.child.output)
         val localSortPlan = SortExecTransformer(sortOrder, false,
           new ColumnarInputAdapter(transformedShuffleExec))
         LimitTransformer(localSortPlan, 0, limit)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -46,13 +46,10 @@ import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 import org.apache.spark.util.SparkUtil
 
 // This rule will conduct the conversion from Spark plan to the plan transformer.
-case class TransformPreOverrides(
-  isTopParentExchange: Boolean,
-  isAdaptiveContext: Boolean) extends Rule[SparkPlan] {
+case class TransformPreOverrides(isAdaptiveContext: Boolean) extends Rule[SparkPlan] {
   val columnarConf: GlutenConfig = GlutenConfig.getConf
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
-  val isAdaptiveContextOrTopParentExchange = isTopParentExchange || isAdaptiveContext
   val reuseSubquery = isAdaptiveContext && conf.subqueryReuseEnabled
 
   /**
@@ -331,8 +328,7 @@ case class TransformPreOverrides(
       case plan: TakeOrderedAndProjectExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
-        TakeOrderedAndProjectExecTransformer(plan.limit, plan.sortOrder, plan.projectList, child,
-          isAdaptiveContextOrTopParentExchange)
+        TakeOrderedAndProjectExecTransformer(plan.limit, plan.sortOrder, plan.projectList, child)
       case plan: ShuffleExchangeExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
@@ -344,15 +340,12 @@ case class TransformPreOverrides(
                 val projectChild = getProjectWithHash(exprs, child)
                 if (projectChild.supportsColumnar) {
                   ColumnarShuffleUtil.genColumnarShuffleExchange(
-                    plan, projectChild, isAdaptiveContextOrTopParentExchange,
-                    projectChild.output.drop(1))
+                    plan, projectChild, projectChild.output.drop(1))
                 } else {
                   plan.withNewChildren(Seq(child))
                 }
               case _ =>
-                ColumnarShuffleUtil.genColumnarShuffleExchange(plan, child,
-                  isAdaptiveContextOrTopParentExchange = isAdaptiveContextOrTopParentExchange,
-                  null)
+                ColumnarShuffleUtil.genColumnarShuffleExchange(plan, child, null)
             }
           } else if (BackendsApiManager.getSettings.supportShuffleWithProject(plan
             .outputPartitioning, plan.child)) {
@@ -364,20 +357,17 @@ case class TransformPreOverrides(
                 val newPlan = ShuffleExchangeExec(newPartitioning, newChild, plan.shuffleOrigin)
                 // the new projections columns are appended at the end.
                 ColumnarShuffleUtil.genColumnarShuffleExchange(
-                  newPlan, newChild, isAdaptiveContextOrTopParentExchange,
-                  newChild.output.dropRight(projectColumnNumber))
+                  newPlan, newChild, newChild.output.dropRight(projectColumnNumber))
               } else {
                 // It's the case that partitioning expressions could be offloaded into native.
                 plan.withNewChildren(Seq(child))
               }
             }
             else {
-              ColumnarShuffleUtil.genColumnarShuffleExchange(
-                plan, child, isAdaptiveContextOrTopParentExchange, null)
+              ColumnarShuffleUtil.genColumnarShuffleExchange(plan, child, null)
             }
           } else {
-            ColumnarShuffleUtil.genColumnarShuffleExchange(
-              plan, child, isAdaptiveContextOrTopParentExchange, null)
+            ColumnarShuffleUtil.genColumnarShuffleExchange(plan, child, null)
           }
         } else {
           plan.withNewChildren(Seq(child))
@@ -659,8 +649,6 @@ case class ColumnarOverrideRules(session: SparkSession)
   lazy val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
   @transient private lazy val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
-  // Tracks whether the given input plan's top parent is exchange.
-  private var isTopParentExchange: Boolean = false
   // Tracks whether the columnar rule is called through AQE.
   private var isAdaptiveContext: Boolean = false
   // This is an empirical value, may need to be changed for supporting other versions of spark.
@@ -683,9 +671,7 @@ case class ColumnarOverrideRules(session: SparkSession)
       (spark: SparkSession) => PlanOneRowRelation(spark),
       (_: SparkSession) => FallbackEmptySchemaRelation(),
       (_: SparkSession) => AddTransformHintRule(),
-      (_: SparkSession) => TransformPreOverrides(
-        this.isTopParentExchange,
-        this.isAdaptiveContext),
+      (_: SparkSession) => TransformPreOverrides(this.isAdaptiveContext),
       (s: SparkSession) => GlutenFallbackReporter(GlutenConfig.getConf, s),
       (_: SparkSession) => RemoveTransformHintRule(),
       (_: SparkSession) => GlutenRemoveRedundantSorts) :::
@@ -708,10 +694,6 @@ case class ColumnarOverrideRules(session: SparkSession)
     maybe(session, plan) {
       var overridden: SparkPlan = plan
       val startTime = System.nanoTime()
-      this.isTopParentExchange = plan match {
-        case _: Exchange => true
-        case _ => false
-      }
       val traceElements = Thread.currentThread.getStackTrace
       assert(traceElements.length > aqeStackTraceIndex,
         s"The number of stack trace elements is expected to be more than $aqeStackTraceIndex")

--- a/gluten-core/src/main/scala/io/glutenproject/utils/ColumnarShuffleUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/ColumnarShuffleUtil.scala
@@ -30,16 +30,11 @@ object ColumnarShuffleUtil {
    * @param child            the child of shuffle exchange.
    * @return a columnar shuffle exchange.
    */
-  def genColumnarShuffleExchange(plan: ShuffleExchangeExec,
-                                 child: SparkPlan,
-                                 isAdaptiveContextOrTopParentExchange: Boolean,
-                                 shuffleOutputAttributes: Seq[Attribute]): SparkPlan = {
-    if (isAdaptiveContextOrTopParentExchange) {
-      ColumnarShuffleExchangeExec(plan.outputPartitioning, child,
-        plan.shuffleOrigin, shuffleOutputAttributes)
-    } else {
-      ColumnarShuffleExchangeExec(
-        plan.outputPartitioning, child, plan.shuffleOrigin, shuffleOutputAttributes)
-    }
+  def genColumnarShuffleExchange(
+      plan: ShuffleExchangeExec,
+      child: SparkPlan,
+      shuffleOutputAttributes: Seq[Attribute]): SparkPlan = {
+    ColumnarShuffleExchangeExec(plan.outputPartitioning, child, plan.shuffleOrigin,
+      shuffleOutputAttributes)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since https://github.com/oap-project/gluten/pull/2145, we removed `CoalesceBatch`. Then the flag `isAdaptiveContextOrTopParentExchange` has no affect any more.

## How was this patch tested?

Pass CI
