### PR TITLE
Revert "[GLUTEN-2199][CH] support dynamically configure per bucket roles"

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeExpressionEvaluator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeExpressionEvaluator.java
@@ -30,7 +30,6 @@ import com.google.protobuf.Any;
 import io.substrait.proto.Plan;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
-import org.apache.spark.sql.internal.SQLConf;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -87,15 +86,7 @@ public class CHNativeExpressionEvaluator {
     long allocId = CHNativeMemoryAllocators.contextInstance().getNativeInstanceId();
     long handle =
         jniWrapper.nativeCreateKernelWithIterator(
-            allocId,
-            getPlanBytesBuf(wsPlan),
-            iterList.toArray(new GeneralInIterator[0]),
-            buildNativeConfNode(
-                    GlutenConfig.getNativeBackendConf(
-                        BackendsApiManager.getSettings().getBackendConfigPrefix(),
-                        SQLConf.get().getAllConfs()))
-                .toProtobuf()
-                .toByteArray());
+            allocId, getPlanBytesBuf(wsPlan), iterList.toArray(new GeneralInIterator[0]));
     return createOutIterator(handle, outAttrs);
   }
 
@@ -105,15 +96,7 @@ public class CHNativeExpressionEvaluator {
       throws RuntimeException, IOException {
     long handle =
         jniWrapper.nativeCreateKernelWithIterator(
-            allocId,
-            wsPlan,
-            iterList.toArray(new GeneralInIterator[0]),
-            buildNativeConfNode(
-                    GlutenConfig.getNativeBackendConf(
-                        BackendsApiManager.getSettings().getBackendConfigPrefix(),
-                        SQLConf.get().getAllConfs()))
-                .toProtobuf()
-                .toByteArray());
+            allocId, wsPlan, iterList.toArray(new GeneralInIterator[0]));
     return createOutIterator(handle, outAttrs);
   }
 

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -48,8 +48,10 @@ public class ExpressionEvaluatorJniWrapper {
    * @return iterator instance id
    */
   public native long nativeCreateKernelWithIterator(
-      long allocatorId, byte[] wsPlan, GeneralInIterator[] batchItr, byte[] confArray)
-      throws RuntimeException;
+      long allocatorId, byte[] wsPlan, GeneralInIterator[] batchItr) throws RuntimeException;
+
+  /** Create a native compute kernel and return a row iterator. */
+  native long nativeCreateKernelWithRowIterator(byte[] wsPlan) throws RuntimeException;
 
   /**
    * Closes the projector referenced by nativeHandler.

--- a/backends-clickhouse/src/test/scala/io/glutenproject/s3/S3AuthSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/s3/S3AuthSuite.scala
@@ -49,8 +49,8 @@ class S3AuthSuite extends AnyFunSuite {
   val trustingEndpoint2 = "s3.us-east-2.amazonaws.com"
 
   // this is the "trusted user part", e.g. consumer of customer's data
-  val trustedAK = System.getenv("S3AuthSuiteAK") // @ global prod
-  val trustedSK = System.getenv("S3AuthSuiteSK")
+  val trustedAK = "" // @ global prod
+  val trustedSK = ""
   val trustedOwnedBucket = "mhb-prod-bucket" // another bucket in us-west-2
   val trustedOwnedParquetPath = s"s3a://$trustedOwnedBucket/tpch10_nation"
   val trustedOwnedEndpoint = "s3.us-west-2.amazonaws.com"
@@ -225,77 +225,8 @@ class S3AuthSuite extends AnyFunSuite {
     }
   }
 
-  test(s"test update config later") {
-    val spark = SparkSession
-      .builder()
-      .appName("Gluten-S3-Test")
-      .master(s"local[1]")
-      .config("spark.plugins", "io.glutenproject.GlutenPlugin")
-      .config(GlutenConfig.GLUTEN_LIB_PATH, libPath)
-      .config("spark.memory.offHeap.enabled", "true")
-      .config("spark.memory.offHeap.size", "1g")
-      .config("spark.gluten.sql.enable.native.validation", "false")
-      .config("spark.hadoop.fs.s3a.endpoint", trustingEndpoint2)
-      .config(
-        "spark.hadoop.fs.s3a.aws.credentials.provider",
-        "org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider")
-      .config(s"spark.hadoop.fs.s3a.bucket.$trustingBucket.assumed.role.arn", trustedAssumeRole)
-      .config(s"spark.hadoop.fs.s3a.bucket.$trustingBucket.assumed.role.externalId", "")
-      .config(
-        s"spark.hadoop.fs.s3a.bucket.$trustingBucket.assumed.role.session.name",
-        trustedSessionName)
-      .config(s"spark.hadoop.fs.s3a.bucket.$trustingBucket.endpoint", trustingEndpoint)
-//      .config(s"spark.hadoop.fs.s3a.bucket.$trustingBucket2.assumed.role.arn", trustedAssumeRole2)
-//      .config(
-//        s"spark.hadoop.fs.s3a.bucket.$trustingBucket2.assumed.role.session.name",
-//        trustedSessionName2)
-//      .config(
-//        s"spark.hadoop.fs.s3a.bucket.$trustingBucket2.assumed.role.externalId",
-//        trustedExternalId2
-//      )
-      // The following two configs are provided to help hadoop-aws to pass.
-      // They're not required by native code (they don't have prefix spark.hadoop so
-      // native code will not see them)
-      // They're also unnecessary in real EC2 instance environment (at least it's the case with Kyligence/hadoop-aws)
-      .config("fs.s3a.assumed.role.sts.endpoint.region", "us-east-1")
-      .config("fs.s3a.assumed.role.sts.endpoint", "sts.us-east-1.amazonaws.com")
-      .withAuthMode("AKSK", assuming = true)
-      .withGluten(true)
-      .enableHiveSupport()
-      .getOrCreate()
-
-    try {
-      spark.read.parquet(trustingParquetPath).show(10)
-      try {
-        spark.read.parquet(trustingParquetPath2).show(10)
-        throw new Exception("should not reach here")
-      } catch {
-        case e: java.io.IOException => println("meet io exception as expected")
-      }
-
-      // compensate the configs for trustingBucket2
-      spark.conf.set(
-        s"spark.hadoop.fs.s3a.bucket.$trustingBucket2.assumed.role.arn",
-        trustedAssumeRole2)
-      spark.conf.set(
-        s"spark.hadoop.fs.s3a.bucket.$trustingBucket2.assumed.role.session.name",
-        trustedSessionName2)
-      // without the following two configs, java side will throw exception.
-      // I guess the spark.hadoop.xx configs are only converted to xx once.
-      spark.conf.set(s"fs.s3a.bucket.$trustingBucket2.assumed.role.arn", trustedAssumeRole2)
-      spark.conf.set(
-        s"fs.s3a.bucket.$trustingBucket2.assumed.role.session.name",
-        trustedSessionName2)
-
-      spark.read.parquet(trustingParquetPath2).show(10)
-    } finally {
-      spark.close
-      FileSystem.closeAll()
-    }
-  }
-
   // a special case for CN aws
-  ignore("CN: simple ak sk") {
+  test("CN: simple ak sk") {
     val spark = SparkSession
       .builder()
       .appName("Gluten-S3-Test")

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -447,17 +447,16 @@ std::map<std::string, std::string> BackendInitializerUtil::getBackendConfMap(con
     return ch_backend_conf;
 }
 
-DB::Context::ConfigurationPtr BackendInitializerUtil::initConfig(std::string * plan)
+void BackendInitializerUtil::initConfig(std::string * plan)
 {
-    DB::Context::ConfigurationPtr config;
     if (plan == nullptr)
     {
         config = Poco::AutoPtr(new Poco::Util::MapConfiguration());
-        return config;
+        return;
     }
 
     /// Parse input substrait plan, and get native conf map from it.
-    std::map<std::string, std::string> backend_conf_map = getBackendConfMap(*plan);
+    backend_conf_map = getBackendConfMap(*plan);
     if (backend_conf_map.count(CH_RUNTIME_CONFIG_FILE))
     {
         if (fs::exists(CH_RUNTIME_CONFIG_FILE) && fs::is_regular_file(CH_RUNTIME_CONFIG_FILE))
@@ -481,13 +480,8 @@ DB::Context::ConfigurationPtr BackendInitializerUtil::initConfig(std::string * p
 
         if (key.starts_with(CH_RUNTIME_CONFIG_PREFIX) && key != CH_RUNTIME_CONFIG_FILE)
         {
-            // Apply spark.gluten.sql.columnar.backend.ch.runtime_config.* to config
+            /// Apply spark.gluten.sql.columnar.backend.ch.runtime_config.* to config
             config->setString(key.substr(CH_RUNTIME_CONFIG_PREFIX.size()), value);
-        }
-        if (key.starts_with(CH_RUNTIME_SETTINGS_PREFIX))
-        {
-            // temporally put runtime_settings into config, so that they can be retrieved later in initSettings
-            config->setString(key, value);
         }
         else if (key.starts_with(SPARK_HADOOP_PREFIX + S3A_PREFIX + "bucket"))
         {
@@ -515,12 +509,11 @@ DB::Context::ConfigurationPtr BackendInitializerUtil::initConfig(std::string * p
             // Apply general S3 configs, e.g. spark.hadoop.fs.s3a.access.key -> set in fs.s3a.access.key
             config->setString(key.substr(SPARK_HADOOP_PREFIX.length()), value);
         }
+
     }
-    return config;
 }
 
-
-void BackendInitializerUtil::initLoggers(DB::Context::ConfigurationPtr config)
+void BackendInitializerUtil::initLoggers()
 {
     auto level = config->getString("logger.level", "error");
     if (config->has("logger.log"))
@@ -531,7 +524,7 @@ void BackendInitializerUtil::initLoggers(DB::Context::ConfigurationPtr config)
     logger = &Poco::Logger::get("ClickHouseBackend");
 }
 
-void BackendInitializerUtil::initEnvs(DB::Context::ConfigurationPtr config)
+void BackendInitializerUtil::initEnvs()
 {
     /// Set environment variable TZ if possible
     if (config->has("timezone"))
@@ -555,53 +548,48 @@ void BackendInitializerUtil::initEnvs(DB::Context::ConfigurationPtr config)
     setenv("HDFS_ENABLE_LOGGING", "true", true); /// NOLINT
 }
 
-std::unique_ptr<DB::Settings> BackendInitializerUtil::initSettings(DB::Context::ConfigurationPtr config)
+void BackendInitializerUtil::initSettings()
 {
     static const std::string settings_path("local_engine.settings");
-    static const std::string runtime_settings_path(CH_RUNTIME_SETTINGS_PREFIX);
 
-    std::unique_ptr<DB::Settings> settings = std::make_unique<DB::Settings>();
+    settings = Settings();
 
     /// Initialize default setting.
-    settings->set("date_time_input_format", "best_effort");
+    settings.set("date_time_input_format", "best_effort");
+
+    Poco::Util::AbstractConfiguration::Keys config_keys;
+    config->keys(settings_path, config_keys);
 
     /// Firstly apply section [local_engine.settings] in config file to settings
-    {
-        Poco::Util::AbstractConfiguration::Keys settings_keys;
-        config->keys(settings_path, settings_keys);
-
-        for (const std::string & key : settings_keys)
-            settings->set(key, config->getString(settings_path + "." + key));
-    }
+    for (const std::string & key : config_keys)
+        settings.set(key, config->getString(settings_path + "." + key));
 
     /// Secondly apply spark.gluten.sql.columnar.backend.ch.runtime_settings.* to settings
+    for (const auto & kv : backend_conf_map)
     {
-        Poco::Util::AbstractConfiguration::Keys runtime_settings_keys;
-        config->keys(runtime_settings_path, runtime_settings_keys);
-
-        for (const std::string & key : runtime_settings_keys)
-            settings->set(key, config->getString(runtime_settings_path + "." + key));
+        const auto & key = kv.first;
+        const auto & value = kv.second;
+        if (key.starts_with(CH_RUNTIME_SETTINGS_PREFIX))
+            settings.set(key.substr(CH_RUNTIME_SETTINGS_PREFIX.size()), value);
     }
 
     /// Finally apply some fixed kvs to settings.
-    settings->set("join_use_nulls", true);
-    settings->set("input_format_orc_allow_missing_columns", true);
-    settings->set("input_format_orc_case_insensitive_column_matching", true);
-    settings->set("input_format_orc_import_nested", true);
-    settings->set("input_format_parquet_allow_missing_columns", true);
-    settings->set("input_format_parquet_case_insensitive_column_matching", true);
-    settings->set("input_format_parquet_import_nested", true);
-    settings->set("output_format_parquet_version", "1.0");
-    settings->set("output_format_parquet_compression_method", "snappy");
-    settings->set("output_format_parquet_string_as_string", true);
-    settings->set("output_format_parquet_fixed_string_as_fixed_byte_array", false);
-    settings->set("function_json_value_return_type_allow_complex", true);
-    settings->set("function_json_value_return_type_allow_nullable", true);
-
-    return settings;
+    settings.set("join_use_nulls", true);
+    settings.set("input_format_orc_allow_missing_columns", true);
+    settings.set("input_format_orc_case_insensitive_column_matching", true);
+    settings.set("input_format_orc_import_nested", true);
+    settings.set("input_format_parquet_allow_missing_columns", true);
+    settings.set("input_format_parquet_case_insensitive_column_matching", true);
+    settings.set("input_format_parquet_import_nested", true);
+    settings.set("output_format_parquet_version", "1.0");
+    settings.set("output_format_parquet_compression_method", "snappy");
+    settings.set("output_format_parquet_string_as_string", true);
+    settings.set("output_format_parquet_fixed_string_as_fixed_byte_array", false);
+    settings.set("function_json_value_return_type_allow_complex", true);
+    settings.set("function_json_value_return_type_allow_nullable", true);
 }
 
-void BackendInitializerUtil::initContexts(DB::Context::ConfigurationPtr config)
+void BackendInitializerUtil::initContexts()
 {
     /// Make sure global_context and shared_context are constructed only once.
     auto & shared_context = SerializedPlanParser::shared_context;
@@ -617,7 +605,7 @@ void BackendInitializerUtil::initContexts(DB::Context::ConfigurationPtr config)
         global_context->makeGlobalContext();
         global_context->setConfig(config);
 
-        auto getDefaultPath = [config] -> auto
+        auto getDefaultPath = [] -> auto
         {
             bool use_current_directory_as_tmp = config->getBool("use_current_directory_as_tmp", false);
             char buffer[PATH_MAX];
@@ -632,18 +620,11 @@ void BackendInitializerUtil::initContexts(DB::Context::ConfigurationPtr config)
     }
 }
 
-void BackendInitializerUtil::applyGlobalConfigAndSettings(DB::Context::ConfigurationPtr config, std::unique_ptr<DB::Settings> & settings)
+void BackendInitializerUtil::applyConfigAndSettings()
 {
     auto & global_context = SerializedPlanParser::global_context;
     global_context->setConfig(config);
-    global_context->setSettings(*settings);
-}
-
-void BackendInitializerUtil::applyConfig(
-    DB::ContextMutablePtr context, DB::Context::ConfigurationPtr config, std::unique_ptr<DB::Settings> & settings)
-{
-    context->setConfig(config);
-    context->setSettings(*settings);
+    global_context->setSettings(settings);
 }
 
 extern void registerAggregateFunctionCombinatorPartialMerge(AggregateFunctionCombinatorFactory &);
@@ -675,7 +656,7 @@ void BackendInitializerUtil::registerAllFactories()
     LOG_INFO(logger, "Register all functions.");
 }
 
-void BackendInitializerUtil::initCompiledExpressionCache(DB::Context::ConfigurationPtr config)
+void BackendInitializerUtil::initCompiledExpressionCache()
 {
 #if USE_EMBEDDED_COMPILER
     /// 128 MB
@@ -692,20 +673,19 @@ void BackendInitializerUtil::initCompiledExpressionCache(DB::Context::Configurat
 
 void BackendInitializerUtil::init(std::string * plan)
 {
-    DB::Context::ConfigurationPtr config = initConfig(plan);
+    initConfig(plan);
+    initLoggers();
 
-    initLoggers(config);
-
-    initEnvs(config);
+    initEnvs();
     LOG_INFO(logger, "Init environment variables.");
 
-    std::unique_ptr<DB::Settings> settings = initSettings(config);
+    initSettings();
     LOG_INFO(logger, "Init settings.");
 
-    initContexts(config);
+    initContexts();
     LOG_INFO(logger, "Init shared context and global context.");
 
-    applyGlobalConfigAndSettings(config, settings);
+    applyConfigAndSettings();
     LOG_INFO(logger, "Apply configuration and setting for global context.");
 
     std::call_once(
@@ -715,7 +695,7 @@ void BackendInitializerUtil::init(std::string * plan)
             registerAllFactories();
             LOG_INFO(logger, "Register all factories.");
 
-            initCompiledExpressionCache(config);
+            initCompiledExpressionCache();
             LOG_INFO(logger, "Init compiled expressions cache factory.");
 
             GlobalThreadPool::initialize();
@@ -728,15 +708,10 @@ void BackendInitializerUtil::init(std::string * plan)
         });
 }
 
-void BackendInitializerUtil::updateConfig(DB::ContextMutablePtr context, std::string * plan)
-{
-    DB::Context::ConfigurationPtr config = initConfig(plan);
-    std::unique_ptr<DB::Settings> settings = initSettings(config);
-    applyConfig(context, config, settings);
-}
-
 void BackendFinalizerUtil::finalizeGlobally()
 {
+
+
     auto & global_context = SerializedPlanParser::global_context;
     auto & shared_context = SerializedPlanParser::shared_context;
     if (global_context)
@@ -749,6 +724,7 @@ void BackendFinalizerUtil::finalizeGlobally()
 
 void BackendFinalizerUtil::finalizeSessionally()
 {
+
 }
 
 }

--- a/cpp-ch/local-engine/Common/CHUtil.h
+++ b/cpp-ch/local-engine/Common/CHUtil.h
@@ -97,9 +97,6 @@ public:
     /// 2. session level resources like settings/configs, they can be initialized multiple times following the lifetime of executor/driver
     static void init(std::string * plan);
 
-    static void updateConfig(DB::ContextMutablePtr , std::string *);
-
-
    // use excel text parser
     inline static const std::string USE_EXCEL_PARSER = "use_excel_serialization";
     inline static const String CH_BACKEND_PREFIX = "spark.gluten.sql.columnar.backend.ch";
@@ -109,7 +106,7 @@ public:
     inline static const String CH_RUNTIME_CONFIG_FILE = CH_RUNTIME_CONFIG_PREFIX + "config_file";
 
     inline static const String CH_RUNTIME_SETTINGS = "runtime_settings";
-    inline static const String CH_RUNTIME_SETTINGS_PREFIX = CH_BACKEND_PREFIX + "." + CH_RUNTIME_SETTINGS;
+    inline static const String CH_RUNTIME_SETTINGS_PREFIX = CH_BACKEND_PREFIX + "." + CH_RUNTIME_SETTINGS + ".";
 
     inline static const String LIBHDFS3_CONF_KEY = "hdfs.libhdfs3_conf";
     inline static const String SETTINGs_PATH = "local_engine.settings";
@@ -129,20 +126,23 @@ private:
     friend class BackendFinalizerUtil;
     friend class JNIUtils;
 
-    static DB::Context::ConfigurationPtr initConfig(std::string * plan);
-    static void initLoggers(DB::Context::ConfigurationPtr config);
-    static void initEnvs(DB::Context::ConfigurationPtr config);
-    static std::unique_ptr<DB::Settings> initSettings(DB::Context::ConfigurationPtr config);
-    static void initContexts(DB::Context::ConfigurationPtr config);
-    static void initCompiledExpressionCache(DB::Context::ConfigurationPtr config);
+    static void initConfig(std::string * plan);
+    static void initConfig();
+    static void initLoggers();
+    static void initEnvs();
+    static void initSettings();
+    static void initContexts();
     static void registerAllFactories();
-    static void applyGlobalConfigAndSettings(DB::Context::ConfigurationPtr, std::unique_ptr<DB::Settings> &);
-    static void applyConfig(DB::ContextMutablePtr, DB::Context::ConfigurationPtr config, std::unique_ptr<DB::Settings> &);
+    static void applyConfigAndSettings();
+    static void initCompiledExpressionCache();
 
     static std::map<std::string, std::string> getBackendConfMap(const std::string & plan);
 
     inline static std::once_flag init_flag;
+    inline static std::map<std::string, std::string> backend_conf_map;
+    inline static DB::Context::ConfigurationPtr config;
     inline static Poco::Logger * logger;
+    inline static DB::Settings settings;
 };
 
 class BackendFinalizerUtil

--- a/cpp-ch/local-engine/Common/QueryContext.h
+++ b/cpp-ch/local-engine/Common/QueryContext.h
@@ -17,7 +17,7 @@ struct NativeAllocatorContext
 {
     std::shared_ptr<DB::CurrentThread::QueryScope> query_scope;
     std::shared_ptr<DB::ThreadStatus> thread_status;
-    DB::ContextMutablePtr query_context;
+    DB::ContextPtr query_context;
     std::shared_ptr<DB::ThreadGroup> group;
     ReservationListenerWrapperPtr listener;
 };

--- a/cpp-ch/local-engine/Common/common.cpp
+++ b/cpp-ch/local-engine/Common/common.cpp
@@ -9,6 +9,16 @@ using namespace DB;
 extern "C" {
 #endif
 
+char * createExecutor(const std::string & plan_string)
+{
+    auto context = Context::createCopy(local_engine::SerializedPlanParser::global_context);
+    local_engine::SerializedPlanParser parser(context);
+    auto query_plan = parser.parse(plan_string);
+    local_engine::LocalExecutor * executor = new local_engine::LocalExecutor(parser.query_context, context);
+    executor->execute(std::move(query_plan));
+    return reinterpret_cast<char *>(executor);
+}
+
 bool executorHasNext(char * executor_address)
 {
     local_engine::LocalExecutor * executor = reinterpret_cast<local_engine::LocalExecutor *>(executor_address);


### PR DESCRIPTION
Reverts oap-project/gluten#2204 for hdfs read problem:

java.lang.RuntimeException: bad_array_new_length
0. std::bad_array_new_length::bad_array_new_length() @ 0x0000000014a2ba2a in /home/ubuntu/[libch.so](http://libch.so/)
1. std::__throw_bad_array_new_length[abi:v15000]() @ 0x0000000006777976 in /home/ubuntu/[libch.so](http://libch.so/)
2. ? @ 0x00000000067795b4 in /home/ubuntu/[libch.so](http://libch.so/)
3. std::pair, void*>*>, bool> std::__hash_table, std::__unordered_map_hasher, std::hash, std::equal_to, true>, std::__unordered_map_equal, std::equal_to, std::hash, true>, std::allocator>>::__emplace_unique_key_args const&>(String const&, std::pair const&) @ 0x00000000067799e2 in /home/ubuntu/[libch.so](http://libch.so/)
4. std::unordered_map, std::equal_to, std::allocator>>::unordered_map(std::unordered_map, std::equal_to, std::allocator>> const&) @ 0x0000000006778e9f in /home/ubuntu/[libch.so](http://libch.so/)
5. local_engine::NormalFileReader::NormalFileReader(std::shared_ptr, std::shared_ptr, DB::Block const&, DB::Block const&) @ 0x0000000006ecd132 in /home/ubuntu/[libch.so](http://libch.so/)
6. std::__unique_if::__unique_single std::make_unique[abi:v15000]&, std::shared_ptr&, DB::Block&, DB::Block&>(std::shared_ptr&, std::shared_ptr&, DB::Block&, DB::Block&) @ 0x0000000006eceb1a in /home/ubuntu/[libch.so](http://libch.so/)
7. local_engine::SubstraitFileSource::tryPrepareReader() @ 0x0000000006ecaf46 in /home/ubuntu/[libch.so](http://libch.so/)
8. local_engine::SubstraitFileSource::generate() @ 0x0000000006eca931 in /home/ubuntu/[libch.so](http://libch.so/)
9. DB::ISource::tryGenerate() @ 0x0000000010cbfdf5 in /home/ubuntu/[libch.so](http://libch.so/)
10. DB::ISource::work() @ 0x0000000010cbfa85 in /home/ubuntu/[libch.so](http://libch.so/)
11. DB::ExecutionThreadContext::executeTask() @ 0x0000000010cd595a in /home/ubuntu/[libch.so](http://libch.so/)
12. DB::PipelineExecutor::executeStepImpl(unsigned long, std::atomic*) @ 0x0000000010ccd470 in /home/ubuntu/[libch.so](http://libch.so/)
13. DB::PipelineExecutor::executeStep(std::atomic*) @ 0x0000000010cccdc9 in /home/ubuntu/[libch.so](http://libch.so/)
14. DB::PullingPipelineExecutor::pull(DB::Chunk&) @ 0x0000000010cda2e8 in /home/ubuntu/[libch.so](http://libch.so/)
15. DB::PullingPipelineExecutor::pull(DB::Block&) @ 0x0000000010cda4d0 in /home/ubuntu/[libch.so](http://libch.so/)
16. local_engine::LocalExecutor::hasNext() @ 0x00000000068c5ff0 in /home/ubuntu/[libch.so](http://libch.so/)
17. Java_io_glutenproject_vectorized_BatchIterator_nativeHasNext @ 0x0000000006761cf7 in /home/ubuntu/[libch.so](http://libch.so/)

        at io.glutenproject.vectorized.BatchIterator.nativeHasNext(Native Method)
        at io.glutenproject.vectorized.BatchIterator.hasNextInternal(BatchIterator.java:50)
        at io.glutenproject.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:37)
        at io.glutenproject.backendsapi.clickhouse.CHIteratorApi$$anon$1.hasNext(CHIteratorApi.scala:131)
        at io.glutenproject.vectorized.CloseableCHColumnBatchIterator.hasNext(CloseableCHColumnBatchIterator.scala:41)
        at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
        at org.apache.spark.shuffle.CHColumnarShuffleWriter.internalCHWrite(CHColumnarShuffleWriter.scala:81)
        at org.apache.spark.shuffle.CHColumnarShuffleWriter.write(CHColumnarShuffleWriter.scala:75)
        at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:59)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:99)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
        at org.apache.spark.scheduler.Task.run(Task.scala:131)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
        
 it happens when running 10 more minutes queries continuously