### PR TITLE
[VL] Use single parent dir for shuffle spill

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
@@ -64,7 +64,7 @@ object SparkDirectoryUtil extends Logging {
 }
 
 class Namespace(private val parents: Array[File], private val name: String) {
-  private val all = parents.map { root =>
+  val all = parents.map { root =>
     val path = Paths.get(root.getAbsolutePath)
       .resolve(name)
     path.toFile

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -22,7 +22,6 @@ import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.memory.Spiller
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.vectorized._
-import org.apache.commons.io.FileUtils
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.memory.{MemoryConsumer, SparkMemoryUtil}
@@ -31,7 +30,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{SparkDirectoryUtil, SparkResourcesUtil, Utils}
 
 import java.io.IOException
-import java.util.UUID
 
 class ColumnarShuffleWriter[K, V](shuffleBlockResolver: IndexShuffleBlockResolver,
                                         handle: BaseShuffleHandle[K, V, V],


### PR DESCRIPTION
Port https://github.com/oap-project/gluten/pull/2249 to main. This will align the behavior of creating/deleting spill file dirs with Spark DiskBlockManager. 