### PR TITLE
[GLUTEN-2193][CH] Support functions array_max/array_min

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -63,8 +63,6 @@ object CHExpressionUtil {
     UNIX_TIMESTAMP -> UnixTimeStampValidator(),
     MIGHT_CONTAIN -> DefaultValidator(),
     GET_JSON_OBJECT -> GetJsonObjectValidator(),
-    ARRAY_MAX -> DefaultValidator(),
-    ARRAY_MIN -> DefaultValidator(),
     ARRAYS_OVERLAP -> DefaultValidator(),
     SORT_ARRAY -> DefaultValidator()
   )

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -526,6 +526,34 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
         s"from lineitem limit 5")(checkOperatorMatch[ProjectExecTransformer])
   }
 
+  test("test array_max") {
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
+      runQueryAndCompare(
+        "select array_max(split(n_comment, ' ')) from nation"
+      )(checkOperatorMatch[ProjectExecTransformer])
+      runQueryAndCompare(
+        "select array_max(null), array_max(array(null)), array_max(array(1, 2, 3, null)), " +
+          "array_max(array(1.0, 2.0, 3.0, null)), array_max(array('z', 't', 'abc'))",
+        noFallBack = false
+      )(checkOperatorMatch[ProjectExecTransformer])
+    }
+  }
+
+  test("test array_min") {
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> (ConstantFolding.ruleName + "," + NullPropagation.ruleName)) {
+      runQueryAndCompare(
+        "select array_min(split(n_comment, ' ')) from nation"
+      )(checkOperatorMatch[ProjectExecTransformer])
+      runQueryAndCompare(
+        "select array_min(null), array_min(array(null)), array_min(array(1, 2, 3, null)), " +
+          "array_min(array(1.0, 2.0, 3.0, null)), array_min(array('z', 't', 'abc'))",
+        noFallBack = false
+      )(checkOperatorMatch[ProjectExecTransformer])
+    }
+  }
+
   test("test slice function") {
     val sql =
       """

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayMaxAndMin.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayMaxAndMin.cpp
@@ -1,0 +1,63 @@
+#include <Parser/FunctionParser.h>
+#include <Common/CHUtil.h>
+#include <Core/Field.h>
+#include <DataTypes/IDataType.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+}
+
+namespace local_engine
+{
+
+class BaseFunctionParserArrayMaxAndMin : public FunctionParser
+{
+public:
+    explicit BaseFunctionParserArrayMaxAndMin(SerializedPlanParser * plan_parser_) : FunctionParser(plan_parser_) { }
+    ~BaseFunctionParserArrayMaxAndMin() override = default;
+
+    const ActionsDAG::Node * parse(
+        const substrait::Expression_ScalarFunction & substrait_func,
+        ActionsDAGPtr & actions_dag) const override
+    {
+        auto parsed_args = parseFunctionArguments(substrait_func, "", actions_dag);
+        if (parsed_args.size() != 1)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Function {} requires exactly one arguments", getName());
+
+        const auto * max_const_node = addColumnToActionsDAG(actions_dag, std::make_shared<DataTypeString>(), getCHFunctionName(substrait_func));
+        const auto * array_reduce_node = toFunctionNode(actions_dag, "arrayReduce", {max_const_node, parsed_args[0]});
+        return convertNodeTypeIfNeeded(substrait_func, array_reduce_node, actions_dag);
+    }
+};
+
+class FunctionParserArrayMax : public BaseFunctionParserArrayMaxAndMin
+{
+public:
+    explicit FunctionParserArrayMax(SerializedPlanParser * plan_parser_) : BaseFunctionParserArrayMaxAndMin(plan_parser_) { }
+    ~FunctionParserArrayMax() override = default;
+
+    static constexpr auto name = "array_max";
+    String getName() const override { return name; }
+    String getCHFunctionName(const substrait::Expression_ScalarFunction &) const override { return "max"; }
+};
+static FunctionParserRegister<FunctionParserArrayMax> register_array_max;
+
+
+class FunctionParserArrayMin : public BaseFunctionParserArrayMaxAndMin
+{
+public:
+    explicit FunctionParserArrayMin(SerializedPlanParser * plan_parser_) : BaseFunctionParserArrayMaxAndMin(plan_parser_) { }
+    ~FunctionParserArrayMin() override = default;
+
+    static constexpr auto name = "array_min";
+    String getName() const override { return name; }
+    String getCHFunctionName(const substrait::Expression_ScalarFunction &) const override { return "min"; }
+};
+static FunctionParserRegister<FunctionParserArrayMin> register_array_min;
+
+}

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -96,6 +96,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "SPARK-33386: element_at ArrayIndexOutOfBoundsException",
       "SPARK-33460: element_at NoSuchElementException"
     )
+    // enable when fix GLUTEN-2390
+    .excludeByPrefix("SPARK-36740")
   enableSuite[GlutenComplexTypeSuite]
     .exclude(
       "CreateNamedStruct",
@@ -330,6 +332,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "misc sha2 function",
       "misc crc32 function",
       "concat function - arrays",
+      "array_max function",
+      "array_min function",
       "array position function",
       "array contains function"
     )


### PR DESCRIPTION
## What changes were proposed in this pull request?
CH arrayMax is different from Spark array_max, since it cannot handle Array(String) type argument.

But we can map Spark array_max(arr) to CH arrayReduce("max", arr)

## How was this patch tested?

UT

