### PR TITLE
[GLUTEN-2193][CH] Support functions array_distinct/array_union

### DIFF
--- a/cpp-ch/local-engine/Functions/SparkFunctionArrayDistinct.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionArrayDistinct.cpp
@@ -1,0 +1,319 @@
+#include <Functions/IFunction.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Common/HashTable/ClearableHashSet.h>
+#include <Common/SipHash.h>
+#include <Common/assert_cast.h>
+#include <Columns/IColumn.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+
+/// copied from src/Functions/array/arrayDistinct.cpp
+/// but have little differences in implementation detail:
+/// We shoud remain the first null value in the array
+/// e.g. select arrayDistinct([1, null, 2, null, 3, 3]) should return [1, null, 2, 3]
+class FunctionArrayDistinctSpark : public IFunction
+{
+public:
+    static constexpr auto name = "arrayDistinctSpark";
+
+    static FunctionPtr create(ContextPtr)
+    {
+        return std::make_shared<FunctionArrayDistinctSpark>();
+    }
+
+    String getName() const override
+    {
+        return name;
+    }
+
+    bool isVariadic() const override { return false; }
+
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+    size_t getNumberOfArguments() const override { return 1; }
+
+    bool useDefaultImplementationForConstants() const override { return true; }
+
+    DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
+    {
+        const DataTypeArray * array_type = checkAndGetDataType<DataTypeArray>(arguments[0].get());
+        if (!array_type)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Argument for function {} must be array but it  has type {}.",
+                getName(), arguments[0]->getName());
+        /// difference: we can return Array(Nullable()) type
+        return std::make_shared<DataTypeArray>(array_type->getNestedType());
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
+
+private:
+    /// Initially allocate a piece of memory for 512 elements. NOTE: This is just a guess.
+    static constexpr size_t INITIAL_SIZE_DEGREE = 9;
+
+    template <typename T>
+    static bool executeNumber(
+        const IColumn & src_data,
+        const ColumnArray::Offsets & src_offsets,
+        IColumn & res_data_col,
+        ColumnArray::Offsets & res_offsets,
+        const ColumnNullable * nullable_col);
+
+    static bool executeString(
+        const IColumn & src_data,
+        const ColumnArray::Offsets & src_offsets,
+        IColumn & res_data_col,
+        ColumnArray::Offsets & res_offsets,
+        const ColumnNullable * nullable_col);
+
+    static void executeHashed(
+        const IColumn & src_data,
+        const ColumnArray::Offsets & src_offsets,
+        IColumn & res_data_col,
+        ColumnArray::Offsets & res_offsets,
+        const ColumnNullable * nullable_col);
+};
+
+
+ColumnPtr FunctionArrayDistinctSpark::executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t /*input_rows_count*/) const
+{
+    ColumnPtr array_ptr = arguments[0].column;
+    const ColumnArray * array = checkAndGetColumn<ColumnArray>(array_ptr.get());
+
+    const auto & return_type = result_type;
+
+    auto res_ptr = return_type->createColumn();
+    ColumnArray & res = assert_cast<ColumnArray &>(*res_ptr);
+
+    const IColumn & src_data = array->getData();
+    const ColumnArray::Offsets & offsets = array->getOffsets();
+
+    IColumn & res_data = res.getData();
+    ColumnArray::Offsets & res_offsets = res.getOffsets();
+
+    const ColumnNullable * nullable_col = checkAndGetColumn<ColumnNullable>(src_data);
+
+    const IColumn * inner_col;
+
+    if (nullable_col)
+    {
+        inner_col = &nullable_col->getNestedColumn();
+    }
+    else
+    {
+        inner_col = &src_data;
+    }
+
+    if (!(executeNumber<UInt8>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<UInt16>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<UInt32>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<UInt64>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<Int8>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<Int16>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<Int32>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<Int64>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<Float32>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeNumber<Float64>(*inner_col, offsets, res_data, res_offsets, nullable_col)
+        || executeString(*inner_col, offsets, res_data, res_offsets, nullable_col)))
+        executeHashed(*inner_col, offsets, res_data, res_offsets, nullable_col);
+
+    return res_ptr;
+}
+
+template <typename T>
+bool FunctionArrayDistinctSpark::executeNumber(
+    const IColumn & src_data,
+    const ColumnArray::Offsets & src_offsets,
+    IColumn & res_data_col,
+    ColumnArray::Offsets & res_offsets,
+    const ColumnNullable * nullable_col)
+{
+    const ColumnVector<T> * src_data_concrete = checkAndGetColumn<ColumnVector<T>>(&src_data);
+
+    if (!src_data_concrete)
+    {
+        return false;
+    }
+
+    const PaddedPODArray<T> & values = src_data_concrete->getData();
+
+    const PaddedPODArray<UInt8> * src_null_map = nullptr;
+
+    if (nullable_col)
+        src_null_map = &nullable_col->getNullMapData();
+
+    using Set = ClearableHashSetWithStackMemory<T, DefaultHash<T>,
+        INITIAL_SIZE_DEGREE>;
+
+    Set set;
+
+    ColumnArray::Offset prev_src_offset = 0;
+    ColumnArray::Offset res_offset = 0;
+
+    for (auto curr_src_offset : src_offsets)
+    {
+        set.clear();
+        bool has_null = false;
+
+        for (ColumnArray::Offset j = prev_src_offset; j < curr_src_offset; ++j)
+        {
+            /// difference: we should remain the first null value
+            if (nullable_col && (*src_null_map)[j])
+            {
+                if (has_null)
+                    continue;
+                res_data_col.insertDefault();
+                has_null = true;
+                continue;
+            }
+
+            if (!set.find(values[j]))
+            {
+                res_data_col.insert(values[j]);
+                set.insert(values[j]);
+            }
+        }
+
+        res_offset += set.size() + has_null;
+        res_offsets.emplace_back(res_offset);
+
+        prev_src_offset = curr_src_offset;
+    }
+    return true;
+}
+
+bool FunctionArrayDistinctSpark::executeString(
+    const IColumn & src_data,
+    const ColumnArray::Offsets & src_offsets,
+    IColumn & res_data_col,
+    ColumnArray::Offsets & res_offsets,
+    const ColumnNullable * nullable_col)
+{
+    const ColumnString * src_data_concrete = checkAndGetColumn<ColumnString>(&src_data);
+
+    if (!src_data_concrete)
+        return false;
+
+    using Set = ClearableHashSetWithStackMemory<StringRef, StringRefHash,
+        INITIAL_SIZE_DEGREE>;
+
+    const PaddedPODArray<UInt8> * src_null_map = nullptr;
+
+    if (nullable_col)
+        src_null_map = &nullable_col->getNullMapData();
+
+    Set set;
+
+    ColumnArray::Offset prev_src_offset = 0;
+    ColumnArray::Offset res_offset = 0;
+
+    for (auto curr_src_offset : src_offsets)
+    {
+        set.clear();
+        bool has_null = false;
+
+        for (ColumnArray::Offset j = prev_src_offset; j < curr_src_offset; ++j)
+        {
+            /// difference: we should remain the first null value
+            if (nullable_col && (*src_null_map)[j])
+            {
+                if (has_null)
+                    continue;
+                res_data_col.insertDefault();
+                has_null = true;
+                continue;
+            }
+
+            StringRef str_ref = src_data_concrete->getDataAt(j);
+
+            if (!set.find(str_ref))
+            {
+                set.insert(str_ref);
+                res_data_col.insertData(str_ref.data, str_ref.size);
+            }
+        }
+
+        res_offset += set.size() + has_null;
+        res_offsets.emplace_back(res_offset);
+
+        prev_src_offset = curr_src_offset;
+    }
+    return true;
+}
+
+void FunctionArrayDistinctSpark::executeHashed(
+    const IColumn & src_data,
+    const ColumnArray::Offsets & src_offsets,
+    IColumn & res_data_col,
+    ColumnArray::Offsets & res_offsets,
+    const ColumnNullable * nullable_col)
+{
+    using Set = ClearableHashSetWithStackMemory<UInt128, UInt128TrivialHash,
+        INITIAL_SIZE_DEGREE>;
+
+    const PaddedPODArray<UInt8> * src_null_map = nullptr;
+
+    if (nullable_col)
+        src_null_map = &nullable_col->getNullMapData();
+
+    Set set;
+
+    ColumnArray::Offset prev_src_offset = 0;
+    ColumnArray::Offset res_offset = 0;
+
+    for (auto curr_src_offset : src_offsets)
+    {
+        set.clear();
+        bool has_null = false;
+
+        for (ColumnArray::Offset j = prev_src_offset; j < curr_src_offset; ++j)
+        {
+            /// difference: we should remain the first null value
+            if (nullable_col && (*src_null_map)[j])
+            {
+                if (has_null)
+                    continue;
+                res_data_col.insertDefault();
+                has_null = true;
+                continue;
+            }
+
+            UInt128 hash;
+            SipHash hash_function;
+            src_data.updateHashWithValue(j, hash_function);
+            hash_function.get128(hash);
+
+            if (!set.find(hash))
+            {
+                set.insert(hash);
+                res_data_col.insertFrom(src_data, j);
+            }
+        }
+
+        res_offset += set.size() + has_null;
+        res_offsets.emplace_back(res_offset);
+
+        prev_src_offset = curr_src_offset;
+    }
+}
+
+
+REGISTER_FUNCTION(ArrayDistinctSpark)
+{
+    factory.registerFunction<FunctionArrayDistinctSpark>();
+}
+
+}

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayDistinct.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayDistinct.cpp
@@ -33,7 +33,7 @@ public:
             throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
 
         const auto * array_distinct_node = toFunctionNode(actions_dag, "arrayDistinctSpark", {parsed_args[0]});
-        /// We cann not call convertNodeTypeIfNeeded which will fail when cast Array(Array(xx)) to Array(Nullable(Array(xx)))
+        /// We can not call convertNodeTypeIfNeeded which will fail when cast Array(Array(xx)) to Array(Nullable(Array(xx)))
         return array_distinct_node;
     }
 };

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayDistinct.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayDistinct.cpp
@@ -1,0 +1,42 @@
+#include <Parser/FunctionParser.h>
+#include <Common/CHUtil.h>
+#include <Core/Field.h>
+#include <DataTypes/IDataType.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+}
+
+namespace local_engine
+{
+
+class FunctionParserArrayDistinct : public FunctionParser
+{
+public:
+    explicit FunctionParserArrayDistinct(SerializedPlanParser * plan_parser_) : FunctionParser(plan_parser_) { }
+
+    static constexpr auto name = "array_distinct";
+
+    String getName() const override { return name; }
+
+    const ActionsDAG::Node * parse(
+        const substrait::Expression_ScalarFunction & substrait_func,
+        ActionsDAGPtr & actions_dag) const override
+    {
+        auto parsed_args = parseFunctionArguments(substrait_func, "", actions_dag);
+        if (parsed_args.size() != 1)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly one arguments", getName());
+
+        const auto * array_distinct_node = toFunctionNode(actions_dag, "arrayDistinctSpark", {parsed_args[0]});
+        /// We cann not call convertNodeTypeIfNeeded which will fail when cast Array(Array(xx)) to Array(Nullable(Array(xx)))
+        return array_distinct_node;
+    }
+};
+
+static FunctionParserRegister<FunctionParserArrayDistinct> register_array_distinct;
+}

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayUnion.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayUnion.cpp
@@ -38,7 +38,7 @@ public:
 
         const auto * array_concat_node = toFunctionNode(actions_dag, "arrayConcat", {left_arg, right_arg});
         const auto * result_node = toFunctionNode(actions_dag, "arrayDistinctSpark", {array_concat_node});
-        /// We cann not call convertNodeTypeIfNeeded which will fail when cast Array(Array(xx)) to Array(Nullable(Array(xx)))
+        /// We can not call convertNodeTypeIfNeeded which will fail when cast Array(Array(xx)) to Array(Nullable(Array(xx)))
         return result_node;
     }
 };

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayUnion.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayUnion.cpp
@@ -1,0 +1,47 @@
+#include <Parser/FunctionParser.h>
+#include <Common/CHUtil.h>
+#include <Core/Field.h>
+#include <DataTypes/IDataType.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+}
+
+namespace local_engine
+{
+
+class FunctionParserArrayUnion : public FunctionParser
+{
+public:
+    explicit FunctionParserArrayUnion(SerializedPlanParser * plan_parser_) : FunctionParser(plan_parser_) { }
+
+    static constexpr auto name = "array_union";
+
+    String getName() const override { return name; }
+
+    const ActionsDAG::Node * parse(
+        const substrait::Expression_ScalarFunction & substrait_func,
+        ActionsDAGPtr & actions_dag) const override
+    {
+        /// parse array_union(a, b) as arrayDistinctSpark(arrayConcat(a, b))
+        auto parsed_args = parseFunctionArguments(substrait_func, "", actions_dag);
+        if (parsed_args.size() != 2)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {} requires exactly two arguments", getName());
+
+        const auto * left_arg = parsed_args[0];
+        const auto * right_arg = parsed_args[1];
+
+        const auto * array_concat_node = toFunctionNode(actions_dag, "arrayConcat", {left_arg, right_arg});
+        const auto * result_node = toFunctionNode(actions_dag, "arrayDistinctSpark", {array_concat_node});
+        /// We cann not call convertNodeTypeIfNeeded which will fail when cast Array(Array(xx)) to Array(Nullable(Array(xx)))
+        return result_node;
+    }
+};
+
+static FunctionParserRegister<FunctionParserArrayUnion> register_array_union;
+}

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -189,6 +189,8 @@ object ExpressionMappings {
     Sig[SortArray](SORT_ARRAY),
     Sig[ArraysOverlap](ARRAYS_OVERLAP),
     Sig[ArrayPosition](ARRAY_POSITION),
+    Sig[ArrayDistinct](ARRAY_DISTINCT),
+    Sig[ArrayUnion](ARRAY_UNION),
     // Map functions
     Sig[CreateMap](CREATE_MAP),
     Sig[GetMapValue](GET_MAP_VALUE),

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -93,6 +93,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "elementAt",
       "Concat",
       "Shuffle",
+      "Array Distinct", // exclude this when fix GLUTEN-2340
       "SPARK-33386: element_at ArrayIndexOutOfBoundsException",
       "SPARK-33460: element_at NoSuchElementException"
     )
@@ -335,7 +336,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "array_max function",
       "array_min function",
       "array position function",
-      "array contains function"
+      "array contains function",
+      "array_distinct functions",
+      "array_union functions"
     )
     .includeByPrefix(
       "reverse function - array"

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -182,6 +182,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Map Concat")
     // Random.
     .exclude("Shuffle")
+    // TODO: ArrayDistinct should handle duplicated Double.NaN
+    .excludeByPrefix("SPARK-36741")
   enableSuite[GlutenDateExpressionsSuite]
     // Rewrite because Spark collect causes long overflow.
     .exclude("TIMESTAMP_MICROS")

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -125,6 +125,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenCollectionExpressionsSuite]
     .exclude("Map Concat")
     .exclude("Shuffle")
+    // TODO: ArrayDistinct should handle duplicated Double.NaN
+    .excludeByPrefix("SPARK-36741")
   enableSuite[GlutenConditionalExpressionSuite]
   enableSuite[GlutenDateExpressionsSuite]
     // Has exception in fallback execution when we use resultDF.collect in evaluation.

--- a/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
@@ -196,6 +196,8 @@ object ExpressionNames {
   final val SORT_ARRAY = "sort_array"
   final val ARRAYS_OVERLAP = "arrays_overlap"
   final val ARRAY_POSITION = "array_position"
+  final val ARRAY_DISTINCT = "array_distinct"
+  final val ARRAY_UNION = "array_union"
 
   // Map functions
   final val CREATE_MAP = "map"


### PR DESCRIPTION
## What changes were proposed in this pull request?
There is a major difference between Spark array_distinct and CH arrayDistinct:
Spark array_distinct can remain null value in the array but CH arrayDistinct will skip it.
e.g. `select arrayDistinct([1, null, 2, null, 3, 3])` Spark return `[1, null, 2, 3]`, CH return `[1, 2, 3]`.
We should make CH arrayDistinct align with Spark.

## How was this patch tested?

UT

