### PR TITLE
[CORE] Correct and simplify stage prep rules

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ScalarSubqueryTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ScalarSubqueryTransformer.scala
@@ -35,7 +35,8 @@ class ScalarSubqueryTransformer(plan: BaseSubqueryExec, exprId: ExprId,
     // the first column in first row from `query`.
     val rows = query.plan.executeCollect()
     if (rows.length > 1) {
-      sys.error(s"more than one row returned by a subquery used as an expression:\n${query.plan}")
+      throw new IllegalStateException(
+        s"more than one row returned by a subquery used as an expression:\n${query.plan}")
     }
     val result: AnyRef = if (rows.length == 1) {
       assert(rows(0).numFields == 1,

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -663,9 +663,14 @@ case class ColumnarOverrideRules(session: SparkSession)
   // while creating the rules. At this time SQLConf may not be there yet.
 
   def preOverrides(): List[SparkSession => Rule[SparkPlan]] = {
+    val tagBeforeTransformHitsRules = if (this.isAdaptiveContext) {
+      // When AQE is supported, rules are applied in ColumnarQueryStagePrepOverrides
+      List.empty
+    } else {
+      TagBeforeTransformHits.ruleBuilders
+    }
+    tagBeforeTransformHitsRules :::
     List(
-      (spark: SparkSession) => FallbackOnANSIMode(spark),
-      (spark: SparkSession) => FallbackMultiCodegens(spark),
       (spark: SparkSession) => PlanOneRowRelation(spark),
       (_: SparkSession) => FallbackEmptySchemaRelation(),
       (_: SparkSession) => AddTransformHintRule(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -663,14 +663,9 @@ case class ColumnarOverrideRules(session: SparkSession)
   // while creating the rules. At this time SQLConf may not be there yet.
 
   def preOverrides(): List[SparkSession => Rule[SparkPlan]] = {
-    val tagBeforeTransformHitsRules = if (this.isAdaptiveContext) {
-      TagBeforeTransformHits.ruleBuilders
-    } else {
-      // When AQE is supported, rules are applied in ColumnarQueryStagePrepOverrides
-      List.empty
-    }
-    tagBeforeTransformHitsRules :::
     List(
+      (spark: SparkSession) => FallbackOnANSIMode(spark),
+      (spark: SparkSession) => FallbackMultiCodegens(spark),
       (spark: SparkSession) => PlanOneRowRelation(spark),
       (_: SparkSession) => FallbackEmptySchemaRelation(),
       (_: SparkSession) => AddTransformHintRule(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -89,7 +89,6 @@ case class FallbackBroadcastExchange(session: SparkSession) extends Rule[SparkPl
 
 object ColumnarQueryStagePrepOverrides extends GlutenSparkExtensionsInjector {
   override def inject(extensions: SparkSessionExtensions): Unit = {
-    val builders = TagBeforeTransformHits.ruleBuilders :+ FallbackBroadcastExchange
-    builders.foreach(extensions.injectQueryStagePrepRule)
+    extensions.injectQueryStagePrepRule(FallbackBroadcastExchange)
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -89,6 +89,7 @@ case class FallbackBroadcastExchange(session: SparkSession) extends Rule[SparkPl
 
 object ColumnarQueryStagePrepOverrides extends GlutenSparkExtensionsInjector {
   override def inject(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectQueryStagePrepRule(FallbackBroadcastExchange)
+    val builders = TagBeforeTransformHits.ruleBuilders :+ FallbackBroadcastExchange
+    builders.foreach(extensions.injectQueryStagePrepRule)
   }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
+import io.glutenproject.extension.columnar.FallbackMultiCodegens
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
@@ -31,6 +32,7 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))
     assert(spark.sessionState.planner.strategies.contains(JoinSelectionOverrides(spark)))

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
-import io.glutenproject.extension.columnar.{FallbackMultiCodegens, FallbackOneRowRelation}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
@@ -32,8 +31,6 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
-    assert(spark.sessionState.queryStagePrepRules.contains(FallbackOneRowRelation(spark)))
-    assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))
     assert(spark.sessionState.planner.strategies.contains(JoinSelectionOverrides(spark)))

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
-import io.glutenproject.extension.columnar.FallbackMultiCodegens
+import io.glutenproject.extension.columnar.{FallbackMultiCodegens, FallbackOnANSIMode}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
@@ -32,6 +32,7 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackOnANSIMode(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
+import io.glutenproject.extension.columnar.FallbackMultiCodegens
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
@@ -31,6 +32,7 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))
     assert(spark.sessionState.planner.strategies.contains(JoinSelectionOverrides(spark)))

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
-import io.glutenproject.extension.columnar.{FallbackMultiCodegens, FallbackOneRowRelation}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
@@ -32,8 +31,6 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
-    assert(spark.sessionState.queryStagePrepRules.contains(FallbackOneRowRelation(spark)))
-    assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))
     assert(spark.sessionState.planner.strategies.contains(JoinSelectionOverrides(spark)))

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/GlutenSessionExtensionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.extension
 
 import io.glutenproject.extension.{ColumnarOverrideRules, FallbackBroadcastExchange, JoinSelectionOverrides}
-import io.glutenproject.extension.columnar.FallbackMultiCodegens
+import io.glutenproject.extension.columnar.{FallbackMultiCodegens, FallbackOnANSIMode}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
@@ -32,6 +32,7 @@ class GlutenSessionExtensionSuite extends GlutenSQLTestsTrait {
   }
 
   test("test gluten extensions") {
+    assert(spark.sessionState.queryStagePrepRules.contains(FallbackOnANSIMode(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackMultiCodegens(spark)))
     assert(spark.sessionState.queryStagePrepRules.contains(FallbackBroadcastExchange(spark)))
     assert(spark.sessionState.columnarRules.contains(ColumnarOverrideRules(spark)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr corrects and simplify: 
- remove rule `FallbackOneRowRelation` which has been covered by `FallbackEmptySchemaRelation`
- only inject `FallbackBroadcastExchange` to stage prep rule so that we can remove the wrong `tagBeforeTransformHitsRules `

## How was this patch tested?

Pass CI