### PR TITLE
[GLUTEN-2139][CORE] Add default fallback reason

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -17,6 +17,7 @@
 
 package io.glutenproject.execution
 
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
 import io.glutenproject.substrait.SubstraitContext
 import org.apache.spark.{Partition, SparkContext, TaskContext}
@@ -52,6 +53,9 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
     case _ =>
       this
   }
+
+  override protected def doValidateInternal(): ValidationResult =
+    ValidationResult.notOk("does not support")
 
   override def doTransform(context: SubstraitContext): TransformContext = {
     throw new UnsupportedOperationException(s"This operator doesn't support doTransform.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ColumnarToRowExecBase.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ColumnarToRowExecBase.scala
@@ -18,26 +18,22 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 
-abstract class ColumnarToRowExecBase(child: SparkPlan) extends ColumnarToRowTransition {
+abstract class ColumnarToRowExecBase(child: SparkPlan)
+  extends ColumnarToRowTransition with GlutenPlan {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genColumnarToRowMetrics(sparkContext)
 
-  def doValidate(): Boolean = {
-    try {
-      buildCheck()
-    } catch {
-      case _: Throwable =>
-        logInfo("NativeColumnarToRow : Falling back to ColumnarToRow...")
-        return false
-    }
-    true
+  override protected def doValidateInternal(): ValidationResult = {
+    buildCheck()
+    ValidationResult.ok
   }
 
   def buildCheck(): Unit

--- a/gluten-core/src/main/scala/io/glutenproject/execution/RowToColumnarExecBase.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/RowToColumnarExecBase.scala
@@ -18,6 +18,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.GlutenPlan
 
 import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
@@ -30,9 +31,9 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 /**
  * Provides a common executor to translate an [[RDD]] of [[InternalRow]] into an [[RDD]] of
  * [[ColumnarBatch]]. This is inserted whenever such a transition is determined to be needed.
- *
  */
-abstract class RowToColumnarExecBase(child: SparkPlan) extends RowToColumnarTransition {
+abstract class RowToColumnarExecBase(child: SparkPlan)
+  extends RowToColumnarTransition with GlutenPlan {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -561,10 +561,11 @@ case class TransformPostOverrides(session: SparkSession, isAdaptiveContext: Bool
       logDebug(s"ColumnarPostOverrides ColumnarToRowExecBase(${child.nodeName})")
       val nativeConversion =
         BackendsApiManager.getSparkPlanExecApiInstance.genColumnarToRowExec(child)
-      if (nativeConversion.doValidate()) {
+      val validationResult = nativeConversion.doValidate()
+      if (validationResult.validated) {
         nativeConversion
       } else {
-        logDebug("NativeColumnarToRow : Falling back to ColumnarToRow...")
+        TransformHints.tagNotTransformable(plan, validationResult)
         plan.withNewChildren(plan.children.map(replaceWithTransformerPlan))
       }
     } else {

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -68,8 +68,7 @@ trait GlutenPlan extends SparkPlan with LogLevelUtil {
     }
   }
 
-  protected def doValidateInternal(): ValidationResult =
-    ValidationResult.notOk(s"$nodeName does not override doValidateInternal")
+  protected def doValidateInternal(): ValidationResult = ValidationResult.ok
 
   protected def logValidateFailure(msg: => String, e: Throwable): Unit = {
     if (printStackOnValidateFailure) {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -57,8 +57,7 @@ case class GlutenFallbackReporter(
       case _: GlutenPlan => // ignore
       case plan: SparkPlan =>
         plan.logicalLink.flatMap(_.getTagValue(FALLBACK_REASON_TAG)) match {
-          case Some(reason) =>
-            logFallbackReason(validateFailureLogLevel, plan.nodeName, reason)
+          case Some(_) => // We have logged it before, so skip it
           case _ =>
             // some SparkPlan do not have hint, e.g., `ColumnarAQEShuffleRead`
             TransformHints.getHintOption(plan) match {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/adaptive/ColumnarAQEShuffleReadExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/adaptive/ColumnarAQEShuffleReadExec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.adaptive
 
+import io.glutenproject.extension.GlutenPlan
+
 import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -34,11 +36,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * @param child          It is usually `ShuffleQueryStageExec`, but can be the shuffle exchange
  *                       node during canonicalization.
  * @param partitionSpecs The partition specs that defines the arrangement.
- * @param description    The string description of this shuffle reader.
  */
-case class ColumnarAQEShuffleReadExec(child: SparkPlan,
-                                      partitionSpecs: Seq[ShufflePartitionSpec])
-  extends UnaryExecNode {
+case class ColumnarAQEShuffleReadExec(
+    child: SparkPlan,
+    partitionSpecs: Seq[ShufflePartitionSpec])
+  extends UnaryExecNode with GlutenPlan {
   // We don't extends AQEShuffleReadExec since it has private constructor
 
   override lazy val outputPartitioning: Partitioning = {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenColumnarRules.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenColumnarRules.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.ColumnarToRowExecBase
+import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.utils.LogicalPlanSelector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SparkSession, Strategy}
@@ -58,7 +59,7 @@ private case class FakeRowLogicAdaptor(child: LogicalPlan) extends OrderPreservi
  * This is usually used in data writing since Spark doesn't expose APIs to write columnar data as of
  * now.
  */
-case class FakeRowAdaptor(child: SparkPlan) extends UnaryExecNode {
+case class FakeRowAdaptor(child: SparkPlan) extends UnaryExecNode with GlutenPlan {
   if (child.logicalLink.isDefined) {
     setLogicalLink(FakeRowLogicAdaptor(child.logicalLink.get))
   }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -87,5 +87,17 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait {
         assert(fallbackReason._2.contains("columnar FileScan is not enabled in FileSourceScanExec"))
       }
     }
+
+    withTable("t1", "t2") {
+      spark.range(10).write.format("parquet").saveAsTable("t1")
+      spark.range(10).write.format("parquet").saveAsTable("t2")
+
+      val id = runExecution("SELECT * FROM t1 JOIN t2")
+      val execution = glutenStore.execution(id)
+      // broadcast exchange and broadcast nested loop join
+      assert(execution.get.numFallbackNodes == 2)
+      assert(execution.get.fallbackNodeToReason.head._2.contains(
+        "Gluten does not touch it or does not support it"))
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The main change in this pr is:
1. Make all gluten plan inherit `GlutenPlan`, e.g., ColumnarToRowExec, RowToColumnarExec
2. Then we can add default fallback reason for all vanilla `SparkPlan`

(Fixes: \#2139)

## How was this patch tested?
add test
