### PR TITLE
[CORE] Minor refactor for doValidate logic and related config

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHValidatorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHValidatorApi.scala
@@ -19,7 +19,7 @@ package io.glutenproject.backendsapi.clickhouse
 import io.glutenproject.backendsapi.ValidatorApi
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.utils.CHExpressionUtil
-import io.glutenproject.validate.NativePlanValidatorInfo
+import io.glutenproject.validate.NativePlanValidationInfo
 import io.glutenproject.vectorized.CHNativeExpressionEvaluator
 
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -34,7 +34,7 @@ class CHValidatorApi extends ValidatorApi with AdaptiveSparkPlanHelper {
     validator.doValidate(plan.toProtobuf.toByteArray)
   }
 
-  override def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidatorInfo = {
+  override def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidationInfo = {
     // not applicable for now but may implement in future
     null
   }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
@@ -16,17 +16,12 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.GlutenConfig
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.SubstraitContext
-import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.RelBuilder
-import io.glutenproject.vectorized.CHNativeExpressionEvaluator
 
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Expression}
 import org.apache.spark.sql.execution.SparkPlan
-
-import com.google.common.collect.Lists
 
 import java.util
 
@@ -41,25 +36,14 @@ case class CHFilterExecTransformer(condition: Expression, child: SparkPlan)
     if (leftCondition == null) {
       // All the filters can be pushed down and the computing of this Filter
       // is not needed.
-      return ok()
+      return ValidationResult.ok
     }
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
     val relNode =
       getRelNode(substraitContext, leftCondition, child.output, operatorId, null, validation = true)
-    val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-    // Then, validate the generated plan in native engine.
-    if (GlutenConfig.getConf.enableNativeValidation) {
-      val validator = new CHNativeExpressionEvaluator()
-      if (validator.doValidate(planNode.toProtobuf.toByteArray)) {
-        ok()
-      } else {
-        notOk("native check failure")
-      }
-    } else {
-      ok()
-    }
+    doNativeValidation(substraitContext, relNode)
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashJoinExecTransformer.scala
@@ -51,7 +51,7 @@ case class CHShuffledHashJoinExecTransformer(
     val shouldFallback =
       CHJoinValidateUtil.shouldFallback(joinType, left.outputSet, right.outputSet, condition)
     if (shouldFallback) {
-      return notOk("ch join validate fail")
+      return ValidationResult.notOk("ch join validate fail")
     }
     super.doValidateInternal()
   }
@@ -86,10 +86,10 @@ case class CHBroadcastHashJoinExecTransformer(
       CHJoinValidateUtil.shouldFallback(joinType, left.outputSet, right.outputSet, condition)
 
     if (shouldFallback) {
-      return notOk("ch join validate fail")
+      return ValidationResult.notOk("ch join validate fail")
     }
     if (isNullAwareAntiJoin) {
-      return notOk("ch does not support NAAJ")
+      return ValidationResult.notOk("ch does not support NAAJ")
     }
     super.doValidateInternal()
   }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSParquetSuite.scala
@@ -45,8 +45,8 @@ class GlutenClickHouseTPCDSParquetSuite extends GlutenClickHouseTPCDSAbstractSui
       //      .set("spark.sql.files.maxPartitionBytes", "134217728")
       //      .set("spark.sql.files.openCostInBytes", "134217728")
       .set("spark.memory.offHeap.size", "4g")
-      .set("spark.gluten.sql.validate.failure.logLevel", "ERROR")
-      .set("spark.gluten.sql.validate.failure.printStack", "true")
+      .set("spark.gluten.sql.validation.logLevel", "ERROR")
+      .set("spark.gluten.sql.validation.printStackOnFailure", "true")
   }
 
   executeTPCDSTest(false)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/TransformerHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/TransformerHandler.scala
@@ -39,7 +39,7 @@ class TransformerHandler extends TransformerApi with Logging {
   override def validateColumnarShuffleExchangeExec(outputPartitioning: Partitioning,
                                                    child: SparkPlan)
   : Boolean = {
-    new VeloxValidator().doSchemaValidate(child.schema)
+    new Validator().doSchemaValidate(child.schema)
   }
 
   /**

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/TransformerHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/TransformerHandler.scala
@@ -39,7 +39,7 @@ class TransformerHandler extends TransformerApi with Logging {
   override def validateColumnarShuffleExchangeExec(outputPartitioning: Partitioning,
                                                    child: SparkPlan)
   : Boolean = {
-    new Validator().doSchemaValidate(child.schema)
+    new VeloxValidator().doSchemaValidate(child.schema)
   }
 
   /**

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -35,7 +35,7 @@ class VeloxBackend extends Backend {
   override def iteratorApi(): IteratorApi = new IteratorHandler
   override def sparkPlanExecApi(): SparkPlanExecApi = new SparkPlanExecHandler
   override def transformerApi(): TransformerApi = new TransformerHandler
-  override def validatorApi(): ValidatorApi = new Validator
+  override def validatorApi(): ValidatorApi = new VeloxValidator
   override def metricsApi(): MetricsApi = new MetricsHandler
   override def settings(): BackendSettingsApi = BackendSettings
   override def contextApi(): ContextApi = new ContextInitializer

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -35,7 +35,7 @@ class VeloxBackend extends Backend {
   override def iteratorApi(): IteratorApi = new IteratorHandler
   override def sparkPlanExecApi(): SparkPlanExecApi = new SparkPlanExecHandler
   override def transformerApi(): TransformerApi = new TransformerHandler
-  override def validatorApi(): ValidatorApi = new VeloxValidator
+  override def validatorApi(): ValidatorApi = new Validator
   override def metricsApi(): MetricsApi = new MetricsHandler
   override def settings(): BackendSettingsApi = BackendSettings
   override def contextApi(): ContextApi = new ContextInitializer

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxValidator.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxValidator.scala
@@ -27,7 +27,7 @@ import io.glutenproject.vectorized.NativePlanEvaluator
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.SparkPlan
 
-class VeloxValidator extends ValidatorApi {
+class Validator extends ValidatorApi {
 
   override def doExprValidate(substraitExprName: String, expr: Expression): Boolean =
     doExprValidate(Map(), substraitExprName, expr)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxValidator.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxValidator.scala
@@ -21,13 +21,13 @@ import io.glutenproject.backendsapi.ValidatorApi
 
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, StructType, TimestampType}
 import io.glutenproject.substrait.plan.PlanNode
-import io.glutenproject.validate.NativePlanValidatorInfo
+import io.glutenproject.validate.NativePlanValidationInfo
 import io.glutenproject.vectorized.NativePlanEvaluator
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.SparkPlan
 
-class Validator extends ValidatorApi {
+class VeloxValidator extends ValidatorApi {
 
   override def doExprValidate(substraitExprName: String, expr: Expression): Boolean =
     doExprValidate(Map(), substraitExprName, expr)
@@ -37,7 +37,7 @@ class Validator extends ValidatorApi {
     validator.doValidate(plan.toProtobuf.toByteArray)
   }
 
-  override def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidatorInfo = {
+  override def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidationInfo = {
     val validator = new NativePlanEvaluator()
     validator.doValidateWithFallBackLog(plan.toProtobuf.toByteArray)
   }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -19,7 +19,7 @@ package io.glutenproject.execution
 
 import scala.collection.mutable.ListBuffer
 
-import io.glutenproject.backendsapi.velox.VeloxValidator
+import io.glutenproject.backendsapi.velox.Validator
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
@@ -54,7 +54,7 @@ case class RowToVeloxColumnarExec(child: SparkPlan)
     // This avoids calling `schema` in the RDD closure, so that we don't need to include the entire
     // plan (this) in the closure.
     val localSchema = schema
-    if (!new VeloxValidator().doSchemaValidate(schema)) {
+    if (!new Validator().doSchemaValidate(schema)) {
       throw new UnsupportedOperationException(
         s"schema ${schema.toString()} contains not support type in row to columnar")
     }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -19,12 +19,13 @@ package io.glutenproject.execution
 
 import scala.collection.mutable.ListBuffer
 
-import io.glutenproject.backendsapi.velox.Validator
+import io.glutenproject.backendsapi.velox.VeloxValidator
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.utils.ArrowAbiUtil
 import io.glutenproject.vectorized._
+
 import org.apache.arrow.c.ArrowSchema
 import org.apache.arrow.memory.ArrowBuf
 
@@ -53,7 +54,7 @@ case class RowToVeloxColumnarExec(child: SparkPlan)
     // This avoids calling `schema` in the RDD closure, so that we don't need to include the entire
     // plan (this) in the closure.
     val localSchema = schema
-    if (!new Validator().doSchemaValidate(schema)) {
+    if (!new VeloxValidator().doSchemaValidate(schema)) {
       throw new UnsupportedOperationException(
         s"schema ${schema.toString()} contains not support type in row to columnar")
     }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -65,7 +65,7 @@ case class VeloxColumnarToRowExec(child: SparkPlan)
         case _: MapType =>
         case _: StructType =>
         case _ =>
-          throw new UnsupportedOperationException(s"${field.dataType} is not supported in " +
+          throw new UnsupportedOperationException(s"${field.dataType} is unsupported in " +
             s"VeloxColumnarToRowExec.")
       }
     }

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -122,9 +122,9 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeDoValidateWithFal
   velox::core::ExecCtx execCtx(pool, &queryCtx);
 
   gluten::SubstraitToVeloxPlanValidator planValidator(pool, &execCtx);
-  jclass infoCls = env->FindClass("Lio/glutenproject/validate/NativePlanValidatorInfo;");
+  jclass infoCls = env->FindClass("Lio/glutenproject/validate/NativePlanValidationInfo;");
   if (infoCls == nullptr) {
-    std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for NativePlanValidatorInfo";
+    std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for NativePlanValidationInfo";
     throw gluten::GlutenException(errorMessage);
   }
   jmethodID method = env->GetMethodID(infoCls, "<init>", "(ILjava/lang/String;)V");

--- a/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidationInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidationInfo.java
@@ -19,10 +19,10 @@ package io.glutenproject.validate;
 
 import java.util.Vector;
 
-public class NativePlanValidatorInfo {
+public class NativePlanValidationInfo {
     private final Vector<String> fallbackInfo = new Vector<>();
     private final int isSupported;
-    public NativePlanValidatorInfo(int isSupported, String fallbackInfo) {
+    public NativePlanValidationInfo(int isSupported, String fallbackInfo) {
         this.isSupported = isSupported;
         String[] splitInfo = fallbackInfo.split("@");
         for(int i = 0; i < splitInfo.length; i++) {

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
@@ -19,7 +19,7 @@ package io.glutenproject.backendsapi
 
 import io.glutenproject.expression.{ExpressionMappings, ExpressionNames}
 import io.glutenproject.substrait.plan.PlanNode
-import io.glutenproject.validate.NativePlanValidatorInfo
+import io.glutenproject.validate.NativePlanValidationInfo
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
 import org.apache.spark.sql.execution.SparkPlan
@@ -90,7 +90,7 @@ trait ValidatorApi {
    */
   def doValidate(plan: PlanNode): Boolean
 
-  def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidatorInfo
+  def doValidateWithFallBackLog(plan: PlanNode): NativePlanValidationInfo
   /**
    * Validate against Compression method, such as bzip2.
    */

--- a/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/CoalesceExecTransformer.scala
@@ -55,10 +55,10 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
   }
 
   override protected def doValidateInternal(): ValidationResult =
-    ValidationResult.notOk("does not support")
+    ValidationResult.notOk(s"$nodeName has not been supported")
 
   override def doTransform(context: SubstraitContext): TransformContext = {
-    throw new UnsupportedOperationException(s"This operator doesn't support doTransform.")
+    throw new UnsupportedOperationException(s"$nodeName doesn't support doTransform.")
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -66,7 +66,7 @@ case class CoalesceExecTransformer(numPartitions: Int, child: SparkPlan)
   }
 
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    throw new UnsupportedOperationException(s"This operator doesn't support doExecuteColumnar().")
+    throw new UnsupportedOperationException(s"$nodeName doesn't support doExecuteColumnar.")
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): CoalesceExecTransformer =

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -17,9 +17,8 @@
 
 package io.glutenproject.execution
 
-import com.google.common.collect.Lists
 import com.google.protobuf.Any
-import io.glutenproject.GlutenConfig
+
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.{ConverterUtils, ExpressionConverter, LiteralTransformer}
 import io.glutenproject.extension.ValidationResult
@@ -28,7 +27,6 @@ import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
-import io.glutenproject.substrait.plan.PlanBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -208,10 +206,10 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
 
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportExpandExec()) {
-      return notOk("backend does not support expand")
+      return ValidationResult.notOk("Current backend does not support expand")
     }
     if (projections.isEmpty) {
-      return notOk("backend does not support empty projections in expand")
+      return ValidationResult.notOk("Current backend does not support empty projections in expand")
     }
 
     val substraitContext = new SubstraitContext
@@ -222,14 +220,7 @@ case class ExpandExecTransformer(projections: Seq[Seq[Expression]],
       projections,
       child.output, operatorId, null, validation = true)
 
-    if (relNode != null && GlutenConfig.getConf.enableNativeValidation) {
-      val planNode = PlanBuilder.makePlan(substraitContext, Lists.newArrayList(relNode))
-      val validateInfo = BackendsApiManager.getValidatorApiInstance
-        .doValidateWithFallBackLog(planNode)
-      nativeValidationResult(validateInfo)
-    } else {
-      ok()
-    }
+    doNativeValidation(substraitContext, relNode)
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -123,8 +123,9 @@ class FileSourceScanExecTransformer(@transient relation: HadoopFsRelation,
 
   override protected def doValidateInternal(): ValidationResult = {
     // Bucketing table has `bucketId` in filename, should apply this in backends
+    // TODO Support bucketed scan
     if (bucketedScan) {
-      throw new UnsupportedOperationException("bucketed scan is not supported")
+      throw new UnsupportedOperationException("Bucketed scan is unsupported for now.")
     }
     super.doValidateInternal()
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -18,6 +18,7 @@ package io.glutenproject.execution
 
 import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.utils.ColumnarShuffleUtil
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression, SortOrder}
@@ -114,5 +115,4 @@ case class TakeOrderedAndProjectExecTransformer(
       finalPlan.doExecuteColumnar()
     }
   }
-
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -28,7 +28,6 @@ import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
 import io.glutenproject.substrait.rel.RelNode
-import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.utils.SubstraitPlanPrinterUtil
 
 import org.apache.spark.rdd.RDD

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarQueryStagePrepOverrides.scala
@@ -67,7 +67,7 @@ case class FallbackBroadcastExchange(session: SparkSession) extends Rule[SparkPl
                     bhj.right,
                     bhj.isNullAwareAntiJoin)
                 val isBhjTransformable = bhjTransformer.doValidate()
-                if (isBhjTransformable.validated) {
+                if (isBhjTransformable.isValid) {
                   val exchangeTransformer = ColumnarBroadcastExchangeExec(mode, child)
                   exchangeTransformer.doValidate()
                 } else {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -129,10 +129,10 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
 
   override protected def doValidateInternal(): ValidationResult = mode match {
     case _: HashedRelationBroadcastMode =>
-      ok()
+      ValidationResult.ok
     case _ =>
-      // IdentityBroadcastMode not supported. Need to support BroadcastNestedLoopJoin first.
-      notOk("only support HashedRelationBroadcastMode")
+      // TODO IdentityBroadcastMode not supported. Need to support BroadcastNestedLoopJoin first.
+      ValidationResult.notOk("Only support HashedRelationBroadcastMode for now.")
   }
 
   override def doPrepare(): Unit = {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -105,9 +105,9 @@ case class ColumnarShuffleExchangeExec(override val outputPartitioning: Partitio
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getTransformerApiInstance.validateColumnarShuffleExchangeExec(
       outputPartitioning, child)) {
-      return notOk("schema check failed")
+      return ValidationResult.notOk("Found schema check failure in shuffle exchange.")
     }
-    ok()
+    ValidationResult.ok
   }
 
   override def nodeName: String = "ColumnarExchange"

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarSubqueryBroadcastExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarSubqueryBroadcastExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
-import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashJoin, HashedRelation, LongHashedRelation}
+import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashedRelation, HashJoin, LongHashedRelation}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.util.ThreadUtils
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -52,7 +52,7 @@ case class GlutenFallbackReporter(
   }
 
   private def printFallbackReason(plan: SparkPlan): Unit = {
-    val validateFailureLogLevel = glutenConfig.validateFailureLogLevel
+    val validationLogLevel = glutenConfig.validationLogLevel
     plan.foreach {
       case _: GlutenPlan => // ignore
       case plan: SparkPlan =>
@@ -62,7 +62,7 @@ case class GlutenFallbackReporter(
             // some SparkPlan do not have hint, e.g., `ColumnarAQEShuffleRead`
             TransformHints.getHintOption(plan) match {
               case Some(TRANSFORM_UNSUPPORTED(reason)) =>
-                logFallbackReason(validateFailureLogLevel, plan.nodeName, reason.getOrElse(""))
+                logFallbackReason(validationLogLevel, plan.nodeName, reason.getOrElse(""))
                 // With in next round stage in AQE, the physical plan would be a new instance that
                 // can not preserve the tag, so we need to set the fallback reason to logical plan.
                 // Then we can be aware of the fallback reason for the whole plan.

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenColumnarRules.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenColumnarRules.scala
@@ -21,6 +21,7 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.ColumnarToRowExecBase
 import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.utils.LogicalPlanSelector
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.InternalRow

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -20,7 +20,7 @@ package io.glutenproject.vectorized;
 import com.google.protobuf.Any;
 import io.glutenproject.GlutenConfig;
 import io.glutenproject.backendsapi.BackendsApiManager;
-import io.glutenproject.validate.NativePlanValidatorInfo;
+import io.glutenproject.validate.NativePlanValidationInfo;
 import io.glutenproject.memory.alloc.NativeMemoryAllocators;
 import io.glutenproject.substrait.expression.ExpressionBuilder;
 import io.glutenproject.substrait.expression.StringMapNode;
@@ -55,7 +55,7 @@ public class NativePlanEvaluator {
     return jniWrapper.nativeDoValidate(subPlan);
   }
 
-  public NativePlanValidatorInfo doValidateWithFallBackLog(byte[] subPlan) {
+  public NativePlanValidationInfo doValidateWithFallBackLog(byte[] subPlan) {
     return jniWrapper.nativeDoValidateWithFallBackLog(subPlan);
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
@@ -17,7 +17,7 @@
 
 package io.glutenproject.vectorized;
 
-import io.glutenproject.validate.NativePlanValidatorInfo;
+import io.glutenproject.validate.NativePlanValidationInfo;
 import io.glutenproject.init.JniInitialized;
 
 /**
@@ -41,7 +41,7 @@ public class PlanEvaluatorJniWrapper extends JniInitialized {
    */
   native boolean nativeDoValidate(byte[] subPlan);
 
-  native NativePlanValidatorInfo nativeDoValidateWithFallBackLog(byte[] subPlan);
+  native NativePlanValidationInfo nativeDoValidateWithFallBackLog(byte[] subPlan);
   /**
    * Create a native compute kernel and return a columnar result iterator.
    *

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -34,7 +34,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.dataFilters,
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan)
-      if (transformer.doValidate().validated) {
+      if (transformer.doValidate().isValid) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -34,7 +34,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
         fileSourceScan.dataFilters,
         fileSourceScan.tableIdentifier,
         fileSourceScan.disableBucketedScan)
-      if (transformer.doValidate().validated) {
+      if (transformer.doValidate().isValid) {
         transformer
       } else {
         plan

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackSuite.scala
@@ -30,7 +30,7 @@ class GlutenFallbackSuite extends GlutenSQLTestsTrait {
     withLogAppender(testAppender) {
       withSQLConf(
         GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key -> "false",
-        GlutenConfig.VALIDATE_FAILURE_LOG_LEVEL.key -> "error") {
+        GlutenConfig.VALIDATION_LOG_LEVEL.key -> "error") {
         withTable("t") {
           spark.range(10).write.format("parquet").saveAsTable("t")
           sql("SELECT * FROM t").collect()

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -207,7 +207,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def substraitPlanLogLevel: String = conf.getConf(SUBSTRAIT_PLAN_LOG_LEVEL)
 
-  def validateFailureLogLevel: String = conf.getConf(VALIDATE_FAILURE_LOG_LEVEL)
+  def validationLogLevel: String = conf.getConf(VALIDATION_LOG_LEVEL)
 
   def softAffinityLogLevel: String = conf.getConf(SOFT_AFFINITY_LOG_LEVEL)
 
@@ -219,8 +219,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def extendedExpressionTransformer: String = conf.getConf(EXTENDED_EXPRESSION_TRAN_CONF)
 
-  def printStackOnValidateFailure: Boolean =
-    conf.getConf(VALIDATE_FAILURE_PRINT_STACK_ENABLED)
+  def printStackOnValidationFailure: Boolean =
+    conf.getConf(VALIDATION_PRINT_FAILURE_STACK_)
 
   def enableFallbackReport: Boolean = conf.getConf(FALLBACK_REPORTER_ENABLED)
 
@@ -912,8 +912,8 @@ object GlutenConfig {
         "Valid values are 'trace', 'debug', 'info', 'warn' and 'error'.")
       .createWithDefault("DEBUG")
 
-  val VALIDATE_FAILURE_LOG_LEVEL =
-    buildConf("spark.gluten.sql.validate.failure.logLevel")
+  val VALIDATION_LOG_LEVEL =
+    buildConf("spark.gluten.sql.validation.logLevel")
       .internal()
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
@@ -921,6 +921,12 @@ object GlutenConfig {
         logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
         "Valid values are 'trace', 'debug', 'info', 'warn' and 'error'.")
       .createWithDefault("INFO")
+
+  val VALIDATION_PRINT_FAILURE_STACK_ =
+    buildConf("spark.gluten.sql.validation.printStackOnFailure")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
 
   val SOFT_AFFINITY_LOG_LEVEL =
     buildConf("spark.gluten.soft-affinity.logLevel")
@@ -931,12 +937,6 @@ object GlutenConfig {
         logLevel => Set("TRACE", "DEBUG", "INFO", "WARN", "ERROR").contains(logLevel),
         "Valid values are 'trace', 'debug', 'info', 'warn' and 'error'.")
       .createWithDefault("DEBUG")
-
-  val VALIDATE_FAILURE_PRINT_STACK_ENABLED =
-    buildConf("spark.gluten.sql.validate.failure.printStack")
-      .internal()
-      .booleanConf
-      .createWithDefault(false)
 
   val DEBUG_LEVEL_ENABLED =
     buildConf("spark.gluten.sql.debug")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unify spark.gluten.sql.enable.native.validation usage, it's only used by GlutenPlan#doNativeValidation now, and user could use it to decide whether validate substrait plan in native side or not.

Rename `spark.gluten.sql.validate.failure.logLevel` to `spark.gluten.sql.validation.logLevel`, `spark.gluten.sql.validate.failure.printStack` to `spark.gluten.sql.validation.printStackOnFailure`

Fix some related class typo and lots of log content.
