### PR TITLE
[GLUTEN-1597][VL] Remove the columnar batch copy operator in VeloxColumnarToRow

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -67,7 +67,7 @@ arrow::Status VeloxColumnarToRowConverter::init() {
 
 arrow::Status VeloxColumnarToRowConverter::write(std::shared_ptr<ColumnarBatch> cb) {
   auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
-  rv_ = veloxBatch->getFlattenedRowVector();
+  rv_ = veloxBatch->getRowVector();
   RETURN_NOT_OK(init());
 
   // Initialize the offsets_ , lengths_

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/rui-mo/velox.git
+VELOX_BRANCH=wip_type
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/rui-mo/velox.git
-VELOX_BRANCH=wip_type
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
@@ -41,8 +41,8 @@ class GlutenParquetIOSuite extends ParquetIOSuite with GlutenSQLTestsBaseTrait {
     withParquetFile(data) { path =>
       val errMsg = intercept[Exception](spark.read.schema(readSchema).parquet(path).collect())
         .getMessage
-      assert(errMsg.contains("BaseVector::compatibleKind(outputType->childAt(i)->kind(), " +
-        "requestedType->childAt(i)->kind())"))
+      assert(errMsg.contains(
+        "BaseVector::compatibleKind( childOutputType->kind(), childRequestedType->kind())"))
     }
   }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
@@ -41,8 +41,8 @@ class GlutenParquetIOSuite extends ParquetIOSuite with GlutenSQLTestsBaseTrait {
     withParquetFile(data) { path =>
       val errMsg = intercept[Exception](spark.read.schema(readSchema).parquet(path).collect())
         .getMessage
-      assert(errMsg.contains(
-        "BaseVector::compatibleKind(BaseVector::typeKind(), source->typeKind())"))
+      assert(errMsg.contains("BaseVector::compatibleKind(outputType->childAt(i)->kind(), " +
+        "requestedType->childAt(i)->kind())"))
     }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
@@ -55,7 +55,8 @@ class GlutenParquetIOSuite extends ParquetIOSuite with GlutenSQLTestsBaseTrait {
       val errMsg = intercept[Exception](spark.read.schema(readSchema).parquet(path).collect())
         .getMessage
       assert(errMsg.contains(
-        "BaseVector::compatibleKind(BaseVector::typeKind(), source->typeKind())"))
+        "BaseVector::compatibleKind(outputType->childAt(i)->kind(), " +
+          "requestedType->childAt(i)->kind())"))
     }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
@@ -55,8 +55,7 @@ class GlutenParquetIOSuite extends ParquetIOSuite with GlutenSQLTestsBaseTrait {
       val errMsg = intercept[Exception](spark.read.schema(readSchema).parquet(path).collect())
         .getMessage
       assert(errMsg.contains(
-        "BaseVector::compatibleKind(outputType->childAt(i)->kind(), " +
-          "requestedType->childAt(i)->kind())"))
+        "BaseVector::compatibleKind( childOutputType->kind(), childRequestedType->kind())"))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR try to remove use the getRowVector instead of getFlattenedRowVector method to avoid the copy action.
(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

