### PR TITLE
[GLUTEN-2217][CH] Introduce Signal Handler to print stack info when get `SIGSEGV`

### DIFF
--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -130,3 +130,7 @@ else()
 endif()
 
 add_subdirectory(tests)
+
+if (ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -10,16 +10,13 @@
 #include <Columns/IColumn.h>
 #include <Core/Block.h>
 #include <Core/ColumnWithTypeAndName.h>
-#include <Core/ColumnsWithTypeAndName.h>
 #include <Core/NamesAndTypes.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/IDataType.h>
 #include <DataTypes/NestedUtils.h>
-#include <DataTypes/Serializations/ISerialization.h>
 #include <Functions/CastOverloadResolver.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsConversion.h>
@@ -27,7 +24,6 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/SharedThreadPools.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
-#include <Interpreters/castColumn.h>
 #include <Parser/RelParser.h>
 #include <Parser/SerializedPlanParser.h>
 #include <Processors/Chunk.h>
@@ -41,6 +37,7 @@
 #include <Poco/Logger.h>
 #include <Poco/Util/MapConfiguration.h>
 #include <Common/Config/ConfigProcessor.h>
+#include <Common/GlutenSignalHandler.h>
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
@@ -509,7 +506,7 @@ void BackendInitializerUtil::initConfig(std::string * plan)
 
 void BackendInitializerUtil::initLoggers()
 {
-    auto level = config->getString("logger.level", "error");
+    auto level = config->getString("logger.level", "warning");
     if (config->has("logger.log"))
         local_engine::Logger::initFileLogger(*config, "ClickHouseBackend");
     else
@@ -686,6 +683,8 @@ void BackendInitializerUtil::init(std::string * plan)
         init_flag,
         [&]
         {
+            SignalHandler::instance().init();
+
             registerAllFactories();
             LOG_INFO(logger, "Register all factories.");
 

--- a/cpp-ch/local-engine/Common/GlutenSignalHandler.cpp
+++ b/cpp-ch/local-engine/Common/GlutenSignalHandler.cpp
@@ -371,7 +371,7 @@ struct SignalHandler::Impl
     /// initialize termination process and signal handlers
     void initializeTerminationAndSignalProcessing()
     {
-        addSignalHandler({SIGABRT, SIGSEGV, SIGBUS, SIGTSTP}, signalHandler, &handled_signals);
+        addSignalHandler({SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGSYS, SIGFPE, SIGPIPE, SIGTSTP, SIGTRAP}, signalHandler, &handled_signals);
 
         /// TODO:: Set up Poco ErrorHandler for Poco Threads.
         // static KillingErrorHandler killing_error_handler;

--- a/cpp-ch/local-engine/Common/GlutenSignalHandler.cpp
+++ b/cpp-ch/local-engine/Common/GlutenSignalHandler.cpp
@@ -1,0 +1,422 @@
+#include <cstring>
+#include <vector>
+#include <IO/ReadBufferFromFileDescriptor.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromFileDescriptorDiscardOnFailure.h>
+#include <IO/WriteHelpers.h>
+#include <Interpreters/Context.h>
+#include <base/getThreadId.h>
+#include <base/phdr_cache.h>
+#include <base/sleep.h>
+#include <Poco/Exception.h>
+#include <Common/GlutenSignalHandler.h>
+#include <Common/MemoryTracker.h>
+#include <Common/PipeFDs.h>
+#include <Common/ThreadStatus.h>
+#include <Common/getHashOfLoadedBinary.h>
+#include <Common/logger_useful.h>
+
+#include "config_version.h"
+
+using namespace local_engine;
+
+using signal_function = void(int, siginfo_t *, void *);
+
+static const size_t signal_pipe_buf_size
+    = sizeof(int) + sizeof(siginfo_t) + sizeof(ucontext_t *) + sizeof(StackTrace) + sizeof(UInt32) + sizeof(void *);
+
+static std::atomic_flag fatal_error_printed;
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int CANNOT_SET_SIGNAL_HANDLER;
+    extern const int CANNOT_SEND_SIGNAL;
+    extern const int SYSTEM_ERROR;
+}
+}
+
+extern String getGitHash();
+
+using namespace DB;
+PipeFDs signal_pipe;
+ALWAYS_INLINE int readFD()
+{
+    return signal_pipe.fds_rw[0];
+}
+
+ALWAYS_INLINE int writeFD()
+{
+    return signal_pipe.fds_rw[1];
+}
+
+static void addSignalHandler(const std::vector<int> & signals, signal_function handler, std::vector<int> * out_handled_signals)
+{
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = handler;
+    sa.sa_flags = SA_SIGINFO;
+
+#if defined(OS_DARWIN)
+    sigemptyset(&sa.sa_mask);
+    for (auto signal : signals)
+        sigaddset(&sa.sa_mask, signal);
+#else
+    if (sigemptyset(&sa.sa_mask))
+        throw Poco::Exception("Cannot set signal handler.");
+
+    for (auto signal : signals)
+        if (sigaddset(&sa.sa_mask, signal))
+            throw Poco::Exception("Cannot set signal handler.");
+#endif
+
+    for (auto signal : signals)
+        if (sigaction(signal, &sa, nullptr))
+            throw Poco::Exception("Cannot set signal handler.");
+
+    if (out_handled_signals)
+        std::copy(signals.begin(), signals.end(), std::back_inserter(*out_handled_signals));
+}
+
+static void writeSignalIDtoSignalPipe(int sig)
+{
+    auto saved_errno = errno; /// We must restore previous value of errno in signal handler.
+    char buf[signal_pipe_buf_size];
+    WriteBufferFromFileDescriptor out(writeFD(), signal_pipe_buf_size, buf);
+    writeBinary(sig, out);
+    out.next();
+    errno = saved_errno;
+}
+
+static void call_default_signal_handler(int sig)
+{
+    if (SIG_ERR == signal(sig, SIG_DFL))
+        DB::throwFromErrno("Cannot set signal handler.", DB::ErrorCodes::CANNOT_SET_SIGNAL_HANDLER);
+
+    if (0 != raise(sig))
+        DB::throwFromErrno("Cannot send signal.", DB::ErrorCodes::CANNOT_SEND_SIGNAL);
+}
+
+static void signalHandler(int sig, siginfo_t * info, void * context) noexcept
+{
+    DENY_ALLOCATIONS_IN_SCOPE;
+    auto saved_errno = errno; /// We must restore previous value of errno in signal handler.
+
+    char buf[signal_pipe_buf_size];
+    DB::WriteBufferFromFileDescriptorDiscardOnFailure out(writeFD(), signal_pipe_buf_size, buf);
+
+    const ucontext_t * signal_context = reinterpret_cast<ucontext_t *>(context);
+    const StackTrace stack_trace(*signal_context);
+
+    DB::writeBinary(sig, out);
+    DB::writePODBinary(*info, out);
+    DB::writePODBinary(signal_context, out);
+    DB::writePODBinary(stack_trace, out);
+    DB::writeBinary(static_cast<UInt32>(getThreadId()), out);
+    DB::writePODBinary(DB::current_thread, out);
+
+    out.next();
+
+    if (sig != SIGTSTP) /// This signal is used for debugging.
+    {
+        /// The time that is usually enough for separate thread to print info into log.
+        /// Under MSan full stack unwinding with DWARF info about inline functions takes 101 seconds in one case.
+        for (size_t i = 0; i < 300; ++i)
+        {
+            /// We will synchronize with the thread printing the messages with an atomic variable to finish earlier.
+            if (fatal_error_printed.test())
+                break;
+
+            /// This coarse method of synchronization is perfectly ok for fatal signals.
+            sleepForSeconds(1);
+        }
+        call_default_signal_handler(sig);
+    }
+
+    errno = saved_errno;
+}
+
+/// Avoid link time dependency on DB/Interpreters - will use this function only when linked.
+__attribute__((__weak__)) void
+collectGlutenCrashLog(Int32 signal, UInt64 thread_id, const String & query_id, const StackTrace & stack_trace);
+
+class SignalListener : public Poco::Runnable
+{
+public:
+    static constexpr int StdTerminate = -1;
+    static constexpr int StopThread = -2;
+    static constexpr int SanitizerTrap = -3;
+    SignalListener() : log(&Poco::Logger::get("SignalListener")), git_hash("getGitHash()") { }
+
+    void run() override
+    {
+        static_assert(PIPE_BUF >= 512);
+        static_assert(
+            signal_pipe_buf_size <= PIPE_BUF,
+            "Only write of PIPE_BUF to pipe is atomic and the minimal known PIPE_BUF across supported platforms is 512");
+        char buf[signal_pipe_buf_size];
+        ReadBufferFromFileDescriptor in(readFD(), signal_pipe_buf_size, buf);
+
+        while (!in.eof())
+        {
+            int sig = 0;
+            readBinary(sig, in);
+            // We may log some specific signals afterward, with different log
+            // levels and more info, but for completeness we log all signals
+            // here at trace level.
+            // Don't use strsignal here, because it's not thread-safe.
+            LOG_TRACE(log, "Received signal {}", sig);
+
+            if (sig == StopThread)
+            {
+                LOG_INFO(log, "Stop SignalListener thread");
+                break;
+            }
+            else if (sig == StdTerminate)
+            {
+                UInt32 thread_num;
+                std::string message;
+
+                readBinary(thread_num, in);
+                readBinary(message, in);
+
+                onTerminate(message, thread_num);
+            }
+            else
+            {
+                siginfo_t info{};
+                ucontext_t * context{};
+                StackTrace stack_trace(NoCapture{});
+                UInt32 thread_num{};
+                ThreadStatus * thread_ptr{};
+
+                if (sig != SanitizerTrap)
+                {
+                    readPODBinary(info, in);
+                    readPODBinary(context, in);
+                }
+
+                readPODBinary(stack_trace, in);
+                readBinary(thread_num, in);
+                readPODBinary(thread_ptr, in);
+
+                /// This allows to receive more signals if failure happens inside onFault function.
+                /// Example: segfault while symbolizing stack trace.
+                std::thread([sig, info, context, stack_trace, thread_num, thread_ptr, this]
+                            { onFault(sig, info, context, stack_trace, thread_num, thread_ptr); })
+                    .detach();
+            }
+        }
+    }
+
+private:
+    Poco::Logger * log;
+    std::string build_id; // TODO : Build ID
+    std::string git_hash;
+    std::string stored_binary_hash; // TODO: binary checksum
+    void onTerminate(std::string_view /*message*/, UInt32 /*thread_num*/) const { }
+
+    void onFault(
+        int sig, const siginfo_t & info, ucontext_t * context, const StackTrace & stack_trace, UInt32 thread_num, ThreadStatus * thread_ptr)
+        const
+    {
+        String query_id;
+        String query;
+
+        /// Send logs from this thread to client if possible.
+        /// It will allow client to see failure messages directly.
+        if (thread_ptr)
+        {
+            query_id = thread_ptr->getQueryId();
+            query = thread_ptr->getQueryForLog();
+
+            if (auto logs_queue = thread_ptr->getInternalTextLogsQueue())
+            {
+                CurrentThread::attachInternalTextLogsQueue(logs_queue, LogsLevel::trace);
+            }
+        }
+        std::string signal_description = "Unknown signal";
+
+        /// Some of these are not really signals, but our own indications on failure reason.
+        if (sig == StdTerminate)
+            signal_description = "std::terminate";
+        else if (sig == SanitizerTrap)
+            signal_description = "sanitizer trap";
+        else if (sig >= 0)
+            signal_description = strsignal(sig); // NOLINT(concurrency-mt-unsafe) // it is not thread-safe but ok in this context
+
+        LOG_FATAL(log, "########################################");
+
+        if (query_id.empty())
+        {
+            LOG_FATAL(
+                log,
+                "(version {}{}, build id: {}, git hash: {}) (from thread {}) (no query) Received signal {} ({})",
+                VERSION_STRING,
+                VERSION_OFFICIAL,
+                build_id,
+                git_hash,
+                thread_num,
+                signal_description,
+                sig);
+        }
+        else
+        {
+            LOG_FATAL(
+                log,
+                "(version {}{}, build id: {}, git hash: {}) (from thread {}) (query_id: {}) (query: {}) Received signal {} ({})",
+                VERSION_STRING,
+                VERSION_OFFICIAL,
+                build_id,
+                git_hash,
+                thread_num,
+                query_id,
+                query,
+                signal_description,
+                sig);
+        }
+        String error_message;
+
+        if (sig != SanitizerTrap)
+            error_message = signalToErrorMessage(sig, info, *context);
+        else
+            error_message = "Sanitizer trap.";
+
+        LOG_FATAL(log, fmt::runtime(error_message));
+
+        /// Write symbolized stack trace line by line for better grep-ability.
+        stack_trace.toStringEveryLine([this](std::string_view s) { LOG_FATAL(log, fmt::runtime(s)); });
+
+#if defined(OS_LINUX)
+        /// Write information about binary checksum. It can be difficult to calculate, so do it only after printing stack trace.
+        /// TODO: Please keep the below log messages in-sync with the ones in ~programs/server/Server.cpp~
+
+        if (stored_binary_hash.empty())
+        {
+            LOG_FATAL(log, "Integrity check of the executable skipped because the reference checksum could not be read.");
+        }
+        else
+        {
+            String calculated_binary_hash = getHashOfLoadedBinaryHex();
+            if (calculated_binary_hash == stored_binary_hash)
+            {
+                LOG_FATAL(log, "Integrity check of the executable successfully passed (checksum: {})", calculated_binary_hash);
+            }
+            else
+            {
+                LOG_FATAL(
+                    log,
+                    "Calculated checksum of the executable ({0}) does not correspond"
+                    " to the reference checksum stored in the executable ({1})."
+                    " This may indicate one of the following:"
+                    " - the executable was changed just after startup;"
+                    " - the executable was corrupted on disk due to faulty hardware;"
+                    " - the loaded executable was corrupted in memory due to faulty hardware;"
+                    " - the file was intentionally modified;"
+                    " - a logical error in the code.",
+                    calculated_binary_hash,
+                    stored_binary_hash);
+            }
+        }
+#endif
+        /// FIXME: Write crash to system.crash_log table if available.
+        if (collectGlutenCrashLog)
+            collectGlutenCrashLog(sig, thread_num, query_id, stack_trace);
+
+        ///TODO: Send crash report to developers (if configured)
+        if (sig != SanitizerTrap)
+        {
+            /// TODO: SentryWriter::onFault(sig, error_message, stack_trace);
+
+            /// TODO:  Advice the user to send it manually.
+        }
+        /// ClickHouse Keeper does not link to some part of Settings.
+#ifndef CLICKHOUSE_PROGRAM_STANDALONE_BUILD
+        /// List changed settings.
+        if (!query_id.empty())
+        {
+            ContextPtr query_context = thread_ptr->getQueryContext();
+            if (query_context)
+            {
+                String changed_settings = query_context->getSettingsRef().toString();
+
+                if (changed_settings.empty())
+                    LOG_FATAL(log, "No settings were changed");
+                else
+                    LOG_FATAL(log, "Changed settings: {}", changed_settings);
+            }
+        }
+#endif
+        /// When everything is done, we will try to send these error messages to client.
+        if (thread_ptr)
+            thread_ptr->onFatalError();
+
+        fatal_error_printed.test_and_set();
+    }
+};
+
+namespace local_engine
+{
+SignalHandler::SignalHandler() = default;
+SignalHandler::~SignalHandler() = default;
+
+struct SignalHandler::Impl
+{
+    /// A thread that acts on HUP and USR1 signal (close logs).
+    Poco::Thread signal_listener_thread;
+    std::unique_ptr<Poco::Runnable> signal_listener;
+    std::vector<int> handled_signals;
+
+    /// initialize termination process and signal handlers
+    void initializeTerminationAndSignalProcessing()
+    {
+        addSignalHandler({SIGABRT, SIGSEGV, SIGBUS, SIGTSTP}, signalHandler, &handled_signals);
+
+        /// TODO:: Set up Poco ErrorHandler for Poco Threads.
+        // static KillingErrorHandler killing_error_handler;
+        // Poco::ErrorHandler::set(&killing_error_handler);
+
+        signal_pipe.setNonBlockingWrite();
+        signal_pipe.tryIncreaseSize(1 << 20);
+        signal_listener = std::make_unique<SignalListener>();
+        signal_listener_thread.start(*signal_listener);
+    }
+
+    ~Impl()
+    {
+        writeSignalIDtoSignalPipe(SignalListener::StopThread);
+        signal_listener_thread.join();
+
+        /// Reset signals to SIG_DFL to avoid trying to write to the signal_pipe that will be closed after.
+        for (int sig : handled_signals)
+            if (SIG_ERR == signal(sig, SIG_DFL))
+                throwFromErrno("Cannot set signal handler.", ErrorCodes::CANNOT_SET_SIGNAL_HANDLER);
+        signal_pipe.close();
+    }
+};
+
+void SignalHandler::init()
+{
+    if (pimpl)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "The SignalHandler is initialized twice");
+
+    // getenv is not thread-safe, but it's fine here.
+    Poco::Logger * log = &Poco::Logger::get("SignalHandler");
+    const char * preload = std::getenv("LD_PRELOAD");
+
+    bool find_libjsig = preload != nullptr && std::string_view(preload).find("libjsig.so") != std::string_view::npos;
+
+    if (find_libjsig)
+    {
+        LOG_WARNING(log, "LD_PRELOAD is {}", preload);
+        updatePHDRCache();
+        pimpl = std::make_unique<Impl>();
+        pimpl->initializeTerminationAndSignalProcessing();
+    }
+    else
+    {
+        LOG_WARNING(log, "LD_PRELOAD is not set, SignalHandler is disabled");
+    }
+}
+}

--- a/cpp-ch/local-engine/Common/GlutenSignalHandler.h
+++ b/cpp-ch/local-engine/Common/GlutenSignalHandler.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <memory>
+
+namespace local_engine
+{
+class SignalHandler
+{
+private:
+    SignalHandler();
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+
+public:
+    ~SignalHandler();
+    static SignalHandler & instance()
+    {
+        static SignalHandler res;
+        return res;
+    }
+    void init();
+};
+}

--- a/cpp-ch/local-engine/examples/CMakeLists.txt
+++ b/cpp-ch/local-engine/examples/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+clickhouse_add_executable (signal_demo signal_demo.cpp)
+target_link_libraries(signal_demo PRIVATE gluten_clickhouse_backend_libs loggers)

--- a/cpp-ch/local-engine/examples/signal_demo.cpp
+++ b/cpp-ch/local-engine/examples/signal_demo.cpp
@@ -1,0 +1,32 @@
+
+#include <base/sleep.h>
+#include <Common/GlutenSignalHandler.h>
+#include <Common/Logger.h>
+#include <Common/logger_useful.h>
+#include <IO/WriteBufferFromFileDescriptorDiscardOnFailure.h>
+#include <IO/WriteHelpers.h>
+
+
+using namespace DB;
+using namespace local_engine;
+
+
+int main(int  /*argc*/, char * /*argv*/[])
+{
+    local_engine::Logger::initConsoleLogger("trace");
+    Poco::Logger * logger = &Poco::Logger::get("signal_demo");
+    SignalHandler::instance().init();
+
+    for (int j = 0; j < 10 ; j++) {
+        LOG_TRACE(logger, "counter {}", j);
+
+        if( j ){
+            int *x = nullptr;
+            *x = 1;
+        }
+        sleepForSeconds(3);
+    }
+
+    LOG_TRACE(logger, "byb bye!");
+    return 0;
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#2217)

## How was this patch tested?

using exited UTs

# Design


Experimental feature.

> Codes are copied from `BaseDameon`, since I believe it's difficult to merge into the main branch.

The idea is very simple, register a single handler via [Signal Chaining](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/signals003.html), when jvm failed to handle signal, it will call ours. We create a pipe during initialization, and in our Signal handler, we collect stack info, and then write those info into pipe. ​We also create a Signal Listener to read from that pipe, and dump the stack info. 

In most cases, the method works as I tried out. However, if the original SIGSEGV issue results from a corrupted stack, such as a JNI [stack overflow](https://pangin.pro/posts/stack-overflow-handling#shadow-pages), our signal handler won't be able to work. I spent a lot of time figuring out why, but I made no progress.

For example, calling the following function in the JNI could easily reproduce the case.

```c
void deepNative64K(Poco::Logger * log, int depth = 10000) {
    char BUF[256*1024];
    memset(BUF, 0x5D5D5D5DL, sizeof(BUF));
    LOG_WARNING(log, "thread({}), stack grows {} kbytes", getThreadId(), (sizeof(BUF) * (10001-depth))/1024);
    if (depth > 0) {
        deepNative64K(log, depth - 1);
    }
}
```

# How to use 

```shell
export LD_PRELOAD=libjvm.so-directory/libjsig.so:libch.so
```
