### PR TITLE
[GLUTEN-2346][VL] Move Velox-Substrait plan conversion to Gluten cpp

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -82,7 +82,6 @@ macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(velox::buffer "${VELOX_COMPONENTS_PATH}/buffer/libvelox_buffer.a")
 
   add_velox_dependency(exec "${VELOX_COMPONENTS_PATH}/exec/libvelox_exec.a")
-  add_velox_dependency(substrait "${VELOX_COMPONENTS_PATH}/substrait/libvelox_substrait_plan_converter.a")
   add_velox_dependency(functions::isnull "${VELOX_COMPONENTS_PATH}/functions/lib/libvelox_is_null_functions.a")
   add_velox_dependency(functions::prestosql "${VELOX_COMPONENTS_PATH}/functions/prestosql/registration/libvelox_functions_prestosql.a")
   add_velox_dependency(functions::prestosql::impl "${VELOX_COMPONENTS_PATH}/functions/prestosql/libvelox_functions_prestosql_impl.a")
@@ -90,8 +89,20 @@ macro(ADD_VELOX_DEPENDENCIES)
   add_velox_dependency(functions::hyperloglog "${VELOX_COMPONENTS_PATH}/common/hyperloglog/libvelox_common_hyperloglog.a")
   add_velox_dependency(functions::lib "${VELOX_COMPONENTS_PATH}/functions/lib/libvelox_functions_lib.a")
   add_velox_dependency(common::test_util "${VELOX_COMPONENTS_PATH}/common/testutil/libvelox_test_util.a")
+  if(BUILD_TESTS)
+    add_velox_dependency(exec::test "${VELOX_COMPONENTS_PATH}/exec/tests/utils/libvelox_exec_test_lib.a")
+    add_velox_dependency(temp::path "${VELOX_COMPONENTS_PATH}/exec/tests/utils/libvelox_temp_path.a")
+    add_velox_dependency(dwio::common::test::utils "${VELOX_COMPONENTS_PATH}/dwio/common/tests/utils/libvelox_dwio_common_test_utils.a")
+  endif()
   add_velox_dependency(parse::parser "${VELOX_COMPONENTS_PATH}/parse/libvelox_parse_parser.a")
+  if(BUILD_TESTS)
+    add_velox_dependency(duckdb::parser "${VELOX_COMPONENTS_PATH}/duckdb/conversion/libvelox_duckdb_parser.a")
+  endif()
   add_velox_dependency(parse::expression "${VELOX_COMPONENTS_PATH}/parse/libvelox_parse_expression.a")
+  if(BUILD_TESTS)
+    add_velox_dependency(parse::utils "${VELOX_COMPONENTS_PATH}/parse/libvelox_parse_utils.a")
+    add_velox_dependency(function::registry "${VELOX_COMPONENTS_PATH}/functions/libvelox_function_registry.a")
+  endif()
   add_velox_dependency(vector::arrow::bridge "${VELOX_COMPONENTS_PATH}/vector/arrow/libvelox_arrow_bridge.a")
   add_velox_dependency(row "${VELOX_COMPONENTS_PATH}/row/libvelox_row_fast.a")
   add_velox_dependency(connector::hive "${VELOX_COMPONENTS_PATH}/connectors/hive/libvelox_hive_connector.a")
@@ -136,6 +147,9 @@ macro(ADD_VELOX_DEPENDENCIES)
 
   add_velox_dependency(common::caching "${VELOX_COMPONENTS_PATH}/common/caching/libvelox_caching.a")
   add_velox_dependency(common::base "${VELOX_COMPONENTS_PATH}/common/base/libvelox_common_base.a")
+  if(BUILD_TESTS)
+    add_velox_dependency(tpch::gen "${VELOX_COMPONENTS_PATH}/tpch/gen/libvelox_tpch_gen.a")
+  endif()
   add_velox_dependency(common::memory "${VELOX_COMPONENTS_PATH}/common/memory/libvelox_memory.a")
   add_velox_dependency(common::serialization "${VELOX_COMPONENTS_PATH}/common/serialization/libvelox_serialization.a")
   add_velox_dependency(common::base::exception "${VELOX_COMPONENTS_PATH}/common/base/libvelox_exception.a")
@@ -226,6 +240,17 @@ set(VELOX_SRCS
     memory/VeloxColumnarBatch.cc
     utils/VeloxArrowUtils.cc
     utils/ArrowTypeUtils.cc
+    substrait/SubstraitParser.cc
+    substrait/SubstraitToVeloxExpr.cc
+    substrait/SubstraitToVeloxPlan.cc
+    substrait/SubstraitToVeloxPlanValidator.cc
+    substrait/VariantToVectorConverter.cc
+    substrait/TypeUtils.cc
+    substrait/SubstraitExtensionCollector.cc
+    substrait/VeloxSubstraitSignature.cc
+    substrait/VeloxToSubstraitExpr.cc
+    substrait/VeloxToSubstraitPlan.cc
+    substrait/VeloxToSubstraitType.cc
     )
 add_library(velox SHARED ${VELOX_SRCS})
 

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -71,10 +71,8 @@ velox::dwio::common::FileFormat getFileFormat(const std::string& fileFormat) {
   }
 }
 
-std::shared_ptr<velox::substrait::SplitInfo> getSplitInfos(
-    const std::string& datasetPath,
-    const std::string& fileFormat) {
-  auto scanInfo = std::make_shared<velox::substrait::SplitInfo>();
+std::shared_ptr<gluten::SplitInfo> getSplitInfos(const std::string& datasetPath, const std::string& fileFormat) {
+  auto scanInfo = std::make_shared<gluten::SplitInfo>();
 
   // Set format to scan info.
   scanInfo->format = getFileFormat(fileFormat);
@@ -97,10 +95,8 @@ std::shared_ptr<velox::substrait::SplitInfo> getSplitInfos(
   return scanInfo;
 }
 
-std::shared_ptr<velox::substrait::SplitInfo> getSplitInfosFromFile(
-    const std::string& fileName,
-    const std::string& fileFormat) {
-  auto scanInfo = std::make_shared<velox::substrait::SplitInfo>();
+std::shared_ptr<gluten::SplitInfo> getSplitInfosFromFile(const std::string& fileName, const std::string& fileFormat) {
+  auto scanInfo = std::make_shared<gluten::SplitInfo>();
 
   // Set format to scan info.
   scanInfo->format = getFileFormat(fileFormat);

--- a/cpp/velox/benchmarks/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/BenchmarkUtils.h
@@ -18,12 +18,12 @@
 #pragma once
 
 #include <benchmark/benchmark.h>
-#include <velox/substrait/SubstraitToVeloxPlan.h>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <thread>
 #include <utility>
+#include "substrait/SubstraitToVeloxPlan.h"
 
 #include "compute/ProtobufUtils.h"
 #include "memory/VeloxColumnarBatch.h"
@@ -81,13 +81,9 @@ std::string getPlanFromFile(const std::string& filePath);
 /// Get the file paths, starts, lengths from a directory.
 /// Use fileFormat to specify the format to read, eg., orc, parquet.
 /// Return a split info.
-std::shared_ptr<facebook::velox::substrait::SplitInfo> getSplitInfos(
-    const std::string& datasetPath,
-    const std::string& fileFormat);
+std::shared_ptr<gluten::SplitInfo> getSplitInfos(const std::string& datasetPath, const std::string& fileFormat);
 
-std::shared_ptr<facebook::velox::substrait::SplitInfo> getSplitInfosFromFile(
-    const std::string& fileName,
-    const std::string& fileFormat);
+std::shared_ptr<gluten::SplitInfo> getSplitInfosFromFile(const std::string& fileName, const std::string& fileFormat);
 
 bool checkPathExists(const std::string& filepath);
 

--- a/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
+++ b/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
@@ -118,7 +118,7 @@ class GoogleBenchmarkParquetWrite {
   std::vector<int> rowGroupIndices_;
   std::vector<int> columnIndices_;
   std::shared_ptr<arrow::Schema> schema_;
-  parquet::ArrowReaderProperties properties_;
+  ::parquet::ArrowReaderProperties properties_;
 };
 
 class GoogleBenchmarkArrowParquetWriteCacheScanBenchmark : public GoogleBenchmarkParquetWrite {
@@ -173,12 +173,12 @@ class GoogleBenchmarkArrowParquetWriteCacheScanBenchmark : public GoogleBenchmar
 
     for (auto _ : state) {
       // Choose compression
-      std::shared_ptr<parquet::WriterProperties> props =
-          parquet::WriterProperties::Builder().compression(arrow::Compression::SNAPPY)->build();
+      std::shared_ptr<::parquet::WriterProperties> props =
+          ::parquet::WriterProperties::Builder().compression(arrow::Compression::SNAPPY)->build();
 
       // Opt to store Arrow schema for easier reads back into Arrow
-      std::shared_ptr<parquet::ArrowWriterProperties> arrow_props =
-          parquet::ArrowWriterProperties::Builder().store_schema()->build();
+      std::shared_ptr<::parquet::ArrowWriterProperties> arrow_props =
+          ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
 
       std::shared_ptr<arrow::io::FileOutputStream> outfile;
       outfile = arrow::io::FileOutputStream::Open(outputPath_ + fileName).ValueOrDie();

--- a/cpp/velox/benchmarks/QueryBenchmark.cc
+++ b/cpp/velox/benchmarks/QueryBenchmark.cc
@@ -35,7 +35,7 @@ const std::string getFilePath(const std::string& fileName) {
 std::shared_ptr<ResultIterator> getResultIterator(
     MemoryAllocator* allocator,
     std::shared_ptr<Backend> backend,
-    const std::vector<std::shared_ptr<velox::substrait::SplitInfo>>& setScanInfos,
+    const std::vector<std::shared_ptr<SplitInfo>>& setScanInfos,
     std::shared_ptr<const facebook::velox::core::PlanNode>& veloxPlan) {
   auto veloxPool = asAggregateVeloxMemoryPool(allocator);
   auto ctxPool = veloxPool->addAggregateChild(
@@ -46,7 +46,7 @@ std::shared_ptr<ResultIterator> getResultIterator(
   veloxPlan = veloxPlanConverter->toVeloxPlan(backend->getPlan());
 
   // In test, use setScanInfos to replace the one got from Substrait.
-  std::vector<std::shared_ptr<velox::substrait::SplitInfo>> scanInfos;
+  std::vector<std::shared_ptr<SplitInfo>> scanInfos;
   std::vector<velox::core::PlanNodeId> scanIds;
   std::vector<velox::core::PlanNodeId> streamIds;
 
@@ -73,7 +73,7 @@ auto BM = [](::benchmark::State& state,
   const auto& filePath = getFilePath("plan/" + jsonFile);
   auto plan = getPlanFromFile(filePath);
 
-  std::vector<std::shared_ptr<velox::substrait::SplitInfo>> scanInfos;
+  std::vector<std::shared_ptr<SplitInfo>> scanInfos;
   scanInfos.reserve(datasetPaths.size());
   for (const auto& datasetPath : datasetPaths) {
     if (std::filesystem::is_directory(datasetPath)) {

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -37,9 +37,9 @@ namespace {} // namespace
 VeloxBackend::VeloxBackend(const std::unordered_map<std::string, std::string>& confMap) : Backend(confMap) {}
 
 void VeloxBackend::getInfoAndIds(
-    const std::unordered_map<velox::core::PlanNodeId, std::shared_ptr<velox::substrait::SplitInfo>>& splitInfoMap,
+    const std::unordered_map<velox::core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfoMap,
     const std::unordered_set<velox::core::PlanNodeId>& leafPlanNodeIds,
-    std::vector<std::shared_ptr<velox::substrait::SplitInfo>>& scanInfos,
+    std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
     std::vector<velox::core::PlanNodeId>& scanIds,
     std::vector<velox::core::PlanNodeId>& streamIds) {
   if (splitInfoMap.size() == 0) {
@@ -75,7 +75,7 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
   veloxPlan_ = veloxPlanConverter->toVeloxPlan(substraitPlan_);
 
   // Scan node can be required.
-  std::vector<std::shared_ptr<velox::substrait::SplitInfo>> scanInfos;
+  std::vector<std::shared_ptr<SplitInfo>> scanInfos;
   std::vector<velox::core::PlanNodeId> scanIds;
   std::vector<velox::core::PlanNodeId> streamIds;
 

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -87,11 +87,9 @@ class VeloxBackend final : public Backend {
   }
 
   static void getInfoAndIds(
-      const std::unordered_map<
-          facebook::velox::core::PlanNodeId,
-          std::shared_ptr<facebook::velox::substrait::SplitInfo>>& splitInfoMap,
+      const std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfoMap,
       const std::unordered_set<facebook::velox::core::PlanNodeId>& leafPlanNodeIds,
-      std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos,
+      std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
       std::vector<facebook::velox::core::PlanNodeId>& scanIds,
       std::vector<facebook::velox::core::PlanNodeId>& streamIds);
 

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -108,7 +108,7 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::ReadRel& sread) {
   }
   // Get the input schema of this iterator.
   uint64_t colNum = 0;
-  std::vector<std::shared_ptr<velox::substrait::SubstraitParser::SubstraitType>> subTypeList;
+  std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> subTypeList;
   if (sread.has_base_schema()) {
     const auto& baseSchema = sread.base_schema();
     // Input names is not used. Instead, new input/output names will be created
@@ -126,7 +126,7 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::ReadRel& sread) {
 
   std::vector<velox::TypePtr> veloxTypeList;
   for (auto subType : subTypeList) {
-    veloxTypeList.push_back(velox::substrait::toVeloxType(subType->type));
+    veloxTypeList.push_back(toVeloxType(subType->type));
   }
   auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
   auto vectorStream = std::make_shared<RowVectorStream>(std::move(inputIters_[iterIdx]), outputType);

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -19,9 +19,9 @@
 
 #include "compute/ResultIterator.h"
 #include "memory/VeloxMemoryPool.h"
+#include "substrait/SubstraitToVeloxPlan.h"
 #include "substrait/plan.pb.h"
 #include "velox/core/PlanNode.h"
-#include "velox/substrait/SubstraitToVeloxPlan.h"
 
 namespace gluten {
 // This class is used to convert the Substrait plan into Velox plan.
@@ -31,8 +31,7 @@ class VeloxPlanConverter {
 
   std::shared_ptr<const facebook::velox::core::PlanNode> toVeloxPlan(::substrait::Plan& substraitPlan);
 
-  const std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<facebook::velox::substrait::SplitInfo>>&
-  splitInfos() {
+  const std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfos() {
     return subVeloxPlanConverter_->splitInfos();
   }
 
@@ -64,11 +63,10 @@ class VeloxPlanConverter {
   int planNodeId_ = 0;
   std::vector<std::shared_ptr<ResultIterator>> inputIters_;
 
-  std::shared_ptr<facebook::velox::substrait::SubstraitParser> subParser_ =
-      std::make_shared<facebook::velox::substrait::SubstraitParser>();
+  std::shared_ptr<SubstraitParser> subParser_ = std::make_shared<SubstraitParser>();
 
-  std::shared_ptr<facebook::velox::substrait::SubstraitVeloxPlanConverter> subVeloxPlanConverter_ =
-      std::make_shared<facebook::velox::substrait::SubstraitVeloxPlanConverter>(defaultLeafVeloxMemoryPool().get());
+  std::shared_ptr<SubstraitVeloxPlanConverter> subVeloxPlanConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(defaultLeafVeloxMemoryPool().get());
 };
 
 } // namespace gluten

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -310,7 +310,7 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
     std::shared_ptr<velox::memory::MemoryPool> pool,
     const std::shared_ptr<const velox::core::PlanNode>& planNode,
     const std::vector<velox::core::PlanNodeId>& scanNodeIds,
-    const std::vector<std::shared_ptr<velox::substrait::SplitInfo>>& scanInfos,
+    const std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
     const std::vector<velox::core::PlanNodeId>& streamIds,
     const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap,

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -3,11 +3,11 @@
 #include "compute/Backend.h"
 #include "memory/ColumnarBatchIterator.h"
 #include "memory/VeloxColumnarBatch.h"
+#include "substrait/SubstraitToVeloxPlan.h"
 #include "substrait/plan.pb.h"
 #include "utils/metrics.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h"
-#include "velox/substrait/SubstraitToVeloxPlan.h"
 
 namespace gluten {
 
@@ -95,7 +95,7 @@ class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::vector<facebook::velox::core::PlanNodeId>& scanNodeIds,
-      const std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>>& scanInfos,
+      const std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
       const std::vector<facebook::velox::core::PlanNodeId>& streamIds,
       const std::string spillDir,
       const std::unordered_map<std::string, std::string>& confMap,
@@ -103,7 +103,7 @@ class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator
 
  private:
   std::vector<facebook::velox::core::PlanNodeId> scanNodeIds_;
-  std::vector<std::shared_ptr<facebook::velox::substrait::SplitInfo>> scanInfos_;
+  std::vector<std::shared_ptr<SplitInfo>> scanInfos_;
   std::vector<facebook::velox::core::PlanNodeId> streamIds_;
   std::vector<std::vector<facebook::velox::exec::Split>> splits_;
   bool noMoreSplits_ = false;

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -27,7 +27,7 @@
 #include "jni/JniErrors.h"
 #include "memory/VeloxMemoryPool.h"
 #include "operators/writer/VeloxParquetDatasource.h"
-#include "velox/substrait/SubstraitToVeloxPlanValidator.h"
+#include "substrait/SubstraitToVeloxPlanValidator.h"
 
 #include <iostream>
 
@@ -94,7 +94,7 @@ JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_PlanEvaluatorJniWrap
   // An execution context used for function validation.
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 
-  velox::substrait::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
+  gluten::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
   try {
     return planValidator.validate(subPlan);
   } catch (std::invalid_argument& e) {
@@ -121,7 +121,7 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeDoValidateWithFal
   // An execution context used for function validation.
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 
-  velox::substrait::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
+  gluten::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
   jclass infoCls = env->FindClass("Lio/glutenproject/validate/NativePlanValidatorInfo;");
   if (infoCls == nullptr) {
     std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for NativePlanValidatorInfo";

--- a/cpp/velox/substrait/SubstraitExtensionCollector.cc
+++ b/cpp/velox/substrait/SubstraitExtensionCollector.cc
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SubstraitExtensionCollector.h"
+
+namespace gluten {
+
+int SubstraitExtensionCollector::getReferenceNumber(
+    const std::string& functionName,
+    const std::vector<TypePtr>& arguments) {
+  const auto& substraitFunctionSignature = VeloxSubstraitSignature::toSubstraitSignature(functionName, arguments);
+  // TODO: Currently we treat all velox registry based function signatures as
+  // custom substrait extension, so no uri link and leave it as empty.
+  return getReferenceNumber({"", substraitFunctionSignature});
+}
+
+int SubstraitExtensionCollector::getReferenceNumber(
+    const std::string& functionName,
+    const std::vector<TypePtr>& arguments,
+    const core::AggregationNode::Step /* aggregationStep */) {
+  // TODO: Ignore aggregationStep for now, will refactor when introduce velox
+  // registry for function signature binding
+  return getReferenceNumber(functionName, arguments);
+}
+
+template <typename T>
+bool SubstraitExtensionCollector::BiDirectionHashMap<T>::putIfAbsent(const int& key, const T& value) {
+  if (forwardMap_.find(key) == forwardMap_.end() && reverseMap_.find(value) == reverseMap_.end()) {
+    forwardMap_[key] = value;
+    reverseMap_[value] = key;
+    return true;
+  }
+  return false;
+}
+
+void SubstraitExtensionCollector::addExtensionsToPlan(::substrait::Plan* plan) const {
+  using SimpleExtensionURI = ::substrait::extensions::SimpleExtensionURI;
+  // Currently we don't introduce any substrait extension YAML files, so always
+  // only have one URI.
+  SimpleExtensionURI* extensionUri = plan->add_extension_uris();
+  extensionUri->set_extension_uri_anchor(1);
+
+  for (const auto& [referenceNum, functionId] : extensionFunctions_->forwardMap()) {
+    auto extensionFunction = plan->add_extensions()->mutable_extension_function();
+    extensionFunction->set_extension_uri_reference(extensionUri->extension_uri_anchor());
+    extensionFunction->set_function_anchor(referenceNum);
+    extensionFunction->set_name(functionId.signature);
+  }
+}
+
+SubstraitExtensionCollector::SubstraitExtensionCollector() {
+  extensionFunctions_ = std::make_shared<BiDirectionHashMap<ExtensionFunctionId>>();
+}
+
+int SubstraitExtensionCollector::getReferenceNumber(const ExtensionFunctionId& extensionFunctionId) {
+  const auto& extensionFunctionAnchorIt = extensionFunctions_->reverseMap().find(extensionFunctionId);
+  if (extensionFunctionAnchorIt != extensionFunctions_->reverseMap().end()) {
+    return extensionFunctionAnchorIt->second;
+  }
+  ++functionReferenceNumber;
+  extensionFunctions_->putIfAbsent(functionReferenceNumber, extensionFunctionId);
+  return functionReferenceNumber;
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitExtensionCollector.h
+++ b/cpp/velox/substrait/SubstraitExtensionCollector.h
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include "VeloxSubstraitSignature.h"
+#include "substrait/algebra.pb.h"
+#include "substrait/plan.pb.h"
+#include "velox/core/Expressions.h"
+#include "velox/core/PlanNode.h"
+#include "velox/type/Type.h"
+
+namespace gluten {
+
+struct ExtensionFunctionId {
+  /// Substrait extension YAML file uri.
+  std::string uri;
+
+  /// Substrait signature used in the function extension declaration is a
+  /// combination of the name of the function along with a list of input
+  /// argument types.The format is as follows : <function
+  /// name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN> for more
+  /// detail information about the argument type please refer to link
+  /// https://substrait.io/extensions/#function-signature-compound-names.
+  std::string signature;
+
+  bool operator==(const ExtensionFunctionId& other) const {
+    return (uri == other.uri && signature == other.signature);
+  }
+};
+
+/// Assigns unique IDs to function signatures using ExtensionFunctionId.
+class SubstraitExtensionCollector {
+ public:
+  SubstraitExtensionCollector();
+
+  /// Given a scalar function name and argument types, return the functionId
+  /// using ExtensionFunctionId.
+  int getReferenceNumber(const std::string& functionName, const std::vector<TypePtr>& arguments);
+
+  /// Given an aggregate function name and argument types and aggregation Step,
+  /// return the functionId using ExtensionFunctionId.
+  int getReferenceNumber(
+      const std::string& functionName,
+      const std::vector<TypePtr>& arguments,
+      core::AggregationNode::Step aggregationStep);
+
+  /// Add extension functions to Substrait plan.
+  void addExtensionsToPlan(::substrait::Plan* plan) const;
+
+ private:
+  /// A bi-direction hash map to keep the relation between reference number and
+  /// either function or type signature.
+  template <class T>
+  class BiDirectionHashMap {
+   public:
+    /// Add (key, value) pair if doesn't exist already, i.e. forwardMap doesn't
+    /// contain the key and reverseMap doesn't contain the value.
+    ///
+    /// @return True if the values were added successfully. False, otherwise.
+    bool putIfAbsent(const int& key, const T& value);
+
+    const std::unordered_map<int, ExtensionFunctionId> forwardMap() const {
+      return forwardMap_;
+    }
+
+    const std::unordered_map<T, int>& reverseMap() const {
+      return reverseMap_;
+    }
+
+   private:
+    std::unordered_map<int, T> forwardMap_;
+    std::unordered_map<T, int> reverseMap_;
+  };
+
+  /// Assigns unique IDs to function signatures using ExtensionFunctionId.
+  int getReferenceNumber(const ExtensionFunctionId& extensionFunctionId);
+
+  int functionReferenceNumber = -1;
+  std::shared_ptr<BiDirectionHashMap<ExtensionFunctionId>> extensionFunctions_;
+};
+
+using SubstraitExtensionCollectorPtr = std::shared_ptr<SubstraitExtensionCollector>;
+
+} // namespace gluten
+
+namespace std {
+
+/// Hash function of gluten::ExtensionFunctionId.
+template <>
+struct hash<gluten::ExtensionFunctionId> {
+  size_t operator()(const gluten::ExtensionFunctionId& k) const {
+    size_t val = hash<std::string>()(k.uri);
+    val = val * 31 + hash<std::string>()(k.signature);
+    return val;
+  }
+};
+
+}; // namespace std

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SubstraitParser.h"
+#include "TypeUtils.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace gluten {
+
+std::shared_ptr<SubstraitParser::SubstraitType> SubstraitParser::parseType(const ::substrait::Type& substraitType) {
+  // The used type names should be aligned with those in Velox.
+  std::string typeName;
+  ::substrait::Type_Nullability nullability;
+  switch (substraitType.kind_case()) {
+    case ::substrait::Type::KindCase::kBool: {
+      typeName = "BOOLEAN";
+      nullability = substraitType.bool_().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kI8: {
+      typeName = "TINYINT";
+      nullability = substraitType.i8().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kI16: {
+      typeName = "SMALLINT";
+      nullability = substraitType.i16().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kI32: {
+      typeName = "INTEGER";
+      nullability = substraitType.i32().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kI64: {
+      typeName = "BIGINT";
+      nullability = substraitType.i64().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kFp32: {
+      typeName = "REAL";
+      nullability = substraitType.fp32().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kFp64: {
+      typeName = "DOUBLE";
+      nullability = substraitType.fp64().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kString: {
+      typeName = "VARCHAR";
+      nullability = substraitType.string().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kBinary: {
+      typeName = "VARBINARY";
+      nullability = substraitType.string().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kStruct: {
+      // The type name of struct is in the format of:
+      // ROW<type0:name0,type1:name1,ROW<type2:name2>,...typen:namen>.
+      typeName = "ROW<";
+      const auto& substraitStruct = substraitType.struct_();
+      const auto& structTypes = substraitStruct.types();
+      const auto& structNames = substraitStruct.names();
+      bool nameProvided = structTypes.size() == structNames.size();
+      for (int i = 0; i < structTypes.size(); i++) {
+        if (i > 0) {
+          typeName += ',';
+        }
+        typeName += parseType(structTypes[i])->type;
+        // Struct names could be empty.
+        if (nameProvided) {
+          typeName += (':' + structNames[i]);
+        }
+      }
+      typeName += '>';
+      nullability = substraitType.struct_().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kList: {
+      // The type name of list is in the format of: ARRAY<T>.
+      const auto& sList = substraitType.list();
+      const auto& sType = sList.type();
+      typeName = "ARRAY<" + parseType(sType)->type + ">";
+      nullability = substraitType.list().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kMap: {
+      // The type name of map is in the format of: MAP<K,V>.
+      const auto& sMap = substraitType.map();
+      const auto& keyType = sMap.key();
+      const auto& valueType = sMap.value();
+      typeName = "MAP<" + parseType(keyType)->type + "," + parseType(valueType)->type + ">";
+      nullability = substraitType.map().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kUserDefined: {
+      // We only support UNKNOWN type to handle the null literal whose type is
+      // not known.
+      VELOX_CHECK_EQ(substraitType.user_defined().type_reference(), 0);
+      typeName = "UNKNOWN";
+      nullability = substraitType.string().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kDate: {
+      typeName = "DATE";
+      nullability = substraitType.date().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kTimestamp: {
+      typeName = "TIMESTAMP";
+      nullability = substraitType.timestamp().nullability();
+      break;
+    }
+    case ::substrait::Type::KindCase::kDecimal: {
+      auto precision = substraitType.decimal().precision();
+      auto scale = substraitType.decimal().scale();
+      if (precision <= 18) {
+        typeName = "SHORT_DECIMAL<" + std::to_string(precision) + "," + std::to_string(scale) + ">";
+      } else {
+        typeName = "LONG_DECIMAL<" + std::to_string(precision) + "," + std::to_string(scale) + ">";
+      }
+
+      nullability = substraitType.decimal().nullability();
+      break;
+    }
+    default:
+      VELOX_NYI("Parsing for Substrait type not supported: {}", substraitType.DebugString());
+  }
+
+  bool nullable;
+  switch (nullability) {
+    case ::substrait::Type_Nullability::Type_Nullability_NULLABILITY_UNSPECIFIED:
+      nullable = true;
+      break;
+    case ::substrait::Type_Nullability::Type_Nullability_NULLABILITY_NULLABLE:
+      nullable = true;
+      break;
+    case ::substrait::Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED:
+      nullable = false;
+      break;
+    default:
+      VELOX_NYI("Substrait parsing for nullability {} not supported.", nullability);
+  }
+  SubstraitType type = {typeName, nullable};
+  return std::make_shared<SubstraitType>(type);
+}
+
+std::string SubstraitParser::parseType(const std::string& substraitType) {
+  auto it = typeMap_.find(substraitType);
+  if (it == typeMap_.end()) {
+    VELOX_NYI("Substrait parsing for type {} not supported.", substraitType);
+  }
+  return it->second;
+};
+
+std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> SubstraitParser::parseNamedStruct(
+    const ::substrait::NamedStruct& namedStruct) {
+  // Note that "names" are not used.
+
+  // Parse Struct.
+  const auto& substraitStruct = namedStruct.struct_();
+  const auto& substraitTypes = substraitStruct.types();
+  std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> substraitTypeList;
+  substraitTypeList.reserve(substraitTypes.size());
+  for (const auto& type : substraitTypes) {
+    substraitTypeList.emplace_back(parseType(type));
+  }
+  return substraitTypeList;
+}
+
+std::vector<bool> SubstraitParser::parsePartitionColumns(const ::substrait::NamedStruct& namedStruct) {
+  const auto& columnsTypes = namedStruct.partition_columns().column_type();
+  std::vector<bool> isPartitionColumns;
+  if (columnsTypes.size() == 0) {
+    // Regard all columns as non-partitioned columns.
+    isPartitionColumns.resize(namedStruct.names().size(), false);
+    return isPartitionColumns;
+  } else {
+    VELOX_CHECK(columnsTypes.size() == namedStruct.names().size(), "Invalid partion columns.");
+  }
+
+  isPartitionColumns.reserve(columnsTypes.size());
+  for (const auto& columnType : columnsTypes) {
+    switch (columnType) {
+      case ::substrait::PartitionColumns::NORMAL_COL:
+        isPartitionColumns.emplace_back(false);
+        break;
+      case ::substrait::PartitionColumns::PARTITION_COL:
+        isPartitionColumns.emplace_back(true);
+        break;
+      default:
+        VELOX_FAIL("Patition column type is not supported.");
+    }
+  }
+  return isPartitionColumns;
+}
+
+int32_t SubstraitParser::parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment) {
+  auto typeCase = refSegment.reference_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression::ReferenceSegment::ReferenceTypeCase::kStructField: {
+      return refSegment.struct_field().field();
+    }
+    default:
+      VELOX_NYI("Substrait conversion not supported for ReferenceSegment '{}'", typeCase);
+  }
+}
+
+std::vector<std::string> SubstraitParser::makeNames(const std::string& prefix, int size) {
+  std::vector<std::string> names;
+  names.reserve(size);
+  for (int i = 0; i < size; i++) {
+    names.emplace_back(fmt::format("{}_{}", prefix, i));
+  }
+  return names;
+}
+
+std::string SubstraitParser::makeNodeName(int node_id, int col_idx) {
+  return fmt::format("n{}_{}", node_id, col_idx);
+}
+
+int SubstraitParser::getIdxFromNodeName(const std::string& nodeName) {
+  // Get the position of "_" in the function name.
+  std::size_t pos = nodeName.find("_");
+  if (pos == std::string::npos) {
+    VELOX_FAIL("Invalid node name.");
+  }
+  if (pos == nodeName.size() - 1) {
+    VELOX_FAIL("Invalid node name.");
+  }
+  // Get the column index.
+  std::string colIdx = nodeName.substr(pos + 1);
+  try {
+    return stoi(colIdx);
+  } catch (const std::exception& err) {
+    VELOX_FAIL(err.what());
+  }
+}
+
+const std::string& SubstraitParser::findFunctionSpec(
+    const std::unordered_map<uint64_t, std::string>& functionMap,
+    uint64_t id) const {
+  if (functionMap.find(id) == functionMap.end()) {
+    VELOX_FAIL("Could not find function id {} in function map.", id);
+  }
+  std::unordered_map<uint64_t, std::string>& map = const_cast<std::unordered_map<uint64_t, std::string>&>(functionMap);
+  return map[id];
+}
+
+std::string SubstraitParser::getSubFunctionName(const std::string& subFuncSpec) const {
+  // Get the position of ":" in the function name.
+  std::size_t pos = subFuncSpec.find(":");
+  if (pos == std::string::npos) {
+    return subFuncSpec;
+  }
+  return subFuncSpec.substr(0, pos);
+}
+
+void SubstraitParser::getSubFunctionTypes(const std::string& subFuncSpec, std::vector<std::string>& types) const {
+  // Get the position of ":" in the function name.
+  std::size_t pos = subFuncSpec.find(":");
+  // Get the parameter types.
+  std::string funcTypes;
+  if (pos == std::string::npos) {
+    funcTypes = subFuncSpec;
+  } else {
+    if (pos == subFuncSpec.size() - 1) {
+      return;
+    }
+    funcTypes = subFuncSpec.substr(pos + 1);
+  }
+  // Split the types with delimiter.
+  std::string delimiter = "_";
+  while ((pos = funcTypes.find(delimiter)) != std::string::npos) {
+    auto type = funcTypes.substr(0, pos);
+    if (type != "opt" && type != "req") {
+      types.emplace_back(type);
+    }
+    funcTypes.erase(0, pos + delimiter.length());
+  }
+  types.emplace_back(funcTypes);
+}
+
+std::string SubstraitParser::findVeloxFunction(
+    const std::unordered_map<uint64_t, std::string>& functionMap,
+    uint64_t id) const {
+  std::string funcSpec = findFunctionSpec(functionMap, id);
+  std::string_view funcName = getNameBeforeDelimiter(funcSpec, ":");
+  std::vector<std::string> types;
+  getSubFunctionTypes(funcSpec, types);
+  bool isDecimal = false;
+  for (auto& type : types) {
+    if (type.find("dec") != std::string::npos) {
+      isDecimal = true;
+      break;
+    }
+  }
+  return mapToVeloxFunction({funcName.begin(), funcName.end()}, isDecimal);
+}
+
+std::string SubstraitParser::mapToVeloxFunction(const std::string& substraitFunction, bool isDecimal) const {
+  auto it = substraitVeloxFunctionMap_.find(substraitFunction);
+  if (isDecimal) {
+    if (substraitFunction == "add" || substraitFunction == "subtract" || substraitFunction == "multiply" ||
+        substraitFunction == "divide" || substraitFunction == "avg" || substraitFunction == "avg_merge" ||
+        substraitFunction == "sum" || substraitFunction == "sum_merge" || substraitFunction == "round") {
+      return "decimal_" + substraitFunction;
+    }
+  }
+  if (it != substraitVeloxFunctionMap_.end()) {
+    return it->second;
+  }
+
+  // If not finding the mapping from Substrait function name to Velox function
+  // name, the original Substrait function name will be used.
+  return substraitFunction;
+}
+
+bool SubstraitParser::configSetInOptimization(
+    const ::substrait::extensions::AdvancedExtension& extension,
+    const std::string& config) const {
+  if (extension.has_optimization()) {
+    google::protobuf::StringValue msg;
+    extension.optimization().UnpackTo(&msg);
+    std::size_t pos = msg.value().find(config);
+    if ((pos != std::string::npos) && (msg.value().substr(pos + config.size(), 1) == "1")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "substrait/algebra.pb.h"
+#include "substrait/capabilities.pb.h"
+#include "substrait/extensions/extensions.pb.h"
+#include "substrait/function.pb.h"
+#include "substrait/parameterized_types.pb.h"
+#include "substrait/plan.pb.h"
+#include "substrait/type.pb.h"
+#include "substrait/type_expressions.pb.h"
+
+#include <google/protobuf/wrappers.pb.h>
+
+namespace gluten {
+
+/// This class contains some common functions used to parse Substrait
+/// components, and convert them into recognizable representations.
+class SubstraitParser {
+ public:
+  /// Stores the type name and nullability.
+  struct SubstraitType {
+    std::string type;
+    bool nullable;
+  };
+
+  /// Used to parse Substrait NamedStruct.
+  std::vector<std::shared_ptr<SubstraitType>> parseNamedStruct(const ::substrait::NamedStruct& namedStruct);
+
+  /// Used to parse partition columns from Substrait NamedStruct.
+  std::vector<bool> parsePartitionColumns(const ::substrait::NamedStruct& namedStruct);
+
+  /// Parse Substrait Type.
+  std::shared_ptr<SubstraitType> parseType(const ::substrait::Type& substraitType);
+
+  // Parse substraitType type such as i32.
+  std::string parseType(const std::string& substraitType);
+
+  /// Parse Substrait ReferenceSegment.
+  int32_t parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment);
+
+  /// Make names in the format of {prefix}_{index}.
+  std::vector<std::string> makeNames(const std::string& prefix, int size);
+
+  /// Make node name in the format of n{nodeId}_{colIdx}.
+  std::string makeNodeName(int nodeId, int colIdx);
+
+  /// Get the column index from a node name in the format of
+  /// n{nodeId}_{colIdx}.
+  int getIdxFromNodeName(const std::string& nodeName);
+
+  /// Find the Substrait function name according to the function id
+  /// from a pre-constructed function map. The function specification can be
+  /// a simple name or a compound name. The compound name format is:
+  /// <function name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN>.
+  /// Currently, the input types in the function specification are not used. But
+  /// in the future, they should be used for the validation according the
+  /// specifications in Substrait yaml files.
+  const std::string& findFunctionSpec(const std::unordered_map<uint64_t, std::string>& functionMap, uint64_t id) const;
+
+  /// Extracts the function name for a function from specified compound name.
+  /// When the input is a simple name, it will be returned.
+  std::string getSubFunctionName(const std::string& functionSpec) const;
+
+  /// This function is used get the types from the compound name.
+  void getSubFunctionTypes(const std::string& subFuncSpec, std::vector<std::string>& types) const;
+
+  /// Used to find the Velox function name according to the function id
+  /// from a pre-constructed function map.
+  std::string findVeloxFunction(const std::unordered_map<uint64_t, std::string>& functionMap, uint64_t id) const;
+
+  /// Map the Substrait function keyword into Velox function keyword.
+  std::string mapToVeloxFunction(const std::string& substraitFunction, bool isDecimal) const;
+
+  /// @brief Return whether a config is set as true in AdvancedExtension
+  /// optimization.
+  /// @param extension Substrait advanced extension.
+  /// @param config the key string of a config.
+  /// @return Whether the config is set as true.
+  bool configSetInOptimization(const ::substrait::extensions::AdvancedExtension& extension, const std::string& config)
+      const;
+
+ private:
+  /// A map used for mapping Substrait function keywords into Velox functions'
+  /// keywords. Key: the Substrait function keyword, Value: the Velox function
+  /// keyword. For those functions with different names in Substrait and Velox,
+  /// a mapping relation should be added here.
+  std::unordered_map<std::string, std::string> substraitVeloxFunctionMap_ = {
+      {"is_not_null", "isnotnull"}, /*Spark functions.*/
+      {"is_null", "isnull"},
+      {"equal", "equalto"},
+      {"equal_null_safe", "equalnullsafe"},
+      {"lt", "lessthan"},
+      {"lte", "lessthanorequal"},
+      {"gt", "greaterthan"},
+      {"gte", "greaterthanorequal"},
+      {"not_equal", "notequalto"},
+      {"char_length", "length"},
+      {"strpos", "instr"},
+      {"ends_with", "endswith"},
+      {"starts_with", "startswith"},
+      {"datediff", "date_diff"},
+      {"named_struct", "row_constructor"},
+      {"bit_or", "bitwise_or_agg"},
+      {"bit_or_merge", "bitwise_or_agg_merge"},
+      {"bit_and", "bitwise_and_agg"},
+      {"bit_and_merge", "bitwise_and_agg_merge"},
+      {"collect_set", "array_distinct"},
+      {"modulus", "mod"} /*Presto functions.*/};
+
+  // The map is uesd for mapping substrait type.
+  // Key: type in function name.
+  // Value: substrait type name.
+  const std::unordered_map<std::string, std::string> typeMap_ = {
+      {"bool", "BOOLEAN"},
+      {"i8", "TINYINT"},
+      {"i16", "SMALLINT"},
+      {"i32", "INTEGER"},
+      {"i64", "BIGINT"},
+      {"fp32", "REAL"},
+      {"fp64", "DOUBLE"},
+      {"date", "DATE"},
+      {"ts", "TIMESTAMP"},
+      {"str", "VARCHAR"},
+      {"vbin", "VARBINARY"},
+      {"decShort", "SHORT_DECIMAL"},
+      {"decLong", "LONG_DECIMAL"}};
+};
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SubstraitToVeloxExpr.h"
+#include "TypeUtils.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/VariantToVector.h"
+
+#include "velox/type/Timestamp.h"
+
+using namespace facebook::velox;
+namespace {
+// Get values for the different supported types.
+template <typename T>
+T getLiteralValue(const ::substrait::Expression::Literal& /* literal */) {
+  VELOX_NYI();
+}
+
+template <>
+int8_t getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return static_cast<int8_t>(literal.i8());
+}
+
+template <>
+int16_t getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return static_cast<int16_t>(literal.i16());
+}
+
+template <>
+int32_t getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.i32();
+}
+
+template <>
+int64_t getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.i64();
+}
+
+template <>
+double getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.fp64();
+}
+
+template <>
+float getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.fp32();
+}
+
+template <>
+bool getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.boolean();
+}
+
+template <>
+uint32_t getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.i32();
+}
+
+template <>
+Timestamp getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return Timestamp::fromMicros(literal.timestamp());
+}
+
+template <>
+Date getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return Date(literal.date());
+}
+
+ArrayVectorPtr makeArrayVector(const VectorPtr& elements) {
+  BufferPtr offsets = allocateOffsets(1, elements->pool());
+  BufferPtr sizes = allocateOffsets(1, elements->pool());
+  sizes->asMutable<vector_size_t>()[0] = elements->size();
+
+  return std::make_shared<ArrayVector>(elements->pool(), ARRAY(elements->type()), nullptr, 1, offsets, sizes, elements);
+}
+
+RowVectorPtr makeRowVector(const std::vector<VectorPtr>& children) {
+  std::vector<std::shared_ptr<const Type>> types;
+  types.resize(children.size());
+  for (int i = 0; i < children.size(); i++) {
+    types[i] = children[i]->type();
+  }
+  const size_t vectorSize = children.empty() ? 0 : children.front()->size();
+  auto rowType = ROW(std::move(types));
+  return std::make_shared<RowVector>(children[0]->pool(), rowType, BufferPtr(nullptr), vectorSize, children);
+}
+
+ArrayVectorPtr makeEmptyArrayVector(memory::MemoryPool* pool) {
+  BufferPtr offsets = allocateOffsets(1, pool);
+  BufferPtr sizes = allocateOffsets(1, pool);
+  return std::make_shared<ArrayVector>(pool, ARRAY(UNKNOWN()), nullptr, 1, offsets, sizes, nullptr);
+}
+
+RowVectorPtr makeEmptyRowVector(memory::MemoryPool* pool) {
+  return makeRowVector({});
+}
+
+template <typename T>
+void setLiteralValue(const ::substrait::Expression::Literal& literal, FlatVector<T>* vector, vector_size_t index) {
+  if (literal.has_null()) {
+    vector->setNull(index, true);
+  } else if constexpr (std::is_same_v<T, StringView>) {
+    if (literal.has_string()) {
+      vector->set(index, StringView(literal.string()));
+    } else if (literal.has_var_char()) {
+      vector->set(index, StringView(literal.var_char().value()));
+    } else if (literal.has_binary()) {
+      vector->set(index, StringView(literal.binary()));
+    } else {
+      VELOX_FAIL("Unexpected string or binary literal");
+    }
+  } else {
+    vector->set(index, getLiteralValue<T>(literal));
+  }
+}
+
+template <TypeKind kind>
+VectorPtr constructFlatVector(
+    const ::substrait::Expression::Literal& listLiteral,
+    const vector_size_t size,
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK(type->isPrimitiveType());
+  auto vector = BaseVector::create(type, size, pool);
+  using T = typename TypeTraits<kind>::NativeType;
+  auto flatVector = vector->as<FlatVector<T>>();
+
+  vector_size_t index = 0;
+  for (auto child : listLiteral.list().values()) {
+    setLiteralValue(child, flatVector, index++);
+  }
+  return vector;
+}
+
+/// Whether null will be returned on cast failure.
+bool isNullOnFailure(::substrait::Expression::Cast::FailureBehavior failureBehavior) {
+  switch (failureBehavior) {
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
+      return false;
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
+      return true;
+    default:
+      VELOX_NYI("The given failure behavior is NOT supported: '{}'", failureBehavior);
+  }
+}
+
+template <TypeKind kind>
+VectorPtr constructFlatVectorForStruct(
+    const ::substrait::Expression::Literal& child,
+    const vector_size_t size,
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK(type->isPrimitiveType());
+  auto vector = BaseVector::create(type, size, pool);
+  using T = typename TypeTraits<kind>::NativeType;
+  auto flatVector = vector->as<FlatVector<T>>();
+  setLiteralValue(child, flatVector, 0);
+  return vector;
+}
+
+core::FieldAccessTypedExprPtr
+makeFieldAccessExpr(const std::string& name, const TypePtr& type, core::FieldAccessTypedExprPtr input) {
+  if (input) {
+    return std::make_shared<core::FieldAccessTypedExpr>(type, input, name);
+  }
+
+  return std::make_shared<core::FieldAccessTypedExpr>(type, name);
+}
+} // namespace
+
+using facebook::velox::core::variantArrayToVector;
+namespace gluten {
+
+std::shared_ptr<const core::FieldAccessTypedExpr> SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression::FieldReference& substraitField,
+    const RowTypePtr& inputType) {
+  auto typeCase = substraitField.reference_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression::FieldReference::ReferenceTypeCase::kDirectReference: {
+      const auto& directRef = substraitField.direct_reference();
+      core::FieldAccessTypedExprPtr fieldAccess{nullptr};
+      const auto* tmp = &directRef.struct_field();
+
+      auto inputColumnType = inputType;
+      for (;;) {
+        auto idx = tmp->field();
+        fieldAccess = makeFieldAccessExpr(inputColumnType->nameOf(idx), inputColumnType->childAt(idx), fieldAccess);
+
+        if (!tmp->has_child()) {
+          break;
+        }
+
+        inputColumnType = asRowType(inputColumnType->childAt(idx));
+        tmp = &tmp->child().struct_field();
+      }
+      return fieldAccess;
+    }
+    default:
+      VELOX_NYI("Substrait conversion not supported for Reference '{}'", typeCase);
+  }
+}
+
+core::TypedExprPtr SubstraitVeloxExprConverter::toExtractExpr(
+    const std::vector<core::TypedExprPtr>& params,
+    const TypePtr& outputType) {
+  VELOX_CHECK_EQ(params.size(), 2);
+  auto functionArg = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(params[0]);
+  if (functionArg) {
+    // Get the function argument.
+    auto variant = functionArg->value();
+    if (!variant.hasValue()) {
+      VELOX_FAIL("Value expected in variant.");
+    }
+    // The first parameter specifies extracting from which field.
+    std::string from = variant.value<std::string>();
+
+    // The second parameter is the function parameter.
+    std::vector<core::TypedExprPtr> exprParams;
+    exprParams.reserve(1);
+    exprParams.emplace_back(params[1]);
+    auto iter = extractDatetimeFunctionMap_.find(from);
+    if (iter != extractDatetimeFunctionMap_.end()) {
+      return std::make_shared<const core::CallTypedExpr>(outputType, std::move(exprParams), iter->second);
+    } else {
+      VELOX_NYI("Extract from {} not supported.", from);
+    }
+  }
+  VELOX_FAIL("Constant is expected to be the first parameter in extract.");
+}
+
+core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression::ScalarFunction& substraitFunc,
+    const RowTypePtr& inputType) {
+  std::vector<core::TypedExprPtr> params;
+  params.reserve(substraitFunc.arguments().size());
+  for (const auto& sArg : substraitFunc.arguments()) {
+    params.emplace_back(toVeloxExpr(sArg.value(), inputType));
+  }
+  const auto& veloxFunction = subParser_->findVeloxFunction(functionMap_, substraitFunc.function_reference());
+  std::string typeName = subParser_->parseType(substraitFunc.output_type())->type;
+
+  if (veloxFunction == "extract") {
+    return toExtractExpr(std::move(params), toVeloxType(typeName));
+  }
+
+  return std::make_shared<const core::CallTypedExpr>(toVeloxType(typeName), std::move(params), veloxFunction);
+}
+
+std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::literalsToConstantExpr(
+    const std::vector<::substrait::Expression::Literal>& literals) {
+  std::vector<variant> variants;
+  variants.reserve(literals.size());
+  VELOX_CHECK_GE(literals.size(), 0, "List should have at least one item.");
+  std::optional<TypePtr> literalType = std::nullopt;
+  for (const auto& literal : literals) {
+    auto veloxVariant = toVeloxExpr(literal)->value();
+    if (!literalType.has_value()) {
+      literalType = veloxVariant.inferType();
+    }
+    variants.emplace_back(veloxVariant);
+  }
+  VELOX_CHECK(literalType.has_value(), "Type expected.");
+  auto varArray = variant::array(variants);
+  ArrayVectorPtr arrayVector = variantArrayToVector(varArray.inferType(), varArray.array(), pool_);
+  // Wrap the array vector into constant vector.
+  auto constantVector = BaseVector::wrapInConstant(1 /*length*/, 0 /*index*/, arrayVector);
+  return std::make_shared<const core::ConstantTypedExpr>(constantVector);
+}
+
+core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression::SingularOrList& singularOrList,
+    const RowTypePtr& inputType) {
+  VELOX_CHECK(singularOrList.options_size() > 0, "At least one option is expected.");
+  auto options = singularOrList.options();
+  std::vector<::substrait::Expression::Literal> literals;
+  literals.reserve(options.size());
+  for (const auto& option : options) {
+    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
+    literals.emplace_back(option.literal());
+  }
+
+  std::vector<core::TypedExprPtr> params;
+  params.reserve(2);
+  // First param is the value, second param is the list.
+  params.emplace_back(toVeloxExpr(singularOrList.value(), inputType));
+  params.emplace_back(literalsToConstantExpr(literals));
+  return std::make_shared<const core::CallTypedExpr>(BOOLEAN(), std::move(params), "in");
+}
+
+std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression::Literal& substraitLit) {
+  auto typeCase = substraitLit.literal_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression_Literal::LiteralTypeCase::kBoolean:
+      return std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), variant(substraitLit.boolean()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI8:
+      // SubstraitLit.i8() will return int32, so we need this type conversion.
+      return std::make_shared<core::ConstantTypedExpr>(TINYINT(), variant(static_cast<int8_t>(substraitLit.i8())));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI16:
+      // SubstraitLit.i16() will return int32, so we need this type conversion.
+      return std::make_shared<core::ConstantTypedExpr>(SMALLINT(), variant(static_cast<int16_t>(substraitLit.i16())));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI32:
+      return std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(substraitLit.i32()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kFp32:
+      return std::make_shared<core::ConstantTypedExpr>(REAL(), variant(substraitLit.fp32()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI64:
+      return std::make_shared<core::ConstantTypedExpr>(BIGINT(), variant(substraitLit.i64()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kFp64:
+      return std::make_shared<core::ConstantTypedExpr>(DOUBLE(), variant(substraitLit.fp64()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kString:
+      return std::make_shared<core::ConstantTypedExpr>(VARCHAR(), variant(substraitLit.string()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
+      return std::make_shared<core::ConstantTypedExpr>(DATE(), variant(Date(substraitLit.date())));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kTimestamp:
+      return std::make_shared<core::ConstantTypedExpr>(
+          TIMESTAMP(), variant(Timestamp::fromMicros(substraitLit.timestamp())));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kVarChar:
+      return std::make_shared<core::ConstantTypedExpr>(VARCHAR(), variant(substraitLit.var_char().value()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kList: {
+      auto constantVector = BaseVector::wrapInConstant(1, 0, literalsToArrayVector(substraitLit));
+      return std::make_shared<const core::ConstantTypedExpr>(constantVector);
+    }
+    case ::substrait::Expression_Literal::LiteralTypeCase::kBinary:
+      return std::make_shared<core::ConstantTypedExpr>(VARBINARY(), variant::binary(substraitLit.binary()));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kStruct: {
+      auto constantVector = BaseVector::wrapInConstant(1, 0, literalsToRowVector(substraitLit));
+      return std::make_shared<const core::ConstantTypedExpr>(constantVector);
+    }
+    case ::substrait::Expression_Literal::LiteralTypeCase::kDecimal: {
+      auto decimal = substraitLit.decimal().value();
+      auto precision = substraitLit.decimal().precision();
+      auto scale = substraitLit.decimal().scale();
+      int128_t decimalValue;
+      memcpy(&decimalValue, decimal.c_str(), 16);
+      if (precision <= 18) {
+        auto type = DECIMAL(precision, scale);
+        return std::make_shared<core::ConstantTypedExpr>(type, variant(static_cast<int64_t>(decimalValue)));
+      } else {
+        auto type = DECIMAL(precision, scale);
+        return std::make_shared<core::ConstantTypedExpr>(
+            type,
+            variant(HugeInt::build(static_cast<uint64_t>(decimalValue >> 64), static_cast<uint64_t>(decimalValue))));
+      }
+    }
+    case ::substrait::Expression_Literal::LiteralTypeCase::kNull: {
+      auto veloxType = toVeloxType(subParser_->parseType(substraitLit.null())->type);
+      if (veloxType->isShortDecimal()) {
+        return std::make_shared<core::ConstantTypedExpr>(veloxType, variant::null(TypeKind::BIGINT));
+      } else if (veloxType->isLongDecimal()) {
+        return std::make_shared<core::ConstantTypedExpr>(veloxType, variant::null(TypeKind::HUGEINT));
+      } else {
+        return std::make_shared<core::ConstantTypedExpr>(veloxType, variant::null(veloxType->kind()));
+      }
+    }
+    default:
+      VELOX_NYI("Substrait conversion not supported for type case '{}'", typeCase);
+  }
+}
+
+ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substrait::Expression::Literal& listLiteral) {
+  auto childSize = listLiteral.list().values().size();
+  if (childSize == 0) {
+    return makeEmptyArrayVector(pool_);
+  }
+  auto typeCase = listLiteral.list().values(0).literal_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression_Literal::LiteralTypeCase::kBoolean:
+      return makeArrayVector(constructFlatVector<TypeKind::BOOLEAN>(listLiteral, childSize, BOOLEAN(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI8:
+      return makeArrayVector(constructFlatVector<TypeKind::TINYINT>(listLiteral, childSize, TINYINT(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI16:
+      return makeArrayVector(constructFlatVector<TypeKind::SMALLINT>(listLiteral, childSize, SMALLINT(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI32:
+      return makeArrayVector(constructFlatVector<TypeKind::INTEGER>(listLiteral, childSize, INTEGER(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kFp32:
+      return makeArrayVector(constructFlatVector<TypeKind::REAL>(listLiteral, childSize, REAL(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI64:
+      return makeArrayVector(constructFlatVector<TypeKind::BIGINT>(listLiteral, childSize, BIGINT(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kFp64:
+      return makeArrayVector(constructFlatVector<TypeKind::DOUBLE>(listLiteral, childSize, DOUBLE(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kString:
+    case ::substrait::Expression_Literal::LiteralTypeCase::kVarChar:
+      return makeArrayVector(constructFlatVector<TypeKind::VARCHAR>(listLiteral, childSize, VARCHAR(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kNull: {
+      auto veloxType = toVeloxType(subParser_->parseType(listLiteral.null())->type);
+      auto kind = veloxType->kind();
+      return makeArrayVector(
+          VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(constructFlatVector, kind, listLiteral, childSize, veloxType, pool_));
+    }
+    case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
+      return makeArrayVector(constructFlatVector<TypeKind::DATE>(listLiteral, childSize, DATE(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kTimestamp:
+      return makeArrayVector(constructFlatVector<TypeKind::TIMESTAMP>(listLiteral, childSize, TIMESTAMP(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kIntervalDayToSecond:
+      return makeArrayVector(constructFlatVector<TypeKind::BIGINT>(listLiteral, childSize, INTERVAL_DAY_TIME(), pool_));
+    case ::substrait::Expression_Literal::LiteralTypeCase::kList: {
+      VectorPtr elements;
+      for (auto it : listLiteral.list().values()) {
+        auto v = literalsToArrayVector(it);
+        if (!elements) {
+          elements = v;
+        } else {
+          elements->append(v.get());
+        }
+      }
+      return makeArrayVector(elements);
+    }
+    default:
+      VELOX_NYI("literalsToArrayVector not supported for type case '{}'", typeCase);
+  }
+}
+
+RowVectorPtr SubstraitVeloxExprConverter::literalsToRowVector(const ::substrait::Expression::Literal& structLiteral) {
+  auto childSize = structLiteral.struct_().fields().size();
+  if (childSize == 0) {
+    return makeEmptyRowVector(pool_);
+  }
+  auto typeCase = structLiteral.struct_().fields(0).literal_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression_Literal::LiteralTypeCase::kBinary: {
+      std::vector<VectorPtr> vectors;
+      vectors.reserve(structLiteral.struct_().fields().size());
+      for (auto& child : structLiteral.struct_().fields()) {
+        vectors.emplace_back(constructFlatVectorForStruct<TypeKind::VARBINARY>(child, 1, VARBINARY(), pool_));
+      }
+      return makeRowVector(vectors);
+    }
+    default:
+      VELOX_NYI("literalsToRowVector not supported for type case '{}'", typeCase);
+  }
+}
+
+core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression::Cast& castExpr,
+    const RowTypePtr& inputType) {
+  auto substraitType = subParser_->parseType(castExpr.type());
+  auto type = toVeloxType(substraitType->type);
+  bool nullOnFailure = isNullOnFailure(castExpr.failure_behavior());
+
+  std::vector<core::TypedExprPtr> inputs{toVeloxExpr(castExpr.input(), inputType)};
+  return std::make_shared<core::CastTypedExpr>(type, inputs, nullOnFailure);
+}
+
+core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression::IfThen& ifThenExpr,
+    const RowTypePtr& inputType) {
+  VELOX_CHECK(ifThenExpr.ifs().size() > 0, "If clause expected.");
+
+  // Params are concatenated conditions and results with an optional "else" at
+  // the end, e.g. {condition1, result1, condition2, result2,..else}
+  std::vector<core::TypedExprPtr> params;
+  // If and then expressions are in pairs.
+  params.reserve(ifThenExpr.ifs().size() * 2);
+  std::optional<TypePtr> outputType = std::nullopt;
+  for (const auto& ifThen : ifThenExpr.ifs()) {
+    params.emplace_back(toVeloxExpr(ifThen.if_(), inputType));
+    const auto& thenExpr = toVeloxExpr(ifThen.then(), inputType);
+    // Get output type from the first then expression.
+    if (!outputType.has_value()) {
+      outputType = thenExpr->type();
+    }
+    params.emplace_back(thenExpr);
+  }
+
+  if (ifThenExpr.has_else_()) {
+    params.reserve(1);
+    params.emplace_back(toVeloxExpr(ifThenExpr.else_(), inputType));
+  }
+
+  VELOX_CHECK(outputType.has_value(), "Output type should be set.");
+  if (ifThenExpr.ifs().size() == 1) {
+    // If there is only one if-then clause, use if expression.
+    return std::make_shared<const core::CallTypedExpr>(outputType.value(), std::move(params), "if");
+  }
+  return std::make_shared<const core::CallTypedExpr>(outputType.value(), std::move(params), "switch");
+}
+
+core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
+    const ::substrait::Expression& substraitExpr,
+    const RowTypePtr& inputType) {
+  core::TypedExprPtr veloxExpr;
+  auto typeCase = substraitExpr.rex_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression::RexTypeCase::kLiteral:
+      return toVeloxExpr(substraitExpr.literal());
+    case ::substrait::Expression::RexTypeCase::kScalarFunction:
+      return toVeloxExpr(substraitExpr.scalar_function(), inputType);
+    case ::substrait::Expression::RexTypeCase::kSelection:
+      return toVeloxExpr(substraitExpr.selection(), inputType);
+    case ::substrait::Expression::RexTypeCase::kCast:
+      return toVeloxExpr(substraitExpr.cast(), inputType);
+    case ::substrait::Expression::RexTypeCase::kIfThen:
+      return toVeloxExpr(substraitExpr.if_then(), inputType);
+    case ::substrait::Expression::RexTypeCase::kSingularOrList:
+      return toVeloxExpr(substraitExpr.singular_or_list(), inputType);
+    default:
+      VELOX_NYI("Substrait conversion not supported for Expression '{}'", typeCase);
+  }
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.h
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.h
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "SubstraitParser.h"
+#include "velox/core/Expressions.h"
+#include "velox/type/StringView.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+/// This class is used to convert Substrait representations to Velox
+/// expressions.
+class SubstraitVeloxExprConverter {
+ public:
+  /// subParser: A Substrait parser used to convert Substrait representations
+  /// into recognizable representations. functionMap: A pre-constructed map
+  /// storing the relations between the function id and the function name.
+  explicit SubstraitVeloxExprConverter(
+      memory::MemoryPool* pool,
+      const std::unordered_map<uint64_t, std::string>& functionMap)
+      : pool_(pool), functionMap_(functionMap) {}
+
+  /// Stores the variant and its type.
+  struct TypedVariant {
+    variant veloxVariant;
+    TypePtr variantType;
+  };
+
+  /// Convert Substrait Field into Velox Field Expression.
+  std::shared_ptr<const core::FieldAccessTypedExpr> toVeloxExpr(
+      const ::substrait::Expression::FieldReference& substraitField,
+      const RowTypePtr& inputType);
+
+  /// Convert Substrait ScalarFunction into Velox Expression.
+  core::TypedExprPtr toVeloxExpr(
+      const ::substrait::Expression::ScalarFunction& substraitFunc,
+      const RowTypePtr& inputType);
+
+  /// Convert Substrait SingularOrList into Velox Expression.
+  core::TypedExprPtr toVeloxExpr(
+      const ::substrait::Expression::SingularOrList& singularOrList,
+      const RowTypePtr& inputType);
+
+  /// Convert Substrait CastExpression to Velox Expression.
+  core::TypedExprPtr toVeloxExpr(const ::substrait::Expression::Cast& castExpr, const RowTypePtr& inputType);
+
+  /// Create expression for extract.
+  core::TypedExprPtr toExtractExpr(const std::vector<core::TypedExprPtr>& params, const TypePtr& outputType);
+
+  /// Used to convert Substrait Literal into Velox Expression.
+  std::shared_ptr<const core::ConstantTypedExpr> toVeloxExpr(const ::substrait::Expression::Literal& substraitLit);
+
+  /// Convert Substrait Expression into Velox Expression.
+  core::TypedExprPtr toVeloxExpr(const ::substrait::Expression& substraitExpr, const RowTypePtr& inputType);
+
+  /// Convert Substrait IfThen into switch or if expression.
+  core::TypedExprPtr toVeloxExpr(const ::substrait::Expression::IfThen& substraitIfThen, const RowTypePtr& inputType);
+
+  /// Wrap a constant vector from literals with an array vector inside to create
+  /// the constant expression.
+  std::shared_ptr<const core::ConstantTypedExpr> literalsToConstantExpr(
+      const std::vector<::substrait::Expression::Literal>& literals);
+
+ private:
+  /// Convert list literal to ArrayVector.
+  ArrayVectorPtr literalsToArrayVector(const ::substrait::Expression::Literal& listLiteral);
+
+  RowVectorPtr literalsToRowVector(const ::substrait::Expression::Literal& structLiteral);
+
+  /// Memory pool.
+  memory::MemoryPool* pool_;
+
+  /// The Substrait parser used to convert Substrait representations into
+  /// recognizable representations.
+  std::shared_ptr<SubstraitParser> subParser_ = std::make_shared<SubstraitParser>();
+
+  /// The map storing the relations between the function id and the function
+  /// name.
+  std::unordered_map<uint64_t, std::string> functionMap_;
+
+  // The map storing the Substrait extract function input field and velox
+  // function name.
+  std::unordered_map<std::string, std::string> extractDatetimeFunctionMap_ = {
+      {"MILLISECOND", "millisecond"},
+      {"SECOND", "second"},
+      {"MINUTE", "minute"},
+      {"HOUR", "hour"},
+      {"DAY", "day"},
+      {"DAY_OF_WEEK", "day_of_week"},
+      {"DAY_OF_YEAR", "day_of_year"},
+      {"MONTH", "month"},
+      {"QUARTER", "quarter"},
+      {"YEAR", "year"},
+      {"YEAR_OF_WEEK", "year_of_week"}};
+};
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1,0 +1,2002 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SubstraitToVeloxPlan.h"
+#include "TypeUtils.h"
+#include "VariantToVectorConverter.h"
+#include "velox/type/Type.h"
+
+namespace gluten {
+namespace {
+
+core::SortOrder toSortOrder(const ::substrait::SortField& sortField) {
+  switch (sortField.direction()) {
+    case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST:
+      return core::kAscNullsFirst;
+    case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST:
+      return core::kAscNullsLast;
+    case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST:
+      return core::kDescNullsFirst;
+    case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
+      return core::kDescNullsLast;
+    default:
+      VELOX_FAIL("Sort direction is not supported.");
+  }
+}
+
+/// Holds the information required to create
+/// a project node to simulate the emit
+/// behavior in Substrait.
+struct EmitInfo {
+  std::vector<core::TypedExprPtr> expressions;
+  std::vector<std::string> projectNames;
+};
+
+/// Helper function to extract the attributes required to create a ProjectNode
+/// used for interpretting Substrait Emit.
+EmitInfo getEmitInfo(const ::substrait::RelCommon& relCommon, const core::PlanNodePtr& node) {
+  const auto& emit = relCommon.emit();
+  int emitSize = emit.output_mapping_size();
+  EmitInfo emitInfo;
+  emitInfo.projectNames.reserve(emitSize);
+  emitInfo.expressions.reserve(emitSize);
+  const auto& outputType = node->outputType();
+  for (int i = 0; i < emitSize; i++) {
+    int32_t mapId = emit.output_mapping(i);
+    emitInfo.projectNames[i] = outputType->nameOf(mapId);
+    emitInfo.expressions[i] =
+        std::make_shared<core::FieldAccessTypedExpr>(outputType->childAt(mapId), outputType->nameOf(mapId));
+  }
+  return emitInfo;
+}
+
+template <typename T>
+// Get the lowest value for numeric type.
+T getLowest() {
+  return std::numeric_limits<T>::lowest();
+};
+
+// Get the lowest value for string.
+template <>
+std::string getLowest<std::string>() {
+  return "";
+};
+
+// Get the max value for numeric type.
+template <typename T>
+T getMax() {
+  return std::numeric_limits<T>::max();
+};
+
+// The max value will be used in BytesRange. Return empty string here instead.
+template <>
+std::string getMax<std::string>() {
+  return "";
+};
+
+// Substrait function names.
+const std::string sIsNotNull = "is_not_null";
+const std::string sGte = "gte";
+const std::string sGt = "gt";
+const std::string sLte = "lte";
+const std::string sLt = "lt";
+const std::string sEqual = "equal";
+const std::string sOr = "or";
+const std::string sNot = "not";
+
+// Substrait types.
+const std::string sI32 = "i32";
+const std::string sI64 = "i64";
+
+/// @brief Get the input type from both sides of join.
+/// @param leftNode the plan node of left side.
+/// @param rightNode the plan node of right side.
+/// @return the input type.
+RowTypePtr getJoinInputType(const core::PlanNodePtr& leftNode, const core::PlanNodePtr& rightNode) {
+  auto outputSize = leftNode->outputType()->size() + rightNode->outputType()->size();
+  std::vector<std::string> outputNames;
+  std::vector<std::shared_ptr<const Type>> outputTypes;
+  outputNames.reserve(outputSize);
+  outputTypes.reserve(outputSize);
+  for (const auto& node : {leftNode, rightNode}) {
+    const auto& names = node->outputType()->names();
+    outputNames.insert(outputNames.end(), names.begin(), names.end());
+    const auto& types = node->outputType()->children();
+    outputTypes.insert(outputTypes.end(), types.begin(), types.end());
+  }
+  return std::make_shared<const RowType>(std::move(outputNames), std::move(outputTypes));
+}
+
+/// @brief Get the direct output type of join.
+/// @param leftNode the plan node of left side.
+/// @param rightNode the plan node of right side.
+/// @param joinType the join type.
+/// @return the output type.
+RowTypePtr getJoinOutputType(
+    const core::PlanNodePtr& leftNode,
+    const core::PlanNodePtr& rightNode,
+    const core::JoinType& joinType) {
+  // Decide output type.
+  // Output of right semi join cannot include columns from the left side.
+  bool outputMayIncludeLeftColumns = !(core::isRightSemiFilterJoin(joinType) || core::isRightSemiProjectJoin(joinType));
+
+  // Output of left semi and anti joins cannot include columns from the right
+  // side.
+  bool outputMayIncludeRightColumns =
+      !(core::isLeftSemiFilterJoin(joinType) || core::isLeftSemiProjectJoin(joinType) || core::isAntiJoin(joinType));
+
+  if (outputMayIncludeLeftColumns && outputMayIncludeRightColumns) {
+    return getJoinInputType(leftNode, rightNode);
+  }
+
+  if (outputMayIncludeLeftColumns) {
+    if (core::isLeftSemiProjectJoin(joinType)) {
+      auto outputSize = leftNode->outputType()->size() + 1;
+      std::vector<std::string> outputNames = leftNode->outputType()->names();
+      std::vector<std::shared_ptr<const Type>> outputTypes = leftNode->outputType()->children();
+      outputNames.emplace_back("exists");
+      outputTypes.emplace_back(BOOLEAN());
+      return std::make_shared<const RowType>(std::move(outputNames), std::move(outputTypes));
+    } else {
+      return leftNode->outputType();
+    }
+  }
+
+  if (outputMayIncludeRightColumns) {
+    if (core::isRightSemiProjectJoin(joinType)) {
+      auto outputSize = rightNode->outputType()->size() + 1;
+      std::vector<std::string> outputNames = rightNode->outputType()->names();
+      std::vector<std::shared_ptr<const Type>> outputTypes = rightNode->outputType()->children();
+      outputNames.emplace_back("exists");
+      outputTypes.emplace_back(BOOLEAN());
+      return std::make_shared<const RowType>(std::move(outputNames), std::move(outputTypes));
+    } else {
+      return rightNode->outputType();
+    }
+  }
+  VELOX_FAIL("Output should include left or right columns.");
+}
+} // namespace
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::processEmit(
+    const ::substrait::RelCommon& relCommon,
+    const core::PlanNodePtr& noEmitNode) {
+  switch (relCommon.emit_kind_case()) {
+    case ::substrait::RelCommon::EmitKindCase::kDirect:
+      return noEmitNode;
+    case ::substrait::RelCommon::EmitKindCase::kEmit: {
+      auto emitInfo = getEmitInfo(relCommon, noEmitNode);
+      return std::make_shared<core::ProjectNode>(
+          nextPlanNodeId(), std::move(emitInfo.projectNames), std::move(emitInfo.expressions), noEmitNode);
+    }
+    default:
+      VELOX_FAIL("unrecognized emit kind");
+  }
+}
+
+core::AggregationNode::Step SubstraitVeloxPlanConverter::toAggregationStep(const ::substrait::AggregateRel& aggRel) {
+  if (aggRel.measures().size() == 0) {
+    // When only groupings exist, set the phase to be Single.
+    return core::AggregationNode::Step::kSingle;
+  }
+
+  // Use the first measure to set aggregation phase.
+  const auto& firstMeasure = aggRel.measures()[0];
+  const auto& aggFunction = firstMeasure.measure();
+  switch (aggFunction.phase()) {
+    case ::substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE:
+      return core::AggregationNode::Step::kPartial;
+    case ::substrait::AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE:
+      return core::AggregationNode::Step::kIntermediate;
+    case ::substrait::AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT:
+      return core::AggregationNode::Step::kFinal;
+    case ::substrait::AGGREGATION_PHASE_INITIAL_TO_RESULT:
+      return core::AggregationNode::Step::kSingle;
+    default:
+      VELOX_FAIL("Aggregate phase is not supported.");
+  }
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::JoinRel& sJoin) {
+  if (!sJoin.has_left()) {
+    VELOX_FAIL("Left Rel is expected in JoinRel.");
+  }
+  if (!sJoin.has_right()) {
+    VELOX_FAIL("Right Rel is expected in JoinRel.");
+  }
+
+  auto leftNode = toVeloxPlan(sJoin.left());
+  auto rightNode = toVeloxPlan(sJoin.right());
+
+  // Map join type.
+  core::JoinType joinType;
+  bool isNullAwareAntiJoin = false;
+  switch (sJoin.type()) {
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_INNER:
+      joinType = core::JoinType::kInner;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_OUTER:
+      joinType = core::JoinType::kFull;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT:
+      joinType = core::JoinType::kLeft;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT:
+      joinType = core::JoinType::kRight;
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_SEMI:
+      // Determine the semi join type based on extracted information.
+      if (sJoin.has_advanced_extension() &&
+          subParser_->configSetInOptimization(sJoin.advanced_extension(), "isExistenceJoin=")) {
+        joinType = core::JoinType::kLeftSemiProject;
+      } else {
+        joinType = core::JoinType::kLeftSemiFilter;
+      }
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT_SEMI:
+      // Determine the semi join type based on extracted information.
+      if (sJoin.has_advanced_extension() &&
+          subParser_->configSetInOptimization(sJoin.advanced_extension(), "isExistenceJoin=")) {
+        joinType = core::JoinType::kRightSemiProject;
+      } else {
+        joinType = core::JoinType::kRightSemiFilter;
+      }
+      break;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_ANTI: {
+      // Determine the anti join type based on extracted information.
+      if (sJoin.has_advanced_extension() &&
+          subParser_->configSetInOptimization(sJoin.advanced_extension(), "isNullAwareAntiJoin=")) {
+        isNullAwareAntiJoin = true;
+      }
+      joinType = core::JoinType::kAnti;
+      break;
+    }
+    default:
+      VELOX_NYI("Unsupported Join type: {}", sJoin.type());
+  }
+
+  // extract join keys from join expression
+  std::vector<const ::substrait::Expression::FieldReference*> leftExprs, rightExprs;
+  extractJoinKeys(sJoin.expression(), leftExprs, rightExprs);
+  VELOX_CHECK_EQ(leftExprs.size(), rightExprs.size());
+  size_t numKeys = leftExprs.size();
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> leftKeys, rightKeys;
+  leftKeys.reserve(numKeys);
+  rightKeys.reserve(numKeys);
+  auto inputRowType = getJoinInputType(leftNode, rightNode);
+  for (size_t i = 0; i < numKeys; ++i) {
+    leftKeys.emplace_back(exprConverter_->toVeloxExpr(*leftExprs[i], inputRowType));
+    rightKeys.emplace_back(exprConverter_->toVeloxExpr(*rightExprs[i], inputRowType));
+  }
+
+  core::TypedExprPtr filter;
+  if (sJoin.has_post_join_filter()) {
+    filter = exprConverter_->toVeloxExpr(sJoin.post_join_filter(), inputRowType);
+  }
+
+  if (sJoin.has_advanced_extension() && subParser_->configSetInOptimization(sJoin.advanced_extension(), "isSMJ=")) {
+    // Create MergeJoinNode node
+    return std::make_shared<core::MergeJoinNode>(
+        nextPlanNodeId(),
+        joinType,
+        leftKeys,
+        rightKeys,
+        filter,
+        leftNode,
+        rightNode,
+        getJoinOutputType(leftNode, rightNode, joinType));
+
+  } else {
+    // Create HashJoinNode node
+    return std::make_shared<core::HashJoinNode>(
+        nextPlanNodeId(),
+        joinType,
+        isNullAwareAntiJoin,
+        leftKeys,
+        rightKeys,
+        filter,
+        leftNode,
+        rightNode,
+        getJoinOutputType(leftNode, rightNode, joinType));
+  }
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::AggregateRel& aggRel) {
+  auto childNode = convertSingleInput<::substrait::AggregateRel>(aggRel);
+  core::AggregationNode::Step aggStep = toAggregationStep(aggRel);
+  const auto& inputType = childNode->outputType();
+  std::vector<core::FieldAccessTypedExprPtr> veloxGroupingExprs;
+
+  // Get the grouping expressions.
+  for (const auto& grouping : aggRel.groupings()) {
+    for (const auto& groupingExpr : grouping.grouping_expressions()) {
+      // Velox's groupings are limited to be Field.
+      veloxGroupingExprs.emplace_back(exprConverter_->toVeloxExpr(groupingExpr.selection(), inputType));
+    }
+  }
+
+  // Parse measures and get the aggregate expressions.
+  // Each measure represents one aggregate expression.
+  std::vector<core::AggregationNode::Aggregate> aggregates;
+  aggregates.reserve(aggRel.measures().size());
+
+  for (const auto& measure : aggRel.measures()) {
+    core::FieldAccessTypedExprPtr mask;
+    ::substrait::Expression substraitAggMask = measure.filter();
+    // Get Aggregation Masks.
+    if (measure.has_filter()) {
+      if (substraitAggMask.ByteSizeLong() > 0) {
+        mask = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+            exprConverter_->toVeloxExpr(substraitAggMask, inputType));
+      }
+    }
+    const auto& aggFunction = measure.measure();
+    auto funcName = subParser_->findVeloxFunction(functionMap_, aggFunction.function_reference());
+    std::vector<core::TypedExprPtr> aggParams;
+    aggParams.reserve(aggFunction.arguments().size());
+    for (const auto& arg : aggFunction.arguments()) {
+      aggParams.emplace_back(exprConverter_->toVeloxExpr(arg.value(), inputType));
+    }
+    auto aggVeloxType = toVeloxType(subParser_->parseType(aggFunction.output_type())->type);
+    auto aggExpr = std::make_shared<const core::CallTypedExpr>(aggVeloxType, std::move(aggParams), funcName);
+    aggregates.emplace_back(core::AggregationNode::Aggregate{aggExpr, mask, {}, {}});
+  }
+
+  bool ignoreNullKeys = false;
+  std::vector<core::FieldAccessTypedExprPtr> preGroupingExprs;
+
+  // Get the output names of Aggregation.
+  std::vector<std::string> aggOutNames;
+  aggOutNames.reserve(aggRel.measures().size());
+  for (int idx = veloxGroupingExprs.size(); idx < veloxGroupingExprs.size() + aggRel.measures().size(); idx++) {
+    aggOutNames.emplace_back(subParser_->makeNodeName(planNodeId_, idx));
+  }
+
+  auto aggregationNode = std::make_shared<core::AggregationNode>(
+      nextPlanNodeId(),
+      aggStep,
+      veloxGroupingExprs,
+      preGroupingExprs,
+      aggOutNames,
+      aggregates,
+      ignoreNullKeys,
+      childNode);
+
+  if (aggRel.has_common()) {
+    return processEmit(aggRel.common(), std::move(aggregationNode));
+  } else {
+    return aggregationNode;
+  }
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::ProjectRel& projectRel) {
+  auto childNode = convertSingleInput<::substrait::ProjectRel>(projectRel);
+  // Construct Velox Expressions.
+  const auto& projectExprs = projectRel.expressions();
+  std::vector<std::string> projectNames;
+  std::vector<core::TypedExprPtr> expressions;
+  projectNames.reserve(projectExprs.size());
+  expressions.reserve(projectExprs.size());
+
+  const auto& inputType = childNode->outputType();
+  int colIdx = 0;
+  // Note that Substrait projection adds the project expressions on top of the
+  // input to the projection node. Thus we need to add the input columns first
+  // and then add the projection expressions.
+
+  // First, adding the project names and expressions from the input to
+  // the project node.
+  for (uint32_t idx = 0; idx < inputType->size(); idx++) {
+    const auto& fieldName = inputType->nameOf(idx);
+    projectNames.emplace_back(fieldName);
+    expressions.emplace_back(std::make_shared<core::FieldAccessTypedExpr>(inputType->childAt(idx), fieldName));
+    colIdx += 1;
+  }
+
+  // Then, adding project expression related project names and expressions.
+  for (const auto& expr : projectExprs) {
+    expressions.emplace_back(exprConverter_->toVeloxExpr(expr, inputType));
+    projectNames.emplace_back(subParser_->makeNodeName(planNodeId_, colIdx));
+    colIdx += 1;
+  }
+
+  if (projectRel.has_common()) {
+    auto relCommon = projectRel.common();
+    const auto& emit = relCommon.emit();
+    int emitSize = emit.output_mapping_size();
+    std::vector<std::string> emitProjectNames(emitSize);
+    std::vector<core::TypedExprPtr> emitExpressions(emitSize);
+    for (int i = 0; i < emitSize; i++) {
+      int32_t mapId = emit.output_mapping(i);
+      emitProjectNames[i] = projectNames[mapId];
+      emitExpressions[i] = expressions[mapId];
+    }
+    return std::make_shared<core::ProjectNode>(
+        nextPlanNodeId(), std::move(emitProjectNames), std::move(emitExpressions), std::move(childNode));
+  } else {
+    return std::make_shared<core::ProjectNode>(
+        nextPlanNodeId(), std::move(projectNames), std::move(expressions), std::move(childNode));
+  }
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::ExpandRel& expandRel) {
+  core::PlanNodePtr childNode;
+  if (expandRel.has_input()) {
+    childNode = toVeloxPlan(expandRel.input());
+  } else {
+    VELOX_FAIL("Child Rel is expected in ExpandRel.");
+  }
+
+  const auto& inputType = childNode->outputType();
+
+  std::vector<std::vector<core::TypedExprPtr>> projectSetExprs;
+  projectSetExprs.reserve(expandRel.fields_size());
+
+  for (const auto& projections : expandRel.fields()) {
+    std::vector<core::TypedExprPtr> projectExprs;
+    projectExprs.reserve(projections.switching_field().duplicates_size());
+
+    for (const auto& projectExpr : projections.switching_field().duplicates()) {
+      if (projectExpr.has_selection()) {
+        auto expression = exprConverter_->toVeloxExpr(projectExpr.selection(), inputType);
+        projectExprs.emplace_back(expression);
+      } else if (projectExpr.has_literal()) {
+        auto expression = exprConverter_->toVeloxExpr(projectExpr.literal());
+        projectExprs.emplace_back(expression);
+      } else {
+        VELOX_FAIL("The project in Expand Operator only support field or literal.");
+      }
+    }
+    projectSetExprs.emplace_back(projectExprs);
+  }
+
+  auto projectSize = expandRel.fields()[0].switching_field().duplicates_size();
+  std::vector<std::string> names;
+  names.reserve(projectSize);
+  for (int idx = 0; idx < projectSize; idx++) {
+    names.push_back(subParser_->makeNodeName(planNodeId_, idx));
+  }
+
+  return std::make_shared<core::ExpandNode>(nextPlanNodeId(), projectSetExprs, std::move(names), childNode);
+}
+
+const core::WindowNode::Frame createWindowFrame(
+    const ::substrait::Expression_WindowFunction_Bound& lower_bound,
+    const ::substrait::Expression_WindowFunction_Bound& upper_bound,
+    const ::substrait::WindowType& type) {
+  core::WindowNode::Frame frame;
+  switch (type) {
+    case ::substrait::WindowType::ROWS:
+      frame.type = core::WindowNode::WindowType::kRows;
+      break;
+    case ::substrait::WindowType::RANGE:
+      frame.type = core::WindowNode::WindowType::kRange;
+      break;
+    default:
+      VELOX_FAIL("the window type only support ROWS and RANGE, and the input type is ", type);
+  }
+
+  auto boundTypeConversion = [](::substrait::Expression_WindowFunction_Bound boundType) -> core::WindowNode::BoundType {
+    if (boundType.has_current_row()) {
+      return core::WindowNode::BoundType::kCurrentRow;
+    } else if (boundType.has_unbounded_following()) {
+      return core::WindowNode::BoundType::kUnboundedFollowing;
+    } else if (boundType.has_unbounded_preceding()) {
+      return core::WindowNode::BoundType::kUnboundedPreceding;
+    } else if (boundType.has_following()) {
+      return core::WindowNode::BoundType::kFollowing;
+    } else if (boundType.has_preceding()) {
+      return core::WindowNode::BoundType::kPreceding;
+    } else {
+      VELOX_FAIL("The BoundType is not supported.");
+    }
+  };
+  frame.startType = boundTypeConversion(lower_bound);
+  switch (frame.startType) {
+    case core::WindowNode::BoundType::kPreceding:
+      // TODO: support non-literal expression.
+      frame.startValue = std::make_shared<core::ConstantTypedExpr>(BIGINT(), variant(lower_bound.preceding().offset()));
+      break;
+    default:
+      frame.startValue = nullptr;
+  }
+  frame.endType = boundTypeConversion(upper_bound);
+  switch (frame.endType) {
+    // TODO: support non-literal expression.
+    case core::WindowNode::BoundType::kFollowing:
+      frame.endValue = std::make_shared<core::ConstantTypedExpr>(BIGINT(), variant(upper_bound.following().offset()));
+      break;
+    default:
+      frame.endValue = nullptr;
+  }
+  return frame;
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::WindowRel& windowRel) {
+  core::PlanNodePtr childNode;
+  if (windowRel.has_input()) {
+    childNode = toVeloxPlan(windowRel.input());
+  } else {
+    VELOX_FAIL("Child Rel is expected in WindowRel.");
+  }
+
+  const auto& inputType = childNode->outputType();
+
+  // Parse measures and get the window expressions.
+  // Each measure represents one window expression.
+  bool ignoreNullKeys = false;
+  std::vector<core::WindowNode::Function> windowNodeFunctions;
+  std::vector<std::string> windowColumnNames;
+
+  windowNodeFunctions.reserve(windowRel.measures().size());
+  for (const auto& smea : windowRel.measures()) {
+    const auto& windowFunction = smea.measure();
+    std::string funcName = subParser_->findVeloxFunction(functionMap_, windowFunction.function_reference());
+    std::vector<core::TypedExprPtr> windowParams;
+    windowParams.reserve(windowFunction.arguments().size());
+    for (const auto& arg : windowFunction.arguments()) {
+      windowParams.emplace_back(exprConverter_->toVeloxExpr(arg.value(), inputType));
+    }
+    auto windowVeloxType = toVeloxType(subParser_->parseType(windowFunction.output_type())->type);
+    auto windowCall = std::make_shared<const core::CallTypedExpr>(windowVeloxType, std::move(windowParams), funcName);
+    auto upperBound = windowFunction.upper_bound();
+    auto lowerBound = windowFunction.lower_bound();
+    auto type = windowFunction.window_type();
+
+    windowColumnNames.push_back(windowFunction.column_name());
+
+    windowNodeFunctions.push_back(
+        {std::move(windowCall), createWindowFrame(lowerBound, upperBound, type), ignoreNullKeys});
+  }
+
+  // Construct partitionKeys
+  std::vector<core::FieldAccessTypedExprPtr> partitionKeys;
+  const auto& partitions = windowRel.partition_expressions();
+  partitionKeys.reserve(partitions.size());
+  for (const auto& partition : partitions) {
+    auto expression = exprConverter_->toVeloxExpr(partition, inputType);
+    auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+    VELOX_CHECK(expr_field != nullptr, " the partition key in Window Operator only support field")
+
+    partitionKeys.emplace_back(std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression));
+  }
+
+  std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<core::SortOrder> sortingOrders;
+
+  const auto& sorts = windowRel.sorts();
+  sortingKeys.reserve(sorts.size());
+  sortingOrders.reserve(sorts.size());
+
+  for (const auto& sort : sorts) {
+    switch (sort.direction()) {
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST:
+        sortingOrders.emplace_back(core::kAscNullsFirst);
+        break;
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST:
+        sortingOrders.emplace_back(core::kAscNullsLast);
+        break;
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST:
+        sortingOrders.emplace_back(core::kDescNullsFirst);
+        break;
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
+        sortingOrders.emplace_back(core::kDescNullsLast);
+        break;
+      default:
+        VELOX_FAIL("Sort direction is not support in WindowRel");
+    }
+
+    if (sort.has_expr()) {
+      auto expression = exprConverter_->toVeloxExpr(sort.expr(), inputType);
+      auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+      VELOX_CHECK(expr_field != nullptr, " the sorting key in Window Operator only support field")
+
+      sortingKeys.emplace_back(std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression));
+    }
+  }
+
+  return std::make_shared<core::WindowNode>(
+      nextPlanNodeId(), partitionKeys, sortingKeys, sortingOrders, windowColumnNames, windowNodeFunctions, childNode);
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::SortRel& sortRel) {
+  auto childNode = convertSingleInput<::substrait::SortRel>(sortRel);
+
+  auto [sortingKeys, sortingOrders] = processSortField(sortRel.sorts(), childNode->outputType());
+
+  return std::make_shared<core::OrderByNode>(
+      nextPlanNodeId(), sortingKeys, sortingOrders, false /*isPartial*/, childNode);
+}
+
+std::pair<std::vector<core::FieldAccessTypedExprPtr>, std::vector<core::SortOrder>>
+SubstraitVeloxPlanConverter::processSortField(
+    const ::google::protobuf::RepeatedPtrField<::substrait::SortField>& sortFields,
+    const RowTypePtr& inputType) {
+  std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<core::SortOrder> sortingOrders;
+  sortingKeys.reserve(sortFields.size());
+  sortingOrders.reserve(sortFields.size());
+
+  for (const auto& sort : sortFields) {
+    sortingOrders.emplace_back(toSortOrder(sort));
+
+    if (sort.has_expr()) {
+      auto expression = exprConverter_->toVeloxExpr(sort.expr(), inputType);
+      auto fieldExpr = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression);
+      VELOX_CHECK_NOT_NULL(fieldExpr, " the sorting key in Sort Operator only support field");
+      sortingKeys.emplace_back(fieldExpr);
+    }
+  }
+  return {sortingKeys, sortingOrders};
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::FilterRel& filterRel) {
+  auto childNode = convertSingleInput<::substrait::FilterRel>(filterRel);
+  auto filterNode = std::make_shared<core::FilterNode>(
+      nextPlanNodeId(), exprConverter_->toVeloxExpr(filterRel.condition(), childNode->outputType()), childNode);
+
+  if (filterRel.has_common()) {
+    return processEmit(filterRel.common(), std::move(filterNode));
+  } else {
+    return filterNode;
+  }
+}
+
+bool isPushDownSupportedByFormat(
+    const dwio::common::FileFormat& format,
+    connector::hive::SubfieldFilters& subfieldFilters) {
+  switch (format) {
+    case dwio::common::FileFormat::PARQUET:
+    case dwio::common::FileFormat::ORC:
+    case dwio::common::FileFormat::DWRF:
+    case dwio::common::FileFormat::RC:
+    case dwio::common::FileFormat::RC_TEXT:
+    case dwio::common::FileFormat::RC_BINARY:
+    case dwio::common::FileFormat::TEXT:
+    case dwio::common::FileFormat::JSON:
+    case dwio::common::FileFormat::ALPHA:
+    case dwio::common::FileFormat::UNKNOWN:
+    default:
+      break;
+  }
+  return true;
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::FetchRel& fetchRel) {
+  core::PlanNodePtr childNode;
+  // Check the input of fetchRel, if it's sortRel, convert them into
+  // topNNode. otherwise, to limitNode.
+  ::substrait::SortRel sortRel;
+  bool topNFlag;
+  if (fetchRel.has_input()) {
+    topNFlag = fetchRel.input().has_sort();
+    if (topNFlag) {
+      sortRel = fetchRel.input().sort();
+      childNode = toVeloxPlan(sortRel.input());
+    } else {
+      childNode = toVeloxPlan(fetchRel.input());
+    }
+  } else {
+    VELOX_FAIL("Child Rel is expected in FetchRel.");
+  }
+
+  if (topNFlag) {
+    auto [sortingKeys, sortingOrders] = processSortField(sortRel.sorts(), childNode->outputType());
+
+    VELOX_CHECK_EQ(fetchRel.offset(), 0);
+
+    return std::make_shared<core::TopNNode>(
+        nextPlanNodeId(), sortingKeys, sortingOrders, (int32_t)fetchRel.count(), false /*isPartial*/, childNode);
+
+  } else {
+    return std::make_shared<core::LimitNode>(
+        nextPlanNodeId(), (int32_t)fetchRel.offset(), (int32_t)fetchRel.count(), false /*isPartial*/, childNode);
+  }
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::ReadRel& readRel) {
+  // emit is not allowed in TableScanNode and ValuesNode related
+  // outputs
+  if (readRel.has_common()) {
+    VELOX_USER_CHECK(
+        !readRel.common().has_emit(), "Emit not supported for ValuesNode and TableScanNode related Substrait plans.");
+  }
+
+  // Check if the ReadRel specifies an input of stream. If yes, the pre-built
+  // input node will be used as the data source.
+  auto splitInfo = std::make_shared<SplitInfo>();
+  auto streamIdx = streamIsInput(readRel);
+  if (streamIdx >= 0) {
+    if (inputNodesMap_.find(streamIdx) == inputNodesMap_.end()) {
+      VELOX_FAIL("Could not find source index {} in input nodes map.", streamIdx);
+    }
+    auto streamNode = inputNodesMap_[streamIdx];
+    splitInfo->isStream = true;
+    splitInfoMap_[streamNode->id()] = splitInfo;
+    return streamNode;
+  }
+
+  // Otherwise, will create TableScan node for ReadRel.
+  // Get output names and types.
+  std::vector<std::string> colNameList;
+  std::vector<TypePtr> veloxTypeList;
+  std::vector<bool> isPartitionColumns;
+  if (readRel.has_base_schema()) {
+    const auto& baseSchema = readRel.base_schema();
+    colNameList.reserve(baseSchema.names().size());
+    for (const auto& name : baseSchema.names()) {
+      colNameList.emplace_back(name);
+    }
+    auto substraitTypeList = subParser_->parseNamedStruct(baseSchema);
+    isPartitionColumns = subParser_->parsePartitionColumns(baseSchema);
+    veloxTypeList.reserve(substraitTypeList.size());
+    for (const auto& substraitType : substraitTypeList) {
+      veloxTypeList.emplace_back(toVeloxType(substraitType->type));
+    }
+  }
+
+  // Parse local files and construct split info.
+  if (readRel.has_local_files()) {
+    using SubstraitFileFormatCase = ::substrait::ReadRel_LocalFiles_FileOrFiles::FileFormatCase;
+    const auto& fileList = readRel.local_files().items();
+    splitInfo->paths.reserve(fileList.size());
+    splitInfo->starts.reserve(fileList.size());
+    splitInfo->lengths.reserve(fileList.size());
+    for (const auto& file : fileList) {
+      // Expect all Partitions share the same index.
+      splitInfo->partitionIndex = file.partition_index();
+      splitInfo->paths.emplace_back(file.uri_file());
+      splitInfo->starts.emplace_back(file.start());
+      splitInfo->lengths.emplace_back(file.length());
+      switch (file.file_format_case()) {
+        case SubstraitFileFormatCase::kOrc:
+          splitInfo->format = dwio::common::FileFormat::ORC;
+          break;
+        case SubstraitFileFormatCase::kDwrf:
+          splitInfo->format = dwio::common::FileFormat::DWRF;
+          break;
+        case SubstraitFileFormatCase::kParquet:
+          splitInfo->format = dwio::common::FileFormat::PARQUET;
+          break;
+        default:
+          splitInfo->format = dwio::common::FileFormat::UNKNOWN;
+      }
+    }
+  }
+  // Do not hard-code connector ID and allow for connectors other than Hive.
+  static const std::string kHiveConnectorId = "test-hive";
+
+  // Velox requires Filter Pushdown must being enabled.
+  bool filterPushdownEnabled = true;
+  std::shared_ptr<connector::hive::HiveTableHandle> tableHandle;
+  if (!readRel.has_filter()) {
+    tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
+        kHiveConnectorId, "hive_table", filterPushdownEnabled, connector::hive::SubfieldFilters{}, nullptr);
+  } else {
+    // Flatten the conditions connected with 'and'.
+    std::vector<::substrait::Expression_ScalarFunction> scalarFunctions;
+    std::vector<::substrait::Expression_SingularOrList> singularOrLists;
+    std::vector<::substrait::Expression_IfThen> ifThens;
+    flattenConditions(readRel.filter(), scalarFunctions, singularOrLists, ifThens);
+
+    std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>> rangeRecorders;
+    for (uint32_t idx = 0; idx < veloxTypeList.size(); idx++) {
+      rangeRecorders[idx] = std::make_shared<RangeRecorder>();
+    }
+
+    // Separate the filters to be two parts. The subfield part can be
+    // pushed down.
+    std::vector<::substrait::Expression_ScalarFunction> subfieldFunctions;
+    std::vector<::substrait::Expression_SingularOrList> subfieldrOrLists;
+
+    std::vector<::substrait::Expression_ScalarFunction> remainingFunctions;
+    std::vector<::substrait::Expression_SingularOrList> remainingrOrLists;
+
+    separateFilters(
+        rangeRecorders,
+        scalarFunctions,
+        subfieldFunctions,
+        remainingFunctions,
+        singularOrLists,
+        subfieldrOrLists,
+        remainingrOrLists);
+
+    // Create subfield filters based on the constructed filter info map.
+    connector::hive::SubfieldFilters subfieldFilters =
+        toSubfieldFilters(colNameList, veloxTypeList, subfieldFunctions, subfieldrOrLists);
+    // Connect the remaining filters with 'and'.
+    core::TypedExprPtr remainingFilter;
+
+    if (!isPushDownSupportedByFormat(splitInfo->format, subfieldFilters)) {
+      // A subfieldFilter is not supported by the format,
+      // mark all filter as remaining filters.
+      subfieldFilters.clear();
+      remainingFilter = connectWithAnd(colNameList, veloxTypeList, scalarFunctions, singularOrLists, ifThens);
+    } else {
+      remainingFilter = connectWithAnd(colNameList, veloxTypeList, remainingFunctions, remainingrOrLists, ifThens);
+    }
+
+    tableHandle = std::make_shared<connector::hive::HiveTableHandle>(
+        kHiveConnectorId, "hive_table", filterPushdownEnabled, std::move(subfieldFilters), remainingFilter);
+  }
+
+  // Get assignments and out names.
+  std::vector<std::string> outNames;
+  outNames.reserve(colNameList.size());
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>> assignments;
+  for (int idx = 0; idx < colNameList.size(); idx++) {
+    auto outName = subParser_->makeNodeName(planNodeId_, idx);
+    auto columnType = isPartitionColumns[idx] ? connector::hive::HiveColumnHandle::ColumnType::kPartitionKey
+                                              : connector::hive::HiveColumnHandle::ColumnType::kRegular;
+    assignments[outName] =
+        std::make_shared<connector::hive::HiveColumnHandle>(colNameList[idx], columnType, veloxTypeList[idx]);
+    outNames.emplace_back(outName);
+  }
+  auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
+
+  if (readRel.has_virtual_table()) {
+    return toVeloxPlan(readRel, outputType);
+  } else {
+    auto tableScanNode = std::make_shared<core::TableScanNode>(
+        nextPlanNodeId(), std::move(outputType), std::move(tableHandle), std::move(assignments));
+    // Set split info map.
+    splitInfoMap_[tableScanNode->id()] = splitInfo;
+    return tableScanNode;
+  }
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
+    const ::substrait::ReadRel& readRel,
+    const RowTypePtr& type) {
+  ::substrait::ReadRel_VirtualTable readVirtualTable = readRel.virtual_table();
+  int64_t numVectors = readVirtualTable.values_size();
+  int64_t numColumns = type->size();
+  int64_t valueFieldNums = readVirtualTable.values(numVectors - 1).fields_size();
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(numVectors);
+
+  int64_t batchSize;
+  // For the empty vectors, eg,vectors = makeRowVector(ROW({}, {}), 1).
+  if (numColumns == 0) {
+    batchSize = 1;
+  } else {
+    batchSize = valueFieldNums / numColumns;
+  }
+
+  for (int64_t index = 0; index < numVectors; ++index) {
+    std::vector<VectorPtr> children;
+    ::substrait::Expression_Literal_Struct rowValue = readRel.virtual_table().values(index);
+    auto fieldSize = rowValue.fields_size();
+    VELOX_CHECK_EQ(fieldSize, batchSize * numColumns);
+
+    for (int64_t col = 0; col < numColumns; ++col) {
+      const TypePtr& outputChildType = type->childAt(col);
+      std::vector<variant> batchChild;
+      batchChild.reserve(batchSize);
+      for (int64_t batchId = 0; batchId < batchSize; batchId++) {
+        // each value in the batch
+        auto fieldIdx = col * batchSize + batchId;
+        ::substrait::Expression_Literal field = rowValue.fields(fieldIdx);
+
+        auto expr = exprConverter_->toVeloxExpr(field);
+        if (auto constantExpr = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(expr)) {
+          if (!constantExpr->hasValueVector()) {
+            batchChild.emplace_back(constantExpr->value());
+          } else {
+            VELOX_UNSUPPORTED("Values node with complex type values is not supported yet");
+          }
+        } else {
+          VELOX_FAIL("Expected constant expression");
+        }
+      }
+      children.emplace_back(setVectorFromVariants(outputChildType, batchChild, pool_));
+    }
+
+    vectors.emplace_back(std::make_shared<RowVector>(pool_, type, nullptr, batchSize, children));
+  }
+
+  return std::make_shared<core::ValuesNode>(nextPlanNodeId(), std::move(vectors));
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::Rel& rel) {
+  if (rel.has_aggregate()) {
+    return toVeloxPlan(rel.aggregate());
+  }
+  if (rel.has_project()) {
+    return toVeloxPlan(rel.project());
+  }
+  if (rel.has_filter()) {
+    return toVeloxPlan(rel.filter());
+  }
+  if (rel.has_join()) {
+    return toVeloxPlan(rel.join());
+  }
+  if (rel.has_read()) {
+    return toVeloxPlan(rel.read());
+  }
+  if (rel.has_sort()) {
+    return toVeloxPlan(rel.sort());
+  }
+  if (rel.has_fetch()) {
+    return toVeloxPlan(rel.fetch());
+  }
+  if (rel.has_sort()) {
+    return toVeloxPlan(rel.sort());
+  }
+  if (rel.has_expand()) {
+    return toVeloxPlan(rel.expand());
+  }
+  if (rel.has_fetch()) {
+    return toVeloxPlan(rel.fetch());
+  }
+  if (rel.has_window()) {
+    return toVeloxPlan(rel.window());
+  }
+  VELOX_NYI("Substrait conversion not supported for Rel.");
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::RelRoot& root) {
+  // TODO: Use the names as the output names for the whole computing.
+  const auto& names = root.names();
+  if (root.has_input()) {
+    const auto& rel = root.input();
+    return toVeloxPlan(rel);
+  }
+  VELOX_FAIL("Input is expected in RelRoot.");
+}
+
+core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(const ::substrait::Plan& substraitPlan) {
+  VELOX_CHECK(checkTypeExtension(substraitPlan), "The type extension only have unknown type.")
+  // Construct the function map based on the Substrait representation,
+  // and initialize the expression converter with it.
+  constructFunctionMap(substraitPlan);
+
+  // In fact, only one RelRoot or Rel is expected here.
+  VELOX_CHECK_EQ(substraitPlan.relations_size(), 1);
+  const auto& rel = substraitPlan.relations(0);
+  if (rel.has_root()) {
+    return toVeloxPlan(rel.root());
+  }
+  if (rel.has_rel()) {
+    return toVeloxPlan(rel.rel());
+  }
+
+  VELOX_FAIL("RelRoot or Rel is expected in Plan.");
+}
+
+std::string SubstraitVeloxPlanConverter::nextPlanNodeId() {
+  auto id = fmt::format("{}", planNodeId_);
+  planNodeId_++;
+  return id;
+}
+void SubstraitVeloxPlanConverter::constructFunctionMap(const ::substrait::Plan& substraitPlan) {
+  // Construct the function map based on the Substrait representation.
+  for (const auto& sExtension : substraitPlan.extensions()) {
+    if (!sExtension.has_extension_function()) {
+      continue;
+    }
+    const auto& sFmap = sExtension.extension_function();
+    auto id = sFmap.function_anchor();
+    auto name = sFmap.name();
+    functionMap_[id] = name;
+  }
+  exprConverter_ = std::make_shared<SubstraitVeloxExprConverter>(pool_, functionMap_);
+}
+
+void SubstraitVeloxPlanConverter::flattenConditions(
+    const ::substrait::Expression& substraitFilter,
+    std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
+    std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
+    std::vector<::substrait::Expression_IfThen>& ifThens) {
+  auto typeCase = substraitFilter.rex_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression::RexTypeCase::kScalarFunction: {
+      auto sFunc = substraitFilter.scalar_function();
+      auto filterNameSpec = subParser_->findFunctionSpec(functionMap_, sFunc.function_reference());
+      // TODO: Only and relation is supported here.
+      if (subParser_->getSubFunctionName(filterNameSpec) == "and") {
+        for (const auto& sCondition : sFunc.arguments()) {
+          flattenConditions(sCondition.value(), scalarFunctions, singularOrLists, ifThens);
+        }
+      } else {
+        scalarFunctions.emplace_back(sFunc);
+      }
+      break;
+    }
+    case ::substrait::Expression::RexTypeCase::kSingularOrList: {
+      singularOrLists.emplace_back(substraitFilter.singular_or_list());
+      break;
+    }
+    case ::substrait::Expression::RexTypeCase::kIfThen: {
+      ifThens.emplace_back(substraitFilter.if_then());
+      break;
+    }
+    default:
+      VELOX_NYI("GetFlatConditions not supported for type '{}'", typeCase);
+  }
+}
+
+std::string SubstraitVeloxPlanConverter::findFuncSpec(uint64_t id) {
+  return subParser_->findFunctionSpec(functionMap_, id);
+}
+
+int32_t SubstraitVeloxPlanConverter::streamIsInput(const ::substrait::ReadRel& sRead) {
+  if (sRead.has_local_files()) {
+    const auto& fileList = sRead.local_files().items();
+    if (fileList.size() == 0) {
+      VELOX_FAIL("At least one file path is expected.");
+    }
+
+    // The stream input will be specified with the format of
+    // "iterator:${index}".
+    std::string filePath = fileList[0].uri_file();
+    std::string prefix = "iterator:";
+    std::size_t pos = filePath.find(prefix);
+    if (pos == std::string::npos) {
+      return -1;
+    }
+
+    // Get the index.
+    std::string idxStr = filePath.substr(pos + prefix.size(), filePath.size());
+    try {
+      return stoi(idxStr);
+    } catch (const std::exception& err) {
+      VELOX_FAIL(err.what());
+    }
+  }
+  if (validationMode_) {
+    return -1;
+  }
+  VELOX_FAIL("Local file is expected.");
+}
+
+void SubstraitVeloxPlanConverter::extractJoinKeys(
+    const ::substrait::Expression& joinExpression,
+    std::vector<const ::substrait::Expression::FieldReference*>& leftExprs,
+    std::vector<const ::substrait::Expression::FieldReference*>& rightExprs) {
+  std::vector<const ::substrait::Expression*> expressions;
+  expressions.push_back(&joinExpression);
+  while (!expressions.empty()) {
+    auto visited = expressions.back();
+    expressions.pop_back();
+    if (visited->rex_type_case() == ::substrait::Expression::RexTypeCase::kScalarFunction) {
+      const auto& funcName = subParser_->getSubFunctionName(
+          subParser_->findVeloxFunction(functionMap_, visited->scalar_function().function_reference()));
+      const auto& args = visited->scalar_function().arguments();
+      if (funcName == "and") {
+        expressions.push_back(&args[0].value());
+        expressions.push_back(&args[1].value());
+      } else if (funcName == "eq" || funcName == "equalto") {
+        VELOX_CHECK(std::all_of(args.cbegin(), args.cend(), [](const ::substrait::FunctionArgument& arg) {
+          return arg.value().has_selection();
+        }));
+        leftExprs.push_back(&args[0].value().selection());
+        rightExprs.push_back(&args[1].value().selection());
+      } else {
+        VELOX_NYI("Join condition {} not supported.", funcName);
+      }
+    } else {
+      VELOX_FAIL("Unable to parse from join expression: {}", joinExpression.DebugString());
+    }
+  }
+}
+
+connector::hive::SubfieldFilters SubstraitVeloxPlanConverter::toSubfieldFilters(
+    const std::vector<std::string>& inputNameList,
+    const std::vector<TypePtr>& inputTypeList,
+    const std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
+    const std::vector<::substrait::Expression_SingularOrList>& singularOrLists) {
+  std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>> colInfoMap;
+  // A map between the column index and the FilterInfo.
+  for (uint32_t idx = 0; idx < inputTypeList.size(); idx++) {
+    colInfoMap[idx] = std::make_shared<FilterInfo>();
+  }
+
+  // Construct the FilterInfo for the related column.
+  for (const auto& scalarFunction : scalarFunctions) {
+    auto filterNameSpec = subParser_->findFunctionSpec(functionMap_, scalarFunction.function_reference());
+    auto filterName = subParser_->getSubFunctionName(filterNameSpec);
+    if (filterName == sNot) {
+      VELOX_CHECK(scalarFunction.arguments().size() == 1);
+      auto expr = scalarFunction.arguments()[0].value();
+      if (expr.has_scalar_function()) {
+        // Set its chid to filter info with reverse enabled.
+        setFilterMap(scalarFunction.arguments()[0].value().scalar_function(), inputTypeList, colInfoMap, true);
+      } else {
+        // TODO: support push down of Not In.
+        VELOX_NYI("Scalar function expected.");
+      }
+      continue;
+    }
+
+    if (filterName == sOr) {
+      VELOX_CHECK(scalarFunction.arguments().size() == 2);
+      VELOX_CHECK(std::all_of(
+          scalarFunction.arguments().cbegin(),
+          scalarFunction.arguments().cend(),
+          [](const ::substrait::FunctionArgument& arg) {
+            return arg.value().has_scalar_function() || arg.value().has_singular_or_list();
+          }));
+      // Set the chidren functions to filter info. They should be
+      // effective to the same field.
+      for (const auto& arg : scalarFunction.arguments()) {
+        auto expr = arg.value();
+        if (expr.has_scalar_function()) {
+          setFilterMap(arg.value().scalar_function(), inputTypeList, colInfoMap);
+        } else if (expr.has_singular_or_list()) {
+          setSingularListValues(expr.singular_or_list(), colInfoMap);
+        } else {
+          VELOX_NYI("Scalar function or SingularOrList expected.");
+        }
+      }
+      continue;
+    }
+
+    setFilterMap(scalarFunction, inputTypeList, colInfoMap);
+  }
+
+  for (const auto& list : singularOrLists) {
+    setSingularListValues(list, colInfoMap);
+  }
+  return mapToFilters(inputNameList, inputTypeList, colInfoMap);
+}
+
+bool SubstraitVeloxPlanConverter::fieldOrWithLiteral(
+    const ::google::protobuf::RepeatedPtrField<::substrait::FunctionArgument>& arguments,
+    uint32_t& fieldIndex) {
+  if (arguments.size() == 1) {
+    if (arguments[0].value().has_selection()) {
+      // Only field exists.
+      fieldIndex = subParser_->parseReferenceSegment(arguments[0].value().selection().direct_reference());
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  if (arguments.size() != 2) {
+    // Not the field and literal combination.
+    return false;
+  }
+  bool fieldExists = false;
+  bool literalExists = false;
+  for (const auto& param : arguments) {
+    auto typeCase = param.value().rex_type_case();
+    switch (typeCase) {
+      case ::substrait::Expression::RexTypeCase::kSelection:
+        fieldIndex = subParser_->parseReferenceSegment(param.value().selection().direct_reference());
+        fieldExists = true;
+        break;
+      case ::substrait::Expression::RexTypeCase::kLiteral:
+        literalExists = true;
+        break;
+      default:
+        break;
+    }
+  }
+  // Whether the field and literal both exist.
+  return fieldExists && literalExists;
+}
+
+bool SubstraitVeloxPlanConverter::chidrenFunctionsOnSameField(const ::substrait::Expression_ScalarFunction& function) {
+  // Get the column indices of the chidren functions.
+  std::vector<int32_t> colIndices;
+  for (const auto& arg : function.arguments()) {
+    if (arg.value().has_scalar_function()) {
+      auto scalarFunction = arg.value().scalar_function();
+      for (const auto& param : scalarFunction.arguments()) {
+        if (param.value().has_selection()) {
+          auto field = param.value().selection();
+          VELOX_CHECK(field.has_direct_reference());
+          int32_t colIdx = subParser_->parseReferenceSegment(field.direct_reference());
+          colIndices.emplace_back(colIdx);
+        }
+      }
+    } else if (arg.value().has_singular_or_list()) {
+      auto singularOrList = arg.value().singular_or_list();
+      int32_t colIdx = getColumnIndexFromSingularOrList(singularOrList);
+      colIndices.emplace_back(colIdx);
+    } else {
+      return false;
+    }
+  }
+
+  if (std::all_of(colIndices.begin(), colIndices.end(), [&](uint32_t idx) { return idx == colIndices[0]; })) {
+    // All indices are the same.
+    return true;
+  }
+  return false;
+}
+
+bool SubstraitVeloxPlanConverter::canPushdownCommonFunction(
+    const ::substrait::Expression_ScalarFunction& scalarFunction,
+    const std::string& filterName,
+    uint32_t& fieldIdx) {
+  // Condtions can be pushed down.
+  std::unordered_set<std::string> supportedCommonFunctions = {sIsNotNull, sGte, sGt, sLte, sLt, sEqual};
+
+  bool canPushdown = false;
+  if (supportedCommonFunctions.find(filterName) != supportedCommonFunctions.end() &&
+      fieldOrWithLiteral(scalarFunction.arguments(), fieldIdx)) {
+    // The arg should be field or field with literal.
+    canPushdown = true;
+  }
+  return canPushdown;
+}
+
+bool SubstraitVeloxPlanConverter::canPushdownNot(
+    const ::substrait::Expression_ScalarFunction& scalarFunction,
+    const std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>>& rangeRecorders) {
+  VELOX_CHECK(scalarFunction.arguments().size() == 1, "Only one arg is expected for Not.");
+  auto notArg = scalarFunction.arguments()[0];
+  if (!notArg.value().has_scalar_function()) {
+    // Not for a Boolean Literal or Or List is not supported curretly.
+    // It can be pushed down with an AlwaysTrue or AlwaysFalse Range.
+    return false;
+  }
+
+  auto argFunction = subParser_->findFunctionSpec(functionMap_, notArg.value().scalar_function().function_reference());
+  auto functionName = subParser_->getSubFunctionName(argFunction);
+
+  std::unordered_set<std::string> supportedNotFunctions = {sGte, sGt, sLte, sLt, sEqual};
+
+  uint32_t fieldIdx;
+  bool isFieldOrWithLiteral = fieldOrWithLiteral(notArg.value().scalar_function().arguments(), fieldIdx);
+
+  if (supportedNotFunctions.find(functionName) != supportedNotFunctions.end() && isFieldOrWithLiteral &&
+      rangeRecorders.at(fieldIdx)->setCertainRangeForFunction(functionName, true /*reverse*/)) {
+    return true;
+  }
+  return false;
+}
+
+bool SubstraitVeloxPlanConverter::canPushdownOr(
+    const ::substrait::Expression_ScalarFunction& scalarFunction,
+    const std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>>& rangeRecorders) {
+  // OR Conditon whose chidren functions are on different columns is not
+  // supported to be pushed down.
+  if (!chidrenFunctionsOnSameField(scalarFunction)) {
+    return false;
+  }
+
+  std::unordered_set<std::string> supportedOrFunctions = {sIsNotNull, sGte, sGt, sLte, sLt, sEqual};
+
+  for (const auto& arg : scalarFunction.arguments()) {
+    if (arg.value().has_scalar_function()) {
+      auto nameSpec = subParser_->findFunctionSpec(functionMap_, arg.value().scalar_function().function_reference());
+      auto functionName = subParser_->getSubFunctionName(nameSpec);
+
+      uint32_t fieldIdx;
+      bool isFieldOrWithLiteral = fieldOrWithLiteral(arg.value().scalar_function().arguments(), fieldIdx);
+      if (supportedOrFunctions.find(functionName) == supportedOrFunctions.end() || !isFieldOrWithLiteral ||
+          !rangeRecorders.at(fieldIdx)->setCertainRangeForFunction(
+              functionName, false /*reverse*/, true /*forOrRelation*/)) {
+        // The arg should be field or field with literal.
+        return false;
+      }
+    } else if (arg.value().has_singular_or_list()) {
+      auto singularOrList = arg.value().singular_or_list();
+      if (!canPushdownSingularOrList(singularOrList, true)) {
+        return false;
+      }
+      uint32_t fieldIdx = getColumnIndexFromSingularOrList(singularOrList);
+      // Disable IN pushdown for int-like types.
+      if (!rangeRecorders.at(fieldIdx)->setInRange(true /*forOrRelation*/)) {
+        return false;
+      }
+    } else {
+      // Or relation betweeen other expressions is not supported to be pushded
+      // down currently.
+      return false;
+    }
+  }
+  return true;
+}
+
+void SubstraitVeloxPlanConverter::separateFilters(
+    const std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>>& rangeRecorders,
+    const std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
+    std::vector<::substrait::Expression_ScalarFunction>& subfieldFunctions,
+    std::vector<::substrait::Expression_ScalarFunction>& remainingFunctions,
+    const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
+    std::vector<::substrait::Expression_SingularOrList>& subfieldOrLists,
+    std::vector<::substrait::Expression_SingularOrList>& remainingOrLists) {
+  for (const auto& singularOrList : singularOrLists) {
+    if (!canPushdownSingularOrList(singularOrList)) {
+      remainingOrLists.emplace_back(singularOrList);
+      continue;
+    }
+    uint32_t colIdx = getColumnIndexFromSingularOrList(singularOrList);
+    if (rangeRecorders.at(colIdx)->setInRange()) {
+      subfieldOrLists.emplace_back(singularOrList);
+    } else {
+      remainingOrLists.emplace_back(singularOrList);
+    }
+  }
+
+  for (const auto& scalarFunction : scalarFunctions) {
+    auto filterNameSpec = subParser_->findFunctionSpec(functionMap_, scalarFunction.function_reference());
+    auto filterName = subParser_->getSubFunctionName(filterNameSpec);
+    if (filterName != sNot && filterName != sOr) {
+      // Check if the condition is supported to be pushed down.
+      uint32_t fieldIdx;
+      if (canPushdownCommonFunction(scalarFunction, filterName, fieldIdx) &&
+          rangeRecorders.at(fieldIdx)->setCertainRangeForFunction(filterName)) {
+        subfieldFunctions.emplace_back(scalarFunction);
+      } else {
+        remainingFunctions.emplace_back(scalarFunction);
+      }
+      continue;
+    }
+
+    // Check whether NOT and OR functions can be pushed down.
+    // If yes, the scalar function will be added into the subfield functions.
+    bool supported = false;
+    if (filterName == sNot) {
+      supported = canPushdownNot(scalarFunction, rangeRecorders);
+    } else if (filterName == sOr) {
+      supported = canPushdownOr(scalarFunction, rangeRecorders);
+    }
+
+    if (supported) {
+      subfieldFunctions.emplace_back(scalarFunction);
+    } else {
+      remainingFunctions.emplace_back(scalarFunction);
+    }
+  }
+}
+
+bool SubstraitVeloxPlanConverter::RangeRecorder::setCertainRangeForFunction(
+    const std::string& functionName,
+    bool reverse,
+    bool forOrRelation) {
+  if (functionName == sLt || functionName == sLte) {
+    if (reverse) {
+      return setLeftBound(forOrRelation);
+    } else {
+      return setRightBound(forOrRelation);
+    }
+  }
+  if (functionName == sGt || functionName == sGte) {
+    if (reverse) {
+      return setRightBound(forOrRelation);
+    } else {
+      return setLeftBound(forOrRelation);
+    }
+  }
+  if (functionName == sEqual) {
+    if (reverse) {
+      // Not equal means lt or gt.
+      return setMultiRange();
+    } else {
+      return setLeftBound(forOrRelation) && setRightBound(forOrRelation);
+    }
+  }
+  if (functionName == sOr) {
+    if (reverse) {
+      // Not supported.
+      return false;
+    } else {
+      return setMultiRange();
+    }
+  }
+  if (functionName == sIsNotNull) {
+    if (reverse) {
+      // Not supported.
+      return false;
+    } else {
+      // Is not null can always coexist with the other range.
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename T>
+void SubstraitVeloxPlanConverter::setColInfoMap(
+    const std::string& filterName,
+    uint32_t colIdx,
+    std::optional<variant> literalVariant,
+    bool reverse,
+    std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap) {
+  if (filterName == sIsNotNull) {
+    if (reverse) {
+      VELOX_NYI("Reverse not supported for filter name '{}'", filterName);
+    }
+    colInfoMap[colIdx]->forbidsNull();
+    return;
+  }
+
+  if (filterName == sGte) {
+    if (reverse) {
+      colInfoMap[colIdx]->setUpper(literalVariant, true);
+    } else {
+      colInfoMap[colIdx]->setLower(literalVariant, false);
+    }
+    return;
+  }
+
+  if (filterName == sGt) {
+    if (reverse) {
+      colInfoMap[colIdx]->setUpper(literalVariant, false);
+    } else {
+      colInfoMap[colIdx]->setLower(literalVariant, true);
+    }
+    return;
+  }
+
+  if (filterName == sLte) {
+    if (reverse) {
+      colInfoMap[colIdx]->setLower(literalVariant, true);
+    } else {
+      colInfoMap[colIdx]->setUpper(literalVariant, false);
+    }
+    return;
+  }
+
+  if (filterName == sLt) {
+    if (reverse) {
+      colInfoMap[colIdx]->setLower(literalVariant, false);
+    } else {
+      colInfoMap[colIdx]->setUpper(literalVariant, true);
+    }
+    return;
+  }
+
+  if (filterName == sEqual) {
+    if (reverse) {
+      colInfoMap[colIdx]->setNotValue(literalVariant);
+    } else {
+      colInfoMap[colIdx]->setLower(literalVariant, false);
+      colInfoMap[colIdx]->setUpper(literalVariant, false);
+    }
+    return;
+  }
+  VELOX_NYI("SetColInfoMap not supported for filter name '{}'", filterName);
+}
+
+void SubstraitVeloxPlanConverter::setFilterMap(
+    const ::substrait::Expression_ScalarFunction& scalarFunction,
+    const std::vector<TypePtr>& inputTypeList,
+    std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap,
+    bool reverse) {
+  auto nameSpec = subParser_->findFunctionSpec(functionMap_, scalarFunction.function_reference());
+  auto functionName = subParser_->getSubFunctionName(nameSpec);
+
+  // Extract the column index and column bound from the scalar function.
+  std::optional<uint32_t> colIdx;
+  std::optional<::substrait::Expression_Literal> substraitLit;
+  std::vector<std::string> typeCases;
+  for (const auto& param : scalarFunction.arguments()) {
+    auto typeCase = param.value().rex_type_case();
+    switch (typeCase) {
+      case ::substrait::Expression::RexTypeCase::kSelection:
+        typeCases.emplace_back("kSelection");
+        colIdx = subParser_->parseReferenceSegment(param.value().selection().direct_reference());
+        break;
+      case ::substrait::Expression::RexTypeCase::kLiteral:
+        typeCases.emplace_back("kLiteral");
+        substraitLit = param.value().literal();
+        break;
+      default:
+        VELOX_NYI("Substrait conversion not supported for arg type '{}'", typeCase);
+    }
+  }
+
+  std::unordered_map<std::string, std::string> functionRevertMap = {{sLt, sGt}, {sGt, sLt}, {sGte, sLte}, {sLte, sGte}};
+
+  // Handle "123 < q1" type expression case
+  if (typeCases.size() > 1 && (typeCases[0] == "kLiteral" && typeCases[1] == "kSelection") &&
+      functionRevertMap.find(functionName) != functionRevertMap.end()) {
+    // change the function name: lt => gt, gt => lt, gte => lte, lte => gte
+    functionName = functionRevertMap[functionName];
+  }
+
+  if (!colIdx.has_value()) {
+    VELOX_NYI("Column index is expected in subfield filters creation.");
+  }
+
+  // Set the extracted bound to the specific column.
+  uint32_t colIdxVal = colIdx.value();
+  auto inputType = inputTypeList[colIdxVal];
+  std::optional<variant> val;
+  switch (inputType->kind()) {
+    case TypeKind::INTEGER:
+      if (substraitLit) {
+        val = variant(substraitLit.value().i32());
+      }
+      setColInfoMap<int>(functionName, colIdxVal, val, reverse, colInfoMap);
+      break;
+    case TypeKind::BIGINT:
+      if (substraitLit) {
+        if (inputType->isShortDecimal()) {
+          auto decimal = substraitLit.value().decimal().value();
+          auto precision = substraitLit.value().decimal().precision();
+          auto scale = substraitLit.value().decimal().scale();
+          int128_t decimalValue;
+          memcpy(&decimalValue, decimal.c_str(), 16);
+          auto type = DECIMAL(precision, scale);
+          val = variant(static_cast<int64_t>(decimalValue));
+        } else {
+          val = variant(substraitLit.value().i64());
+        }
+      }
+      setColInfoMap<int64_t>(functionName, colIdxVal, val, reverse, colInfoMap);
+      break;
+    case TypeKind::DOUBLE:
+      if (substraitLit) {
+        val = variant(substraitLit.value().fp64());
+      }
+      setColInfoMap<double>(functionName, colIdxVal, val, reverse, colInfoMap);
+      break;
+    case TypeKind::BOOLEAN:
+      if (substraitLit) {
+        val = variant(substraitLit.value().boolean());
+      }
+      setColInfoMap<bool>(functionName, colIdxVal, val, reverse, colInfoMap);
+      break;
+    case TypeKind::VARCHAR:
+      if (substraitLit) {
+        val = variant(substraitLit.value().string());
+      }
+      setColInfoMap<std::string>(functionName, colIdxVal, val, reverse, colInfoMap);
+      break;
+    case TypeKind::DATE:
+      if (substraitLit) {
+        val = variant(Date(substraitLit.value().date()));
+      }
+      setColInfoMap<int>(functionName, colIdxVal, val, reverse, colInfoMap);
+      break;
+    default:
+      VELOX_NYI("Subfield filters creation not supported for input type '{}'", inputType);
+  }
+}
+
+template <TypeKind KIND, typename FilterType>
+void SubstraitVeloxPlanConverter::createNotEqualFilter(
+    variant notVariant,
+    bool nullAllowed,
+    std::vector<std::unique_ptr<FilterType>>& colFilters) {
+  using NativeType = typename RangeTraits<KIND>::NativeType;
+  using RangeType = typename RangeTraits<KIND>::RangeType;
+  // Value > lower
+  std::unique_ptr<FilterType> lowerFilter = std::make_unique<RangeType>(
+      notVariant.value<NativeType>(), /*lower*/
+      false, /*lowerUnbounded*/
+      true, /*lowerExclusive*/
+      getMax<NativeType>(), /*upper*/
+      true, /*upperUnbounded*/
+      false, /*upperExclusive*/
+      nullAllowed); /*nullAllowed*/
+  colFilters.emplace_back(std::move(lowerFilter));
+
+  // Value < upper
+  std::unique_ptr<FilterType> upperFilter = std::make_unique<RangeType>(
+      getLowest<NativeType>(), /*lower*/
+      true, /*lowerUnbounded*/
+      false, /*lowerExclusive*/
+      notVariant.value<NativeType>(), /*upper*/
+      false, /*upperUnbounded*/
+      true, /*upperExclusive*/
+      nullAllowed); /*nullAllowed*/
+  colFilters.emplace_back(std::move(upperFilter));
+}
+
+template <TypeKind KIND>
+void SubstraitVeloxPlanConverter::setInFilter(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {}
+
+template <>
+void SubstraitVeloxPlanConverter::setInFilter<TypeKind::BIGINT>(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {
+  std::vector<int64_t> values;
+  values.reserve(variants.size());
+  for (const auto& variant : variants) {
+    int64_t value = variant.value<int64_t>();
+    values.emplace_back(value);
+  }
+  filters[common::Subfield(inputName, true)] = common::createBigintValues(values, nullAllowed);
+}
+
+template <>
+void SubstraitVeloxPlanConverter::setInFilter<TypeKind::INTEGER>(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {
+  // Use bigint values for int type.
+  std::vector<int64_t> values;
+  values.reserve(variants.size());
+  for (const auto& variant : variants) {
+    // Use the matched type to get value from variant.
+    int64_t value = variant.value<int32_t>();
+    values.emplace_back(value);
+  }
+  filters[common::Subfield(inputName, true)] = common::createBigintValues(values, nullAllowed);
+}
+
+template <>
+void SubstraitVeloxPlanConverter::setInFilter<TypeKind::SMALLINT>(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {
+  // Use bigint values for small int type.
+  std::vector<int64_t> values;
+  values.reserve(variants.size());
+  for (const auto& variant : variants) {
+    // Use the matched type to get value from variant.
+    int64_t value = variant.value<int16_t>();
+    values.emplace_back(value);
+  }
+  filters[common::Subfield(inputName, true)] = common::createBigintValues(values, nullAllowed);
+}
+
+template <>
+void SubstraitVeloxPlanConverter::setInFilter<TypeKind::TINYINT>(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {
+  // Use bigint values for tiny int type.
+  std::vector<int64_t> values;
+  values.reserve(variants.size());
+  for (const auto& variant : variants) {
+    // Use the matched type to get value from variant.
+    int64_t value = variant.value<int8_t>();
+    values.emplace_back(value);
+  }
+  filters[common::Subfield(inputName, true)] = common::createBigintValues(values, nullAllowed);
+}
+
+template <>
+void SubstraitVeloxPlanConverter::setInFilter<TypeKind::DATE>(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {
+  // Use bigint values for int type.
+  std::vector<int64_t> values;
+  values.reserve(variants.size());
+  for (const auto& variant : variants) {
+    // Use int32 to get value from date variant.
+    int64_t value = variant.value<int32_t>();
+    values.emplace_back(value);
+  }
+  filters[common::Subfield(inputName, true)] = common::createBigintValues(values, nullAllowed);
+}
+
+template <>
+void SubstraitVeloxPlanConverter::setInFilter<TypeKind::VARCHAR>(
+    const std::vector<variant>& variants,
+    bool nullAllowed,
+    const std::string& inputName,
+    connector::hive::SubfieldFilters& filters) {
+  std::vector<std::string> values;
+  values.reserve(variants.size());
+  for (const auto& variant : variants) {
+    std::string value = variant.value<std::string>();
+    values.emplace_back(value);
+  }
+  filters[common::Subfield(inputName, true)] = std::make_unique<common::BytesValues>(values, nullAllowed);
+}
+
+template <TypeKind KIND, typename FilterType>
+void SubstraitVeloxPlanConverter::setSubfieldFilter(
+    std::vector<std::unique_ptr<FilterType>> colFilters,
+    const std::string& inputName,
+    bool nullAllowed,
+    connector::hive::SubfieldFilters& filters) {
+  using MultiRangeType = typename RangeTraits<KIND>::MultiRangeType;
+
+  if (colFilters.size() == 1) {
+    filters[common::Subfield(inputName, true)] = std::move(colFilters[0]);
+  } else if (colFilters.size() > 1) {
+    // BigintMultiRange should have been sorted
+    if (colFilters[0]->kind() == common::FilterKind::kBigintRange) {
+      std::sort(colFilters.begin(), colFilters.end(), [](const auto& a, const auto& b) {
+        return dynamic_cast<common::BigintRange*>(a.get())->lower() <
+            dynamic_cast<common::BigintRange*>(b.get())->lower();
+      });
+    }
+    filters[common::Subfield(inputName, true)] = std::make_unique<MultiRangeType>(std::move(colFilters), nullAllowed);
+  }
+}
+
+template <TypeKind KIND, typename FilterType>
+void SubstraitVeloxPlanConverter::constructSubfieldFilters(
+    uint32_t colIdx,
+    const std::string& inputName,
+    const TypePtr& inputType,
+    const std::shared_ptr<FilterInfo>& filterInfo,
+    connector::hive::SubfieldFilters& filters) {
+  using NativeType = typename RangeTraits<KIND>::NativeType;
+  using RangeType = typename RangeTraits<KIND>::RangeType;
+  using MultiRangeType = typename RangeTraits<KIND>::MultiRangeType;
+
+  if (!filterInfo->isInitialized()) {
+    return;
+  }
+
+  uint32_t rangeSize = std::max(filterInfo->lowerBounds_.size(), filterInfo->upperBounds_.size());
+  bool nullAllowed = filterInfo->nullAllowed_;
+
+  // Handle 'in' filter.
+  if (filterInfo->valuesVector_.size() > 0) {
+    // To filter out null is a default behaviour of Spark IN expression.
+    nullAllowed = false;
+    setInFilter<KIND>(filterInfo->valuesVector_, nullAllowed, inputName, filters);
+    // Currently, In cannot coexist with other filter conditions
+    // due to multirange is in 'OR' relation but 'AND' is needed.
+    VELOX_CHECK(rangeSize == 0, "LowerBounds or upperBounds conditons cannot be supported after IN filter.");
+    VELOX_CHECK(!filterInfo->notValue_.has_value(), "Not equal cannot be supported after IN filter.");
+    return;
+  }
+
+  // Construct the Filters.
+  std::vector<std::unique_ptr<FilterType>> colFilters;
+
+  // Handle not(equal) filter.
+  if (filterInfo->notValue_) {
+    variant notVariant = filterInfo->notValue_.value();
+    createNotEqualFilter<KIND, FilterType>(notVariant, filterInfo->nullAllowed_, colFilters);
+    // Currently, Not-equal cannot coexist with other filter conditions
+    // due to multirange is in 'OR' relation but 'AND' is needed.
+    VELOX_CHECK(rangeSize == 0, "LowerBounds or upperBounds conditons cannot be supported after not-equal filter.");
+    filters[common::Subfield(inputName, true)] = std::make_unique<MultiRangeType>(std::move(colFilters), nullAllowed);
+    return;
+  }
+
+  // Handle null filtering.
+  if (rangeSize == 0 && !nullAllowed) {
+    std::unique_ptr<common::IsNotNull> filter = std::make_unique<common::IsNotNull>();
+    filters[common::Subfield(inputName, true)] = std::move(filter);
+    return;
+  }
+
+  // Handle other filter ranges.
+  NativeType lowerBound;
+  if constexpr (KIND == facebook::velox::TypeKind::BIGINT) {
+    if (inputType->isShortDecimal()) {
+      lowerBound = DecimalUtil::kShortDecimalMin;
+    } else {
+      lowerBound = getLowest<NativeType>();
+    }
+  } else {
+    lowerBound = getLowest<NativeType>();
+  }
+
+  NativeType upperBound;
+  if constexpr (KIND == facebook::velox::TypeKind::BIGINT) {
+    if (inputType->isShortDecimal()) {
+      upperBound = DecimalUtil::kShortDecimalMax;
+    } else {
+      upperBound = getMax<NativeType>();
+    }
+  } else {
+    upperBound = getMax<NativeType>();
+  }
+
+  bool lowerUnbounded = true;
+  bool upperUnbounded = true;
+  bool lowerExclusive = false;
+  bool upperExclusive = false;
+
+  for (uint32_t idx = 0; idx < rangeSize; idx++) {
+    if (idx < filterInfo->lowerBounds_.size() && filterInfo->lowerBounds_[idx]) {
+      lowerUnbounded = false;
+      variant lowerVariant = filterInfo->lowerBounds_[idx].value();
+
+      lowerBound = lowerVariant.value<NativeType>();
+
+      lowerExclusive = filterInfo->lowerExclusives_[idx];
+    }
+    if (idx < filterInfo->upperBounds_.size() && filterInfo->upperBounds_[idx]) {
+      upperUnbounded = false;
+      variant upperVariant = filterInfo->upperBounds_[idx].value();
+      upperBound = upperVariant.value<NativeType>();
+
+      upperExclusive = filterInfo->upperExclusives_[idx];
+    }
+    std::unique_ptr<FilterType> filter = std::make_unique<RangeType>(
+        lowerBound, lowerUnbounded, lowerExclusive, upperBound, upperUnbounded, upperExclusive, nullAllowed);
+    colFilters.emplace_back(std::move(filter));
+  }
+
+  // Set the SubfieldFilter.
+  setSubfieldFilter<KIND, FilterType>(std::move(colFilters), inputName, filterInfo->nullAllowed_, filters);
+}
+
+bool SubstraitVeloxPlanConverter::checkTypeExtension(const ::substrait::Plan& substraitPlan) {
+  for (const auto& sExtension : substraitPlan.extensions()) {
+    if (!sExtension.has_extension_type()) {
+      continue;
+    }
+
+    // Only support UNKNOWN type in UserDefined type extension.
+    if (sExtension.extension_type().name() != "UNKNOWN") {
+      return false;
+    }
+  }
+  return true;
+}
+
+connector::hive::SubfieldFilters SubstraitVeloxPlanConverter::mapToFilters(
+    const std::vector<std::string>& inputNameList,
+    const std::vector<TypePtr>& inputTypeList,
+    std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>> colInfoMap) {
+  // Construct the subfield filters based on the filter info map.
+  connector::hive::SubfieldFilters filters;
+  for (uint32_t colIdx = 0; colIdx < inputNameList.size(); colIdx++) {
+    auto inputType = inputTypeList[colIdx];
+    switch (inputType->kind()) {
+      case TypeKind::TINYINT:
+        constructSubfieldFilters<TypeKind::TINYINT, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::SMALLINT:
+        constructSubfieldFilters<TypeKind::SMALLINT, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::INTEGER:
+        constructSubfieldFilters<TypeKind::INTEGER, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::BIGINT:
+        constructSubfieldFilters<TypeKind::BIGINT, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::DOUBLE:
+        constructSubfieldFilters<TypeKind::DOUBLE, common::Filter>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::BOOLEAN:
+        constructSubfieldFilters<TypeKind::BOOLEAN, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::VARCHAR:
+        constructSubfieldFilters<TypeKind::VARCHAR, common::Filter>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      case TypeKind::DATE:
+        constructSubfieldFilters<TypeKind::DATE, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, colInfoMap[colIdx], filters);
+        break;
+      default:
+        VELOX_NYI("Subfield filters creation not supported for input type '{}'", inputType);
+    }
+  }
+  return filters;
+}
+
+core::TypedExprPtr SubstraitVeloxPlanConverter::connectWithAnd(
+    std::vector<std::string> inputNameList,
+    std::vector<TypePtr> inputTypeList,
+    const std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
+    const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
+    const std::vector<::substrait::Expression_IfThen>& ifThens) {
+  if (scalarFunctions.size() == 0 && singularOrLists.size() == 0 && ifThens.size() == 0) {
+    return nullptr;
+  }
+  auto inputType = ROW(std::move(inputNameList), std::move(inputTypeList));
+
+  // Filter for scalar functions.
+  std::vector<core::TypedExprPtr> allFilters;
+  for (auto scalar : scalarFunctions) {
+    auto filter = exprConverter_->toVeloxExpr(scalar, inputType);
+    if (filter != nullptr) {
+      allFilters.emplace_back(filter);
+    }
+  }
+  for (auto orList : singularOrLists) {
+    auto filter = exprConverter_->toVeloxExpr(orList, inputType);
+    if (filter != nullptr) {
+      allFilters.emplace_back(filter);
+    }
+  }
+  for (auto ifThen : ifThens) {
+    auto filter = exprConverter_->toVeloxExpr(ifThen, inputType);
+    if (filter != nullptr) {
+      allFilters.emplace_back(filter);
+    }
+  }
+  VELOX_CHECK_GT(allFilters.size(), 0, "One filter should be valid.")
+  core::TypedExprPtr andFilter = allFilters[0];
+  for (auto i = 1; i < allFilters.size(); i++) {
+    andFilter = connectWithAnd(andFilter, allFilters[i]);
+  }
+  return andFilter;
+}
+
+core::TypedExprPtr SubstraitVeloxPlanConverter::connectWithAnd(
+    core::TypedExprPtr leftExpr,
+    core::TypedExprPtr rightExpr) {
+  std::vector<core::TypedExprPtr> params;
+  params.reserve(2);
+  params.emplace_back(leftExpr);
+  params.emplace_back(rightExpr);
+  return std::make_shared<const core::CallTypedExpr>(BOOLEAN(), std::move(params), "and");
+}
+
+bool SubstraitVeloxPlanConverter::canPushdownSingularOrList(
+    const ::substrait::Expression_SingularOrList& singularOrList,
+    bool disableIntLike) {
+  VELOX_CHECK(singularOrList.options_size() > 0, "At least one option is expected.");
+  // Check whether the value is field.
+  bool hasField = singularOrList.value().has_selection();
+  auto options = singularOrList.options();
+  for (const auto& option : options) {
+    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
+    auto type = option.literal().literal_type_case();
+    // Only BigintValues and BytesValues are supported.
+    if (type != ::substrait::Expression_Literal::LiteralTypeCase::kI32 &&
+        type != ::substrait::Expression_Literal::LiteralTypeCase::kI64 &&
+        type != ::substrait::Expression_Literal::LiteralTypeCase::kString) {
+      return false;
+    }
+    // BigintMultiRange can only accept BigintRange, so disableIntLike is set to
+    // true for OR pushdown of int-like types.
+    if (disableIntLike &&
+        (type == ::substrait::Expression_Literal::LiteralTypeCase::kI32 ||
+         type == ::substrait::Expression_Literal::LiteralTypeCase::kI64)) {
+      return false;
+    }
+  }
+  return hasField;
+}
+
+uint32_t SubstraitVeloxPlanConverter::getColumnIndexFromSingularOrList(
+    const ::substrait::Expression_SingularOrList& singularOrList) {
+  // Get the column index.
+  ::substrait::Expression_FieldReference selection;
+  if (singularOrList.value().has_scalar_function()) {
+    selection = singularOrList.value().scalar_function().arguments()[0].value().selection();
+  } else if (singularOrList.value().has_selection()) {
+    selection = singularOrList.value().selection();
+  } else {
+    VELOX_FAIL("Unsupported type in IN pushdown.");
+  }
+  return subParser_->parseReferenceSegment(selection.direct_reference());
+}
+
+void SubstraitVeloxPlanConverter::setSingularListValues(
+    const ::substrait::Expression_SingularOrList& singularOrList,
+    std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap) {
+  VELOX_CHECK(singularOrList.options_size() > 0, "At least one option is expected.");
+  // Get the column index.
+  uint32_t colIdx = getColumnIndexFromSingularOrList(singularOrList);
+
+  // Get the value list.
+  auto options = singularOrList.options();
+  std::vector<variant> variants;
+  variants.reserve(options.size());
+  for (const auto& option : options) {
+    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
+    variants.emplace_back(exprConverter_->toVeloxExpr(option.literal())->value());
+  }
+  // Set the value list to filter info.
+  colInfoMap[colIdx]->setValues(variants);
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -1,0 +1,507 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "SubstraitToVeloxExpr.h"
+#include "TypeUtils.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/core/PlanNode.h"
+
+namespace gluten {
+struct SplitInfo {
+  /// Whether the split comes from arrow array stream node.
+  bool isStream = false;
+
+  /// The Partition index.
+  u_int32_t partitionIndex;
+
+  /// The file paths to be scanned.
+  std::vector<std::string> paths;
+
+  /// The file starts in the scan.
+  std::vector<u_int64_t> starts;
+
+  /// The lengths to be scanned.
+  std::vector<u_int64_t> lengths;
+
+  /// The file format of the files to be scanned.
+  dwio::common::FileFormat format;
+};
+
+/// This class is used to convert the Substrait plan into Velox plan.
+class SubstraitVeloxPlanConverter {
+ public:
+  SubstraitVeloxPlanConverter(memory::MemoryPool* pool, bool validationMode = false)
+      : pool_(pool), validationMode_(validationMode) {}
+  /// Used to convert Substrait ExpandRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& expandRel);
+
+  /// Used to convert Substrait SortRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::WindowRel& windowRel);
+
+  /// Used to convert Substrait JoinRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::JoinRel& joinRel);
+
+  /// Used to convert Substrait AggregateRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::AggregateRel& aggRel);
+
+  /// Convert Substrait ProjectRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::ProjectRel& projectRel);
+
+  /// Convert Substrait FilterRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::FilterRel& filterRel);
+
+  /// Convert Substrait FetchRel into Velox LimitNode or TopNNode according the
+  /// different input of fetchRel.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::FetchRel& fetchRel);
+
+  /// Convert Substrait ReadRel into Velox Values Node.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::ReadRel& readRel, const RowTypePtr& type);
+
+  /// Convert Substrait SortRel into Velox OrderByNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::SortRel& sortRel);
+
+  /// Check the Substrait type extension only has one unknown extension.
+  bool checkTypeExtension(const ::substrait::Plan& substraitPlan);
+
+  /// Convert Substrait ReadRel into Velox PlanNode.
+  /// Index: the index of the partition this item belongs to.
+  /// Starts: the start positions in byte to read from the items.
+  /// Lengths: the lengths in byte to read from the items.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::ReadRel& sRead);
+
+  /// Used to convert Substrait Rel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::Rel& sRel);
+
+  /// Used to convert Substrait RelRoot into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::RelRoot& sRoot);
+
+  /// Used to convert Substrait Plan into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::Plan& substraitPlan);
+
+  /// Used to construct the function map between the index
+  /// and the Substrait function name. Initialize the expression
+  /// converter based on the constructed function map.
+  void constructFunctionMap(const ::substrait::Plan& substraitPlan);
+
+  /// Will return the function map used by this plan converter.
+  const std::unordered_map<uint64_t, std::string>& getFunctionMap() const {
+    return functionMap_;
+  }
+
+  /// Return the splitInfo map used by this plan converter.
+  const std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfos() const {
+    return splitInfoMap_;
+  }
+
+  /// Integrate Substrait emit feature. Here a given 'substrait::RelCommon'
+  /// is passed and check if emit is defined for this relation. Basically a
+  /// ProjectNode is added on top of 'noEmitNode' to represent output order
+  /// specified in 'relCommon::emit'. Return 'noEmitNode' as is
+  /// if output order is 'kDriect'.
+  core::PlanNodePtr processEmit(const ::substrait::RelCommon& relCommon, const core::PlanNodePtr& noEmitNode);
+
+  /// Used to insert certain plan node as input. The plan node
+  /// id will start from the setted one.
+  void insertInputNode(uint64_t inputIdx, const std::shared_ptr<const core::PlanNode>& inputNode, int planNodeId) {
+    inputNodesMap_[inputIdx] = inputNode;
+    planNodeId_ = planNodeId;
+  }
+
+  /// Used to check if ReadRel specifies an input of stream.
+  /// If yes, the index of input stream will be returned.
+  /// If not, -1 will be returned.
+  int32_t streamIsInput(const ::substrait::ReadRel& sRel);
+
+  /// Multiple conditions are connected to a binary tree structure with
+  /// the relation key words, including AND, OR, and etc. Currently, only
+  /// AND is supported. This function is used to extract all the Substrait
+  /// conditions in the binary tree structure into a vector.
+  void flattenConditions(
+      const ::substrait::Expression& sFilter,
+      std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
+      std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
+      std::vector<::substrait::Expression_IfThen>& ifThens);
+
+  /// Used to find the function specification in the constructed function map.
+  std::string findFuncSpec(uint64_t id);
+
+  /// Extract join keys from joinExpression.
+  /// joinExpression is a boolean condition that describes whether each record
+  /// from the left set “match” the record from the right set. The condition
+  /// must only include the following operations: AND, ==, field references.
+  /// Field references correspond to the direct output order of the data.
+  void extractJoinKeys(
+      const ::substrait::Expression& joinExpression,
+      std::vector<const ::substrait::Expression::FieldReference*>& leftExprs,
+      std::vector<const ::substrait::Expression::FieldReference*>& rightExprs);
+
+  /// Get aggregation step from AggregateRel.
+  core::AggregationNode::Step toAggregationStep(const ::substrait::AggregateRel& sAgg);
+
+ private:
+  /// Range filter recorder for a field is used to make sure only the conditions
+  /// that can coexist for this field being pushed down with a range filter.
+  class RangeRecorder {
+   public:
+    /// Set the existence of values range and returns whether this condition can
+    /// coexist with existing conditions for one field. Conditions in OR
+    /// relation can coexist with each other.
+    bool setInRange(bool forOrRelation = false) {
+      if (forOrRelation) {
+        return true;
+      }
+      if (inRange_ || multiRange_ || leftBound_ || rightBound_) {
+        return false;
+      }
+      inRange_ = true;
+      return true;
+    }
+
+    /// Set the existence of left bound and returns whether it can coexist with
+    /// existing conditions for this field.
+    bool setLeftBound(bool forOrRelation = false) {
+      if (forOrRelation) {
+        if (!rightBound_)
+          leftBound_ = true;
+        return !rightBound_;
+      }
+      if (leftBound_ || inRange_ || multiRange_) {
+        return false;
+      }
+      leftBound_ = true;
+      return true;
+    }
+
+    /// Set the existence of right bound and returns whether it can coexist with
+    /// existing conditions for this field.
+    bool setRightBound(bool forOrRelation = false) {
+      if (forOrRelation) {
+        if (!leftBound_)
+          rightBound_ = true;
+        return !leftBound_;
+      }
+      if (rightBound_ || inRange_ || multiRange_) {
+        return false;
+      }
+      rightBound_ = true;
+      return true;
+    }
+
+    /// Set the multi-range and returns whether it can coexist with
+    /// existing conditions for this field.
+    bool setMultiRange() {
+      if (inRange_ || multiRange_ || leftBound_ || rightBound_) {
+        return false;
+      }
+      multiRange_ = true;
+      return true;
+    }
+
+    /// Set certain existence according to function name and returns whether it
+    /// can coexist with existing conditions for this field.
+    bool setCertainRangeForFunction(const std::string& functionName, bool reverse = false, bool forOrRelation = false);
+
+   private:
+    /// The existence of values range.
+    bool inRange_ = false;
+
+    /// The existence of left bound.
+    bool leftBound_ = false;
+
+    /// The existence of right bound.
+    bool rightBound_ = false;
+
+    /// The existence of multi-range.
+    bool multiRange_ = false;
+  };
+
+  /// Filter info for a column used in filter push down.
+  class FilterInfo {
+   public:
+    // Disable null allow.
+    void forbidsNull() {
+      nullAllowed_ = false;
+      if (!isInitialized_) {
+        isInitialized_ = true;
+      }
+    }
+
+    // Return the initialization status.
+    bool isInitialized() {
+      return isInitialized_ ? true : false;
+    }
+
+    // Add a lower bound to the range. Multiple lower bounds are
+    // regarded to be in 'or' relation.
+    void setLower(const std::optional<variant>& left, bool isExclusive) {
+      lowerBounds_.emplace_back(left);
+      lowerExclusives_.emplace_back(isExclusive);
+      if (!isInitialized_) {
+        isInitialized_ = true;
+      }
+    }
+
+    // Add a upper bound to the range. Multiple upper bounds are
+    // regarded to be in 'or' relation.
+    void setUpper(const std::optional<variant>& right, bool isExclusive) {
+      upperBounds_.emplace_back(right);
+      upperExclusives_.emplace_back(isExclusive);
+      if (!isInitialized_) {
+        isInitialized_ = true;
+      }
+    }
+
+    // Set a list of values to be used in the push down of 'in' expression.
+    void setValues(const std::vector<variant>& values) {
+      for (const auto& value : values) {
+        valuesVector_.emplace_back(value);
+      }
+      if (!isInitialized_) {
+        isInitialized_ = true;
+      }
+    }
+
+    // Set a value for the not(equal) condition.
+    void setNotValue(const std::optional<variant>& notValue) {
+      notValue_ = notValue;
+      if (!isInitialized_) {
+        isInitialized_ = true;
+      }
+    }
+
+    // Whether this filter map is initialized.
+    bool isInitialized_ = false;
+
+    // The null allow.
+    bool nullAllowed_ = false;
+
+    // If true, left bound will be exclusive.
+    std::vector<bool> lowerExclusives_;
+
+    // If true, right bound will be exclusive.
+    std::vector<bool> upperExclusives_;
+
+    // A value should not be equal to.
+    std::optional<variant> notValue_ = std::nullopt;
+
+    // The lower bounds in 'or' relation.
+    std::vector<std::optional<variant>> lowerBounds_;
+
+    // The upper bounds in 'or' relation.
+    std::vector<std::optional<variant>> upperBounds_;
+
+    // The list of values used in 'in' expression.
+    std::vector<variant> valuesVector_;
+  };
+
+  /// Helper Function to convert Substrait sortField to Velox sortingKeys and
+  /// sortingOrders.
+  std::pair<std::vector<core::FieldAccessTypedExprPtr>, std::vector<core::SortOrder>> processSortField(
+      const ::google::protobuf::RepeatedPtrField<::substrait::SortField>& sortField,
+      const RowTypePtr& inputType);
+
+  /// Returns unique ID to use for plan node. Produces sequential numbers
+  /// starting from zero.
+  std::string nextPlanNodeId();
+
+  /// Returns whether the args of a scalar function being field or
+  /// field with literal. If yes, extract and set the field index.
+  bool fieldOrWithLiteral(
+      const ::google::protobuf::RepeatedPtrField<::substrait::FunctionArgument>& arguments,
+      uint32_t& fieldIndex);
+
+  /// Separate the functions to be two parts:
+  /// subfield functions to be handled by the subfieldFilters in HiveConnector,
+  /// and remaining functions to be handled by the remainingFilter in
+  /// HiveConnector.
+  void separateFilters(
+      const std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>>& rangeRecorders,
+      const std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
+      std::vector<::substrait::Expression_ScalarFunction>& subfieldFunctions,
+      std::vector<::substrait::Expression_ScalarFunction>& remainingFunctions,
+      const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
+      std::vector<::substrait::Expression_SingularOrList>& subfieldrOrLists,
+      std::vector<::substrait::Expression_SingularOrList>& remainingrOrLists);
+
+  /// Returns whether a function can be pushed down.
+  bool canPushdownCommonFunction(
+      const ::substrait::Expression_ScalarFunction& scalarFunction,
+      const std::string& filterName,
+      uint32_t& fieldIdx);
+
+  /// Returns whether a NOT function can be pushed down.
+  bool canPushdownNot(
+      const ::substrait::Expression_ScalarFunction& scalarFunction,
+      const std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>>& rangeRecorders);
+
+  /// Returns whether a OR function can be pushed down.
+  bool canPushdownOr(
+      const ::substrait::Expression_ScalarFunction& scalarFunction,
+      const std::unordered_map<uint32_t, std::shared_ptr<RangeRecorder>>& rangeRecorders);
+
+  /// Returns whether a SingularOrList can be pushed down.
+  bool canPushdownSingularOrList(
+      const ::substrait::Expression_SingularOrList& singularOrList,
+      bool disableIntLike = false);
+
+  /// Returns a set of unique column indices for IN function to be pushed down.
+  std::unordered_set<uint32_t> getInColIndices(
+      const std::vector<::substrait::Expression_SingularOrList>& singularOrLists);
+
+  /// Check whether the chidren functions of this scalar function have the same
+  /// column index. Curretly used to check whether the two chilren functions of
+  /// 'or' expression are effective on the same column.
+  bool chidrenFunctionsOnSameField(const ::substrait::Expression_ScalarFunction& function);
+
+  /// Extract the scalar function, and set the filter info for different types
+  /// of columns. If reverse is true, the opposite filter info will be set.
+  void setFilterMap(
+      const ::substrait::Expression_ScalarFunction& scalarFunction,
+      const std::vector<TypePtr>& inputTypeList,
+      std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap,
+      bool reverse = false);
+
+  /// Extract SingularOrList and returns the field index.
+  uint32_t getColumnIndexFromSingularOrList(const ::substrait::Expression_SingularOrList& singularOrList);
+
+  /// Extract SingularOrList and set it to the filter info map.
+  void setSingularListValues(
+      const ::substrait::Expression_SingularOrList& singularOrList,
+      std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap);
+
+  /// Set the filter info for a column base on the information
+  /// extracted from filter condition.
+  template <typename T>
+  void setColInfoMap(
+      const std::string& filterName,
+      uint32_t colIdx,
+      std::optional<variant> literalVariant,
+      bool reverse,
+      std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap);
+
+  /// Create a multirange to specify the filter 'x != notValue' with:
+  /// x > notValue or x < notValue.
+  template <TypeKind KIND, typename FilterType>
+  void createNotEqualFilter(variant notVariant, bool nullAllowed, std::vector<std::unique_ptr<FilterType>>& colFilters);
+
+  /// Create a values range to handle in filter.
+  /// variants: the list of values extracted from the in expression.
+  /// inputName: the column input name.
+  template <TypeKind KIND>
+  void setInFilter(
+      const std::vector<variant>& variants,
+      bool nullAllowed,
+      const std::string& inputName,
+      connector::hive::SubfieldFilters& filters);
+
+  /// Set the constructed filters into SubfieldFilters.
+  /// The FilterType is used to distinguish BigintRange and
+  /// Filter (the base class). This is needed because BigintMultiRange
+  /// can only accept the unique ptr of BigintRange as parameter.
+  template <TypeKind KIND, typename FilterType>
+  void setSubfieldFilter(
+      std::vector<std::unique_ptr<FilterType>> colFilters,
+      const std::string& inputName,
+      bool nullAllowed,
+      connector::hive::SubfieldFilters& filters);
+
+  /// Create the subfield filter based on the constructed filter info.
+  /// inputName: the input name of a column.
+  template <TypeKind KIND, typename FilterType>
+  void constructSubfieldFilters(
+      uint32_t colIdx,
+      const std::string& inputName,
+      const TypePtr& inputType,
+      const std::shared_ptr<FilterInfo>& filterInfo,
+      connector::hive::SubfieldFilters& filters);
+
+  /// Construct subfield filters according to the pre-set map of filter info.
+  connector::hive::SubfieldFilters mapToFilters(
+      const std::vector<std::string>& inputNameList,
+      const std::vector<TypePtr>& inputTypeList,
+      std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>> colInfoMap);
+
+  /// Convert subfield functions into subfieldFilters to
+  /// be used in Hive Connector.
+  connector::hive::SubfieldFilters toSubfieldFilters(
+      const std::vector<std::string>& inputNameList,
+      const std::vector<TypePtr>& inputTypeList,
+      const std::vector<::substrait::Expression_ScalarFunction>& subfieldFunctions,
+      const std::vector<::substrait::Expression_SingularOrList>& singularOrLists);
+
+  /// Connect all remaining functions with 'and' relation
+  /// for the use of remaingFilter in Hive Connector.
+  core::TypedExprPtr connectWithAnd(
+      std::vector<std::string> inputNameList,
+      std::vector<TypePtr> inputTypeList,
+      const std::vector<::substrait::Expression_ScalarFunction>& remainingFunctions,
+      const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
+      const std::vector<::substrait::Expression_IfThen>& ifThens);
+
+  /// Connect the left and right expressions with 'and' relation.
+  core::TypedExprPtr connectWithAnd(core::TypedExprPtr leftExpr, core::TypedExprPtr rightExpr);
+
+  /// Set the phase of Aggregation.
+  void setPhase(const ::substrait::AggregateRel& sAgg, core::AggregationNode::Step& aggStep);
+
+  /// Used to convert AggregateRel into Velox plan node.
+  /// The output of child node will be used as the input of Aggregation.
+  std::shared_ptr<const core::PlanNode> toVeloxAgg(
+      const ::substrait::AggregateRel& sAgg,
+      const std::shared_ptr<const core::PlanNode>& childNode,
+      const core::AggregationNode::Step& aggStep);
+
+  /// Helper function to convert the input of Substrait Rel to Velox Node.
+  template <typename T>
+  core::PlanNodePtr convertSingleInput(T rel) {
+    VELOX_CHECK(rel.has_input(), "Child Rel is expected here.");
+    return toVeloxPlan(rel.input());
+  }
+
+  /// The unique identification for each PlanNode.
+  int planNodeId_ = 0;
+
+  /// The map storing the relations between the function id and the function
+  /// name. Will be constructed based on the Substrait representation.
+  std::unordered_map<uint64_t, std::string> functionMap_;
+
+  /// The map storing the split stats for each PlanNode.
+  std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>> splitInfoMap_;
+
+  /// The map storing the pre-built plan nodes which can be accessed through
+  /// index. This map is only used when the computation of a Substrait plan
+  /// depends on other input nodes.
+  std::unordered_map<uint64_t, std::shared_ptr<const core::PlanNode>> inputNodesMap_;
+
+  /// The Substrait parser used to convert Substrait representations into
+  /// recognizable representations.
+  std::shared_ptr<SubstraitParser> subParser_{std::make_shared<SubstraitParser>()};
+
+  /// The Expression converter used to convert Substrait representations into
+  /// Velox expressions.
+  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
+
+  /// Memory pool.
+  memory::MemoryPool* pool_;
+
+  /// A flag used to specify validation.
+  bool validationMode_ = false;
+};
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1,0 +1,1104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SubstraitToVeloxPlanValidator.h"
+#include <google/protobuf/wrappers.pb.h>
+#include <string>
+#include "TypeUtils.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Tokenizer.h"
+
+namespace gluten {
+namespace {
+bool validateColNames(const ::substrait::NamedStruct& schema) {
+  for (auto& name : schema.names()) {
+    common::Tokenizer token(name);
+    for (auto i = 0; i < name.size(); i++) {
+      auto c = name[i];
+      if (!token.isUnquotedPathCharacter(c)) {
+        std::cout << "native validation failed due to: Illegal column charactor " << c << "in column " << name
+                  << std::endl;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+} // namespace
+bool SubstraitToVeloxPlanValidator::validateInputTypes(
+    const ::substrait::extensions::AdvancedExtension& extension,
+    std::vector<TypePtr>& types) {
+  // The input type is wrapped in enhancement.
+  if (!extension.has_enhancement()) {
+    logValidateMsg("native validation failed due to: {input type is not wrapped in enhancement}.");
+    return false;
+  }
+  const auto& enhancement = extension.enhancement();
+  ::substrait::Type inputType;
+  if (!enhancement.UnpackTo(&inputType)) {
+    logValidateMsg("native validation failed due to: {enhancement can't be unpacked to inputType}.");
+    return false;
+  }
+  if (!inputType.has_struct_()) {
+    logValidateMsg("native validation failed due to: {input type has no struct}.");
+    return false;
+  }
+
+  // Get the input types.
+  const auto& sTypes = inputType.struct_().types();
+  for (const auto& sType : sTypes) {
+    try {
+      types.emplace_back(toVeloxType(subParser_->parseType(sType)->type));
+    } catch (const VeloxException& err) {
+      logValidateMsg("native validation failed due to: Type is not supported, " + err.message());
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validateRound(
+    const ::substrait::Expression::ScalarFunction& scalarFunction,
+    const RowTypePtr& inputType) {
+  const auto& arguments = scalarFunction.arguments();
+  if (arguments.size() < 2) {
+    return false;
+  }
+  if (!arguments[1].value().has_literal()) {
+    logValidateMsg("native validation failued due to: Round scale is expected.");
+    return false;
+  }
+  // Velox has different result with Spark on negative scale.
+  auto typeCase = arguments[1].value().literal().literal_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI32:
+      return (arguments[1].value().literal().i32() >= 0);
+    case ::substrait::Expression_Literal::LiteralTypeCase::kI64:
+      return (arguments[1].value().literal().i64() >= 0);
+    default:
+      logValidateMsg(
+          "native validation failed due to: Round scale validation is not supported for type case '{}'" + typeCase);
+      return false;
+  }
+}
+
+bool SubstraitToVeloxPlanValidator::validateExtractExpr(const std::vector<core::TypedExprPtr>& params) {
+  if (params.size() != 2) {
+    logValidateMsg("native validation failed due to: Value expected in variant in ExtractExpr.");
+    return false;
+  }
+  auto functionArg = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(params[0]);
+  if (functionArg) {
+    // Get the function argument.
+    auto variant = functionArg->value();
+    if (!variant.hasValue()) {
+      logValidateMsg("native validation failed due to: Value expected in variant in ExtractExpr.");
+      return false;
+    }
+    // The first parameter specifies extracting from which field.
+    std::string from = variant.value<std::string>();
+    // Hour causes incorrect result.
+    if (from == "HOUR") {
+      logValidateMsg("native validation failed due to: {extract from hour}.");
+      return false;
+    }
+    return true;
+  }
+  logValidateMsg("native validation failed due to: Constant is expected to be the first parameter in extract.");
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validateScalarFunction(
+    const ::substrait::Expression::ScalarFunction& scalarFunction,
+    const RowTypePtr& inputType) {
+  std::vector<core::TypedExprPtr> params;
+  params.reserve(scalarFunction.arguments().size());
+  for (const auto& argument : scalarFunction.arguments()) {
+    if (argument.has_value() && !validateExpression(argument.value(), inputType)) {
+      return false;
+    }
+    params.emplace_back(exprConverter_->toVeloxExpr(argument.value(), inputType));
+  }
+
+  const auto& function =
+      subParser_->findFunctionSpec(planConverter_->getFunctionMap(), scalarFunction.function_reference());
+  const auto& name = subParser_->getSubFunctionName(function);
+  std::vector<std::string> types;
+  subParser_->getSubFunctionTypes(function, types);
+  if (name == "round") {
+    return validateRound(scalarFunction, inputType);
+  }
+  if (name == "extract") {
+    return validateExtractExpr(params);
+  }
+  if (name == "regexp_extract_all" && !scalarFunction.arguments()[1].value().has_literal()) {
+    logValidateMsg("native validation failed due to: pattern is not literal for regex_extract_all.");
+    return false;
+  }
+  if (name == "char_length") {
+    VELOX_CHECK(types.size() == 1);
+    if (types[0] == "vbin") {
+      logValidateMsg("native validation failed due to: Binary type is not supported in " + name);
+      return false;
+    }
+  }
+  if (name == "murmur3hash") {
+    for (const auto& type : types) {
+      if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos ||
+          type.find("list") != std::string::npos) {
+        logValidateMsg("native validation failed due to: " + type + "is not supported in murmur3hash.");
+        return false;
+      }
+    }
+  }
+  std::unordered_set<std::string> functions = {"regexp_replace",    "split",         "split_part",
+                                               "factorial",         "concat_ws",     "rand",
+                                               "json_array_length", "from_unixtime", "to_unix_timestamp",
+                                               "unix_timestamp",    "repeat",        "translate",
+                                               "add_months",        "date_format",   "trunc",
+                                               "sequence",          "posexplode",    "arrays_overlap",
+                                               "array_min",         "array_max",     "approx_percentile"};
+  if (functions.find(name) != functions.end()) {
+    logValidateMsg("native validation failed due to: Function is not supported: " + name);
+    return false;
+  }
+
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validateLiteral(
+    const ::substrait::Expression_Literal& literal,
+    const RowTypePtr& inputType) {
+  if (literal.has_list() && literal.list().values_size() == 0) {
+    logValidateMsg("native validation failed due to: literal is a list but has no value.");
+    return false;
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validateCast(
+    const ::substrait::Expression::Cast& castExpr,
+    const RowTypePtr& inputType) {
+  if (!validateExpression(castExpr.input(), inputType)) {
+    return false;
+  }
+
+  const auto& toType = toVeloxType(subParser_->parseType(castExpr.type())->type);
+  if (toType->kind() == TypeKind::TIMESTAMP) {
+    logValidateMsg("native validation failed due to: Casting to TIMESTAMP is not supported.");
+    return false;
+  }
+
+  core::TypedExprPtr input = exprConverter_->toVeloxExpr(castExpr.input(), inputType);
+
+  // Casting from some types is not supported. See CastExpr::applyCast.
+  switch (input->type()->kind()) {
+    case TypeKind::ARRAY:
+    case TypeKind::MAP:
+    case TypeKind::ROW:
+    case TypeKind::VARBINARY:
+      logValidateMsg("native validation failed due to: Invalid input type in casting: ARRAY/MAP/ROW/VARBINARY");
+      return false;
+    case TypeKind::DATE: {
+      if (toType->kind() == TypeKind::TIMESTAMP) {
+        logValidateMsg("native validation failed due to: Casting from DATE to TIMESTAMP is not supported.");
+        return false;
+      }
+    }
+    case TypeKind::TIMESTAMP: {
+      logValidateMsg(
+          "native validation failed due to: Casting from TIMESTAMP is not supported or has incorrect result.");
+      return false;
+    }
+    default: {
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validateExpression(
+    const ::substrait::Expression& expression,
+    const RowTypePtr& inputType) {
+  core::TypedExprPtr veloxExpr;
+  auto typeCase = expression.rex_type_case();
+  switch (typeCase) {
+    case ::substrait::Expression::RexTypeCase::kScalarFunction:
+      return validateScalarFunction(expression.scalar_function(), inputType);
+    case ::substrait::Expression::RexTypeCase::kLiteral:
+      return validateLiteral(expression.literal(), inputType);
+    case ::substrait::Expression::RexTypeCase::kCast:
+      return validateCast(expression.cast(), inputType);
+    default:
+      return true;
+  }
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchRel) {
+  const auto& extension = fetchRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: unsupported input types in FetchRel.");
+    return false;
+  }
+
+  if (fetchRel.offset() < 0 || fetchRel.count() < 0) {
+    logValidateMsg("native validation failed due to: Offset and count should be valid in FetchRel.");
+    return false;
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expandRel) {
+  if (expandRel.has_input() && !validate(expandRel.input())) {
+    logValidateMsg("native validation failed due to: input validation fails in ExpandRel.");
+    return false;
+  }
+  RowTypePtr rowType = nullptr;
+  // Get and validate the input types from extension.
+  if (expandRel.has_advanced_extension()) {
+    const auto& extension = expandRel.advanced_extension();
+    std::vector<TypePtr> types;
+    if (!validateInputTypes(extension, types)) {
+      logValidateMsg("native validation failed due to: unsupported input types in ExpandRel.");
+      return false;
+    }
+    int32_t inputPlanNodeId = 0;
+    std::vector<std::string> names;
+    names.reserve(types.size());
+    for (auto colIdx = 0; colIdx < types.size(); colIdx++) {
+      names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+    }
+    rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+  }
+
+  int32_t projectSize = 0;
+  // Validate fields.
+  for (const auto& fields : expandRel.fields()) {
+    std::vector<core::TypedExprPtr> expressions;
+    if (fields.has_switching_field()) {
+      auto projectExprs = fields.switching_field().duplicates();
+      expressions.reserve(projectExprs.size());
+      if (projectSize == 0) {
+        projectSize = projectExprs.size();
+      } else if (projectSize != projectExprs.size()) {
+        logValidateMsg(
+            "native validation failed due to: SwitchingField expressions size should be constant in ExpandRel.");
+        return false;
+      }
+
+      try {
+        for (const auto& projectExpr : projectExprs) {
+          const auto& typeCase = projectExpr.rex_type_case();
+          switch (typeCase) {
+            case ::substrait::Expression::RexTypeCase::kSelection:
+            case ::substrait::Expression::RexTypeCase::kLiteral:
+              break;
+            default:
+              logValidateMsg(
+                  "native validation failed due to: Only field or literal is supported in project of ExpandRel.");
+              return false;
+          }
+          if (rowType) {
+            expressions.emplace_back(exprConverter_->toVeloxExpr(projectExpr, rowType));
+          }
+        }
+
+        if (rowType) {
+          // Try to compile the expressions. If there is any unregistered
+          // function or mismatched type, exception will be thrown.
+          exec::ExprSet exprSet(std::move(expressions), execCtx_);
+        }
+
+      } catch (const VeloxException& err) {
+        logValidateMsg("native validation failed due to: in ExpandRel, " + err.message());
+        return false;
+      }
+    } else {
+      logValidateMsg("native validation failed due to: Only SwitchingField is supported in ExpandRel.");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool validateBoundType(::substrait::Expression_WindowFunction_Bound boundType) {
+  switch (boundType.kind_case()) {
+    case ::substrait::Expression_WindowFunction_Bound::kUnboundedFollowing:
+    case ::substrait::Expression_WindowFunction_Bound::kUnboundedPreceding:
+    case ::substrait::Expression_WindowFunction_Bound::kCurrentRow:
+    case ::substrait::Expression_WindowFunction_Bound::kFollowing:
+    case ::substrait::Expression_WindowFunction_Bound::kPreceding:
+      break;
+    default:
+      VLOG(1) << "native validation failed due to: The Bound Type is not supported. ";
+      return false;
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windowRel) {
+  if (windowRel.has_input() && !validate(windowRel.input())) {
+    logValidateMsg("native validation failed due to: windowRel input fails to validate. ");
+    return false;
+  }
+
+  // Get and validate the input types from extension.
+  if (!windowRel.has_advanced_extension()) {
+    logValidateMsg("native validation failed due to: Input types are expected in WindowRel.");
+    return false;
+  }
+  const auto& extension = windowRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: Validation failed for input types in WindowRel.");
+    return false;
+  }
+
+  int32_t inputPlanNodeId = 0;
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (auto colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  // Validate WindowFunction
+  std::vector<std::string> funcSpecs;
+  funcSpecs.reserve(windowRel.measures().size());
+  for (const auto& smea : windowRel.measures()) {
+    try {
+      const auto& windowFunction = smea.measure();
+      funcSpecs.emplace_back(planConverter_->findFuncSpec(windowFunction.function_reference()));
+      toVeloxType(subParser_->parseType(windowFunction.output_type())->type);
+      for (const auto& arg : windowFunction.arguments()) {
+        auto typeCase = arg.value().rex_type_case();
+        switch (typeCase) {
+          case ::substrait::Expression::RexTypeCase::kSelection:
+          case ::substrait::Expression::RexTypeCase::kLiteral:
+            break;
+          default:
+            logValidateMsg("native validation failed due to: Only field is supported in window functions.");
+            return false;
+        }
+      }
+      // Validate BoundType and Frame Type
+      switch (windowFunction.window_type()) {
+        case ::substrait::WindowType::ROWS:
+        case ::substrait::WindowType::RANGE:
+          break;
+        default:
+          logValidateMsg(
+              "native validation failed due to: the window type only support ROWS and RANGE, and the input type is " +
+              windowFunction.window_type());
+          return false;
+      }
+
+      bool boundTypeSupported =
+          validateBoundType(windowFunction.upper_bound()) && validateBoundType(windowFunction.lower_bound());
+      if (!boundTypeSupported) {
+        logValidateMsg(
+            "native validation failed due to: The Bound Type is not supported. " +
+            windowFunction.lower_bound().kind_case());
+        return false;
+      }
+    } catch (const VeloxException& err) {
+      logValidateMsg("native validation failed due to: in window function, " + err.message());
+      return false;
+    }
+  }
+
+  // Validate supported aggregate functions.
+  std::unordered_set<std::string> unsupportedFuncs = {"collect_list", "collect_set"};
+  for (const auto& funcSpec : funcSpecs) {
+    auto funcName = subParser_->getSubFunctionName(funcSpec);
+    if (unsupportedFuncs.find(funcName) != unsupportedFuncs.end()) {
+      logValidateMsg("native validation failed due to: " + funcName + " was not supported in WindowRel.");
+      return false;
+    }
+  }
+
+  // Validate groupby expression
+  const auto& groupByExprs = windowRel.partition_expressions();
+  std::vector<core::TypedExprPtr> expressions;
+  expressions.reserve(groupByExprs.size());
+  try {
+    for (const auto& expr : groupByExprs) {
+      auto expression = exprConverter_->toVeloxExpr(expr, rowType);
+      auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+      if (expr_field == nullptr) {
+        logValidateMsg(
+            "native validation failed due to: Only field is supported for partition key in Window Operator!");
+        return false;
+      } else {
+        expressions.emplace_back(expression);
+      }
+    }
+    // Try to compile the expressions. If there is any unregistred funciton or
+    // mismatched type, exception will be thrown.
+    exec::ExprSet exprSet(std::move(expressions), execCtx_);
+  } catch (const VeloxException& err) {
+    logValidateMsg("native validation failed due to: in WindowRel, " + err.message());
+    return false;
+  }
+
+  // Validate Sort expression
+  const auto& sorts = windowRel.sorts();
+  for (const auto& sort : sorts) {
+    switch (sort.direction()) {
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST:
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST:
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST:
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
+        break;
+      default:
+        logValidateMsg("native validation failed due to: in windowRel, unsupported Sort direction " + sort.direction());
+        return false;
+    }
+
+    if (sort.has_expr()) {
+      try {
+        auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
+        auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+        if (!expr_field) {
+          logValidateMsg(
+              "native validation failed due to: in windowRel, the sorting key in Sort Operator only support field");
+          return false;
+        }
+        exec::ExprSet exprSet({std::move(expression)}, execCtx_);
+      } catch (const VeloxException& err) {
+        logValidateMsg("native validation failed due to: in WindowRel, " + err.message());
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel) {
+  if (sortRel.has_input() && !validate(sortRel.input())) {
+    return false;
+  }
+  // Get and validate the input types from extension.
+  if (!sortRel.has_advanced_extension()) {
+    logValidateMsg("native validation failed due to: Input types are expected in SortRel.");
+    return false;
+  }
+  const auto& extension = sortRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: Validation failed for input types in SortRel.");
+    return false;
+  }
+  for (const auto& type : types) {
+    if (type->kind() == TypeKind::TIMESTAMP) {
+      logValidateMsg("native validation failed due to: Timestamp type is not supported in SortRel.");
+      return false;
+    }
+  }
+
+  int32_t inputPlanNodeId = 0;
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (auto colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  const auto& sorts = sortRel.sorts();
+  for (const auto& sort : sorts) {
+    switch (sort.direction()) {
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST:
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST:
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST:
+      case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
+        break;
+      default:
+        logValidateMsg("native validation failed due to: in sortRel, unsupported Sort direction " + sort.direction());
+        return false;
+    }
+
+    if (sort.has_expr()) {
+      try {
+        auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
+        auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+        if (!expr_field) {
+          logValidateMsg(
+              "native validation failed due to: in SortRel, the sorting key in Sort Operator only support field");
+          return false;
+        }
+        exec::ExprSet exprSet({std::move(expression)}, execCtx_);
+      } catch (const VeloxException& err) {
+        logValidateMsg("native validation failed due to: in SortRel, expression validation fails as" + err.message());
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ProjectRel& projectRel) {
+  if (projectRel.has_input() && !validate(projectRel.input())) {
+    logValidateMsg("native validation failed due to: Validation failed for ProjectRel input.");
+    return false;
+  }
+
+  // Get and validate the input types from extension.
+  if (!projectRel.has_advanced_extension()) {
+    logValidateMsg("native validation failed due to: Input types are expected in ProjectRel.");
+    return false;
+  }
+  const auto& extension = projectRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: Validation failed for input types in ProjectRel.");
+    return false;
+  }
+
+  for (auto i = 0; i < types.size(); i++) {
+    switch (types[i]->kind()) {
+      case TypeKind::ARRAY:
+        logValidateMsg("native validation failed due to: unsupported input type ARRAY in ProjectRel.");
+        return false;
+      default:;
+    }
+  }
+
+  int32_t inputPlanNodeId = 0;
+  // Create the fake input names to be used in row type.
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (uint32_t colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  // Validate the project expressions.
+  const auto& projectExprs = projectRel.expressions();
+  std::vector<core::TypedExprPtr> expressions;
+  expressions.reserve(projectExprs.size());
+  try {
+    for (const auto& expr : projectExprs) {
+      if (!validateExpression(expr, rowType)) {
+        return false;
+      }
+      expressions.emplace_back(exprConverter_->toVeloxExpr(expr, rowType));
+    }
+    // Try to compile the expressions. If there is any unregistered function or
+    // mismatched type, exception will be thrown.
+    exec::ExprSet exprSet(std::move(expressions), execCtx_);
+  } catch (const VeloxException& err) {
+    logValidateMsg("native validation failed due to: in ProjectRel, " + err.message());
+    return false;
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filterRel) {
+  if (filterRel.has_input() && !validate(filterRel.input())) {
+    logValidateMsg("native validation failed due to: input of FilterRel validation fails");
+    return false;
+  }
+
+  // Get and validate the input types from extension.
+  if (!filterRel.has_advanced_extension()) {
+    logValidateMsg("native validation failed due to: Input types are expected in FilterRel.");
+    return false;
+  }
+  const auto& extension = filterRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: Validation failed for input types in FilterRel.");
+    return false;
+  }
+  for (const auto& type : types) {
+    if (type->kind() == TypeKind::TIMESTAMP) {
+      logValidateMsg("native validation failed due to: Timestamp is not fully supported in Filter");
+      return false;
+    }
+  }
+
+  int32_t inputPlanNodeId = 0;
+  // Create the fake input names to be used in row type.
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (uint32_t colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  std::vector<core::TypedExprPtr> expressions;
+  expressions.reserve(1);
+  try {
+    if (!validateExpression(filterRel.condition(), rowType)) {
+      return false;
+    }
+    expressions.emplace_back(exprConverter_->toVeloxExpr(filterRel.condition(), rowType));
+    // Try to compile the expressions. If there is any unregistered function
+    // or mismatched type, exception will be thrown.
+    exec::ExprSet exprSet(std::move(expressions), execCtx_);
+  } catch (const VeloxException& err) {
+    logValidateMsg("native validation failed due to: validation fails for FilterRel expression, " + err.message());
+    return false;
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel) {
+  if (joinRel.has_left() && !validate(joinRel.left())) {
+    logValidateMsg("native validation failed due to: validation fails for join left input. ");
+    return false;
+  }
+  if (joinRel.has_right() && !validate(joinRel.right())) {
+    logValidateMsg("native validation failed due to: validation fails for join right input. ");
+    return false;
+  }
+
+  if (joinRel.has_advanced_extension() && subParser_->configSetInOptimization(joinRel.advanced_extension(), "isSMJ=")) {
+    switch (joinRel.type()) {
+      case ::substrait::JoinRel_JoinType_JOIN_TYPE_INNER:
+      case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT:
+        break;
+      default:
+        logValidateMsg("native validation failed due to: Sort merge join only support inner and left join");
+        return false;
+    }
+  }
+  switch (joinRel.type()) {
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_INNER:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_OUTER:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT_SEMI:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_RIGHT_SEMI:
+    case ::substrait::JoinRel_JoinType_JOIN_TYPE_ANTI:
+      break;
+    default:
+      logValidateMsg("native validation failed due to: Sort merge join only support inner and left join");
+      return false;
+  }
+
+  // Validate input types.
+  if (!joinRel.has_advanced_extension()) {
+    logValidateMsg("native validation failed due to: Input types are expected in JoinRel.");
+    return false;
+  }
+
+  const auto& extension = joinRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: Validation failed for input types in JoinRel");
+    return false;
+  }
+
+  int32_t inputPlanNodeId = 0;
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (auto colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  if (joinRel.has_expression()) {
+    std::vector<const ::substrait::Expression::FieldReference*> leftExprs, rightExprs;
+    try {
+      planConverter_->extractJoinKeys(joinRel.expression(), leftExprs, rightExprs);
+    } catch (const VeloxException& err) {
+      logValidateMsg("native validation failed due to: JoinRel expression validation fails, " + err.message());
+      return false;
+    }
+  }
+
+  if (joinRel.has_post_join_filter()) {
+    try {
+      auto expression = exprConverter_->toVeloxExpr(joinRel.post_join_filter(), rowType);
+      exec::ExprSet exprSet({std::move(expression)}, execCtx_);
+    } catch (const VeloxException& err) {
+      logValidateMsg("native validation failed due to: in post join filter, " + err.message());
+      return false;
+    }
+  }
+  return true;
+}
+
+TypePtr SubstraitToVeloxPlanValidator::getDecimalType(const std::string& decimalType) {
+  // Decimal info is in the format of dec<precision,scale>.
+  auto precisionStart = decimalType.find_first_of('<');
+  auto tokenIndex = decimalType.find_first_of(',');
+  auto scaleStart = decimalType.find_first_of('>');
+  auto precision = stoi(decimalType.substr(precisionStart + 1, (tokenIndex - precisionStart - 1)));
+  auto scale = stoi(decimalType.substr(tokenIndex + 1, (scaleStart - tokenIndex - 1)));
+  return DECIMAL(precision, scale);
+}
+
+TypePtr SubstraitToVeloxPlanValidator::getRowType(const std::string& structType) {
+  // Struct info is in the format of struct<T1,T2, ...,Tn>.
+  // TODO: nested struct is not supported.
+  auto structStart = structType.find_first_of('<');
+  auto structEnd = structType.find_last_of('>');
+  if (structEnd - structStart > 1) {
+    logValidateMsg("native validation failed due to: More information is needed to create RowType");
+  }
+  VELOX_CHECK(
+      structEnd - structStart > 1, "native validation failed due to: More information is needed to create RowType");
+  std::string childrenTypes = structType.substr(structStart + 1, structEnd - structStart - 1);
+
+  // Split the types with delimiter.
+  std::string delimiter = ",";
+  std::size_t pos;
+  std::vector<TypePtr> types;
+  std::vector<std::string> names;
+  while ((pos = childrenTypes.find(delimiter)) != std::string::npos) {
+    const auto& typeStr = childrenTypes.substr(0, pos);
+    std::string decDelimiter = ">";
+    if (typeStr.find("dec") != std::string::npos) {
+      std::size_t endPos = childrenTypes.find(decDelimiter);
+      VELOX_CHECK(endPos >= pos + 1, "Decimal scale is expected.");
+      const auto& decimalStr = typeStr + childrenTypes.substr(pos, endPos - pos) + decDelimiter;
+      types.emplace_back(getDecimalType(decimalStr));
+      names.emplace_back("");
+      childrenTypes.erase(0, endPos + delimiter.length() + decDelimiter.length());
+      continue;
+    }
+
+    types.emplace_back(toVeloxType(subParser_->parseType(typeStr)));
+    names.emplace_back("");
+    childrenTypes.erase(0, pos + delimiter.length());
+  }
+  types.emplace_back(toVeloxType(subParser_->parseType(childrenTypes)));
+  names.emplace_back("");
+  return std::make_shared<RowType>(std::move(names), std::move(types));
+}
+
+bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait::AggregateRel& aggRel) {
+  if (aggRel.measures_size() == 0) {
+    return true;
+  }
+
+  for (const auto& smea : aggRel.measures()) {
+    const auto& aggFunction = smea.measure();
+    auto funcSpec = planConverter_->findFuncSpec(aggFunction.function_reference());
+    std::vector<TypePtr> types;
+    bool isDecimal = false;
+    try {
+      std::vector<std::string> funcTypes;
+      subParser_->getSubFunctionTypes(funcSpec, funcTypes);
+      types.reserve(funcTypes.size());
+      for (auto& type : funcTypes) {
+        if (!isDecimal && type.find("dec") != std::string::npos) {
+          isDecimal = true;
+        }
+        if (type.find("struct") != std::string::npos) {
+          types.emplace_back(getRowType(type));
+        } else if (type.find("dec") != std::string::npos) {
+          types.emplace_back(getDecimalType(type));
+        } else {
+          types.emplace_back(toVeloxType(subParser_->parseType(type)));
+        }
+      }
+    } catch (const VeloxException& err) {
+      logValidateMsg(
+          "native validation failed due to: Validation failed for input type in AggregateRel function due to:" +
+          err.message());
+      return false;
+    }
+    auto funcName = subParser_->mapToVeloxFunction(subParser_->getSubFunctionName(funcSpec), isDecimal);
+    if (auto signatures = exec::getAggregateFunctionSignatures(funcName)) {
+      for (const auto& signature : signatures.value()) {
+        exec::SignatureBinder binder(*signature, types);
+        if (binder.tryBind()) {
+          auto resolveType = binder.tryResolveType(
+              exec::isPartialOutput(planConverter_->toAggregationStep(aggRel)) ? signature->intermediateType()
+                                                                               : signature->returnType());
+          if (resolveType == nullptr) {
+            logValidateMsg(
+                "native validation failed due to: Validation failed for function " + funcName +
+                "resolve type in AggregateRel.");
+            return false;
+          }
+          return true;
+        }
+      }
+      logValidateMsg(
+          "native validation failed due to: Validation failed for function " + funcName + " bind in AggregateRel.");
+      return false;
+    }
+  }
+  logValidateMsg("native validation failed due to: Validation failed for function resolve in AggregateRel.");
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& aggRel) {
+  if (aggRel.has_input() && !validate(aggRel.input())) {
+    logValidateMsg("native validation failed due to: input validation fails in AggregateRel.");
+    return false;
+  }
+
+  // Validate input types.
+  if (aggRel.has_advanced_extension()) {
+    std::vector<TypePtr> types;
+    const auto& extension = aggRel.advanced_extension();
+    if (!validateInputTypes(extension, types)) {
+      logValidateMsg("native validation failed due to: Validation failed for input types in AggregateRel.");
+      return false;
+    }
+  }
+
+  // Validate groupings.
+  for (const auto& grouping : aggRel.groupings()) {
+    for (const auto& groupingExpr : grouping.grouping_expressions()) {
+      const auto& typeCase = groupingExpr.rex_type_case();
+      switch (typeCase) {
+        case ::substrait::Expression::RexTypeCase::kSelection:
+          break;
+        default:
+          logValidateMsg("native validation failed due to: Only field is supported in groupings.");
+          return false;
+      }
+    }
+  }
+
+  // Validate aggregate functions.
+  std::vector<std::string> funcSpecs;
+  funcSpecs.reserve(aggRel.measures().size());
+  for (const auto& smea : aggRel.measures()) {
+    try {
+      // Validate the filter expression
+      if (smea.has_filter()) {
+        ::substrait::Expression aggRelMask = smea.filter();
+        if (aggRelMask.ByteSizeLong() > 0) {
+          auto typeCase = aggRelMask.rex_type_case();
+          switch (typeCase) {
+            case ::substrait::Expression::RexTypeCase::kSelection:
+              break;
+            default:
+              logValidateMsg(
+                  "native validation failed due to: Only field is supported in aggregate filter expression.");
+              return false;
+          }
+        }
+      }
+
+      const auto& aggFunction = smea.measure();
+      const auto& functionSpec = planConverter_->findFuncSpec(aggFunction.function_reference());
+      funcSpecs.emplace_back(functionSpec);
+      toVeloxType(subParser_->parseType(aggFunction.output_type())->type);
+      // Validate the size of arguments.
+      if (subParser_->getSubFunctionName(functionSpec) == "count" && aggFunction.arguments().size() > 1) {
+        logValidateMsg("native validation failed due to: count should have only one argument");
+        // Count accepts only one argument.
+        return false;
+      }
+      for (const auto& arg : aggFunction.arguments()) {
+        auto typeCase = arg.value().rex_type_case();
+        switch (typeCase) {
+          case ::substrait::Expression::RexTypeCase::kSelection:
+          case ::substrait::Expression::RexTypeCase::kLiteral:
+            break;
+          default:
+            logValidateMsg("native validation failed due to: Only field is supported in aggregate functions.");
+            return false;
+        }
+      }
+    } catch (const VeloxException& err) {
+      logValidateMsg("native validation failed due to: aggregate function validation fails, " + err.message());
+      return false;
+    }
+  }
+
+  // The supported aggregation functions.
+  std::unordered_set<std::string> supportedAggFuncs = {
+      "sum",
+      "sum_merge",
+      "collect_set",
+      "count",
+      "count_merge",
+      "avg",
+      "avg_merge",
+      "min",
+      "min_merge",
+      "max",
+      "max_merge",
+      "stddev_samp",
+      "stddev_samp_merge",
+      "stddev_pop",
+      "stddev_pop_merge",
+      "bloom_filter_agg",
+      "var_samp",
+      "var_samp_merge",
+      "var_pop",
+      "var_pop_merge",
+      "bit_and",
+      "bit_and_merge",
+      "bit_or",
+      "bit_or_merge",
+      "bit_xor",
+      "bit_xor_merge",
+      "first",
+      "first_merge",
+      "first_ignore_null",
+      "first_ignore_null_merge",
+      "last",
+      "last_merge",
+      "last_ignore_null",
+      "last_ignore_null_merge",
+      "corr",
+      "corr_merge",
+      "covar_pop",
+      "covar_pop_merge",
+      "covar_samp",
+      "covar_samp_merge",
+      "approx_distinct"};
+  for (const auto& funcSpec : funcSpecs) {
+    auto funcName = subParser_->getSubFunctionName(funcSpec);
+    if (supportedAggFuncs.find(funcName) == supportedAggFuncs.end()) {
+      logValidateMsg("native validation failed due to:  " + funcName + " was not supported in AggregateRel.");
+      return false;
+    }
+  }
+
+  if (!validateAggRelFunctionType(aggRel)) {
+    return false;
+  }
+
+  // Validate both groupby and aggregates input are empty, which is corner case.
+  if (aggRel.measures_size() == 0) {
+    bool hasExpr = false;
+    for (const auto& grouping : aggRel.groupings()) {
+      if (grouping.grouping_expressions().size() > 0) {
+        hasExpr = true;
+        break;
+      }
+    }
+    if (!hasExpr) {
+      logValidateMsg("native validation failed due to: aggregation must specify either grouping keys or aggregates.");
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ReadRel& readRel) {
+  try {
+    planConverter_->toVeloxPlan(readRel);
+  } catch (const VeloxException& err) {
+    logValidateMsg("native validation failed due to: in ReadRel, " + err.message());
+    return false;
+  }
+
+  // Validate filter in ReadRel.
+  if (readRel.has_filter()) {
+    std::vector<core::TypedExprPtr> expressions;
+    expressions.reserve(1);
+
+    std::vector<TypePtr> veloxTypeList;
+    if (readRel.has_base_schema()) {
+      const auto& baseSchema = readRel.base_schema();
+      auto substraitTypeList = subParser_->parseNamedStruct(baseSchema);
+      veloxTypeList.reserve(substraitTypeList.size());
+      for (const auto& substraitType : substraitTypeList) {
+        veloxTypeList.emplace_back(toVeloxType(substraitType->type));
+      }
+    }
+    std::vector<std::string> names;
+    int32_t inputPlanNodeId = 0;
+    names.reserve(veloxTypeList.size());
+    for (auto colIdx = 0; colIdx < veloxTypeList.size(); colIdx++) {
+      names.emplace_back(subParser_->makeNodeName(inputPlanNodeId, colIdx));
+    }
+    auto rowType = std::make_shared<RowType>(std::move(names), std::move(veloxTypeList));
+
+    try {
+      expressions.emplace_back(exprConverter_->toVeloxExpr(readRel.filter(), rowType));
+      // Try to compile the expressions. If there is any unregistered function
+      // or mismatched type, exception will be thrown.
+      exec::ExprSet exprSet(std::move(expressions), execCtx_);
+    } catch (const VeloxException& err) {
+      logValidateMsg(
+          "native validation failed due to: filter expression validation fails in ReadRel, " + err.message());
+      return false;
+    }
+  }
+  if (readRel.has_base_schema()) {
+    const auto& baseSchema = readRel.base_schema();
+    if (!validateColNames(baseSchema)) {
+      logValidateMsg("native validation failed due to: Validation failed for column name contains illegal charactor.");
+      return false;
+    }
+  }
+  return true;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::Rel& rel) {
+  if (rel.has_aggregate()) {
+    return validate(rel.aggregate());
+  }
+  if (rel.has_project()) {
+    return validate(rel.project());
+  }
+  if (rel.has_filter()) {
+    return validate(rel.filter());
+  }
+  if (rel.has_join()) {
+    return validate(rel.join());
+  }
+  if (rel.has_read()) {
+    return validate(rel.read());
+  }
+  if (rel.has_sort()) {
+    return validate(rel.sort());
+  }
+  if (rel.has_expand()) {
+    return validate(rel.expand());
+  }
+  if (rel.has_fetch()) {
+    return validate(rel.fetch());
+  }
+  if (rel.has_window()) {
+    return validate(rel.window());
+  }
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::RelRoot& relRoot) {
+  if (relRoot.has_input()) {
+    const auto& rel = relRoot.input();
+    return validate(rel);
+  }
+  return false;
+}
+
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::Plan& plan) {
+  // Create plan converter and expression converter to help the validation.
+  planConverter_->constructFunctionMap(plan);
+  exprConverter_ = std::make_shared<SubstraitVeloxExprConverter>(pool_, planConverter_->getFunctionMap());
+
+  for (const auto& rel : plan.relations()) {
+    if (rel.has_root()) {
+      return validate(rel.root());
+    }
+    if (rel.has_rel()) {
+      return validate(rel.rel());
+    }
+  }
+  return false;
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "SubstraitToVeloxPlan.h"
+
+namespace gluten {
+
+/// This class is used to validate whether the computing of
+/// a Substrait plan is supported in Velox.
+class SubstraitToVeloxPlanValidator {
+ public:
+  SubstraitToVeloxPlanValidator(memory::MemoryPool* pool, core::ExecCtx* execCtx) : pool_(pool), execCtx_(execCtx) {}
+
+  /// Used to validate whether the computing of this Limit is supported.
+  bool validate(const ::substrait::FetchRel& fetchRel);
+
+  /// Used to validate whether the computing of this Expand is supported.
+  bool validate(const ::substrait::ExpandRel& expandRel);
+
+  /// Used to validate whether the computing of this Sort is supported.
+  bool validate(const ::substrait::SortRel& sortRel);
+
+  /// Used to validate whether the computing of this Window is supported.
+  bool validate(const ::substrait::WindowRel& windowRel);
+
+  /// Used to validate whether the computing of this Aggregation is supported.
+  bool validate(const ::substrait::AggregateRel& aggRel);
+
+  /// Used to validate whether the computing of this Project is supported.
+  bool validate(const ::substrait::ProjectRel& projectRel);
+
+  /// Used to validate whether the computing of this Filter is supported.
+  bool validate(const ::substrait::FilterRel& filterRel);
+
+  /// Used to validate Join.
+  bool validate(const ::substrait::JoinRel& joinRel);
+
+  /// Used to validate whether the computing of this Read is supported.
+  bool validate(const ::substrait::ReadRel& readRel);
+
+  /// Used to validate whether the computing of this Rel is supported.
+  bool validate(const ::substrait::Rel& rel);
+
+  /// Used to validate whether the computing of this RelRoot is supported.
+  bool validate(const ::substrait::RelRoot& relRoot);
+
+  /// Used to validate whether the computing of this Plan is supported.
+  bool validate(const ::substrait::Plan& plan);
+
+  std::vector<std::string> getValidateLog() {
+    return validateLog_;
+  }
+
+ private:
+  /// A memory pool used for function validation.
+  memory::MemoryPool* pool_;
+
+  /// An execution context used for function validation.
+  core::ExecCtx* execCtx_;
+
+  /// A converter used to convert Substrait plan into Velox's plan node.
+  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(pool_, true);
+
+  /// A parser used to convert Substrait plan into recognizable representations.
+  std::shared_ptr<SubstraitParser> subParser_ = std::make_shared<SubstraitParser>();
+
+  /// An expression converter used to convert Substrait representations into
+  /// Velox expressions.
+  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
+
+  std::vector<std::string> validateLog_;
+
+  /// Used to get types from advanced extension and validate them.
+  bool validateInputTypes(const ::substrait::extensions::AdvancedExtension& extension, std::vector<TypePtr>& types);
+
+  bool validateAggRelFunctionType(const ::substrait::AggregateRel& substraitAgg);
+
+  /// Validate the round scalar function.
+  bool validateRound(const ::substrait::Expression::ScalarFunction& scalarFunction, const RowTypePtr& inputType);
+
+  /// Validate extract function.
+  bool validateExtractExpr(const std::vector<core::TypedExprPtr>& params);
+
+  /// Validate Substrait scarlar function.
+  bool validateScalarFunction(
+      const ::substrait::Expression::ScalarFunction& scalarFunction,
+      const RowTypePtr& inputType);
+
+  /// Validate Substrait Cast expression.
+  bool validateCast(const ::substrait::Expression::Cast& castExpr, const RowTypePtr& inputType);
+
+  /// Validate Substrait expression.
+  bool validateExpression(const ::substrait::Expression& expression, const RowTypePtr& inputType);
+
+  /// Validate Substrait literal.
+  bool validateLiteral(const ::substrait::Expression_Literal& literal, const RowTypePtr& inputType);
+
+  /// Create RowType based on the type information in string.
+  TypePtr getRowType(const std::string& structType);
+
+  /// Create DecimalType based on the type information in string.
+  TypePtr getDecimalType(const std::string& decimalType);
+
+  /// Add necessary log for fallback
+  void logValidateMsg(const std::string& log) {
+    this->validateLog_.emplace_back(log);
+  }
+};
+
+} // namespace gluten

--- a/cpp/velox/substrait/TypeUtils.cc
+++ b/cpp/velox/substrait/TypeUtils.cc
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TypeUtils.h"
+#include "velox/type/Type.h"
+
+namespace gluten {
+std::vector<std::string_view> getTypesFromCompoundName(std::string_view compoundName) {
+  // CompoundName is like ARRAY<BIGINT> or MAP<BIGINT,DOUBLE>
+  // or ROW<BIGINT,ROW<DOUBLE,BIGINT>,ROW<DOUBLE,BIGINT>>
+  // the position of then delimiter is where the number of leftAngleBracket
+  // equals rightAngleBracket need to split.
+  std::vector<std::string_view> types;
+  std::vector<int> angleBracketNumEqualPos;
+  auto leftAngleBracketPos = compoundName.find("<");
+  auto rightAngleBracketPos = compoundName.rfind(">");
+  auto typesName = compoundName.substr(leftAngleBracketPos + 1, rightAngleBracketPos - leftAngleBracketPos - 1);
+  int leftAngleBracketNum = 0;
+  int rightAngleBracketNum = 0;
+  for (auto index = 0; index < typesName.length(); index++) {
+    if (typesName[index] == '<') {
+      leftAngleBracketNum++;
+    }
+    if (typesName[index] == '>') {
+      rightAngleBracketNum++;
+    }
+    if (typesName[index] == ',' && rightAngleBracketNum == leftAngleBracketNum) {
+      angleBracketNumEqualPos.push_back(index);
+    }
+  }
+  int startPos = 0;
+  for (auto delimeterPos : angleBracketNumEqualPos) {
+    types.emplace_back(typesName.substr(startPos, delimeterPos - startPos));
+    startPos = delimeterPos + 1;
+  }
+  types.emplace_back(std::string_view(typesName.data() + startPos, typesName.length() - startPos));
+  return types;
+}
+
+// TODO Refactor using Bison.
+std::string_view getNameBeforeDelimiter(const std::string& compoundName, const std::string& delimiter) {
+  std::size_t pos = compoundName.find(delimiter);
+  if (pos == std::string::npos) {
+    return compoundName;
+  }
+  return std::string_view(compoundName.data(), pos);
+}
+
+std::pair<int32_t, int32_t> getPrecisionAndScale(const std::string& typeName) {
+  std::size_t start = typeName.find_first_of("<");
+  std::size_t end = typeName.find_last_of(">");
+  if (start == std::string::npos || end == std::string::npos) {
+    throw std::runtime_error("Invalid decimal type.");
+  }
+
+  std::string decimalType = typeName.substr(start + 1, end - start - 1);
+  std::size_t token_pos = decimalType.find_first_of(",");
+  auto precision = stoi(decimalType.substr(0, token_pos));
+  auto scale = stoi(decimalType.substr(token_pos + 1, decimalType.length() - 1));
+  return std::make_pair(precision, scale);
+}
+
+TypePtr toVeloxType(const std::string& typeName) {
+  VELOX_CHECK(!typeName.empty(), "Cannot convert empty string to Velox type.");
+  auto type = getNameBeforeDelimiter(typeName, "<");
+  auto typeKind = mapNameToTypeKind(std::string(type));
+  switch (typeKind) {
+    case TypeKind::BOOLEAN:
+      return BOOLEAN();
+    case TypeKind::TINYINT:
+      return TINYINT();
+    case TypeKind::SMALLINT:
+      return SMALLINT();
+    case TypeKind::INTEGER:
+      return INTEGER();
+    case TypeKind::BIGINT:
+      if (type == "SHORT_DECIMAL") {
+        auto decimal = getPrecisionAndScale(typeName);
+        return DECIMAL(decimal.first, decimal.second);
+      } else {
+        return BIGINT();
+      }
+    case TypeKind::HUGEINT: {
+      auto decimal = getPrecisionAndScale(typeName);
+      return DECIMAL(decimal.first, decimal.second);
+    }
+    case TypeKind::REAL:
+      return REAL();
+    case TypeKind::DOUBLE:
+      return DOUBLE();
+    case TypeKind::VARCHAR:
+      return VARCHAR();
+    case TypeKind::VARBINARY:
+      return VARBINARY();
+    case TypeKind::ARRAY: {
+      auto fieldTypes = getTypesFromCompoundName(typeName);
+      VELOX_CHECK_EQ(fieldTypes.size(), 1, "The size of ARRAY type should be only one.");
+      return ARRAY(toVeloxType(std::string(fieldTypes[0])));
+    }
+    case TypeKind::MAP: {
+      auto fieldTypes = getTypesFromCompoundName(typeName);
+      VELOX_CHECK_EQ(fieldTypes.size(), 2, "The size of MAP type should be two.");
+      auto keyType = toVeloxType(std::string(fieldTypes[0]));
+      auto valueType = toVeloxType(std::string(fieldTypes[1]));
+      return MAP(keyType, valueType);
+    }
+    case TypeKind::ROW: {
+      auto fieldTypes = getTypesFromCompoundName(typeName);
+      VELOX_CHECK(!fieldTypes.empty(), "Converting empty ROW type from Substrait to Velox is not supported.");
+
+      std::vector<TypePtr> types;
+      std::vector<std::string> names;
+      for (int idx = 0; idx < fieldTypes.size(); idx++) {
+        std::string fieldTypeAndName = std::string(fieldTypes[idx]);
+        size_t pos = fieldTypeAndName.find_last_of(':');
+        if (pos == std::string::npos) {
+          // Name does not exist.
+          types.emplace_back(toVeloxType(fieldTypeAndName));
+          names.emplace_back("col_" + std::to_string(idx));
+        } else {
+          types.emplace_back(toVeloxType(fieldTypeAndName.substr(0, pos)));
+          names.emplace_back(fieldTypeAndName.substr(pos + 1, fieldTypeAndName.length()));
+        }
+      }
+      return ROW(std::move(names), std::move(types));
+    }
+    case TypeKind::DATE: {
+      return DATE();
+    }
+    case TypeKind::TIMESTAMP: {
+      return TIMESTAMP();
+    }
+    case TypeKind::UNKNOWN:
+      return UNKNOWN();
+    default:
+      VELOX_NYI("Velox type conversion not supported for type {}.", typeName);
+  }
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/TypeUtils.h
+++ b/cpp/velox/substrait/TypeUtils.h
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SubstraitParser.h"
+#include "velox/type/Filter.h"
+#include "velox/type/Type.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+/// Return the Velox type according to the typename.
+TypePtr toVeloxType(const std::string& typeName);
+
+std::string_view getNameBeforeDelimiter(const std::string& compoundName, const std::string& delimiter);
+#ifndef RANGETRAITS_H
+#define RANGETRAITS_H
+
+// Traits used to map type kind to the range used in Filter.
+template <TypeKind KIND>
+struct RangeTraits {};
+
+template <>
+struct RangeTraits<TypeKind::TINYINT> {
+  using RangeType = common::BigintRange;
+  using MultiRangeType = common::BigintMultiRange;
+  using NativeType = int8_t;
+};
+
+template <>
+struct RangeTraits<TypeKind::SMALLINT> {
+  using RangeType = common::BigintRange;
+  using MultiRangeType = common::BigintMultiRange;
+  using NativeType = int16_t;
+};
+
+template <>
+struct RangeTraits<TypeKind::INTEGER> {
+  using RangeType = common::BigintRange;
+  using MultiRangeType = common::BigintMultiRange;
+  using NativeType = int32_t;
+};
+
+template <>
+struct RangeTraits<TypeKind::BIGINT> {
+  using RangeType = common::BigintRange;
+  using MultiRangeType = common::BigintMultiRange;
+  using NativeType = int64_t;
+};
+
+template <>
+struct RangeTraits<TypeKind::DOUBLE> {
+  using RangeType = common::DoubleRange;
+  using MultiRangeType = common::MultiRange;
+  using NativeType = double;
+};
+
+template <>
+struct RangeTraits<TypeKind::BOOLEAN> {
+  using RangeType = common::BigintRange;
+  using MultiRangeType = common::BigintMultiRange;
+  using NativeType = bool;
+};
+
+template <>
+struct RangeTraits<TypeKind::VARCHAR> {
+  using RangeType = common::BytesRange;
+  using MultiRangeType = common::MultiRange;
+  using NativeType = std::string;
+};
+
+template <>
+struct RangeTraits<TypeKind::DATE> {
+  using RangeType = common::BigintRange;
+  using MultiRangeType = common::BigintMultiRange;
+  using NativeType = int32_t;
+};
+
+template <>
+struct RangeTraits<TypeKind::HUGEINT> {
+  using NativeType = int128_t;
+};
+
+#endif /* RANGETRAITS_H */
+
+} // namespace gluten

--- a/cpp/velox/substrait/VariantToVectorConverter.cc
+++ b/cpp/velox/substrait/VariantToVectorConverter.cc
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VariantToVectorConverter.h"
+#include "velox/vector/FlatVector.h"
+
+namespace gluten {
+
+namespace {
+template <TypeKind KIND>
+VectorPtr
+setVectorFromVariantsByKind(const std::vector<variant>& values, const TypePtr& type, memory::MemoryPool* pool) {
+  using T = typename TypeTraits<KIND>::NativeType;
+
+  auto flatVector = BaseVector::create<FlatVector<T>>(type, values.size(), pool);
+
+  for (vector_size_t i = 0; i < values.size(); i++) {
+    if (values[i].isNull()) {
+      flatVector->setNull(i, true);
+    } else {
+      flatVector->set(i, values[i].value<T>());
+    }
+  }
+  return flatVector;
+}
+
+template <>
+VectorPtr setVectorFromVariantsByKind<TypeKind::VARBINARY>(
+    const std::vector<variant>& /* values */,
+    const TypePtr& /*type*/,
+    memory::MemoryPool* /* pool */) {
+  VELOX_UNSUPPORTED("Return of VARBINARY data is not supported");
+}
+
+template <>
+VectorPtr setVectorFromVariantsByKind<TypeKind::VARCHAR>(
+    const std::vector<variant>& values,
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
+  auto flatVector = BaseVector::create<FlatVector<StringView>>(type, values.size(), pool);
+
+  for (vector_size_t i = 0; i < values.size(); i++) {
+    if (values[i].isNull()) {
+      flatVector->setNull(i, true);
+    } else {
+      flatVector->set(i, StringView(values[i].value<Varchar>()));
+    }
+  }
+  return flatVector;
+}
+} // namespace
+
+VectorPtr setVectorFromVariants(const TypePtr& type, const std::vector<variant>& values, memory::MemoryPool* pool) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(setVectorFromVariantsByKind, type->kind(), values, type, pool);
+}
+} // namespace gluten

--- a/cpp/velox/substrait/VariantToVectorConverter.h
+++ b/cpp/velox/substrait/VariantToVectorConverter.h
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+/// Create Base Vector from velox variants.
+/// Only scalar types are supported except VARBINARY.
+VectorPtr setVectorFromVariants(const TypePtr& type, const std::vector<variant>& values, memory::MemoryPool* pool);
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxSubstraitSignature.cc
+++ b/cpp/velox/substrait/VeloxSubstraitSignature.cc
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VeloxSubstraitSignature.h"
+#include "velox/functions/FunctionRegistry.h"
+
+namespace gluten {
+
+std::string VeloxSubstraitSignature::toSubstraitSignature(const TypeKind typeKind) {
+  switch (typeKind) {
+    case TypeKind::BOOLEAN:
+      return "bool";
+    case TypeKind::TINYINT:
+      return "i8";
+    case TypeKind::SMALLINT:
+      return "i16";
+    case TypeKind::INTEGER:
+      return "i32";
+    case TypeKind::BIGINT:
+      return "i64";
+    case TypeKind::REAL:
+      return "fp32";
+    case TypeKind::DOUBLE:
+      return "fp64";
+    case TypeKind::VARCHAR:
+      return "str";
+    case TypeKind::VARBINARY:
+      return "vbin";
+    case TypeKind::TIMESTAMP:
+      return "ts";
+    case TypeKind::DATE:
+      return "date";
+    case TypeKind::ARRAY:
+      return "list";
+    case TypeKind::MAP:
+      return "map";
+    case TypeKind::ROW:
+      return "struct";
+    case TypeKind::UNKNOWN:
+      return "u!name";
+    default:
+      VELOX_UNSUPPORTED("Substrait type signature conversion not supported for type {}.", mapTypeKindToName(typeKind));
+  }
+}
+
+std::string VeloxSubstraitSignature::toSubstraitSignature(
+    const std::string& functionName,
+    const std::vector<TypePtr>& arguments) {
+  if (arguments.empty()) {
+    return functionName;
+  }
+  std::vector<std::string> substraitTypeSignatures;
+  substraitTypeSignatures.reserve(arguments.size());
+  for (const auto& type : arguments) {
+    substraitTypeSignatures.emplace_back(toSubstraitSignature(type->kind()));
+  }
+  return functionName + ":" + folly::join("_", substraitTypeSignatures);
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxSubstraitSignature.h
+++ b/cpp/velox/substrait/VeloxSubstraitSignature.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace gluten {
+
+using namespace facebook::velox;
+
+class VeloxSubstraitSignature {
+ public:
+  /// Given a velox type kind, return the Substrait type signature, throw if no
+  /// match found, Substrait signature used in the function extension
+  /// declaration is a combination of the name of the function along with a list
+  /// of input argument types.The format is as follows : <function
+  /// name>:<short_arg_type0>_<short_arg_type1>_..._<short_arg_typeN> for more
+  /// detail information about the argument type please refer to link
+  /// https://substrait.io/extensions/#function-signature-compound-names.
+  static std::string toSubstraitSignature(const TypeKind typeKind);
+
+  /// Given a velox scalar function name and argument types, return the
+  /// substrait function signature.
+  static std::string toSubstraitSignature(const std::string& functionName, const std::vector<TypePtr>& arguments);
+};
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.cc
@@ -1,0 +1,589 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VeloxToSubstraitExpr.h"
+#include "velox/vector/FlatVector.h"
+
+namespace gluten {
+
+namespace {
+const ::substrait::Expression_Literal& toSubstraitNullLiteral(
+    google::protobuf::Arena& arena,
+    const velox::TypeKind& typeKind) {
+  ::substrait::Expression_Literal* substraitField =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  switch (typeKind) {
+    case velox::TypeKind::BOOLEAN: {
+      ::substrait::Type_Boolean* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_Boolean>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_bool_(nullValue);
+      break;
+    }
+    case velox::TypeKind::TINYINT: {
+      ::substrait::Type_I8* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_I8>(&arena);
+
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_i8(nullValue);
+      break;
+    }
+    case velox::TypeKind::SMALLINT: {
+      ::substrait::Type_I16* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_I16>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_i16(nullValue);
+      break;
+    }
+    case velox::TypeKind::INTEGER: {
+      ::substrait::Type_I32* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_I32>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_i32(nullValue);
+      break;
+    }
+    case velox::TypeKind::BIGINT: {
+      ::substrait::Type_I64* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_I64>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_i64(nullValue);
+      break;
+    }
+    case velox::TypeKind::VARCHAR: {
+      ::substrait::Type_String* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_String>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_string(nullValue);
+      break;
+    }
+    case velox::TypeKind::REAL: {
+      ::substrait::Type_FP32* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_FP32>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_fp32(nullValue);
+      break;
+    }
+    case velox::TypeKind::DOUBLE: {
+      ::substrait::Type_FP64* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_FP64>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_fp64(nullValue);
+      break;
+    }
+    case velox::TypeKind::ARRAY: {
+      ::substrait::Type_List* nullValue = google::protobuf::Arena::CreateMessage<::substrait::Type_List>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitField->mutable_null()->set_allocated_list(nullValue);
+      break;
+    }
+    case velox::TypeKind::UNKNOWN: {
+      ::substrait::Type_UserDefined* nullValue =
+          google::protobuf::Arena::CreateMessage<::substrait::Type_UserDefined>(&arena);
+      nullValue->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      nullValue->set_type_reference(0);
+      substraitField->mutable_null()->set_allocated_user_defined(nullValue);
+
+      break;
+    }
+    default: {
+      VELOX_UNSUPPORTED("Unsupported type '{}'", mapTypeKindToName(typeKind));
+    }
+  }
+  substraitField->set_nullable(true);
+  return *substraitField;
+}
+
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral(
+    google::protobuf::Arena& arena,
+    const velox::variant& variantValue) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  switch (variantValue.kind()) {
+    case velox::TypeKind::BOOLEAN: {
+      literalExpr->set_boolean(variantValue.value<TypeKind::BOOLEAN>());
+      break;
+    }
+    case velox::TypeKind::TINYINT: {
+      literalExpr->set_i8(variantValue.value<TypeKind::TINYINT>());
+      break;
+    }
+    case velox::TypeKind::SMALLINT: {
+      literalExpr->set_i16(variantValue.value<TypeKind::SMALLINT>());
+      break;
+    }
+    case velox::TypeKind::INTEGER: {
+      literalExpr->set_i32(variantValue.value<TypeKind::INTEGER>());
+      break;
+    }
+    case velox::TypeKind::BIGINT: {
+      literalExpr->set_i64(variantValue.value<TypeKind::BIGINT>());
+      break;
+    }
+    case velox::TypeKind::REAL: {
+      literalExpr->set_fp32(variantValue.value<TypeKind::REAL>());
+      break;
+    }
+    case velox::TypeKind::DOUBLE: {
+      literalExpr->set_fp64(variantValue.value<TypeKind::DOUBLE>());
+      break;
+    }
+    case velox::TypeKind::TIMESTAMP: {
+      auto vTimeStamp = variantValue.value<TypeKind::TIMESTAMP>();
+      auto micros = vTimeStamp.getSeconds() * 1000000 + vTimeStamp.getNanos() / 1000;
+      literalExpr->set_timestamp(micros);
+      break;
+    }
+    case velox::TypeKind::DATE: {
+      literalExpr->set_date(variantValue.value<TypeKind::DATE>().days());
+      break;
+    }
+    case velox::TypeKind::VARCHAR: {
+      auto vCharValue = variantValue.value<StringView>();
+      ::substrait::Expression_Literal::VarChar* sVarChar = new ::substrait::Expression_Literal::VarChar();
+      sVarChar->set_value(vCharValue.data());
+      sVarChar->set_length(vCharValue.size());
+      literalExpr->set_allocated_var_char(sVarChar);
+      break;
+    }
+    default:
+      VELOX_NYI("Unsupported constant Type '{}' ", mapTypeKindToName(variantValue.kind()));
+  }
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <TypeKind kind>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral(
+    google::protobuf::Arena& arena,
+    const typename TypeTraits<kind>::NativeType& /* value */) {
+  VELOX_UNSUPPORTED("toSubstraitNotNullLiteral function doesn't support {} type", TypeTraits<kind>::name);
+
+  // Make compiler happy.
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::BOOLEAN>(
+    google::protobuf::Arena& arena,
+    const bool& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_boolean(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::TINYINT>(
+    google::protobuf::Arena& arena,
+    const int8_t& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_i8(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::SMALLINT>(
+    google::protobuf::Arena& arena,
+    const int16_t& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_i16(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::INTEGER>(
+    google::protobuf::Arena& arena,
+    const int32_t& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_i32(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::BIGINT>(
+    google::protobuf::Arena& arena,
+    const int64_t& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_i64(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::REAL>(
+    google::protobuf::Arena& arena,
+    const float& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_fp32(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::DOUBLE>(
+    google::protobuf::Arena& arena,
+    const double& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_fp64(value);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::DATE>(
+    google::protobuf::Arena& arena,
+    const Date& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  literalExpr->set_date(value.days());
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::TIMESTAMP>(
+    google::protobuf::Arena& arena,
+    const Timestamp& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  auto micros = value.getSeconds() * 1000000 + value.getNanos() / 1000;
+  literalExpr->set_timestamp(micros);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <>
+const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::VARCHAR>(
+    google::protobuf::Arena& arena,
+    const velox::StringView& value) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  ::substrait::Expression_Literal::VarChar* sVarChar = new ::substrait::Expression_Literal::VarChar();
+  sVarChar->set_value(value.data());
+  sVarChar->set_length(value.size());
+  literalExpr->set_allocated_var_char(sVarChar);
+  literalExpr->set_nullable(false);
+  return *literalExpr;
+}
+
+template <TypeKind Kind>
+void arrayVectorToLiteral(
+    google::protobuf::Arena& arena,
+    const ArrayVector* arrayVector,
+    ::substrait::Expression_Literal_List* listLiteral,
+    vector_size_t offset,
+    vector_size_t size) {
+  using T = typename TypeTraits<Kind>::NativeType;
+  auto elements = arrayVector->elements()->as<SimpleVector<T>>();
+  for (auto i = offset; i < offset + size; ++i) {
+    ::substrait::Expression_Literal* childLiteral = listLiteral->add_values();
+    if (elements->isNullAt(i)) {
+      childLiteral->MergeFrom(toSubstraitNullLiteral(arena, Kind));
+    } else {
+      childLiteral->MergeFrom(toSubstraitNotNullLiteral<Kind>(arena, elements->valueAt(i)));
+    }
+  }
+}
+
+template <TypeKind kind>
+void convertVectorValue(
+    google::protobuf::Arena& arena,
+    const velox::VectorPtr& vectorValue,
+    ::substrait::Expression_Literal_Struct* litValue,
+    ::substrait::Expression_Literal* substraitField) {
+  const TypePtr& childType = vectorValue->type();
+
+  using T = typename TypeTraits<kind>::NativeType;
+
+  auto childToFlatVec = vectorValue->as<SimpleVector<T>>();
+
+  //  Get the batchSize and convert each value in it.
+  vector_size_t flatVecSize = childToFlatVec->size();
+  for (int64_t i = 0; i < flatVecSize; i++) {
+    substraitField = litValue->add_fields();
+    if (childToFlatVec->isNullAt(i)) {
+      // Process the null value.
+      substraitField->MergeFrom(toSubstraitNullLiteral(arena, childType->kind()));
+    } else {
+      substraitField->MergeFrom(toSubstraitNotNullLiteral<kind>(arena, childToFlatVec->valueAt(i)));
+    }
+  }
+}
+
+uint32_t getFieldIdForIntermediateNode(
+    const std::string& exprName,
+    const ::substrait::Expression_ReferenceSegment_StructField& structField,
+    const RowTypePtr& inputType) {
+  auto inputColumnType = inputType;
+  std::vector<int32_t> ids;
+  const auto* tmp = &structField;
+  for (;;) {
+    ids.push_back(tmp->field());
+    if (!tmp->has_child()) {
+      break;
+    }
+    tmp = &tmp->child().struct_field();
+  }
+  for (int32_t i = ids.size() - 1; i >= 0; --i) {
+    inputColumnType = asRowType(inputColumnType->childAt(ids[i]));
+  }
+  return inputColumnType->getChildIdx(exprName);
+}
+} // namespace
+
+const ::substrait::Expression& VeloxToSubstraitExprConvertor::toSubstraitExpr(
+    google::protobuf::Arena& arena,
+    const core::TypedExprPtr& expr,
+    const RowTypePtr& inputType) {
+  ::substrait::Expression* substraitExpr = google::protobuf::Arena::CreateMessage<::substrait::Expression>(&arena);
+  if (auto constExpr = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(expr)) {
+    substraitExpr->mutable_literal()->MergeFrom(toSubstraitExpr(arena, constExpr));
+    return *substraitExpr;
+  }
+  if (auto callTypeExpr = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
+    substraitExpr->MergeFrom(toSubstraitExpr(arena, callTypeExpr, inputType));
+    return *substraitExpr;
+  }
+  if (auto fieldExpr = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expr)) {
+    substraitExpr->mutable_selection()->MergeFrom(toSubstraitExpr(arena, fieldExpr, inputType));
+
+    return *substraitExpr;
+  }
+  if (auto castExpr = std::dynamic_pointer_cast<const core::CastTypedExpr>(expr)) {
+    substraitExpr->mutable_cast()->MergeFrom(toSubstraitExpr(arena, castExpr, inputType));
+
+    return *substraitExpr;
+  }
+
+  VELOX_UNSUPPORTED("Unsupport Expr '{}' in Substrait", expr->toString());
+}
+
+const ::substrait::Expression_Cast& VeloxToSubstraitExprConvertor::toSubstraitExpr(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::CastTypedExpr>& castExpr,
+    const RowTypePtr& inputType) {
+  ::substrait::Expression_Cast* substraitCastExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Cast>(&arena);
+  std::vector<core::TypedExprPtr> castExprInputs = castExpr->inputs();
+
+  substraitCastExpr->mutable_type()->MergeFrom(typeConvertor_->toSubstraitType(arena, castExpr->type()));
+
+  for (auto& arg : castExprInputs) {
+    substraitCastExpr->mutable_input()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
+  }
+  if (castExpr->nullOnFailure()) {
+    substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL);
+  } else {
+    substraitCastExpr->set_failure_behavior(
+        ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION);
+  }
+  return *substraitCastExpr;
+}
+
+const ::substrait::Expression_FieldReference& VeloxToSubstraitExprConvertor::toSubstraitExpr(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::FieldAccessTypedExpr>& fieldExpr,
+    const RowTypePtr& inputType) {
+  ::substrait::Expression_FieldReference* substraitFieldExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_FieldReference>(&arena);
+
+  std::string exprName = fieldExpr->name();
+
+  ::substrait::Expression_ReferenceSegment_StructField* directStruct =
+      substraitFieldExpr->mutable_direct_reference()->mutable_struct_field();
+
+  // FieldAccessTypedExpr represents one of two things: a leaf in an expression
+  // or a dereference expression(fieldExpr->isInputColumn() == false)
+  // for a leaf in an expression, find idx from child by exprName.
+  // for a dereference expression, find idx from every child by exprName.
+  if (fieldExpr->isInputColumn()) {
+    uint32_t idx = inputType->getChildIdx(exprName);
+    directStruct->set_field(idx);
+  } else {
+    auto tmp = toSubstraitExpr(arena, fieldExpr->inputs()[0], inputType).selection().direct_reference();
+    if (!tmp.has_struct_field()) {
+      uint32_t idx = inputType->getChildIdx(exprName);
+      directStruct->set_field(idx);
+    } else {
+      ::substrait::Expression_ReferenceSegment_StructField* childStruct =
+          google::protobuf::Arena::CreateMessage<::substrait::Expression_ReferenceSegment_StructField>(&arena);
+      ::substrait::Expression_ReferenceSegment* refSegment =
+          google::protobuf::Arena::CreateMessage<::substrait::Expression_ReferenceSegment>(&arena);
+      directStruct->MergeFrom(tmp.struct_field());
+      childStruct->set_field(getFieldIdForIntermediateNode(exprName, tmp.struct_field(), inputType));
+      refSegment->set_allocated_struct_field(childStruct);
+      ::substrait::Expression_ReferenceSegment_StructField* innerChild = directStruct;
+      while (innerChild->has_child()) {
+        innerChild = innerChild->mutable_child()->mutable_struct_field();
+      }
+      innerChild->set_allocated_child(refSegment);
+    }
+  }
+
+  return *substraitFieldExpr;
+}
+
+const ::substrait::Expression& VeloxToSubstraitExprConvertor::toSubstraitExpr(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::CallTypedExpr>& callTypeExpr,
+    const RowTypePtr& inputType) {
+  ::substrait::Expression* substraitExpr = google::protobuf::Arena::CreateMessage<::substrait::Expression>(&arena);
+
+  auto inputs = callTypeExpr->inputs();
+  auto& functionName = callTypeExpr->name();
+
+  if (functionName != "if" && functionName != "switch") {
+    ::substrait::Expression_ScalarFunction* scalarExpr = substraitExpr->mutable_scalar_function();
+
+    std::vector<TypePtr> types;
+    types.reserve(callTypeExpr->inputs().size());
+    for (auto& typedExpr : callTypeExpr->inputs()) {
+      types.emplace_back(typedExpr->type());
+    }
+
+    scalarExpr->set_function_reference(extensionCollector_->getReferenceNumber(functionName, types));
+
+    for (auto& arg : inputs) {
+      scalarExpr->add_arguments()->mutable_value()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
+    }
+
+    scalarExpr->mutable_output_type()->MergeFrom(typeConvertor_->toSubstraitType(arena, callTypeExpr->type()));
+
+  } else {
+    // For today's version of Substrait, you'd have to use IfThen if you need
+    // the switch cases to be call typed expression.
+
+    size_t inputsSize = callTypeExpr->inputs().size();
+    bool hasElseInput = inputsSize % 2 == 1;
+
+    auto ifThenExpr = substraitExpr->mutable_if_then();
+    for (int i = 0; i < inputsSize / 2; i++) {
+      auto ifClauseExpr = ifThenExpr->add_ifs();
+      ifClauseExpr->mutable_if_()->MergeFrom(toSubstraitExpr(arena, callTypeExpr->inputs().at(i * 2), inputType));
+      ifClauseExpr->mutable_then()->MergeFrom(toSubstraitExpr(arena, callTypeExpr->inputs().at(i * 2 + 1), inputType));
+    }
+    if (hasElseInput) {
+      ifThenExpr->mutable_else_()->MergeFrom(
+          toSubstraitExpr(arena, callTypeExpr->inputs().at(inputsSize - 1), inputType));
+    }
+  }
+
+  return *substraitExpr;
+}
+
+const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstraitExpr(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::ConstantTypedExpr>& constExpr,
+    ::substrait::Expression_Literal_Struct* litValue) {
+  if (constExpr->hasValueVector()) {
+    return toSubstraitLiteral(arena, constExpr->valueVector(), litValue);
+  } else {
+    return toSubstraitLiteral(arena, constExpr->value());
+  }
+}
+
+const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstraitLiteral(
+    google::protobuf::Arena& arena,
+    const velox::variant& variantValue) {
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+
+  if (variantValue.isNull()) {
+    literalExpr->MergeFrom(toSubstraitNullLiteral(arena, variantValue.kind()));
+  } else {
+    literalExpr->MergeFrom(toSubstraitNotNullLiteral(arena, variantValue));
+  }
+  return *literalExpr;
+}
+
+const ::substrait::Expression_Literal_List& VeloxToSubstraitExprConvertor::toSubstraitLiteralList(
+    google::protobuf::Arena& arena,
+    const ArrayVector* arrayVector,
+    vector_size_t row) {
+  ::substrait::Expression_Literal_List* listLiteral =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal_List>(&arena);
+  auto size = arrayVector->sizeAt(row);
+  if (size == 0) {
+    return *listLiteral;
+  }
+  auto offset = arrayVector->offsetAt(row);
+  if (arrayVector->elements()->isScalar()) {
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        arrayVectorToLiteral, arrayVector->elements()->type()->kind(), arena, arrayVector, listLiteral, offset, size);
+    return *listLiteral;
+  }
+
+  if (arrayVector->elements()->typeKind() == TypeKind::ARRAY) {
+    auto encoding = arrayVector->elements()->encoding();
+    if (encoding == VectorEncoding::Simple::ARRAY) {
+      auto nestedArrayVector = arrayVector->elements()->as<ArrayVector>();
+      VELOX_CHECK_NOT_NULL(nestedArrayVector);
+      for (auto i = offset; i < offset + size; ++i) {
+        ::substrait::Expression_Literal* literal = listLiteral->add_values();
+        literal->set_allocated_list(
+            const_cast<::substrait::Expression_Literal_List*>(&toSubstraitLiteralList(arena, nestedArrayVector, i)));
+      }
+      return *listLiteral;
+    }
+  }
+  VELOX_NYI("Complex type literals are not supported: {}", arrayVector->elements()->type()->toString());
+}
+
+const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstraitLiteralComplex(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<ConstantVector<ComplexType>>& constantVector) {
+  ::substrait::Expression_Literal* substraitField =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  if (constantVector->typeKind() == TypeKind::ARRAY) {
+    if (constantVector->isNullAt(0)) {
+      // Process the null value.
+      substraitField->MergeFrom(toSubstraitNullLiteral(arena, constantVector->typeKind()));
+      return *substraitField;
+    }
+    auto encoding = constantVector->valueVector()->encoding();
+    if (encoding == VectorEncoding::Simple::ARRAY) {
+      auto arrayVector = constantVector->valueVector()->as<ArrayVector>();
+      substraitField->mutable_list()->MergeFrom(toSubstraitLiteralList(arena, arrayVector, constantVector->index()));
+      return *substraitField;
+    }
+  }
+  VELOX_NYI("Complex type literals are not supported: {}", constantVector->type()->toString());
+}
+
+const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstraitLiteral(
+    google::protobuf::Arena& arena,
+    const velox::VectorPtr& vectorValue,
+    ::substrait::Expression_Literal_Struct* litValue) {
+  ::substrait::Expression_Literal* substraitField =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+  if (vectorValue->isScalar()) {
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        convertVectorValue, vectorValue->type()->kind(), arena, vectorValue, litValue, substraitField);
+    return *substraitField;
+  }
+
+  if (auto constantVector = std::dynamic_pointer_cast<ConstantVector<ComplexType>>(vectorValue)) {
+    return toSubstraitLiteralComplex(arena, constantVector);
+  }
+  return *substraitField;
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.h
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.h
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+#include "SubstraitExtensionCollector.h"
+#include "VeloxToSubstraitType.h"
+#include "substrait/algebra.pb.h"
+#include "velox/vector/ConstantVector.h"
+
+namespace gluten {
+
+class VeloxToSubstraitExprConvertor {
+ public:
+  explicit VeloxToSubstraitExprConvertor(const SubstraitExtensionCollectorPtr& extensionCollector)
+      : extensionCollector_(extensionCollector) {}
+
+  /// Convert Velox Expression to Substrait Expression.
+  /// @param arena Arena to use for allocating Substrait plan objects.
+  /// @param expr Velox expression needed to be converted.
+  /// @param inputType The input row Type of the current processed node,
+  /// which also equals the output row type of the previous node of the current.
+  /// @return A pointer to Substrait expression object allocated on the arena
+  /// and representing the input Velox expression.
+  const ::substrait::Expression&
+  toSubstraitExpr(google::protobuf::Arena& arena, const core::TypedExprPtr& expr, const RowTypePtr& inputType);
+
+  /// Convert Velox Constant Expression to Substrait
+  /// Literal Expression.
+  /// @param arena Arena to use for allocating Substrait plan objects.
+  /// @param constExpr Velox Constant expression needed to be converted.
+  /// @param litValue The Struct that returned literal expression belong to.
+  /// @return A pointer to Substrait Literal expression object allocated on
+  /// the arena and representing the input Velox Constant expression.
+  const ::substrait::Expression_Literal& toSubstraitExpr(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::ConstantTypedExpr>& constExpr,
+      ::substrait::Expression_Literal_Struct* litValue = nullptr);
+
+  /// Convert Velox FieldAccessTypedExpr to Substrait FieldReference Expression.
+  const ::substrait::Expression_FieldReference& toSubstraitExpr(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::FieldAccessTypedExpr>& fieldExpr,
+      const RowTypePtr& inputType);
+
+  /// Convert Velox vector to Substrait literal.
+  const ::substrait::Expression_Literal& toSubstraitLiteral(
+      google::protobuf::Arena& arena,
+      const velox::VectorPtr& vectorValue,
+      ::substrait::Expression_Literal_Struct* litValue);
+
+ private:
+  /// Convert Velox Cast Expression to Substrait Cast Expression.
+  const ::substrait::Expression_Cast& toSubstraitExpr(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::CastTypedExpr>& castExpr,
+      const RowTypePtr& inputType);
+
+  /// Convert Velox CallTypedExpr Expression to Substrait Expression.
+  const ::substrait::Expression& toSubstraitExpr(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::CallTypedExpr>& callTypeExpr,
+      const RowTypePtr& inputType);
+
+  /// Convert Velox variant to Substrait Literal Expression.
+  const ::substrait::Expression_Literal& toSubstraitLiteral(
+      google::protobuf::Arena& arena,
+      const velox::variant& variantValue);
+
+  /// Convert values in Velox array vector to Substrait Literal List.
+  const ::substrait::Expression_Literal_List&
+  toSubstraitLiteralList(google::protobuf::Arena& arena, const ArrayVector* arrayVector, vector_size_t row);
+
+  /// Convert values in Velox complex vector to Substrait Literal.
+  const ::substrait::Expression_Literal& toSubstraitLiteralComplex(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<ConstantVector<ComplexType>>& constantVector);
+
+  VeloxToSubstraitTypeConvertorPtr typeConvertor_;
+
+  SubstraitExtensionCollectorPtr extensionCollector_;
+};
+
+using VeloxToSubstraitExprConvertorPtr = std::shared_ptr<VeloxToSubstraitExprConvertor>;
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitPlan.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.cc
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VeloxToSubstraitPlan.h"
+
+namespace gluten {
+
+namespace {
+::substrait::AggregationPhase toAggregationPhase(core::AggregationNode::Step step) {
+  switch (step) {
+    case core::AggregationNode::Step::kPartial: {
+      return ::substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE;
+    }
+    case core::AggregationNode::Step::kIntermediate: {
+      return ::substrait::AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE;
+    }
+    case core::AggregationNode::Step::kSingle: {
+      return ::substrait::AGGREGATION_PHASE_INITIAL_TO_RESULT;
+    }
+    case core::AggregationNode::Step::kFinal: {
+      return ::substrait::AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT;
+    }
+    default:
+      VELOX_UNSUPPORTED("Unsupported Aggregate Step '{}' in Substrait ", mapAggregationStepToName(step));
+  }
+}
+
+::substrait::SortField_SortDirection toSortDirection(core::SortOrder sortOrder) {
+  if (sortOrder.isNullsFirst()) {
+    if (sortOrder.isAscending()) {
+      return ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST;
+    } else {
+      return ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST;
+    }
+  } else {
+    if (sortOrder.isAscending()) {
+      return ::substrait::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST;
+    } else {
+      return ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST;
+    }
+  }
+}
+
+} // namespace
+
+::substrait::Plan& VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const core::PlanNodePtr& plan) {
+  // Construct the extension colllector.
+  extensionCollector_ = std::make_shared<SubstraitExtensionCollector>();
+  // Construct the expression converter.
+  exprConvertor_ = std::make_shared<VeloxToSubstraitExprConvertor>(extensionCollector_);
+
+  auto substraitPlan = google::protobuf::Arena::CreateMessage<::substrait::Plan>(&arena);
+
+  // Add unknown type in extension.
+  auto unknownType = substraitPlan->add_extensions()->mutable_extension_type();
+
+  unknownType->set_extension_uri_reference(0);
+  unknownType->set_type_anchor(0);
+  unknownType->set_name("UNKNOWN");
+
+  // Do conversion.
+  ::substrait::RelRoot* rootRel = substraitPlan->add_relations()->mutable_root();
+
+  toSubstrait(arena, plan, rootRel->mutable_input());
+
+  // Add extensions for all functions and types seen in the plan.
+  extensionCollector_->addExtensionsToPlan(substraitPlan);
+
+  // Set RootRel names.
+  for (const auto& name : plan->outputType()->names()) {
+    rootRel->add_names(name);
+  }
+
+  return *substraitPlan;
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const core::PlanNodePtr& planNode,
+    ::substrait::Rel* rel) {
+  if (auto filterNode = std::dynamic_pointer_cast<const core::FilterNode>(planNode)) {
+    auto filterRel = rel->mutable_filter();
+    toSubstrait(arena, filterNode, filterRel);
+    return;
+  }
+  if (auto valuesNode = std::dynamic_pointer_cast<const core::ValuesNode>(planNode)) {
+    ::substrait::ReadRel* readRel = rel->mutable_read();
+    toSubstrait(arena, valuesNode, readRel);
+    return;
+  }
+  if (auto projectNode = std::dynamic_pointer_cast<const core::ProjectNode>(planNode)) {
+    ::substrait::ProjectRel* projectRel = rel->mutable_project();
+    toSubstrait(arena, projectNode, projectRel);
+    return;
+  }
+  if (auto aggregationNode = std::dynamic_pointer_cast<const core::AggregationNode>(planNode)) {
+    ::substrait::AggregateRel* aggregateRel = rel->mutable_aggregate();
+    toSubstrait(arena, aggregationNode, aggregateRel);
+    return;
+  }
+  if (auto orderbyNode = std::dynamic_pointer_cast<const core::OrderByNode>(planNode)) {
+    toSubstrait(arena, orderbyNode, rel->mutable_sort());
+    return;
+  }
+  if (auto topNNode = std::dynamic_pointer_cast<const core::TopNNode>(planNode)) {
+    toSubstrait(arena, topNNode, rel->mutable_fetch());
+    return;
+  }
+  if (auto limitNode = std::dynamic_pointer_cast<const core::LimitNode>(planNode)) {
+    toSubstrait(arena, limitNode, rel->mutable_fetch());
+    return;
+  }
+  VELOX_UNSUPPORTED("Unsupported plan node '{}' .", planNode->name());
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::FilterNode>& filterNode,
+    ::substrait::FilterRel* filterRel) {
+  const auto& source = getSingleSource(filterNode);
+
+  toSubstrait(arena, source, filterRel->mutable_input());
+
+  // Construct substrait expr(Filter condition).
+  auto filterCondition = filterNode->filter();
+  auto inputType = source->outputType();
+  filterRel->mutable_condition()->MergeFrom(exprConvertor_->toSubstraitExpr(arena, filterCondition, inputType));
+
+  filterRel->mutable_common()->mutable_direct();
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::ValuesNode>& valuesNode,
+    ::substrait::ReadRel* readRel) {
+  const auto& outputType = valuesNode->outputType();
+
+  ::substrait::ReadRel_VirtualTable* virtualTable = readRel->mutable_virtual_table();
+
+  for (const auto& vector : valuesNode->values()) {
+    ::substrait::Expression_Literal_Struct* litValue = virtualTable->add_values();
+
+    for (const auto& column : vector->children()) {
+      ::substrait::Expression_Literal* substraitField =
+          google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
+
+      substraitField->MergeFrom(exprConvertor_->toSubstraitLiteral(arena, column, litValue));
+    }
+  }
+
+  readRel->mutable_base_schema()->MergeFrom(typeConvertor_->toSubstraitNamedStruct(arena, outputType));
+
+  readRel->mutable_common()->mutable_direct();
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::ProjectNode>& projectNode,
+    ::substrait::ProjectRel* projectRel) {
+  const auto& projections = projectNode->projections();
+
+  const auto& source = getSingleSource(projectNode);
+
+  // Process the source Node.
+  toSubstrait(arena, source, projectRel->mutable_input());
+
+  // Remap the output.
+  ::substrait::RelCommon_Emit* projRelEmit = projectRel->mutable_common()->mutable_emit();
+
+  int64_t projectionSize = projections.size();
+
+  auto inputType = source->outputType();
+  int64_t inputTypeSize = inputType->size();
+
+  for (int64_t i = 0; i < projectionSize; i++) {
+    const auto& veloxExpr = projections.at(i);
+
+    projectRel->add_expressions()->MergeFrom(exprConvertor_->toSubstraitExpr(arena, veloxExpr, inputType));
+
+    // Add outputMapping for each expression.
+    projRelEmit->add_output_mapping(inputTypeSize + i);
+  }
+
+  return;
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::AggregationNode>& aggregateNode,
+    ::substrait::AggregateRel* aggregateRel) {
+  // Process the source Node.
+  const auto& source = getSingleSource(aggregateNode);
+  toSubstrait(arena, source, aggregateRel->mutable_input());
+
+  // Convert aggregate grouping keys, such as: group by key1, key2.
+  auto inputType = source->outputType();
+  auto groupingKeys = aggregateNode->groupingKeys();
+  int64_t groupingKeySize = groupingKeys.size();
+  ::substrait::AggregateRel_Grouping* aggGroupings = aggregateRel->add_groupings();
+
+  for (int64_t i = 0; i < groupingKeySize; i++) {
+    aggGroupings->add_grouping_expressions()->mutable_selection()->MergeFrom(
+        exprConvertor_->toSubstraitExpr(arena, groupingKeys.at(i), inputType));
+  }
+
+  // AggregatesSize should be equal to or greater than the aggregateMasks Size.
+  // Two cases: 1. aggregateMasksSize = 0, aggregatesSize > aggregateMasksSize.
+  // 2. aggregateMasksSize != 0, aggregatesSize = aggregateMasksSize.
+  auto aggregates = aggregateNode->aggregates();
+  int64_t aggregatesSize = aggregates.size();
+
+  for (int64_t i = 0; i < aggregatesSize; i++) {
+    const auto& aggregate = aggregates.at(i);
+
+    ::substrait::AggregateRel_Measure* aggMeasures = aggregateRel->add_measures();
+
+    // Set substrait filter.
+    ::substrait::Expression* aggFilter = aggMeasures->mutable_filter();
+    if (const auto& mask = aggregate.mask) {
+      aggFilter->mutable_selection()->MergeFrom(exprConvertor_->toSubstraitExpr(arena, mask, inputType));
+    } else {
+      // Set null.
+      aggFilter = nullptr;
+    }
+
+    // Process measure, eg:sum(a).
+    ::substrait::AggregateFunction* aggFunction = aggMeasures->mutable_measure();
+
+    // Aggregation function name.
+    const auto& funName = aggregate.call->name();
+    // set aggFunction args.
+
+    std::vector<TypePtr> arguments;
+    arguments.reserve(aggregate.call->inputs().size());
+    for (const auto& expr : aggregate.call->inputs()) {
+      // If the expr is CallTypedExpr, people need to do project firstly.
+      if (auto aggregatesExprInput = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
+        VELOX_NYI("In Velox Plan, the aggregates type cannot be CallTypedExpr");
+      } else {
+        aggFunction->add_arguments()->mutable_value()->MergeFrom(
+            exprConvertor_->toSubstraitExpr(arena, expr, inputType));
+
+        arguments.emplace_back(expr->type());
+      }
+    }
+
+    auto referenceNumber = extensionCollector_->getReferenceNumber(funName, arguments, aggregateNode->step());
+
+    aggFunction->set_function_reference(referenceNumber);
+
+    aggFunction->mutable_output_type()->MergeFrom(typeConvertor_->toSubstraitType(arena, aggregate.call->type()));
+
+    // Set substrait aggregate Function phase.
+    aggFunction->set_phase(toAggregationPhase(aggregateNode->step()));
+  }
+
+  // Direct output.
+  aggregateRel->mutable_common()->mutable_direct();
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::OrderByNode>& orderByNode,
+    ::substrait::SortRel* sortRel) {
+  const auto& source = getSingleSource(orderByNode);
+  toSubstrait(arena, source, sortRel->mutable_input());
+
+  sortRel->MergeFrom(
+      processSortFields(arena, orderByNode->sortingKeys(), orderByNode->sortingOrders(), source->outputType()));
+
+  VELOX_CHECK(!orderByNode->isPartial(), "Substrait doesn't support partial order by yet")
+  sortRel->mutable_common()->mutable_direct();
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::TopNNode>& topNNode,
+    ::substrait::FetchRel* fetchRel) {
+  const auto& source = getSingleSource(topNNode);
+
+  // Construct the sortRel as the FetchRel input.
+  ::substrait::SortRel* sortRel = fetchRel->mutable_input()->mutable_sort();
+  toSubstrait(arena, source, sortRel->mutable_input());
+
+  sortRel->MergeFrom(
+      processSortFields(arena, topNNode->sortingKeys(), topNNode->sortingOrders(), source->outputType()));
+
+  sortRel->mutable_common()->mutable_direct();
+
+  VELOX_CHECK(!topNNode->isPartial(), "Substrait doesn't support partial topN yet")
+
+  fetchRel->set_offset(0);
+  fetchRel->set_count(topNNode->count());
+  fetchRel->mutable_common()->mutable_direct();
+}
+
+const ::substrait::SortRel& VeloxToSubstraitPlanConvertor::processSortFields(
+    google::protobuf::Arena& arena,
+    const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
+    const std::vector<core::SortOrder>& sortingOrders,
+    const facebook::velox::RowTypePtr& inputType) {
+  ::substrait::SortRel* sortRel = google::protobuf::Arena::CreateMessage<::substrait::SortRel>(&arena);
+
+  VELOX_CHECK_EQ(
+      sortingKeys.size(), sortingOrders.size(), "Number of sorting keys and sorting orders must be the same");
+
+  for (int64_t i = 0; i < sortingKeys.size(); i++) {
+    ::substrait::SortField* sortField = sortRel->add_sorts();
+    sortField->mutable_expr()->mutable_selection()->MergeFrom(
+        exprConvertor_->toSubstraitExpr(arena, sortingKeys[i], inputType));
+
+    sortField->set_direction(toSortDirection(sortingOrders[i]));
+  }
+  return *sortRel;
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::LimitNode>& limitNode,
+    ::substrait::FetchRel* fetchRel) {
+  const auto& source = getSingleSource(limitNode);
+  toSubstrait(arena, source, fetchRel->mutable_input());
+
+  fetchRel->set_offset(limitNode->offset());
+  fetchRel->set_count(limitNode->count());
+
+  VELOX_CHECK(!limitNode->isPartial(), "Substrait doesn't support partial limit yet")
+
+  fetchRel->mutable_common()->mutable_direct();
+}
+
+const core::PlanNodePtr& VeloxToSubstraitPlanConvertor::getSingleSource(const core::PlanNodePtr& node) {
+  const auto& sources = node->sources();
+
+  VELOX_USER_CHECK_EQ(1, sources.size(), "Plan node must have exactly one source.");
+  return sources[0];
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitPlan.h
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.h
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <google/protobuf/arena.h>
+#include <string>
+#include <typeinfo>
+
+#include "velox/core/PlanNode.h"
+#include "velox/type/Type.h"
+
+#include "SubstraitExtensionCollector.h"
+#include "VeloxToSubstraitExpr.h"
+#include "substrait/algebra.pb.h"
+#include "substrait/plan.pb.h"
+
+namespace gluten {
+
+/// Convert the Velox plan into Substrait plan.
+class VeloxToSubstraitPlanConvertor {
+ public:
+  /// Convert Velox PlanNode into Substrait Plan.
+  /// @param vPlan Velox query plan to convert.
+  /// @param arena Arena to use for allocating Substrait plan objects.
+  /// @return A pointer to Substrait plan object allocated on the arena and
+  /// representing the input Velox plan.
+  ::substrait::Plan& toSubstrait(google::protobuf::Arena& arena, const core::PlanNodePtr& planNode);
+
+ private:
+  /// Convert Velox PlanNode into Substrait Rel.
+  void toSubstrait(google::protobuf::Arena& arena, const core::PlanNodePtr& planNode, ::substrait::Rel* rel);
+
+  /// Convert Velox FilterNode into Substrait FilterRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::FilterNode>& filterNode,
+      ::substrait::FilterRel* filterRel);
+
+  /// Convert Velox ValuesNode into Substrait ReadRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::ValuesNode>& valuesNode,
+      ::substrait::ReadRel* readRel);
+
+  /// Convert Velox ProjectNode into Substrait ProjectRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::ProjectNode>& projectNode,
+      ::substrait::ProjectRel* projectRel);
+
+  /// Convert Velox Aggregation Node into Substrait AggregateRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::AggregationNode>& aggregateNode,
+      ::substrait::AggregateRel* aggregateRel);
+
+  /// Convert Velox OrderBy Node into Substrait SortRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::OrderByNode>& orderByNode,
+      ::substrait::SortRel* sortRel);
+
+  /// Convert Velox TopN Node into Substrait SortRel->FetchRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::TopNNode>& topNNode,
+      ::substrait::FetchRel* fetchRel);
+
+  /// Helper function to process sortingKeys and sortingOrders in Velox to
+  /// convert them to the sortField of SortRel in Substrait.
+  const ::substrait::SortRel& processSortFields(
+      google::protobuf::Arena& arena,
+      const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders,
+      const RowTypePtr& inputType);
+
+  /// Convert Velox Limit Node into Substrait FetchRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::LimitNode>& limitNode,
+      ::substrait::FetchRel* fetchRel);
+
+  /// Check there only have one source for the velox node and return it.
+  const core::PlanNodePtr& getSingleSource(const core::PlanNodePtr& node);
+
+  /// The Expression converter used to convert Velox representations into
+  /// Substrait expressions.
+  VeloxToSubstraitExprConvertorPtr exprConvertor_;
+
+  /// The Type converter used to conver velox representation into Substrait
+  /// type.
+  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
+
+  /// The Extension collector storing the relations between the function
+  /// signature and the function reference number.
+  SubstraitExtensionCollectorPtr extensionCollector_;
+};
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitType.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitType.cc
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VeloxToSubstraitType.h"
+
+#include "velox/expression/Expr.h"
+
+namespace gluten {
+
+const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
+    google::protobuf::Arena& arena,
+    const velox::TypePtr& type) {
+  ::substrait::Type* substraitType = google::protobuf::Arena::CreateMessage<::substrait::Type>(&arena);
+  switch (type->kind()) {
+    case velox::TypeKind::BOOLEAN: {
+      auto substraitBool = google::protobuf::Arena::CreateMessage<::substrait::Type_Boolean>(&arena);
+      substraitBool->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_bool_(substraitBool);
+
+      break;
+    }
+    case velox::TypeKind::TINYINT: {
+      auto substraitI8 = google::protobuf::Arena::CreateMessage<::substrait::Type_I8>(&arena);
+      substraitI8->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_i8(substraitI8);
+      break;
+    }
+    case velox::TypeKind::SMALLINT: {
+      auto substraitI16 = google::protobuf::Arena::CreateMessage<::substrait::Type_I16>(&arena);
+      substraitI16->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_i16(substraitI16);
+      break;
+    }
+    case velox::TypeKind::INTEGER: {
+      auto substraitI32 = google::protobuf::Arena::CreateMessage<::substrait::Type_I32>(&arena);
+      substraitI32->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_i32(substraitI32);
+      break;
+    }
+    case velox::TypeKind::BIGINT: {
+      auto substraitI64 = google::protobuf::Arena::CreateMessage<::substrait::Type_I64>(&arena);
+      substraitI64->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_i64(substraitI64);
+      break;
+    }
+    case velox::TypeKind::REAL: {
+      auto substraitFp32 = google::protobuf::Arena::CreateMessage<::substrait::Type_FP32>(&arena);
+      substraitFp32->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_fp32(substraitFp32);
+      break;
+    }
+    case velox::TypeKind::DOUBLE: {
+      auto substraitFp64 = google::protobuf::Arena::CreateMessage<::substrait::Type_FP64>(&arena);
+      substraitFp64->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_fp64(substraitFp64);
+      break;
+    }
+    case velox::TypeKind::VARCHAR: {
+      auto substraitString = google::protobuf::Arena::CreateMessage<::substrait::Type_String>(&arena);
+      substraitString->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_string(substraitString);
+      break;
+    }
+    case velox::TypeKind::VARBINARY: {
+      auto substraitVarBinary = google::protobuf::Arena::CreateMessage<::substrait::Type_Binary>(&arena);
+      substraitVarBinary->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_binary(substraitVarBinary);
+      break;
+    }
+    case velox::TypeKind::TIMESTAMP: {
+      auto substraitTimestamp = google::protobuf::Arena::CreateMessage<::substrait::Type_Timestamp>(&arena);
+      substraitTimestamp->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_timestamp(substraitTimestamp);
+      break;
+    }
+    case velox::TypeKind::ARRAY: {
+      ::substrait::Type_List* substraitList = google::protobuf::Arena::CreateMessage<::substrait::Type_List>(&arena);
+
+      substraitList->mutable_type()->MergeFrom(toSubstraitType(arena, type->asArray().elementType()));
+
+      substraitList->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+
+      substraitType->set_allocated_list(substraitList);
+
+      break;
+    }
+    case velox::TypeKind::MAP: {
+      ::substrait::Type_Map* substraitMap = google::protobuf::Arena::CreateMessage<::substrait::Type_Map>(&arena);
+
+      substraitMap->mutable_key()->MergeFrom(toSubstraitType(arena, type->asMap().keyType()));
+      substraitMap->mutable_value()->MergeFrom(toSubstraitType(arena, type->asMap().valueType()));
+
+      substraitMap->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+
+      substraitType->set_allocated_map(substraitMap);
+
+      break;
+    }
+    case velox::TypeKind::ROW: {
+      ::substrait::Type_Struct* substraitStruct =
+          google::protobuf::Arena::CreateMessage<::substrait::Type_Struct>(&arena);
+      for (const auto& child : type->asRow().children()) {
+        substraitStruct->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+        substraitStruct->add_types()->MergeFrom(toSubstraitType(arena, child));
+      }
+      substraitStruct->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_struct_(substraitStruct);
+      break;
+    }
+    case velox::TypeKind::UNKNOWN: {
+      auto substraitUserDefined = google::protobuf::Arena::CreateMessage<::substrait::Type_UserDefined>(&arena);
+      substraitUserDefined->set_type_reference(0);
+      substraitUserDefined->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_user_defined(substraitUserDefined);
+      break;
+    }
+    case velox::TypeKind::DATE: {
+      auto substraitDate = google::protobuf::Arena::CreateMessage<::substrait::Type_Date>(&arena);
+      substraitDate->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_date(substraitDate);
+      break;
+    }
+    case velox::TypeKind::FUNCTION:
+    case velox::TypeKind::OPAQUE:
+    case velox::TypeKind::INVALID:
+    default:
+      VELOX_UNSUPPORTED("Unsupported velox type '{}'", type->toString());
+  }
+  return *substraitType;
+}
+
+const ::substrait::NamedStruct& VeloxToSubstraitTypeConvertor::toSubstraitNamedStruct(
+    google::protobuf::Arena& arena,
+    const velox::RowTypePtr& rowType) {
+  ::substrait::NamedStruct* substraitNamedStruct =
+      google::protobuf::Arena::CreateMessage<::substrait::NamedStruct>(&arena);
+
+  const auto size = rowType->size();
+  if (size != 0) {
+    const auto& names = rowType->names();
+    const auto& veloxTypes = rowType->children();
+
+    auto substraitType = substraitNamedStruct->mutable_struct_();
+
+    substraitType->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+
+    for (int64_t i = 0; i < size; ++i) {
+      const auto& name = names.at(i);
+      const auto& veloxType = veloxTypes.at(i);
+      substraitNamedStruct->add_names(name);
+
+      substraitType->add_types()->MergeFrom(toSubstraitType(arena, veloxType));
+    }
+  }
+
+  return *substraitNamedStruct;
+}
+
+} // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitType.h
+++ b/cpp/velox/substrait/VeloxToSubstraitType.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+#include "substrait/algebra.pb.h"
+#include "substrait/type.pb.h"
+
+namespace gluten {
+
+using namespace facebook;
+
+class VeloxToSubstraitTypeConvertor {
+ public:
+  /// Convert Velox RowType to Substrait NamedStruct.
+  const ::substrait::NamedStruct& toSubstraitNamedStruct(
+      google::protobuf::Arena& arena,
+      const velox::RowTypePtr& rowType);
+
+  /// Convert Velox Type to Substrait Type.
+  const ::substrait::Type& toSubstraitType(google::protobuf::Arena& arena, const velox::TypePtr& type);
+};
+
+using VeloxToSubstraitTypeConvertorPtr = std::shared_ptr<VeloxToSubstraitTypeConvertor>;
+
+} // namespace gluten

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -39,8 +39,20 @@ function(add_velox_test TEST_EXEC)
   gtest_discover_tests(${TEST_EXEC})
 endfunction()
 
-# velox test
 add_velox_test(velox_shuffle_writer_test SOURCES VeloxShuffleWriterTest.cc)
-add_velox_test(velox_converter_test SOURCES ArrowToVeloxTest.cc VeloxColumnarToRowTest.cc VeloxRowToColumnarTest.cc ColumnarToRowTest.cc)
+add_velox_test(velox_data_conversion_test SOURCES ArrowToVeloxTest.cc VeloxColumnarToRowTest.cc VeloxRowToColumnarTest.cc ColumnarToRowTest.cc)
 add_velox_test(orc_test SOURCES OrcTest.cc)
 add_velox_test(velox_operators_test SOURCES VeloxColumnarBatchSerializerTest.cc)
+add_velox_test(
+  velox_plan_conversion_test
+  SOURCES
+  Substrait2VeloxPlanConversionTest.cc
+  Substrait2VeloxPlanValidatorTest.cc
+  Substrait2VeloxValuesNodeConversionTest.cc
+  SubstraitExtensionCollectorTest.cc
+  VeloxSubstraitRoundTripTest.cc
+  VeloxSubstraitSignatureTest.cc
+  VeloxToSubstraitTypeTest.cc
+  FunctionTest.cc
+  JsonToProtoConverter.cc
+  FilePathGenerator.cc)

--- a/cpp/velox/tests/FilePathGenerator.cc
+++ b/cpp/velox/tests/FilePathGenerator.cc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FilePathGenerator.h"
+#include <filesystem>
+
+const std::string FilePathGenerator::getDataFilePath(const std::string& fileName) {
+  const std::string currentPath = std::filesystem::current_path().c_str();
+  const std::string filePath = currentPath + "/../../../velox/tests/data/" + fileName;
+  return filePath;
+}

--- a/cpp/velox/tests/FilePathGenerator.h
+++ b/cpp/velox/tests/FilePathGenerator.h
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+class FilePathGenerator {
+ public:
+  static const std::string getDataFilePath(const std::string& fileName);
+};

--- a/cpp/velox/tests/FunctionTest.cc
+++ b/cpp/velox/tests/FunctionTest.cc
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "JsonToProtoConverter.h"
+
+#include "velox/common/base/Fs.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+
+#include "substrait/SubstraitToVeloxPlan.h"
+#include "substrait/TypeUtils.h"
+#include "substrait/VariantToVectorConverter.h"
+#include "substrait/VeloxToSubstraitType.h"
+
+#include "FilePathGenerator.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace gluten {
+class FunctionTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<core::QueryCtx> queryCtx_ = std::make_shared<core::QueryCtx>();
+
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::addDefaultLeafMemoryPool();
+
+  std::shared_ptr<gluten::SubstraitParser> substraitParser_ = std::make_shared<gluten::SubstraitParser>();
+
+  std::shared_ptr<gluten::SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<gluten::SubstraitVeloxPlanConverter>(pool_.get());
+};
+
+TEST_F(FunctionTest, makeNames) {
+  std::string prefix = "n";
+  int size = 0;
+  std::vector<std::string> names = substraitParser_->makeNames(prefix, size);
+  ASSERT_EQ(names.size(), size);
+
+  size = 5;
+  names = substraitParser_->makeNames(prefix, size);
+  ASSERT_EQ(names.size(), size);
+  for (int i = 0; i < size; i++) {
+    std::string expected = "n_" + std::to_string(i);
+    ASSERT_EQ(names[i], expected);
+  }
+}
+
+TEST_F(FunctionTest, makeNodeName) {
+  std::string nodeName = substraitParser_->makeNodeName(1, 0);
+  ASSERT_EQ(nodeName, "n1_0");
+}
+
+TEST_F(FunctionTest, getIdxFromNodeName) {
+  std::string nodeName = "n1_0";
+  int index = substraitParser_->getIdxFromNodeName(nodeName);
+  ASSERT_EQ(index, 0);
+}
+
+TEST_F(FunctionTest, getNameBeforeDelimiter) {
+  std::string functionSpec = "lte:fp64_fp64";
+  std::string_view funcName = getNameBeforeDelimiter(functionSpec, ":");
+  ASSERT_EQ(funcName, "lte");
+
+  functionSpec = "lte:";
+  funcName = getNameBeforeDelimiter(functionSpec, ":");
+  ASSERT_EQ(funcName, "lte");
+
+  functionSpec = "lte";
+  funcName = getNameBeforeDelimiter(functionSpec, ":");
+  ASSERT_EQ(funcName, "lte");
+}
+
+TEST_F(FunctionTest, constructFunctionMap) {
+  std::string planPath = FilePathGenerator::getDataFilePath("q1_first_stage.json");
+  ::substrait::Plan substraitPlan;
+  JsonToProtoConverter::readFromFile(planPath, substraitPlan);
+  planConverter_->constructFunctionMap(substraitPlan);
+
+  auto functionMap = planConverter_->getFunctionMap();
+  ASSERT_EQ(functionMap.size(), 9);
+
+  std::string function = planConverter_->findFuncSpec(1);
+  ASSERT_EQ(function, "lte:fp64_fp64");
+
+  function = planConverter_->findFuncSpec(2);
+  ASSERT_EQ(function, "and:bool_bool");
+
+  function = planConverter_->findFuncSpec(3);
+  ASSERT_EQ(function, "subtract:opt_fp64_fp64");
+
+  function = planConverter_->findFuncSpec(4);
+  ASSERT_EQ(function, "multiply:opt_fp64_fp64");
+
+  function = planConverter_->findFuncSpec(5);
+  ASSERT_EQ(function, "add:opt_fp64_fp64");
+
+  function = planConverter_->findFuncSpec(6);
+  ASSERT_EQ(function, "sum:opt_fp64");
+
+  function = planConverter_->findFuncSpec(7);
+  ASSERT_EQ(function, "count:opt_fp64");
+
+  function = planConverter_->findFuncSpec(8);
+  ASSERT_EQ(function, "count:opt_i32");
+
+  function = planConverter_->findFuncSpec(9);
+  ASSERT_EQ(function, "is_not_null:fp64");
+}
+
+TEST_F(FunctionTest, setVectorFromVariants) {
+  auto resultVec = setVectorFromVariants(BOOLEAN(), {variant(false), variant(true)}, pool_.get());
+  ASSERT_EQ(false, resultVec->asFlatVector<bool>()->valueAt(0));
+  ASSERT_EQ(true, resultVec->asFlatVector<bool>()->valueAt(1));
+
+  auto min8 = std::numeric_limits<int8_t>::min();
+  auto max8 = std::numeric_limits<int8_t>::max();
+  resultVec = setVectorFromVariants(TINYINT(), {variant(min8), variant(max8)}, pool_.get());
+  EXPECT_EQ(min8, resultVec->asFlatVector<int8_t>()->valueAt(0));
+  EXPECT_EQ(max8, resultVec->asFlatVector<int8_t>()->valueAt(1));
+
+  auto min16 = std::numeric_limits<int16_t>::min();
+  auto max16 = std::numeric_limits<int16_t>::max();
+  resultVec = setVectorFromVariants(SMALLINT(), {variant(min16), variant(max16)}, pool_.get());
+  EXPECT_EQ(min16, resultVec->asFlatVector<int16_t>()->valueAt(0));
+  EXPECT_EQ(max16, resultVec->asFlatVector<int16_t>()->valueAt(1));
+
+  auto min32 = std::numeric_limits<int32_t>::min();
+  auto max32 = std::numeric_limits<int32_t>::max();
+  resultVec = setVectorFromVariants(INTEGER(), {variant(min32), variant(max32)}, pool_.get());
+  EXPECT_EQ(min32, resultVec->asFlatVector<int32_t>()->valueAt(0));
+  EXPECT_EQ(max32, resultVec->asFlatVector<int32_t>()->valueAt(1));
+
+  auto min64 = std::numeric_limits<int64_t>::min();
+  auto max64 = std::numeric_limits<int64_t>::max();
+  resultVec = setVectorFromVariants(BIGINT(), {variant(min64), variant(max64)}, pool_.get());
+  EXPECT_EQ(min64, resultVec->asFlatVector<int64_t>()->valueAt(0));
+  EXPECT_EQ(max64, resultVec->asFlatVector<int64_t>()->valueAt(1));
+
+  // Floats are harder to compare because of low-precision. Just making sure
+  // they don't throw.
+  EXPECT_NO_THROW(setVectorFromVariants(REAL(), {variant(float(0.99L)), variant(float(-1.99L))}, pool_.get()));
+
+  resultVec = setVectorFromVariants(DOUBLE(), {variant(double(0.99L)), variant(double(-1.99L))}, pool_.get());
+  ASSERT_EQ(double(0.99L), resultVec->asFlatVector<double>()->valueAt(0));
+  ASSERT_EQ(double(-1.99L), resultVec->asFlatVector<double>()->valueAt(1));
+
+  resultVec = setVectorFromVariants(VARCHAR(), {variant(""), variant("asdf")}, pool_.get());
+  ASSERT_EQ("", resultVec->asFlatVector<StringView>()->valueAt(0).str());
+  ASSERT_EQ("asdf", resultVec->asFlatVector<StringView>()->valueAt(1).str());
+
+  ASSERT_ANY_THROW(setVectorFromVariants(VARBINARY(), {variant(""), variant("asdf")}, pool_.get()));
+
+  resultVec =
+      setVectorFromVariants(TIMESTAMP(), {variant(Timestamp(9020, 0)), variant(Timestamp(8875, 0))}, pool_.get());
+  ASSERT_EQ("1970-01-01T02:30:20.000000000", resultVec->asFlatVector<Timestamp>()->valueAt(0).toString());
+  ASSERT_EQ("1970-01-01T02:27:55.000000000", resultVec->asFlatVector<Timestamp>()->valueAt(1).toString());
+
+  resultVec = setVectorFromVariants(DATE(), {variant(Date(9020)), variant(Date(8875))}, pool_.get());
+  ASSERT_EQ("1994-09-12", resultVec->asFlatVector<Date>()->valueAt(0).toString());
+  ASSERT_EQ("1994-04-20", resultVec->asFlatVector<Date>()->valueAt(1).toString());
+
+  resultVec = setVectorFromVariants(INTERVAL_DAY_TIME(), {variant(9020LL), variant(8875LL)}, pool_.get());
+  ASSERT_TRUE(isIntervalDayTimeType(resultVec->type()));
+  ASSERT_EQ(9020, resultVec->asFlatVector<int64_t>()->valueAt(0));
+  ASSERT_EQ(8875, resultVec->asFlatVector<int64_t>()->valueAt(1));
+}
+
+TEST_F(FunctionTest, getFunctionType) {
+  std::vector<std::string> types;
+  substraitParser_->getSubFunctionTypes("sum:opt_i32", types);
+  ASSERT_EQ("i32", types[0]);
+
+  types.clear();
+  substraitParser_->getSubFunctionTypes("sum:i32", types);
+  ASSERT_EQ("i32", types[0]);
+
+  types.clear();
+  substraitParser_->getSubFunctionTypes("sum:opt_str_str", types);
+  ASSERT_EQ(2, types.size());
+  ASSERT_EQ("str", types[0]);
+  ASSERT_EQ("str", types[1]);
+}
+} // namespace gluten

--- a/cpp/velox/tests/JsonToProtoConverter.cc
+++ b/cpp/velox/tests/JsonToProtoConverter.cc
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/substrait/tests/JsonToProtoConverter.h"
+#include <fstream>
+#include <sstream>
+#include "velox/common/base/Exceptions.h"
+
+void JsonToProtoConverter::readFromFile(const std::string& msgPath, google::protobuf::Message& msg) {
+  // Read json file and resume the Substrait plan.
+  std::ifstream msgJson(msgPath);
+  VELOX_CHECK(!msgJson.fail(), "Failed to open file: {}. {}", msgPath, strerror(errno));
+  std::stringstream buffer;
+  buffer << msgJson.rdbuf();
+  std::string msgData = buffer.str();
+  auto status = google::protobuf::util::JsonStringToMessage(msgData, &msg);
+  VELOX_CHECK(status.ok(), "Failed to parse Substrait JSON: {} {}", status.code(), status.message());
+}

--- a/cpp/velox/tests/JsonToProtoConverter.h
+++ b/cpp/velox/tests/JsonToProtoConverter.h
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <google/protobuf/util/json_util.h>
+
+class JsonToProtoConverter {
+ public:
+  /// Reconstruct Protobuf message from Json file.
+  static void readFromFile(const std::string& msgPath, google::protobuf::Message& msg);
+};

--- a/cpp/velox/tests/OrcTest.cc
+++ b/cpp/velox/tests/OrcTest.cc
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "arrow/c/abi.h"
 #include "benchmarks/BatchStreamIterator.h"
 #include "benchmarks/BenchmarkUtils.h"

--- a/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "JsonToProtoConverter.h"
+
+#include <filesystem>
+#include "substrait/SubstraitToVeloxPlan.h"
+#include "substrait/SubstraitToVeloxPlanValidator.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/type/Type.h"
+
+#include "FilePathGenerator.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec;
+
+namespace gluten {
+class Substrait2VeloxPlanConversionTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>> makeSplits(
+      const SubstraitVeloxPlanConverter& converter,
+      std::shared_ptr<const core::PlanNode> planNode) {
+    const auto& splitInfos = converter.splitInfos();
+    auto leafPlanNodeIds = planNode->leafPlanNodeIds();
+    // Only one leaf node is expected here.
+    EXPECT_EQ(1, leafPlanNodeIds.size());
+    const auto& splitInfo = splitInfos.at(*leafPlanNodeIds.begin());
+
+    const auto& paths = splitInfo->paths;
+    const auto& starts = splitInfo->starts;
+    const auto& lengths = splitInfo->lengths;
+    const auto fileFormat = splitInfo->format;
+
+    std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>> splits;
+    splits.reserve(paths.size());
+
+    for (int i = 0; i < paths.size(); i++) {
+      auto path = fmt::format("{}{}", tmpDir_->path, paths[i]);
+      auto start = starts[i];
+      auto length = lengths[i];
+      auto split = facebook::velox::exec::test::HiveConnectorSplitBuilder(path)
+                       .fileFormat(fileFormat)
+                       .start(start)
+                       .length(length)
+                       .build();
+      splits.emplace_back(split);
+    }
+    return splits;
+  }
+
+  std::shared_ptr<exec::test::TempDirectoryPath> tmpDir_{exec::test::TempDirectoryPath::create()};
+  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(memoryPool_.get());
+
+ private:
+  std::shared_ptr<memory::MemoryPool> memoryPool_{memory::addDefaultLeafMemoryPool()};
+};
+
+// This test will firstly generate mock TPC-H lineitem ORC file. Then, Velox's
+// computing will be tested based on the generated ORC file.
+// Input: Json file of the Substrait plan for the below modified TPC-H Q6 query:
+//
+//  SELECT sum(l_extendedprice * l_discount) AS revenue
+//  FROM lineitem
+//  WHERE
+//    l_shipdate_new >= 8766 AND l_shipdate_new < 9131 AND
+//    l_discount BETWEEN .06 - 0.01 AND .06 + 0.01 AND
+//    l_quantity < 24
+//
+//  Tested Velox operators: TableScan (Filter Pushdown), Project, Aggregate.
+TEST_F(Substrait2VeloxPlanConversionTest, q6) {
+  // Generate the used ORC file.
+  auto type =
+      ROW({"l_orderkey",
+           "l_partkey",
+           "l_suppkey",
+           "l_linenumber",
+           "l_quantity",
+           "l_extendedprice",
+           "l_discount",
+           "l_tax",
+           "l_returnflag",
+           "l_linestatus",
+           "l_shipdate",
+           "l_commitdate",
+           "l_receiptdate",
+           "l_shipinstruct",
+           "l_shipmode",
+           "l_comment"},
+          {BIGINT(),
+           BIGINT(),
+           BIGINT(),
+           INTEGER(),
+           DOUBLE(),
+           DOUBLE(),
+           DOUBLE(),
+           DOUBLE(),
+           VARCHAR(),
+           VARCHAR(),
+           DOUBLE(),
+           DOUBLE(),
+           DOUBLE(),
+           VARCHAR(),
+           VARCHAR(),
+           VARCHAR()});
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::vector<VectorPtr> vectors;
+  // TPC-H lineitem table has 16 columns.
+  int colNum = 16;
+  vectors.reserve(colNum);
+  std::vector<int64_t> lOrderkeyData = {
+      4636438147,
+      2012485446,
+      1635327427,
+      8374290148,
+      2972204230,
+      8001568994,
+      989963396,
+      2142695974,
+      6354246853,
+      4141748419};
+  vectors.emplace_back(makeFlatVector<int64_t>(lOrderkeyData));
+  std::vector<int64_t> lPartkeyData = {
+      263222018, 255918298, 143549509, 96877642, 201976875, 196938305, 100260625, 273511608, 112999357, 299103530};
+  vectors.emplace_back(makeFlatVector<int64_t>(lPartkeyData));
+  std::vector<int64_t> lSuppkeyData = {
+      2102019, 13998315, 12989528, 4717643, 9976902, 12618306, 11940632, 871626, 1639379, 3423588};
+  vectors.emplace_back(makeFlatVector<int64_t>(lSuppkeyData));
+  std::vector<int32_t> lLinenumberData = {4, 6, 1, 5, 1, 2, 1, 5, 2, 6};
+  vectors.emplace_back(makeFlatVector<int32_t>(lLinenumberData));
+  std::vector<double> lQuantityData = {6.0, 1.0, 19.0, 4.0, 6.0, 12.0, 23.0, 11.0, 16.0, 19.0};
+  vectors.emplace_back(makeFlatVector<double>(lQuantityData));
+  std::vector<double> lExtendedpriceData = {
+      30586.05, 7821.0, 1551.33, 30681.2, 1941.78, 66673.0, 6322.44, 41754.18, 8704.26, 63780.36};
+  vectors.emplace_back(makeFlatVector<double>(lExtendedpriceData));
+  std::vector<double> lDiscountData = {0.05, 0.06, 0.01, 0.07, 0.05, 0.06, 0.07, 0.05, 0.06, 0.07};
+  vectors.emplace_back(makeFlatVector<double>(lDiscountData));
+  std::vector<double> lTaxData = {0.02, 0.03, 0.01, 0.0, 0.01, 0.01, 0.03, 0.07, 0.01, 0.04};
+  vectors.emplace_back(makeFlatVector<double>(lTaxData));
+  std::vector<std::string> lReturnflagData = {"N", "A", "A", "R", "A", "N", "A", "A", "N", "R"};
+  vectors.emplace_back(makeFlatVector<std::string>(lReturnflagData));
+  std::vector<std::string> lLinestatusData = {"O", "F", "F", "F", "F", "O", "F", "F", "O", "F"};
+  vectors.emplace_back(makeFlatVector<std::string>(lLinestatusData));
+  std::vector<double> lShipdateNewData = {
+      8953.666666666666,
+      8773.666666666666,
+      9034.666666666666,
+      8558.666666666666,
+      9072.666666666666,
+      8864.666666666666,
+      9004.666666666666,
+      8778.666666666666,
+      9013.666666666666,
+      8832.666666666666};
+  vectors.emplace_back(makeFlatVector<double>(lShipdateNewData));
+  std::vector<double> lCommitdateNewData = {
+      10447.666666666666,
+      8953.666666666666,
+      8325.666666666666,
+      8527.666666666666,
+      8438.666666666666,
+      10049.666666666666,
+      9036.666666666666,
+      8666.666666666666,
+      9519.666666666666,
+      9138.666666666666};
+  vectors.emplace_back(makeFlatVector<double>(lCommitdateNewData));
+  std::vector<double> lReceiptdateNewData = {
+      10456.666666666666,
+      8979.666666666666,
+      8299.666666666666,
+      8474.666666666666,
+      8525.666666666666,
+      9996.666666666666,
+      9103.666666666666,
+      8726.666666666666,
+      9593.666666666666,
+      9178.666666666666};
+  vectors.emplace_back(makeFlatVector<double>(lReceiptdateNewData));
+  std::vector<std::string> lShipinstructData = {
+      "COLLECT COD",
+      "NONE",
+      "TAKE BACK RETURN",
+      "NONE",
+      "TAKE BACK RETURN",
+      "NONE",
+      "DELIVER IN PERSON",
+      "DELIVER IN PERSON",
+      "TAKE BACK RETURN",
+      "NONE"};
+  vectors.emplace_back(makeFlatVector<std::string>(lShipinstructData));
+  std::vector<std::string> lShipmodeData = {
+      "FOB", "REG AIR", "MAIL", "FOB", "RAIL", "SHIP", "REG AIR", "REG AIR", "TRUCK", "AIR"};
+  vectors.emplace_back(makeFlatVector<std::string>(lShipmodeData));
+  std::vector<std::string> lCommentData = {
+      " the furiously final foxes. quickly final p",
+      "thely ironic",
+      "ate furiously. even, pending pinto bean",
+      "ackages af",
+      "odolites. slyl",
+      "ng the regular requests sleep above",
+      "lets above the slyly ironic theodolites sl",
+      "lyly regular excuses affi",
+      "lly unusual theodolites grow slyly above",
+      " the quickly ironic pains lose car"};
+  vectors.emplace_back(makeFlatVector<std::string>(lCommentData));
+
+  // Write data into an DWRF file.
+  writeToFile(tmpDir_->path + "/mock_lineitem.dwrf", {makeRowVector(type->names(), vectors)});
+
+  // Find and deserialize Substrait plan json file.
+  std::string subPlanPath = FilePathGenerator::getDataFilePath("q6_first_stage.json");
+
+  // Read q6_first_stage.json and resume the Substrait plan.
+  ::substrait::Plan substraitPlan;
+  JsonToProtoConverter::readFromFile(subPlanPath, substraitPlan);
+
+  // Convert to Velox PlanNode.
+  auto planNode = planConverter_->toVeloxPlan(substraitPlan);
+
+  auto expectedResult = makeRowVector({
+      makeFlatVector<double>(1, [](auto /*row*/) { return 13613.1921; }),
+  });
+
+  exec::test::AssertQueryBuilder(planNode).splits(makeSplits(*planConverter_, planNode)).assertResults(expectedResult);
+}
+
+TEST_F(Substrait2VeloxPlanConversionTest, ifthenTest) {
+  std::string subPlanPath = FilePathGenerator::getDataFilePath("if_then.json");
+
+  ::substrait::Plan substraitPlan;
+  JsonToProtoConverter::readFromFile(subPlanPath, substraitPlan);
+
+  // Convert to Velox PlanNode.
+  auto planNode = planConverter_->toVeloxPlan(substraitPlan);
+  ASSERT_EQ(
+      "-- Project[expressions: ] -> \n  "
+      "-- TableScan[table: hive_table, range filters: [(hd_demo_sk, Filter(IsNotNull, deterministic, null not allowed)),"
+      " (hd_vehicle_count, BigintRange: [1, 9223372036854775807] no nulls)], remaining filter: "
+      "(and(or(equalto(\"hd_buy_potential\",\">10000\"),equalto(\"hd_buy_potential\",\"unknown\")),"
+      "if(greaterthan(\"hd_vehicle_count\",0),greaterthan(divide(cast \"hd_dep_count\" as DOUBLE,"
+      "cast \"hd_vehicle_count\" as DOUBLE),1.2))))] -> n0_0:BIGINT, n0_1:VARCHAR, n0_2:BIGINT, n0_3:BIGINT\n",
+      planNode->toString(true, true));
+}
+
+TEST_F(Substrait2VeloxPlanConversionTest, filterUpper) {
+  std::string subPlanPath = FilePathGenerator::getDataFilePath("filter_upper.json");
+
+  ::substrait::Plan substraitPlan;
+  JsonToProtoConverter::readFromFile(subPlanPath, substraitPlan);
+
+  // Convert to Velox PlanNode.
+  auto planNode = planConverter_->toVeloxPlan(substraitPlan);
+  ASSERT_EQ(
+      "-- Project[expressions: ] -> \n  -- TableScan[table: hive_table, range filters: "
+      "[(key, BigintRange: [-2147483648, 2] no nulls)]] -> n0_0:INTEGER\n",
+      planNode->toString(true, true));
+}
+} // namespace gluten

--- a/cpp/velox/tests/Substrait2VeloxPlanValidatorTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanValidatorTest.cc
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FilePathGenerator.h"
+#include "JsonToProtoConverter.h"
+
+#include "substrait/SubstraitToVeloxPlan.h"
+#include "substrait/SubstraitToVeloxPlanValidator.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/type/Type.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec;
+
+namespace gluten {
+class Substrait2VeloxPlanValidatorTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(memoryPool_.get());
+
+  bool validatePlan(std::string file) {
+    std::string subPlanPath = FilePathGenerator::getDataFilePath(file);
+
+    ::substrait::Plan substraitPlan;
+    JsonToProtoConverter::readFromFile(subPlanPath, substraitPlan);
+    return validatePlan(substraitPlan);
+  }
+
+  bool validatePlan(::substrait::Plan& plan) {
+    std::shared_ptr<core::QueryCtx> queryCtx = std::make_shared<core::QueryCtx>();
+
+    // An execution context used for function validation.
+    std::unique_ptr<core::ExecCtx> execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+
+    auto planValidator = std::make_shared<SubstraitToVeloxPlanValidator>(pool_.get(), execCtx.get());
+    return planValidator->validate(plan);
+  }
+
+ private:
+  std::shared_ptr<memory::MemoryPool> memoryPool_{memory::addDefaultLeafMemoryPool()};
+};
+
+TEST_F(Substrait2VeloxPlanValidatorTest, group) {
+  std::string subPlanPath = FilePathGenerator::getDataFilePath("group.json");
+
+  ::substrait::Plan substraitPlan;
+  JsonToProtoConverter::readFromFile(subPlanPath, substraitPlan);
+
+  ASSERT_FALSE(validatePlan(substraitPlan));
+}
+} // namespace gluten

--- a/cpp/velox/tests/Substrait2VeloxValuesNodeConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxValuesNodeConversionTest.cc
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FilePathGenerator.h"
+#include "JsonToProtoConverter.h"
+
+#include "velox/common/base/Fs.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include "substrait/SubstraitToVeloxPlan.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace gluten {
+class Substrait2VeloxValuesNodeConversionTest : public OperatorTestBase {
+ protected:
+  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(pool_.get(), true);
+};
+
+// SELECT * FROM tmp
+TEST_F(Substrait2VeloxValuesNodeConversionTest, valuesNode) {
+  auto planPath = FilePathGenerator::getDataFilePath("substrait_virtualTable.json");
+
+  ::substrait::Plan substraitPlan;
+  JsonToProtoConverter::readFromFile(planPath, substraitPlan);
+
+  auto veloxPlan = planConverter_->toVeloxPlan(substraitPlan);
+
+  RowVectorPtr expectedData = makeRowVector(
+      {makeFlatVector<int64_t>({2499109626526694126, 2342493223442167775, 4077358421272316858}),
+       makeFlatVector<int32_t>({581869302, -708632711, -133711905}),
+       makeFlatVector<double>({0.90579193414549275, 0.96886777112423139, 0.63235925003444637}),
+       makeFlatVector<bool>({true, false, false}),
+       makeFlatVector<int32_t>(3, nullptr, nullEvery(1))
+
+      });
+
+  createDuckDbTable({expectedData});
+  assertQuery(veloxPlan, "SELECT * FROM tmp");
+}
+} // namespace gluten

--- a/cpp/velox/tests/SubstraitExtensionCollectorTest.cc
+++ b/cpp/velox/tests/SubstraitExtensionCollectorTest.cc
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "substrait/SubstraitExtensionCollector.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/PlanNode.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+class SubstraitExtensionCollectorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    Test::SetUp();
+    functions::prestosql::registerAllScalarFunctions();
+  }
+
+  int getReferenceNumber(const std::string& functionName, std::vector<TypePtr>&& arguments) {
+    int referenceNumber1 = extensionCollector_->getReferenceNumber(functionName, arguments);
+    // Repeat the call to make sure properly de-duplicated.
+    int referenceNumber2 = extensionCollector_->getReferenceNumber(functionName, arguments);
+    EXPECT_EQ(referenceNumber1, referenceNumber2);
+    return referenceNumber1;
+  }
+
+  int getReferenceNumber(
+      const std::string& functionName,
+      std::vector<TypePtr>&& arguments,
+      core::AggregationNode::Step step) {
+    int referenceNumber1 = extensionCollector_->getReferenceNumber(functionName, arguments, step);
+    // Repeat the call to make sure properly de-duplicated.
+    int referenceNumber2 = extensionCollector_->getReferenceNumber(functionName, arguments, step);
+    EXPECT_EQ(referenceNumber1, referenceNumber2);
+    return referenceNumber2;
+  }
+
+  /// Given a substrait plan, return the sorted extension functions by the
+  /// function anchor.
+  ::google::protobuf::RepeatedPtrField<::substrait::extensions::SimpleExtensionDeclaration> getSortedSubstraitExtension(
+      const ::substrait::Plan* substraitPlan) {
+    auto substraitExtensions = substraitPlan->extensions();
+    std::sort(substraitExtensions.begin(), substraitExtensions.end(), [](const auto& a, const auto& b) {
+      return a.extension_function().function_anchor() < b.extension_function().function_anchor();
+    });
+
+    return substraitExtensions;
+  }
+
+  SubstraitExtensionCollectorPtr extensionCollector_ = std::make_shared<SubstraitExtensionCollector>();
+};
+
+TEST_F(SubstraitExtensionCollectorTest, getReferenceNumberForScalarFunction) {
+  ASSERT_EQ(getReferenceNumber("plus", {INTEGER(), INTEGER()}), 0);
+  ASSERT_EQ(getReferenceNumber("divide", {INTEGER(), INTEGER()}), 1);
+  ASSERT_EQ(getReferenceNumber("cardinality", {ARRAY(INTEGER())}), 2);
+  ASSERT_EQ(getReferenceNumber("array_sum", {ARRAY(INTEGER())}), 3);
+
+  auto functionType = std::make_shared<const FunctionType>(std::vector<TypePtr>{INTEGER(), VARCHAR()}, BIGINT());
+  std::vector<TypePtr> types = {MAP(INTEGER(), VARCHAR()), functionType};
+  ASSERT_ANY_THROW(getReferenceNumber("transform_keys", std::move(types)));
+}
+
+TEST_F(SubstraitExtensionCollectorTest, getReferenceNumberForAggregateFunction) {
+  // Sum aggregate function have same argument type for each aggregation step.
+  ASSERT_EQ(getReferenceNumber("sum", {INTEGER()}, core::AggregationNode::Step::kSingle), 0);
+
+  // Partial avg aggregate function should use primitive integral type.
+  ASSERT_EQ(getReferenceNumber("avg", {INTEGER()}, core::AggregationNode::Step::kPartial), 1);
+
+  // Final avg aggregate function should use struct type, like
+  // 'ROW<DOUBLE,BIGINT>'
+  ASSERT_EQ(getReferenceNumber("avg", {ROW({DOUBLE(), BIGINT()})}, core::AggregationNode::Step::kFinal), 2);
+
+  // Count aggregate function have same argument type for each aggregation step.
+  ASSERT_EQ(getReferenceNumber("count", {INTEGER()}, core::AggregationNode::Step::kFinal), 3);
+}
+
+TEST_F(SubstraitExtensionCollectorTest, addExtensionsToPlan) {
+  getReferenceNumber("plus", {INTEGER(), INTEGER()});
+  getReferenceNumber("divide", {INTEGER(), INTEGER()});
+  getReferenceNumber("cardinality", {ARRAY(INTEGER())});
+  getReferenceNumber("array_sum", {ARRAY(INTEGER())});
+  getReferenceNumber("sum", {INTEGER()});
+  getReferenceNumber("avg", {INTEGER()});
+  getReferenceNumber("avg", {ROW({DOUBLE(), BIGINT()})});
+  getReferenceNumber("count", {INTEGER()});
+
+  google::protobuf::Arena arena;
+  auto* substraitPlan = google::protobuf::Arena::CreateMessage<::substrait::Plan>(&arena);
+
+  extensionCollector_->addExtensionsToPlan(substraitPlan);
+
+  const auto& substraitExtensions = getSortedSubstraitExtension(substraitPlan);
+  auto getFunctionName = [&](auto id) { return substraitExtensions[id].extension_function().name(); };
+
+  ASSERT_EQ(substraitPlan->extensions().size(), 8);
+  ASSERT_EQ(getFunctionName(0), "plus:i32_i32");
+  ASSERT_EQ(getFunctionName(1), "divide:i32_i32");
+  ASSERT_EQ(getFunctionName(2), "cardinality:list");
+  ASSERT_EQ(getFunctionName(3), "array_sum:list");
+  ASSERT_EQ(getFunctionName(4), "sum:i32");
+  ASSERT_EQ(getFunctionName(5), "avg:i32");
+  ASSERT_EQ(getFunctionName(6), "avg:struct");
+  ASSERT_EQ(getFunctionName(7), "count:i32");
+}
+
+} // namespace gluten

--- a/cpp/velox/tests/VeloxSubstraitRoundTripTest.cc
+++ b/cpp/velox/tests/VeloxSubstraitRoundTripTest.cc
@@ -1,0 +1,447 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Random.h>
+#include <folly/init/Init.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+#include "substrait/SubstraitToVeloxPlan.h"
+#include "substrait/VeloxToSubstraitPlan.h"
+#include "velox/functions/sparksql/Register.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include "substrait/VariantToVectorConverter.h"
+#include "substrait/VeloxToSubstraitPlan.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec::test;
+
+namespace gluten {
+class VeloxSubstraitRoundTripTest : public OperatorTestBase {
+ protected:
+  /// Makes a vector of INTEGER type with 'size' RowVectorPtr.
+  /// @param size The number of RowVectorPtr.
+  /// @param childSize The number of columns for each row.
+  /// @param batchSize The batch Size of the data.
+  std::vector<RowVectorPtr> makeVectors(int64_t size, int64_t childSize, int64_t batchSize) {
+    std::vector<RowVectorPtr> vectors;
+    std::mt19937 gen(std::mt19937::default_seed);
+    for (int i = 0; i < size; i++) {
+      std::vector<VectorPtr> children;
+      for (int j = 0; j < childSize; j++) {
+        children.emplace_back(makeFlatVector<int32_t>(
+            batchSize,
+            [&](auto /*row*/) { return folly::Random::rand32(INT32_MAX / 4, INT32_MAX / 2, gen); },
+            nullEvery(2)));
+      }
+
+      vectors.push_back(makeRowVector({children}));
+    }
+    return vectors;
+  }
+
+  void assertPlanConversion(const std::shared_ptr<const core::PlanNode>& plan, const std::string& duckDbSql) {
+    assertQuery(plan, duckDbSql);
+
+    // Convert Velox Plan to Substrait Plan.
+    google::protobuf::Arena arena;
+    auto substraitPlan = veloxConvertor_->toSubstrait(arena, plan);
+
+    // Convert Substrait Plan to the same Velox Plan.
+    auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
+
+    // Assert velox again.
+    assertQuery(samePlan, duckDbSql);
+  }
+
+  void assertFailingPlanConversion(
+      const std::shared_ptr<const core::PlanNode>& plan,
+      const std::string& expectedErrorMessage) {
+    CursorParameters params;
+    params.planNode = plan;
+    VELOX_ASSERT_THROW(readCursor(params, [](auto /*task*/) {}), expectedErrorMessage);
+
+    // Convert Velox Plan to Substrait Plan.
+    google::protobuf::Arena arena;
+    auto substraitPlan = veloxConvertor_->toSubstrait(arena, plan);
+
+    // Convert Substrait Plan to the same Velox Plan.
+    auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
+
+    // Assert velox again.
+    params.planNode = samePlan;
+    VELOX_ASSERT_THROW(readCursor(params, [](auto /*task*/) {}), expectedErrorMessage);
+  }
+
+  std::shared_ptr<VeloxToSubstraitPlanConvertor> veloxConvertor_ = std::make_shared<VeloxToSubstraitPlanConvertor>();
+  std::shared_ptr<SubstraitVeloxPlanConverter> substraitConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(pool_.get(), true);
+};
+
+TEST_F(VeloxSubstraitRoundTripTest, project) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).project({"c0 + c1", "c1 / c2"}).planNode();
+  assertPlanConversion(plan, "SELECT c0 + c1, c1 / c2 FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, cast) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  // Cast int32 to int64.
+  auto plan = PlanBuilder().values(vectors).project({"cast(c0 as bigint)"}).planNode();
+  assertPlanConversion(plan, "SELECT cast(c0 as bigint) FROM tmp");
+
+  // Cast literal "abc" to int64 and allow cast failure, expecting no exception.
+  plan = PlanBuilder().values(vectors).project({"try_cast('abc' as bigint)"}).planNode();
+  assertPlanConversion(plan, "SELECT try_cast('abc' as bigint) FROM tmp");
+
+  // Cast literal "abc" to int64, expecting an exception to be thrown.
+  plan = PlanBuilder().values(vectors).project({"cast('abc' as bigint)"}).planNode();
+  assertFailingPlanConversion(plan, "Failed to cast from VARCHAR to BIGINT");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, filter) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder().values(vectors).filter("c2 < 1000").planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c2 < 1000");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, null) {
+  auto vectors = makeRowVector(ROW({}, {}), 1);
+  auto plan = PlanBuilder().values({vectors}).project({"NULL"}).planNode();
+  assertPlanConversion(plan, "SELECT NULL ");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, values) {
+  RowVectorPtr vectors = makeRowVector(
+      {makeFlatVector<int64_t>({2499109626526694126, 2342493223442167775, 4077358421272316858}),
+       makeFlatVector<int32_t>({581869302, -708632711, -133711905}),
+       makeFlatVector<double>({0.90579193414549275, 0.96886777112423139, 0.63235925003444637}),
+       makeFlatVector<bool>({true, false, false}),
+       makeFlatVector<int32_t>(3, nullptr, nullEvery(1))
+
+      });
+  createDuckDbTable({vectors});
+
+  auto plan = PlanBuilder().values({vectors}).planNode();
+
+  assertPlanConversion(plan, "SELECT * FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, count) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .filter("c6 < 24")
+                  .singleAggregation({"c0", "c1"}, {"count(c4) as num_price"})
+                  .project({"num_price"})
+                  .planNode();
+
+  assertPlanConversion(plan, "SELECT count(c4) as num_price FROM tmp WHERE c6 < 24 GROUP BY c0, c1");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, countAll) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .filter("c6 < 24")
+                  .singleAggregation({"c0", "c1"}, {"count(1) as num_price"})
+                  .project({"num_price"})
+                  .planNode();
+
+  assertPlanConversion(plan, "SELECT count(*) as num_price FROM tmp WHERE c6 < 24 GROUP BY c0, c1");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, sum) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder().values(vectors).partialAggregation({}, {"sum(1)", "count(c4)"}).planNode();
+
+  assertPlanConversion(plan, "SELECT sum(1), count(c4) FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, sumAndCount) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan =
+      PlanBuilder().values(vectors).partialAggregation({}, {"sum(c1)", "count(c4)"}).finalAggregation().planNode();
+
+  assertPlanConversion(plan, "SELECT sum(c1), count(c4) FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, sumGlobal) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  // Global final aggregation.
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .partialAggregation({"c0"}, {"sum(c0)", "sum(c1)"})
+                  .intermediateAggregation()
+                  .finalAggregation()
+                  .planNode();
+  assertPlanConversion(plan, "SELECT c0, sum(c0), sum(c1) FROM tmp GROUP BY c0");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, sumMask) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .project({"c0", "c1", "c2 % 2 < 10 AS m0", "c3 % 3 = 0 AS m1"})
+                  .partialAggregation({}, {"sum(c0)", "sum(c0)", "sum(c1)"}, {"m0", "m1", "m1"})
+                  .finalAggregation()
+                  .planNode();
+
+  assertPlanConversion(
+      plan,
+      "SELECT sum(c0) FILTER (WHERE c2 % 2 < 10), "
+      "sum(c0) FILTER (WHERE c3 % 3 = 0), sum(c1) FILTER (WHERE c3 % 3 = 0) "
+      "FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, rowConstructor) {
+  RowVectorPtr vectors = makeRowVector(
+      {makeFlatVector<double_t>({0.905791934145, 0.968867771124}),
+       makeFlatVector<int64_t>({2499109626526694126, 2342493223442167775}),
+       makeFlatVector<int32_t>({581869302, -133711905})});
+  createDuckDbTable({vectors});
+
+  auto plan = PlanBuilder().values({vectors}).project({"row_constructor(c1, c2)"}).planNode();
+  assertPlanConversion(plan, "SELECT row(c1, c2) FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, projectAs) {
+  RowVectorPtr vectors = makeRowVector(
+      {makeFlatVector<double_t>({0.905791934145, 0.968867771124}),
+       makeFlatVector<int64_t>({2499109626526694126, 2342493223442167775}),
+       makeFlatVector<int32_t>({581869302, -133711905})});
+  createDuckDbTable({vectors});
+
+  auto plan = PlanBuilder()
+                  .values({vectors})
+                  .filter("c0 < 0.5")
+                  .project({"c1 * c2 as revenue"})
+                  .partialAggregation({}, {"sum(revenue)"})
+                  .planNode();
+  assertPlanConversion(plan, "SELECT sum(c1 * c2) as revenue FROM tmp WHERE c0 < 0.5");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, avg) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder().values(vectors).partialAggregation({}, {"avg(c4)"}).finalAggregation().planNode();
+
+  assertPlanConversion(plan, "SELECT avg(c4) FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, caseWhen) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan =
+      PlanBuilder().values(vectors).project({"case when c0=1 then c1 when c0=2 then c2 else c3  end as x"}).planNode();
+
+  assertPlanConversion(plan, "SELECT case when c0=1 then c1 when c0=2 then c2 else c3 end as x FROM tmp");
+
+  // Switch expression without else.
+  plan = PlanBuilder().values(vectors).project({"case when c0=1 then c1 when c0=2 then c2 end as x"}).planNode();
+  assertPlanConversion(plan, "SELECT case when c0=1 then c1 when c0=2 then c2  end as x FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, ifThen) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).project({"if (c0=1, c0 + 1, c1 + 2) as x"}).planNode();
+  assertPlanConversion(plan, "SELECT if (c0=1, c0 + 1, c1 + 2) as x FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, orderBySingleKey) {
+  auto vectors = makeVectors(10, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).orderBy({"c0 DESC NULLS LAST"}, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, orderBy) {
+  auto vectors = makeVectors(10, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).orderBy({"c0 ASC NULLS FIRST", "c1 ASC NULLS LAST"}, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, limit) {
+  auto vectors = makeVectors(10, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).limit(0, 10, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp LIMIT 10");
+
+  // With offset.
+  plan = PlanBuilder().values(vectors).limit(5, 10, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp OFFSET 5 LIMIT 10");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, topN) {
+  auto vectors = makeVectors(10, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).topN({"c0 NULLS FIRST"}, 10, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST LIMIT 10");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, topNFilter) {
+  auto vectors = makeVectors(10, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).filter("c0 > 15").topN({"c0 DESC NULLS FIRST"}, 10, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 DESC NULLS FIRST LIMIT 10");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, topNTwoKeys) {
+  auto vectors = makeVectors(10, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .filter("c0 > 15")
+                  .topN({"c0 NULLS FIRST", "c1 DESC NULLS LAST"}, 10, false)
+                  .planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 NULLS FIRST, c1 DESC NULLS LAST LIMIT 10");
+}
+
+namespace {
+core::TypedExprPtr makeConstantExpr(const TypePtr& type, const variant& value) {
+  return std::make_shared<const core::ConstantTypedExpr>(type, value);
+}
+
+core::TypedExprPtr makeConstantExpr(const VectorPtr& vector) {
+  return std::make_shared<const core::ConstantTypedExpr>(BaseVector::wrapInConstant(1, 0, vector));
+}
+} // namespace
+
+TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {
+  auto vectors = makeRowVector(ROW({}, {}), 1);
+  auto plan = PlanBuilder(pool_.get())
+                  .values({vectors})
+                  .addNode([&](std::string id, core::PlanNodePtr input) {
+                    std::vector<std::string> projectNames = {"a", "b", "c", "d", "e", "f", "g", "h"};
+                    std::vector<core::TypedExprPtr> projectExpressions = {
+                        makeConstantExpr(BOOLEAN(), (bool)1),
+                        makeConstantExpr(TINYINT(), (int8_t)23),
+                        makeConstantExpr(SMALLINT(), (int16_t)45),
+                        makeConstantExpr(INTEGER(), (int32_t)678),
+                        makeConstantExpr(BIGINT(), (int64_t)910),
+                        makeConstantExpr(REAL(), (float)1.23),
+                        makeConstantExpr(DOUBLE(), (double)4.56),
+                        makeConstantExpr(VARCHAR(), "789")};
+                    return std::make_shared<core::ProjectNode>(
+                        id, std::move(projectNames), std::move(projectExpressions), input);
+                  })
+                  .planNode();
+  assertPlanConversion(plan, "SELECT true, 23, 45, 678, 910, 1.23, 4.56, '789'");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, arrayLiteral) {
+  auto vectors = makeRowVector(ROW({}), 1);
+  auto plan = PlanBuilder(pool_.get())
+                  .values({vectors})
+                  .addNode([&](std::string id, core::PlanNodePtr input) {
+                    std::vector<core::TypedExprPtr> expressions = {
+                        makeConstantExpr(makeNullableArrayVector<bool>({{true, std::nullopt}})),
+                        makeConstantExpr(makeNullableArrayVector<int8_t>({{0, std::nullopt}})),
+                        makeConstantExpr(makeNullableArrayVector<int16_t>({{1, std::nullopt}})),
+                        makeConstantExpr(makeNullableArrayVector<int32_t>({{2, std::nullopt}})),
+                        makeConstantExpr(makeNullableArrayVector<int64_t>({{3, std::nullopt}})),
+                        makeConstantExpr(makeNullableArrayVector<float>({{4.4, std::nullopt}})),
+                        makeConstantExpr(makeNullableArrayVector<double>({{5.5, std::nullopt}})),
+                        makeConstantExpr(makeArrayVector<StringView>({{StringView("6")}})),
+                        makeConstantExpr(makeArrayVector<Timestamp>({{Timestamp(123'456, 123'000)}})),
+                        makeConstantExpr(makeArrayVector<Date>({{Date(8035)}})),
+                        makeConstantExpr(makeArrayVector<int64_t>({{54 * 1000}}, INTERVAL_DAY_TIME())),
+                        makeConstantExpr(makeArrayVector<int64_t>({{}})),
+                        // Nested array: [[1, 2, 3], [4, 5]]
+                        makeConstantExpr(makeArrayVector({0}, makeArrayVector<int64_t>({{1, 2, 3}, {4, 5}}))),
+                    };
+                    std::vector<std::string> names(expressions.size());
+                    for (auto i = 0; i < names.size(); ++i) {
+                      names[i] = fmt::format("e{}", i);
+                    }
+                    return std::make_shared<core::ProjectNode>(id, std::move(names), std::move(expressions), input);
+                  })
+                  .planNode();
+  assertPlanConversion(
+      plan,
+      "SELECT array[true, null], array[0, null], array[1, null], "
+      "array[2, null], array[3, null], array[4.4, null], array[5.5, null], "
+      "array[6],"
+      "array['1970-01-02T10:17:36.000123000'::TIMESTAMP],"
+      "array['1992-01-01'::DATE],"
+      "array[INTERVAL 54 MILLISECONDS], "
+      "array[], array[array[1,2,3], array[4,5]]");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, dateType) {
+  auto a = makeFlatVector<int32_t>({0, 1});
+  auto b = makeFlatVector<double_t>({0.3, 0.4});
+  auto c = makeFlatVector<Date>({Date(8036), Date(8035)});
+
+  auto vectors = makeRowVector({"a", "b", "c"}, {a, b, c});
+  createDuckDbTable({vectors});
+
+  auto plan = PlanBuilder().values({vectors}).filter({"c > DATE '1992-01-01'"}).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c > DATE '1992-01-01'");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, subField) {
+  RowVectorPtr data = makeRowVector(
+      {"a", "b", "c"},
+      {
+          makeFlatVector<int64_t>({249, 235, 858}),
+          makeFlatVector<int32_t>({581, -708, -133}),
+          makeFlatVector<double>({0.905, 0.968, 0.632}),
+      });
+  createDuckDbTable({data});
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .project({"cast(row_constructor(a, b) as row(a bigint, b bigint)) as ab", "a", "b", "c"})
+          .project({"cast(row_constructor(ab, c) as row(ab row(a bigint, b bigint), c bigint)) as abc", "a", "b"})
+          .project({"(cast(row_constructor(a, b) as row(a bigint, b bigint))).a", "(abc).ab.a", "(abc).ab.b", "abc.c"})
+          .planNode();
+
+  assertPlanConversion(plan, "SELECT a, a, b, c FROM tmp");
+}
+} // namespace gluten
+
+int main(int argc, char** argv) {
+  facebook::velox::functions::sparksql::registerFunctions("");
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/cpp/velox/tests/VeloxSubstraitSignatureTest.cc
+++ b/cpp/velox/tests/VeloxSubstraitSignatureTest.cc
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "substrait/VeloxSubstraitSignature.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+class VeloxSubstraitSignatureTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    Test::SetUp();
+    functions::prestosql::registerAllScalarFunctions();
+  }
+
+  static std::string toSubstraitSignature(const TypePtr& type) {
+    return VeloxSubstraitSignature::toSubstraitSignature(type->kind());
+  }
+
+  static std::string toSubstraitSignature(const std::string& functionName, const std::vector<TypePtr>& arguments) {
+    return VeloxSubstraitSignature::toSubstraitSignature(functionName, arguments);
+  }
+};
+
+TEST_F(VeloxSubstraitSignatureTest, toSubstraitSignatureWithType) {
+  ASSERT_EQ(toSubstraitSignature(BOOLEAN()), "bool");
+
+  ASSERT_EQ(toSubstraitSignature(TINYINT()), "i8");
+  ASSERT_EQ(toSubstraitSignature(SMALLINT()), "i16");
+  ASSERT_EQ(toSubstraitSignature(INTEGER()), "i32");
+  ASSERT_EQ(toSubstraitSignature(BIGINT()), "i64");
+  ASSERT_EQ(toSubstraitSignature(REAL()), "fp32");
+  ASSERT_EQ(toSubstraitSignature(DOUBLE()), "fp64");
+  ASSERT_EQ(toSubstraitSignature(VARCHAR()), "str");
+  ASSERT_EQ(toSubstraitSignature(VARBINARY()), "vbin");
+  ASSERT_EQ(toSubstraitSignature(TIMESTAMP()), "ts");
+  ASSERT_EQ(toSubstraitSignature(DATE()), "date");
+  ASSERT_EQ(toSubstraitSignature(ARRAY(BOOLEAN())), "list");
+  ASSERT_EQ(toSubstraitSignature(ARRAY(INTEGER())), "list");
+  ASSERT_EQ(toSubstraitSignature(MAP(INTEGER(), BIGINT())), "map");
+  ASSERT_EQ(toSubstraitSignature(ROW({INTEGER(), BIGINT()})), "struct");
+  ASSERT_EQ(toSubstraitSignature(ROW({ARRAY(INTEGER())})), "struct");
+  ASSERT_EQ(toSubstraitSignature(ROW({MAP(INTEGER(), INTEGER())})), "struct");
+  ASSERT_EQ(toSubstraitSignature(ROW({ROW({INTEGER()})})), "struct");
+  ASSERT_EQ(toSubstraitSignature(UNKNOWN()), "u!name");
+}
+
+TEST_F(VeloxSubstraitSignatureTest, toSubstraitSignatureWithFunctionNameAndArguments) {
+  ASSERT_EQ(toSubstraitSignature("eq", {INTEGER(), INTEGER()}), "eq:i32_i32");
+  ASSERT_EQ(toSubstraitSignature("gt", {INTEGER(), INTEGER()}), "gt:i32_i32");
+  ASSERT_EQ(toSubstraitSignature("lt", {INTEGER(), INTEGER()}), "lt:i32_i32");
+  ASSERT_EQ(toSubstraitSignature("gte", {INTEGER(), INTEGER()}), "gte:i32_i32");
+  ASSERT_EQ(toSubstraitSignature("lte", {INTEGER(), INTEGER()}), "lte:i32_i32");
+
+  ASSERT_EQ(toSubstraitSignature("and", {BOOLEAN(), BOOLEAN()}), "and:bool_bool");
+  ASSERT_EQ(toSubstraitSignature("or", {BOOLEAN(), BOOLEAN()}), "or:bool_bool");
+  ASSERT_EQ(toSubstraitSignature("not", {BOOLEAN()}), "not:bool");
+  ASSERT_EQ(toSubstraitSignature("xor", {BOOLEAN(), BOOLEAN()}), "xor:bool_bool");
+
+  ASSERT_EQ(toSubstraitSignature("between", {INTEGER(), INTEGER(), INTEGER()}), "between:i32_i32_i32");
+
+  ASSERT_EQ(toSubstraitSignature("plus", {INTEGER(), INTEGER()}), "plus:i32_i32");
+  ASSERT_EQ(toSubstraitSignature("divide", {INTEGER(), INTEGER()}), "divide:i32_i32");
+
+  ASSERT_EQ(toSubstraitSignature("cardinality", {ARRAY(INTEGER())}), "cardinality:list");
+  ASSERT_EQ(toSubstraitSignature("array_sum", {ARRAY(INTEGER())}), "array_sum:list");
+
+  ASSERT_EQ(toSubstraitSignature("sum", {INTEGER()}), "sum:i32");
+  ASSERT_EQ(toSubstraitSignature("avg", {INTEGER()}), "avg:i32");
+  ASSERT_EQ(toSubstraitSignature("count", {INTEGER()}), "count:i32");
+
+  auto functionType = std::make_shared<const FunctionType>(std::vector<TypePtr>{INTEGER(), VARCHAR()}, BIGINT());
+  std::vector<TypePtr> types = {MAP(INTEGER(), VARCHAR()), functionType};
+  ASSERT_ANY_THROW(toSubstraitSignature("transform_keys", std::move(types)));
+}
+
+} // namespace gluten

--- a/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
+++ b/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include "substrait/SubstraitParser.h"
+#include "substrait/TypeUtils.h"
+#include "substrait/VeloxToSubstraitType.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+class VeloxToSubstraitTypeTest : public ::testing::Test {
+ protected:
+  void testTypeConversion(const TypePtr& type) {
+    SCOPED_TRACE(type->toString());
+
+    google::protobuf::Arena arena;
+    auto substraitType = typeConvertor_->toSubstraitType(arena, type);
+    auto sameType = toVeloxType(substraitParser_->parseType(substraitType)->type);
+    ASSERT_TRUE(sameType->kindEquals(type))
+        << "Expected: " << type->toString() << ", but got: " << sameType->toString();
+  }
+
+  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
+
+  std::shared_ptr<SubstraitParser> substraitParser_ = std::make_shared<SubstraitParser>();
+};
+
+TEST_F(VeloxToSubstraitTypeTest, basic) {
+  testTypeConversion(BOOLEAN());
+
+  testTypeConversion(TINYINT());
+  testTypeConversion(SMALLINT());
+  testTypeConversion(INTEGER());
+  testTypeConversion(BIGINT());
+
+  testTypeConversion(REAL());
+  testTypeConversion(DOUBLE());
+
+  testTypeConversion(VARCHAR());
+  testTypeConversion(VARBINARY());
+
+  testTypeConversion(ARRAY(BIGINT()));
+  testTypeConversion(MAP(BIGINT(), DOUBLE()));
+
+  testTypeConversion(ROW({"a", "b", "c"}, {BIGINT(), BOOLEAN(), VARCHAR()}));
+  testTypeConversion(ROW({"a", "b", "c"}, {BIGINT(), ROW({"x", "y"}, {BOOLEAN(), VARCHAR()}), REAL()}));
+  ASSERT_ANY_THROW(testTypeConversion(ROW({}, {})));
+}
+} // namespace gluten

--- a/cpp/velox/tests/data/filter_upper.json
+++ b/cpp/velox/tests/data/filter_upper.json
@@ -1,0 +1,137 @@
+{
+  "extensions": [{
+          "extensionFunction": {
+              "name": "is_not_null:opt_bool_i32"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 2,
+              "name": "and:opt_bool_bool"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 1,
+              "name": "lt:opt_i32_i32"
+          }
+      }
+  ],
+  "relations": [{
+          "root": {
+              "input": {
+                  "project": {
+                      "common": {
+                          "direct": {}
+                      },
+                      "input": {
+                          "read": {
+                              "common": {
+                                  "direct": {}
+                              },
+                              "baseSchema": {
+                                  "names": ["key"],
+                                  "struct": {
+                                      "types": [{
+                                              "i32": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                          }
+                                      ]
+                                  },
+                                  "partitionColumns": {
+                                      "columnType": ["NORMAL_COL"]
+                                  }
+                              },
+                              "filter": {
+                                  "scalarFunction": {
+                                      "functionReference": 2,
+                                      "outputType": {
+                                          "bool": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                      },
+                                      "arguments": [{
+                                              "value": {
+                                                  "scalarFunction": {
+                                                      "outputType": {
+                                                          "bool": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                      },
+                                                      "arguments": [{
+                                                              "value": {
+                                                                  "selection": {
+                                                                      "directReference": {
+                                                                          "structField": {}
+                                                                      }
+                                                                  }
+                                                              }
+                                                          }
+                                                      ]
+                                                  }
+                                              }
+                                          }, {
+                                              "value": {
+                                                  "scalarFunction": {
+                                                      "functionReference": 1,
+                                                      "outputType": {
+                                                          "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                      },
+                                                      "arguments": [{
+                                                              "value": {
+                                                                  "selection": {
+                                                                      "directReference": {
+                                                                          "structField": {}
+                                                                      }
+                                                                  }
+                                                              }
+                                                          }, {
+                                                              "value": {
+                                                                  "literal": {
+                                                                      "i32": 3
+                                                                  }
+                                                              }
+                                                          }
+                                                      ]
+                                                  }
+                                              }
+                                          }
+                                      ]
+                                  }
+                              },
+                              "localFiles": {
+                                  "items": [{
+                                          "uriFile": "file:///tmp/file.parquet",
+                                          "length": "1486",
+                                          "parquet": {}
+                                      }
+                                  ]
+                              }
+                          }
+                      },
+                      "expressions": [{
+                              "cast": {
+                                  "type": {
+                                      "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                  },
+                                  "input": {
+                                      "selection": {
+                                          "directReference": {
+                                              "structField": {}
+                                          }
+                                      }
+                                  },
+                                  "failureBehavior": "FAILURE_BEHAVIOR_RETURN_NULL"
+                              }
+                          }
+                      ]
+                  }
+              },
+              "names": ["key#173"]
+          }
+      }
+  ]
+}

--- a/cpp/velox/tests/data/group.json
+++ b/cpp/velox/tests/data/group.json
@@ -1,0 +1,34 @@
+{
+  "relations": [{
+          "root": {
+              "input": {
+                  "aggregate": {
+                      "common": {
+                          "direct": {}
+                      },
+                      "input": {
+                          "read": {
+                              "common": {
+                                  "direct": {}
+                              },
+                              "baseSchema": {
+                                  "struct": {}
+                              },
+                              "localFiles": {
+                                "items": [{
+                                        "uriFile": "file:///tmp/tmp_file",
+                                        "length": "31979",
+                                        "parquet": {}
+                                    }
+                                ]
+                            }
+                          }
+                      },
+                      "groupings": [{}
+                      ]
+                  }
+              }
+          }
+      }
+  ]
+}

--- a/cpp/velox/tests/data/if_then.json
+++ b/cpp/velox/tests/data/if_then.json
@@ -1,0 +1,398 @@
+{
+  "extensions": [{
+          "extensionFunction": {
+              "functionAnchor": 4,
+              "name": "gt:i64_i64"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 2,
+              "name": "or:bool_bool"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 1,
+              "name": "equal:str_str"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 5,
+              "name": "divide:opt_fp64_fp64"
+          }
+      }, {
+          "extensionFunction": {
+              "name": "is_not_null:i64"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 3,
+              "name": "and:bool_bool"
+          }
+      }, {
+          "extensionFunction": {
+              "functionAnchor": 6,
+              "name": "gt:fp64_fp64"
+          }
+      }
+  ],
+  "relations": [{
+          "root": {
+              "input": {
+                  "project": {
+                      "common": {
+                          "direct": {}
+                      },
+                      "input": {
+                          "read": {
+                              "common": {
+                                  "direct": {}
+                              },
+                              "baseSchema": {
+                                  "names": ["hd_demo_sk", "hd_buy_potential", "hd_dep_count", "hd_vehicle_count"],
+                                  "struct": {
+                                      "types": [{
+                                              "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                          }, {
+                                              "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                          }, {
+                                              "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                          }, {
+                                              "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                          }
+                                      ]
+                                  },
+                                  "partitionColumns": {
+                                      "columnType": ["NORMAL_COL", "NORMAL_COL", "NORMAL_COL", "NORMAL_COL"]
+                                  }
+                              },
+                              "filter": {
+                                  "scalarFunction": {
+                                      "functionReference": 3,
+                                      "outputType": {
+                                          "bool": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                      },
+                                      "arguments": [{
+                                              "value": {
+                                                  "scalarFunction": {
+                                                      "functionReference": 3,
+                                                      "outputType": {
+                                                          "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                      },
+                                                      "arguments": [{
+                                                              "value": {
+                                                                  "scalarFunction": {
+                                                                      "functionReference": 3,
+                                                                      "outputType": {
+                                                                          "bool": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                      },
+                                                                      "arguments": [{
+                                                                              "value": {
+                                                                                  "scalarFunction": {
+                                                                                      "functionReference": 3,
+                                                                                      "outputType": {
+                                                                                          "bool": {
+                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                              "value": {
+                                                                                                  "scalarFunction": {
+                                                                                                      "outputType": {
+                                                                                                          "bool": {
+                                                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                                                          }
+                                                                                                      },
+                                                                                                      "arguments": [{
+                                                                                                              "value": {
+                                                                                                                  "selection": {
+                                                                                                                      "directReference": {
+                                                                                                                          "structField": {
+                                                                                                                              "field": 3
+                                                                                                                          }
+                                                                                                                      }
+                                                                                                                  }
+                                                                                                              }
+                                                                                                          }
+                                                                                                      ]
+                                                                                                  }
+                                                                                              }
+                                                                                          }, {
+                                                                                              "value": {
+                                                                                                  "scalarFunction": {
+                                                                                                      "functionReference": 2,
+                                                                                                      "outputType": {
+                                                                                                          "bool": {
+                                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                                          }
+                                                                                                      },
+                                                                                                      "arguments": [{
+                                                                                                              "value": {
+                                                                                                                  "scalarFunction": {
+                                                                                                                      "functionReference": 1,
+                                                                                                                      "outputType": {
+                                                                                                                          "bool": {
+                                                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                          }
+                                                                                                                      },
+                                                                                                                      "arguments": [{
+                                                                                                                              "value": {
+                                                                                                                                  "selection": {
+                                                                                                                                      "directReference": {
+                                                                                                                                          "structField": {
+                                                                                                                                              "field": 1
+                                                                                                                                          }
+                                                                                                                                      }
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }, {
+                                                                                                                              "value": {
+                                                                                                                                  "literal": {
+                                                                                                                                      "string": "\u003e10000"
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }
+                                                                                                                      ]
+                                                                                                                  }
+                                                                                                              }
+                                                                                                          }, {
+                                                                                                              "value": {
+                                                                                                                  "scalarFunction": {
+                                                                                                                      "functionReference": 1,
+                                                                                                                      "outputType": {
+                                                                                                                          "bool": {
+                                                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                          }
+                                                                                                                      },
+                                                                                                                      "arguments": [{
+                                                                                                                              "value": {
+                                                                                                                                  "selection": {
+                                                                                                                                      "directReference": {
+                                                                                                                                          "structField": {
+                                                                                                                                              "field": 1
+                                                                                                                                          }
+                                                                                                                                      }
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }, {
+                                                                                                                              "value": {
+                                                                                                                                  "literal": {
+                                                                                                                                      "string": "unknown"
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }
+                                                                                                                      ]
+                                                                                                                  }
+                                                                                                              }
+                                                                                                          }
+                                                                                                      ]
+                                                                                                  }
+                                                                                              }
+                                                                                          }
+                                                                                      ]
+                                                                                  }
+                                                                              }
+                                                                          }, {
+                                                                              "value": {
+                                                                                  "scalarFunction": {
+                                                                                      "functionReference": 4,
+                                                                                      "outputType": {
+                                                                                          "bool": {
+                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                              "value": {
+                                                                                                  "selection": {
+                                                                                                      "directReference": {
+                                                                                                          "structField": {
+                                                                                                              "field": 3
+                                                                                                          }
+                                                                                                      }
+                                                                                                  }
+                                                                                              }
+                                                                                          }, {
+                                                                                              "value": {
+                                                                                                  "literal": {
+                                                                                                      "i64": "0"
+                                                                                                  }
+                                                                                              }
+                                                                                          }
+                                                                                      ]
+                                                                                  }
+                                                                              }
+                                                                          }
+                                                                      ]
+                                                                  }
+                                                              }
+                                                          }, {
+                                                              "value": {
+                                                                  "ifThen": {
+                                                                      "ifs": [{
+                                                                              "if": {
+                                                                                  "scalarFunction": {
+                                                                                      "functionReference": 4,
+                                                                                      "outputType": {
+                                                                                          "bool": {
+                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                              "value": {
+                                                                                                  "selection": {
+                                                                                                      "directReference": {
+                                                                                                          "structField": {
+                                                                                                              "field": 3
+                                                                                                          }
+                                                                                                      }
+                                                                                                  }
+                                                                                              }
+                                                                                          }, {
+                                                                                              "value": {
+                                                                                                  "literal": {
+                                                                                                      "i64": "0"
+                                                                                                  }
+                                                                                              }
+                                                                                          }
+                                                                                      ]
+                                                                                  }
+                                                                              },
+                                                                              "then": {
+                                                                                  "scalarFunction": {
+                                                                                      "functionReference": 6,
+                                                                                      "outputType": {
+                                                                                          "bool": {
+                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                      },
+                                                                                      "arguments": [{
+                                                                                              "value": {
+                                                                                                  "scalarFunction": {
+                                                                                                      "functionReference": 5,
+                                                                                                      "outputType": {
+                                                                                                          "fp64": {
+                                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                                          }
+                                                                                                      },
+                                                                                                      "arguments": [{
+                                                                                                              "value": {
+                                                                                                                  "cast": {
+                                                                                                                      "type": {
+                                                                                                                          "fp64": {
+                                                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                          }
+                                                                                                                      },
+                                                                                                                      "input": {
+                                                                                                                          "selection": {
+                                                                                                                              "directReference": {
+                                                                                                                                  "structField": {
+                                                                                                                                      "field": 2
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }
+                                                                                                                      }
+                                                                                                                  }
+                                                                                                              }
+                                                                                                          }, {
+                                                                                                              "value": {
+                                                                                                                  "cast": {
+                                                                                                                      "type": {
+                                                                                                                          "fp64": {
+                                                                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                          }
+                                                                                                                      },
+                                                                                                                      "input": {
+                                                                                                                          "selection": {
+                                                                                                                              "directReference": {
+                                                                                                                                  "structField": {
+                                                                                                                                      "field": 3
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }
+                                                                                                                      }
+                                                                                                                  }
+                                                                                                              }
+                                                                                                          }
+                                                                                                      ]
+                                                                                                  }
+                                                                                              }
+                                                                                          }, {
+                                                                                              "value": {
+                                                                                                  "literal": {
+                                                                                                      "fp64": 1.2
+                                                                                                  }
+                                                                                              }
+                                                                                          }
+                                                                                      ]
+                                                                                  }
+                                                                              }
+                                                                          }
+                                                                      ]
+                                                                  }
+                                                              }
+                                                          }
+                                                      ]
+                                                  }
+                                              }
+                                          }, {
+                                              "value": {
+                                                  "scalarFunction": {
+                                                      "outputType": {
+                                                          "bool": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                      },
+                                                      "arguments": [{
+                                                              "value": {
+                                                                  "selection": {
+                                                                      "directReference": {
+                                                                          "structField": {}
+                                                                      }
+                                                                  }
+                                                              }
+                                                          }
+                                                      ]
+                                                  }
+                                              }
+                                          }
+                                      ]
+                                  }
+                              },
+                              "localFiles": {
+                                  "items": [{
+                                          "uriFile": "file:///tmp/tmp_file",
+                                          "length": "31979",
+                                          "parquet": {}
+                                      }
+                                  ]
+                              }
+                          }
+                      },
+                      "expressions": [{
+                              "selection": {
+                                  "directReference": {
+                                      "structField": {}
+                                  }
+                              }
+                          }
+                      ]
+                  }
+              },
+              "names": ["hd_demo_sk#1927"]
+          }
+      }
+  ]
+}

--- a/cpp/velox/tests/data/q1_first_stage.json
+++ b/cpp/velox/tests/data/q1_first_stage.json
@@ -1,0 +1,877 @@
+{
+    "extension_uris": [
+        {
+            "extension_uri_anchor": 1,
+            "uri": "/functions_datetime.yaml"
+        }
+    ],
+    "extensions": [
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 1,
+                "name": "lte:fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 6,
+                "name": "sum:opt_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 3,
+                "name": "subtract:opt_fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 9,
+                "name": "is_not_null:fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 2,
+                "name": "and:bool_bool"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 5,
+                "name": "add:opt_fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 7,
+                "name": "count:opt_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 4,
+                "name": "multiply:opt_fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 8,
+                "name": "count:opt_i32"
+            }
+        }
+    ],
+    "relations": [
+        {
+            "root": {
+                "input": {
+                    "aggregate": {
+                        "common": {
+                            "direct": {}
+                        },
+                        "input": {
+                            "project": {
+                                "common": {
+                                    "direct": {}
+                                },
+                                "input": {
+                                    "project": {
+                                        "common": {
+                                            "direct": {}
+                                        },
+                                        "input": {
+                                            "read": {
+                                                "common": {
+                                                    "direct": {}
+                                                },
+                                                "base_schema": {
+                                                    "names": [
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate"
+                                                    ],
+                                                    "struct": {
+                                                        "types": [
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "string": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "string": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "type_variation_reference": 0,
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                },
+                                                "filter": {
+                                                    "scalar_function": {
+                                                        "function_reference": 2,
+                                                        "arguments": [
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 9,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "selection": {
+                                                                                        "direct_reference": {
+                                                                                            "struct_field": {
+                                                                                                "field": 6
+                                                                                            }
+                                                                                        },
+                                                                                        "root_reference": {}
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 1,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "selection": {
+                                                                                        "direct_reference": {
+                                                                                            "struct_field": {
+                                                                                                "field": 6
+                                                                                            }
+                                                                                        },
+                                                                                        "root_reference": {}
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "value": {
+                                                                                    "literal": {
+                                                                                        "nullable": false,
+                                                                                        "fp64": 10471
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "output_type": {
+                                                            "bool": {
+                                                                "type_variation_reference": 0,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "local_files": {
+                                                    "items": [
+                                                        {
+                                                            "orc": {},
+                                                            "partition_index": "0",
+                                                            "start": "0",
+                                                            "length": "3719",
+                                                            "uri_file": "/mock_lineitem.orc"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "expressions": [
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 0
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 1
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 4
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 5
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "expressions": [
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 4
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 5
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 0
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 1
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    },
+                                    {
+                                        "scalar_function": {
+                                            "function_reference": 4,
+                                            "arguments": [
+                                                {
+                                                    "value": {
+                                                        "selection": {
+                                                            "direct_reference": {
+                                                                "struct_field": {
+                                                                    "field": 1
+                                                                }
+                                                            },
+                                                            "root_reference": {}
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "value": {
+                                                        "scalar_function": {
+                                                            "function_reference": 3,
+                                                            "arguments": [
+                                                                {
+                                                                    "value": {
+                                                                        "literal": {
+                                                                            "nullable": false,
+                                                                            "fp64": 1
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "value": {
+                                                                        "selection": {
+                                                                            "direct_reference": {
+                                                                                "struct_field": {
+                                                                                    "field": 2
+                                                                                }
+                                                                            },
+                                                                            "root_reference": {}
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_type": {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "output_type": {
+                                                "fp64": {
+                                                    "type_variation_reference": 0,
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "scalar_function": {
+                                            "function_reference": 4,
+                                            "arguments": [
+                                                {
+                                                    "value": {
+                                                        "scalar_function": {
+                                                            "function_reference": 4,
+                                                            "arguments": [
+                                                                {
+                                                                    "value": {
+                                                                        "selection": {
+                                                                            "direct_reference": {
+                                                                                "struct_field": {
+                                                                                    "field": 1
+                                                                                }
+                                                                            },
+                                                                            "root_reference": {}
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "value": {
+                                                                        "scalar_function": {
+                                                                            "function_reference": 3,
+                                                                            "arguments": [
+                                                                                {
+                                                                                    "value": {
+                                                                                        "literal": {
+                                                                                            "nullable": false,
+                                                                                            "fp64": 1
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "value": {
+                                                                                        "selection": {
+                                                                                            "direct_reference": {
+                                                                                                "struct_field": {
+                                                                                                    "field": 2
+                                                                                                }
+                                                                                            },
+                                                                                            "root_reference": {}
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "output_type": {
+                                                                                "fp64": {
+                                                                                    "type_variation_reference": 0,
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_type": {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "value": {
+                                                        "scalar_function": {
+                                                            "function_reference": 5,
+                                                            "arguments": [
+                                                                {
+                                                                    "value": {
+                                                                        "literal": {
+                                                                            "nullable": false,
+                                                                            "fp64": 1
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "value": {
+                                                                        "selection": {
+                                                                            "direct_reference": {
+                                                                                "struct_field": {
+                                                                                    "field": 3
+                                                                                }
+                                                                            },
+                                                                            "root_reference": {}
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_type": {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "output_type": {
+                                                "fp64": {
+                                                    "type_variation_reference": 0,
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 2
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    },
+                                    {
+                                        "literal": {
+                                            "nullable": false,
+                                            "i32": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "groupings": [
+                            {
+                                "grouping_expressions": [
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 0
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 1
+                                                }
+                                            },
+                                            "root_reference": {}
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "measures": [
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 4
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 5
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "directReference": {
+                                                        "structField": {
+                                                            "field": 2
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 7,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "i64": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 7,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "i64": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 6
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 7,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 6
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 8,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 7
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "i64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "names": [
+                    "l_returnflag#8",
+                    "l_linestatus#9",
+                    "sum#108",
+                    "sum#109",
+                    "sum#110",
+                    "sum#111",
+                    "sum#112",
+                    "count#113",
+                    "sum#114",
+                    "count#115",
+                    "sum#116",
+                    "count#117",
+                    "count#118"
+                ]
+            }
+        }
+    ],
+    "expected_type_urls": []
+}

--- a/cpp/velox/tests/data/q6_first_stage.json
+++ b/cpp/velox/tests/data/q6_first_stage.json
@@ -1,0 +1,603 @@
+{
+    "extension_uris": [
+        {
+            "extension_uri_anchor": 1,
+            "uri": "/functions_boolean.yaml"
+        }
+    ],
+    "extensions": [
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 4,
+                "name": "lte:fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 6,
+                "name": "sum:opt_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 3,
+                "name": "lt:fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 7,
+                "name": "is_not_null:fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 1,
+                "name": "and:bool_bool"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 2,
+                "name": "gte:fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 1,
+                "function_anchor": 5,
+                "name": "multiply:opt_fp64_fp64"
+            }
+        }
+    ],
+    "relations": [
+        {
+            "root": {
+                "input": {
+                    "aggregate": {
+                        "common": {
+                            "direct": {}
+                        },
+                        "input": {
+                            "project": {
+                                "common": {
+                                    "emit": {
+                                        "outputMapping": [
+                                            2
+                                        ]
+                                    }
+                                },
+                                "input": {
+                                    "project": {
+                                        "common": {
+                                            "emit": {
+                                                "outputMapping": [
+                                                    4,
+                                                    5
+                                                ]
+                                            }
+                                        },
+                                        "input": {
+                                            "read": {
+                                                "common": {
+                                                    "direct": {}
+                                                },
+                                                "base_schema": {
+                                                    "names": [
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_shipdate"
+                                                    ],
+                                                    "struct": {
+                                                        "types": [
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "type_variation_reference": 0,
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                },
+                                                "filter": {
+                                                    "scalar_function": {
+                                                        "function_reference": 1,
+                                                        "arguments": [
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 1,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "scalar_function": {
+                                                                                        "function_reference": 1,
+                                                                                        "arguments": [
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "scalar_function": {
+                                                                                                        "function_reference": 1,
+                                                                                                        "arguments": [
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "scalar_function": {
+                                                                                                                        "function_reference": 1,
+                                                                                                                        "arguments": [
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "scalar_function": {
+                                                                                                                                        "function_reference": 1,
+                                                                                                                                        "arguments": [
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "scalar_function": {
+                                                                                                                                                        "function_reference": 1,
+                                                                                                                                                        "arguments": [
+                                                                                                                                                            {
+                                                                                                                                                                "value": {
+                                                                                                                                                                    "scalar_function": {
+                                                                                                                                                                        "function_reference": 7,
+                                                                                                                                                                        "arguments": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "value": {
+                                                                                                                                                                                    "selection": {
+                                                                                                                                                                                        "direct_reference": {
+                                                                                                                                                                                            "struct_field": {
+                                                                                                                                                                                                "field": 3
+                                                                                                                                                                                            }
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "root_reference": {}
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ],
+                                                                                                                                                                        "output_type": {
+                                                                                                                                                                            "bool": {
+                                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "value": {
+                                                                                                                                                                    "scalar_function": {
+                                                                                                                                                                        "function_reference": 7,
+                                                                                                                                                                        "arguments": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "value": {
+                                                                                                                                                                                    "selection": {
+                                                                                                                                                                                        "direct_reference": {
+                                                                                                                                                                                            "struct_field": {
+                                                                                                                                                                                                "field": 2
+                                                                                                                                                                                            }
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "root_reference": {}
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ],
+                                                                                                                                                                        "output_type": {
+                                                                                                                                                                            "bool": {
+                                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ],
+                                                                                                                                                        "output_type": {
+                                                                                                                                                            "bool": {
+                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "scalar_function": {
+                                                                                                                                                        "function_reference": 7,
+                                                                                                                                                        "arguments": [
+                                                                                                                                                            {
+                                                                                                                                                                "value": {
+                                                                                                                                                                    "selection": {
+                                                                                                                                                                        "direct_reference": {
+                                                                                                                                                                            "struct_field": {
+                                                                                                                                                                                "field": 0
+                                                                                                                                                                            }
+                                                                                                                                                                        },
+                                                                                                                                                                        "root_reference": {}
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ],
+                                                                                                                                                        "output_type": {
+                                                                                                                                                            "bool": {
+                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ],
+                                                                                                                                        "output_type": {
+                                                                                                                                            "bool": {
+                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "scalar_function": {
+                                                                                                                                        "function_reference": 2,
+                                                                                                                                        "arguments": [
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "selection": {
+                                                                                                                                                        "direct_reference": {
+                                                                                                                                                            "struct_field": {
+                                                                                                                                                                "field": 3
+                                                                                                                                                            }
+                                                                                                                                                        },
+                                                                                                                                                        "root_reference": {}
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "literal": {
+                                                                                                                                                        "nullable": false,
+                                                                                                                                                        "fp64": 8766
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ],
+                                                                                                                                        "output_type": {
+                                                                                                                                            "bool": {
+                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ],
+                                                                                                                        "output_type": {
+                                                                                                                            "bool": {
+                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "scalar_function": {
+                                                                                                                        "function_reference": 3,
+                                                                                                                        "arguments": [
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "selection": {
+                                                                                                                                        "direct_reference": {
+                                                                                                                                            "struct_field": {
+                                                                                                                                                "field": 3
+                                                                                                                                            }
+                                                                                                                                        },
+                                                                                                                                        "root_reference": {}
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "literal": {
+                                                                                                                                        "nullable": false,
+                                                                                                                                        "fp64": 9131
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ],
+                                                                                                                        "output_type": {
+                                                                                                                            "bool": {
+                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ],
+                                                                                                        "output_type": {
+                                                                                                            "bool": {
+                                                                                                                "type_variation_reference": 0,
+                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "scalar_function": {
+                                                                                                        "function_reference": 2,
+                                                                                                        "arguments": [
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "selection": {
+                                                                                                                        "direct_reference": {
+                                                                                                                            "struct_field": {
+                                                                                                                                "field": 2
+                                                                                                                            }
+                                                                                                                        },
+                                                                                                                        "root_reference": {}
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "literal": {
+                                                                                                                        "nullable": false,
+                                                                                                                        "fp64": 0.05
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ],
+                                                                                                        "output_type": {
+                                                                                                            "bool": {
+                                                                                                                "type_variation_reference": 0,
+                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        ],
+                                                                                        "output_type": {
+                                                                                            "bool": {
+                                                                                                "type_variation_reference": 0,
+                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "value": {
+                                                                                    "scalar_function": {
+                                                                                        "function_reference": 4,
+                                                                                        "arguments": [
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "selection": {
+                                                                                                        "direct_reference": {
+                                                                                                            "struct_field": {
+                                                                                                                "field": 2
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "root_reference": {}
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "literal": {
+                                                                                                        "nullable": false,
+                                                                                                        "fp64": 0.07
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        ],
+                                                                                        "output_type": {
+                                                                                            "bool": {
+                                                                                                "type_variation_reference": 0,
+                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 3,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "selection": {
+                                                                                        "direct_reference": {
+                                                                                            "struct_field": {
+                                                                                                "field": 0
+                                                                                            }
+                                                                                        },
+                                                                                        "root_reference": {}
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "value": {
+                                                                                    "literal": {
+                                                                                        "nullable": false,
+                                                                                        "fp64": 24
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "output_type": {
+                                                            "bool": {
+                                                                "type_variation_reference": 0,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "local_files": {
+                                                    "items": [
+                                                        {
+                                                            "partition_index": "0",
+                                                            "start": "0",
+                                                            "length": "3719",
+                                                            "uri_file": "/mock_lineitem.dwrf",
+                                                            "dwrf": {}
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "expressions": [
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 1
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "expressions": [
+                                    {
+                                        "scalar_function": {
+                                            "function_reference": 5,
+                                            "arguments": [
+                                                {
+                                                    "value": {
+                                                        "selection": {
+                                                            "direct_reference": {
+                                                                "struct_field": {
+                                                                    "field": 0
+                                                                }
+                                                            },
+                                                            "root_reference": {}
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "value": {
+                                                        "selection": {
+                                                            "direct_reference": {
+                                                                "struct_field": {
+                                                                    "field": 1
+                                                                }
+                                                            },
+                                                            "root_reference": {}
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "output_type": {
+                                                "fp64": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "groupings": [
+                            {}
+                        ],
+                        "measures": [
+                            {
+                                "measure": {
+                                    "functionReference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 0
+                                                        }
+                                                    },
+                                                    "root_reference": {}
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "names": [
+                    "sum#43"
+                ]
+            }
+        }
+    ]
+}

--- a/cpp/velox/tests/data/substrait_virtualTable.json
+++ b/cpp/velox/tests/data/substrait_virtualTable.json
@@ -1,0 +1,153 @@
+{
+ "extension_uris": [],
+ "extensions": [],
+ "relations": [
+  {
+   "root": {
+    "input": {
+     "read": {
+      "common": {
+       "direct": {}
+      },
+      "base_schema": {
+       "names": [
+        "c0",
+        "c1",
+        "c2",
+        "c3",
+        "c4"
+       ],
+       "struct": {
+        "types": [
+         {
+          "i64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_REQUIRED"
+          }
+         },
+         {
+          "i32": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_REQUIRED"
+          }
+         },
+         {
+          "fp64": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_REQUIRED"
+          }
+         },
+         {
+          "bool": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_REQUIRED"
+          }
+         },
+         {
+          "i32": {
+           "type_variation_reference": 0,
+           "nullability": "NULLABILITY_NULLABLE"
+          }
+         }
+        ],
+        "type_variation_reference": 0,
+        "nullability": "NULLABILITY_NULLABLE"
+       }
+      },
+      "virtual_table": {
+       "values": [
+        {
+         "fields": [
+          {
+           "nullable": false,
+           "i64": "2499109626526694126"
+          },
+          {
+           "nullable": false,
+           "i64": "2342493223442167775"
+          },
+          {
+           "nullable": false,
+           "i64": "4077358421272316858"
+          },
+          {
+           "nullable": false,
+           "i32": 581869302
+          },
+          {
+           "nullable": false,
+           "i32": -708632711
+          },
+          {
+           "nullable": false,
+           "i32": -133711905
+          },
+          {
+           "nullable": false,
+           "fp64": 0.90579193414549275
+          },
+          {
+           "nullable": false,
+           "fp64": 0.96886777112423139
+          },
+          {
+           "nullable": false,
+           "fp64": 0.63235925003444637
+          },
+          {
+           "nullable": false,
+           "boolean": true
+          },
+          {
+           "nullable": false,
+           "boolean": false
+          },
+          {
+           "nullable": false,
+           "boolean": false
+          },
+          {
+           "null": {
+            "i32": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           },
+           "nullable": true
+          },
+          {
+           "null": {
+            "i32": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           },
+           "nullable": true
+          },
+          {
+           "null": {
+            "i32": {
+             "type_variation_reference": 0,
+             "nullability": "NULLABILITY_NULLABLE"
+            }
+           },
+           "nullable": true
+          }
+         ]
+        }
+       ]
+      }
+     }
+    },
+    "names": [
+     "c0",
+     "c1",
+     "c2",
+     "c3",
+     "c4"
+    ]
+   }
+  }
+ ],
+ "expected_type_urls": []
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

To simply the process of Velox rebase and enhance code maintainability, this PR moves the Velox-Substrait plan conversion from Velox to Gluten cpp.

(Fixes: \#2346)

## How was this patch tested?

under test

