### PR TITLE
[GLUTEN-2199] let all reader buffer builder to use query context rath…

### DIFF
--- a/cpp-ch/local-engine/Storages/Output/WriteBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/Output/WriteBufferBuilder.cpp
@@ -56,7 +56,7 @@ public:
         Poco::URI file_uri(file_uri_);
         std::unique_ptr<DB::WriteBuffer> write_buffer;
 
-        auto builder = DB::createHDFSBuilder(file_uri_, context->getGlobalContext()->getConfigRef());
+        auto builder = DB::createHDFSBuilder(file_uri_, context->getConfigRef());
         auto fs = DB::createHDFSFS(builder.get());
         auto first = file_uri_.find('/', file_uri_.find("//") + 2);
         auto last = file_uri_.find_last_of('/');
@@ -68,7 +68,7 @@ public:
         }
 
         DB::WriteSettings write_settings;
-        write_buffer = std::make_unique<DB::WriteBufferFromHDFS>(file_uri_, context->getGlobalContext()->getConfigRef(), 0, write_settings);
+        write_buffer = std::make_unique<DB::WriteBufferFromHDFS>(file_uri_, context->getConfigRef(), 0, write_settings);
         return write_buffer;
     }
 };

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -101,7 +101,7 @@ public:
                 start_end_pos.first,
                 start_end_pos.second);
             read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
-                uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(),
+                uri_path, file_uri.getPath(), context->getConfigRef(),
                 read_settings, start_end_pos.second);
 
             if (auto * seekable_in = dynamic_cast<DB::SeekableReadBuffer *>(read_buffer.get()))
@@ -111,7 +111,7 @@ public:
         else
         {
             read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
-                uri_path, file_uri.getPath(), context->getGlobalContext()->getConfigRef(), read_settings);
+                uri_path, file_uri.getPath(), context->getConfigRef(), read_settings);
         }
         return read_buffer;
     }
@@ -120,7 +120,7 @@ public:
     adjustFileReadStartAndEndPos(size_t read_start_pos, size_t read_end_pos, std::string uri_path, std::string file_path)
     {
         std::string hdfs_file_path = uri_path + file_path;
-        auto builder = DB::createHDFSBuilder(hdfs_file_path, context->getGlobalContext()->getConfigRef());
+        auto builder = DB::createHDFSBuilder(hdfs_file_path, context->getConfigRef());
         auto fs = DB::createHDFSFS(builder.get());
         hdfsFile fin = hdfsOpenFile(fs.get(), file_path.c_str(), O_RDONLY, 0, 0, 0);
         if (!fin)
@@ -371,7 +371,7 @@ private:
         DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
             region_name,
             context->getRemoteHostFilter(),
-            static_cast<unsigned>(context->getGlobalContext()->getSettingsRef().s3_max_redirects),
+            static_cast<unsigned>(context->getSettingsRef().s3_max_redirects),
             false,
             false,
             nullptr,


### PR DESCRIPTION
…er than global context, to avoid lock conflict

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

