### PR TITLE
[GLUTEN-1141][FOLLOWUP][VL]Fix q31 join key not found

### DIFF
--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -150,10 +150,10 @@ case class ColumnarBuildSideRelation(mode: BroadcastMode,
               throw new IllegalArgumentException(s"Multiple key columns found in expression: $key")
             }
             val columnExpr = columnNames.head
-
+            val oneColumnWithSameName = output.find(_.name == columnExpr.name).size == 1
             val columnInOutput = output.zipWithIndex.filter {
               p: (Attribute, Int) =>
-                if (output.map(_.toAttribute).find(_.name == columnExpr.name).size == 1) {
+                if (oneColumnWithSameName) {
                   // The comparison of exprId can be ignored when
                   // only one attribute name match is found.
                   p._1.name == columnExpr.name

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -153,7 +153,9 @@ case class ColumnarBuildSideRelation(mode: BroadcastMode,
 
             val columnInOutput = output.zipWithIndex.filter {
               p: (Attribute, Int) =>
-                if (output.size == 1) {
+                if (output.map(_.toAttribute).find(_.name == columnExpr.name).size == 1) {
+                  // The comparison of exprId can be ignored when
+                  // only one attribute name match is found.
                   p._1.name == columnExpr.name
                 } else {
                   // A case where output has multiple columns with same name


### PR DESCRIPTION
## What changes were proposed in this pull request?

Related to https://github.com/oap-project/gluten/issues/1141
![image](https://github.com/oap-project/gluten/assets/13622031/3d37877b-385b-43d9-bc1e-160514f93d86)

We can ignore the comparison of exprId when only one attribute name match is found in output.

## How was this patch tested?
tpcds q31 3g

