### PR TITLE
[VL] Support spill-to-heap first using JniFileSystem

### DIFF
--- a/cpp/velox/jni/JniFileSystem.cc
+++ b/cpp/velox/jni/JniFileSystem.cc
@@ -20,307 +20,206 @@
 #include "jni/JniErrors.h"
 
 namespace {
+
 constexpr std::string_view kFileScheme("jni:");
 
 static JavaVM* vm;
-
-static jclass jniFileSystemClass;
-static jclass jniReadFileClass;
-static jclass jniWriteFileClass;
-
-static jmethodID jniGetFileSystem;
-static jmethodID jniFileSystemOpenFileForRead;
-static jmethodID jniFileSystemOpenFileForWrite;
-static jmethodID jniFileSystemRemove;
-static jmethodID jniFileSystemRename;
-static jmethodID jniFileSystemExists;
-static jmethodID jniFileSystemList;
-static jmethodID jniFileSystemMkdir;
-static jmethodID jniFileSystemRmdir;
-
-static jmethodID jniReadFilePread;
-static jmethodID jniReadFileShouldCoalesce;
-static jmethodID jniReadFileSize;
-static jmethodID jniReadFileMemoryUsage;
-static jmethodID jniReadFileGetNaturalReadSize;
-
-static jmethodID jniWriteFileAppend;
-static jmethodID jniWriteFileFlush;
-static jmethodID jniWriteFileClose;
-static jmethodID jniWriteFileSize;
 
 jstring createJString(JNIEnv* env, const std::string_view& path) {
   return env->NewStringUTF(std::string(path).c_str());
 }
 
-} // namespace
-
-void gluten::initVeloxJniFileSystem(JNIEnv* env) {
-  // vm
-  if (env->GetJavaVM(&vm) != JNI_OK) {
-    throw gluten::GlutenException("Unable to get JavaVM instance");
-  }
-
-  // classes
-  jniFileSystemClass = createGlobalClassReferenceOrError(env, "Lio/glutenproject/fs/JniFilesystem;");
-  jniReadFileClass = createGlobalClassReferenceOrError(env, "Lio/glutenproject/fs/JniFilesystem$ReadFile;");
-  jniWriteFileClass = createGlobalClassReferenceOrError(env, "Lio/glutenproject/fs/JniFilesystem$WriteFile;");
-
-  // methods in JniFilesystem
-  jniGetFileSystem = getStaticMethodIdOrError(
-      env, jniFileSystemClass, "getFileSystem", "(Ljava/lang/String;)Lio/glutenproject/fs/JniFilesystem;");
-  jniFileSystemOpenFileForRead = getMethodIdOrError(
-      env, jniFileSystemClass, "openFileForRead", "(Ljava/lang/String;)Lio/glutenproject/fs/JniFilesystem$ReadFile;");
-  jniFileSystemOpenFileForWrite = getMethodIdOrError(
-      env, jniFileSystemClass, "openFileForWrite", "(Ljava/lang/String;)Lio/glutenproject/fs/JniFilesystem$WriteFile;");
-  jniFileSystemRemove = getMethodIdOrError(env, jniFileSystemClass, "remove", "(Ljava/lang/String;)V");
-  jniFileSystemRename =
-      getMethodIdOrError(env, jniFileSystemClass, "rename", "(Ljava/lang/String;Ljava/lang/String;Z)V");
-  jniFileSystemExists = getMethodIdOrError(env, jniFileSystemClass, "exists", "(Ljava/lang/String;)Z");
-  jniFileSystemList = getMethodIdOrError(env, jniFileSystemClass, "list", "(Ljava/lang/String;)[Ljava/lang/String;");
-  jniFileSystemMkdir = getMethodIdOrError(env, jniFileSystemClass, "mkdir", "(Ljava/lang/String;)V");
-  jniFileSystemRmdir = getMethodIdOrError(env, jniFileSystemClass, "rmdir", "(Ljava/lang/String;)V");
-
-  // methods in JniFilesystem$ReadFile
-  jniReadFilePread = getMethodIdOrError(env, jniReadFileClass, "pread", "(JJJ)V");
-  jniReadFileShouldCoalesce = getMethodIdOrError(env, jniReadFileClass, "shouldCoalesce", "()Z");
-  jniReadFileSize = getMethodIdOrError(env, jniReadFileClass, "size", "()J");
-  jniReadFileMemoryUsage = getMethodIdOrError(env, jniReadFileClass, "memoryUsage", "()J");
-  jniReadFileGetNaturalReadSize = getMethodIdOrError(env, jniReadFileClass, "getNaturalReadSize", "()J");
-
-  // methods in JniFilesystem$WriteFile
-  jniWriteFileAppend = getMethodIdOrError(env, jniWriteFileClass, "append", "([B)V");
-  jniWriteFileFlush = getMethodIdOrError(env, jniWriteFileClass, "flush", "()V");
-  jniWriteFileClose = getMethodIdOrError(env, jniWriteFileClass, "close", "()V");
-  jniWriteFileSize = getMethodIdOrError(env, jniWriteFileClass, "size", "()J");
+std::shared_ptr<facebook::velox::filesystems::FileSystem> getLocalFileSystem() {
+  return facebook::velox::filesystems::getFileSystem("file:", nullptr);
 }
 
-void gluten::finalizeVeloxJniFileSystem(JNIEnv* env) {
-  env->DeleteGlobalRef(jniWriteFileClass);
-  env->DeleteGlobalRef(jniReadFileClass);
-  env->DeleteGlobalRef(jniFileSystemClass);
+// TODO: determine the value according to spilling code
+size_t getFileSizeLimit(const facebook::velox::filesystems::FileOptions& options) {
+  auto x = options.values.find("fileSizeLimit");
+  if (x == options.values.end()) {
+    return (1 << 20); // 1 Mega Bytes
+  }
+  return std::atoi(x->second.c_str());
+}
 
+} // namespace
+
+namespace gluten {
+
+void initVeloxJniFileSystem(JNIEnv* env) {
+  if (env->GetJavaVM(&vm) != JNI_OK) {
+    throw GlutenException("Unable to get JavaVM instance");
+  }
+}
+
+void finalizeVeloxJniFileSystem(JNIEnv* env) {
   vm = nullptr;
 }
 
-std::string_view gluten::JniReadFile::pread(uint64_t offset, uint64_t length, void* buf) const {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(
-      obj_, jniReadFilePread, static_cast<jlong>(offset), static_cast<jlong>(length), reinterpret_cast<jlong>(buf));
-  checkException(env);
+std::string_view JniReadFile::pread(uint64_t offset, uint64_t length, void* buf) const {
+  GLUTEN_CHECK(false, "JniWriteFile::pread TODO");
   return std::string_view(reinterpret_cast<const char*>(buf));
 }
 
-bool gluten::JniReadFile::shouldCoalesce() const {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jboolean out = env->CallBooleanMethod(obj_, jniReadFileShouldCoalesce);
-  checkException(env);
-  return out;
+bool JniReadFile::shouldCoalesce() const {
+  GLUTEN_CHECK(false, "JniWriteFile::shouldCoalesce TODO");
+  return false;
 }
 
-uint64_t gluten::JniReadFile::size() const {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jlong out = env->CallLongMethod(obj_, jniReadFileSize);
-  checkException(env);
-  return static_cast<uint64_t>(out);
+uint64_t JniReadFile::size() const {
+  GLUTEN_CHECK(false, "JniWriteFile::size TODO");
+  return 0;
 }
 
-uint64_t gluten::JniReadFile::memoryUsage() const {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jlong out = env->CallLongMethod(obj_, jniReadFileMemoryUsage);
-  checkException(env);
-  return static_cast<uint64_t>(out);
+uint64_t JniReadFile::memoryUsage() const {
+  GLUTEN_CHECK(false, "JniWriteFile::memoryUsage TODO");
+  return 0;
 }
 
-uint64_t gluten::JniReadFile::getNaturalReadSize() const {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jlong out = env->CallLongMethod(obj_, jniReadFileGetNaturalReadSize);
-  checkException(env);
-  return static_cast<uint64_t>(out);
+uint64_t JniReadFile::getNaturalReadSize() const {
+  GLUTEN_CHECK(false, "JniWriteFile::getNaturalReadSize TODO");
+  return 0;
 }
 
-std::string gluten::JniReadFile::getName() const {
-  return "<JniReadFile>";
+void JniWriteFile::append(std::string_view data) {
+  GLUTEN_CHECK(false, "JniWriteFile::append TODO");
 }
 
-gluten::JniReadFile::JniReadFile(jobject obj) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  obj_ = env->NewGlobalRef(obj);
-  checkException(env);
+void JniWriteFile::flush() {
+  GLUTEN_CHECK(false, "JniWriteFile::flush TODO");
 }
 
-gluten::JniReadFile::~JniReadFile() {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->DeleteGlobalRef(obj_);
-  checkException(env);
+void JniWriteFile::close() {
+  GLUTEN_CHECK(false, "JniWriteFile::close TODO");
 }
 
-void gluten::JniWriteFile::append(std::string_view data) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniWriteFileAppend);
-  checkException(env);
+uint64_t JniWriteFile::size() const {
+  GLUTEN_CHECK(false, "JniWriteFile::size TODO");
+  return 0;
 }
 
-void gluten::JniWriteFile::flush() {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniWriteFileFlush);
-  checkException(env);
-}
-
-void gluten::JniWriteFile::close() {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniWriteFileClose);
-  checkException(env);
-}
-
-uint64_t gluten::JniWriteFile::size() const {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jlong out = env->CallLongMethod(obj_, jniWriteFileSize);
-  checkException(env);
-  return static_cast<uint64_t>(out);
-}
-
-gluten::JniWriteFile::JniWriteFile(jobject obj) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  obj_ = env->NewGlobalRef(obj);
-  checkException(env);
-}
-
-gluten::JniWriteFile::~JniWriteFile() {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->DeleteGlobalRef(obj_);
-  checkException(env);
-}
-
-std::string gluten::JniFileSystem::name() const {
-  return "JNI FS";
-}
-
-std::unique_ptr<facebook::velox::ReadFile> gluten::JniFileSystem::openFileForRead(
+std::unique_ptr<facebook::velox::ReadFile> JniFileSystem::openFileForRead(
     std::string_view path,
     const facebook::velox::filesystems::FileOptions& options) {
+  // path = "jni:/spillDir/pipelineId_driverId_operatorId-fileNo-ordinal";
+  // spillDir is set by task_->setSpillDirectory(spillDir) in the constructor of WholeStageResultIteratorFirstStage
+
   GLUTEN_CHECK(
       !options.values.empty(),
       "JniFileSystem::openFileForRead: file options is not empty, this is not currently supported");
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jobject obj = env->CallObjectMethod(obj_, jniFileSystemOpenFileForRead, createJString(env, path));
-  auto out = std::make_unique<JniReadFile>(obj);
-  checkException(env);
-  return out;
+
+  // get stub
+  FileStub stub;
+  {
+    std::lock_guard<std::mutex> lg(fileStubsMutex_);
+    auto x = fileStubs_.find(std::string(path));
+    GLUTEN_CHECK(x != fileStubs_.end(), "JniFileSystem::openFileForRead not found stub");
+    stub = x->second;
+  }
+
+  std::unique_ptr<facebook::velox::ReadFile> readFile;
+  if (stub.type == FileStub::HEAP) {
+    readFile = std::make_unique<JniReadFile>(stub.handle);
+  } else {
+    auto filename = path.substr(kFileScheme.size()); // skip 'jni:'
+    readFile = getLocalFileSystem()->openFileForRead(filename);
+  }
+
+  return readFile;
 }
 
-std::unique_ptr<facebook::velox::WriteFile> gluten::JniFileSystem::openFileForWrite(
+std::unique_ptr<facebook::velox::WriteFile> JniFileSystem::openFileForWrite(
     std::string_view path,
     const facebook::velox::filesystems::FileOptions& options) {
-  GLUTEN_CHECK(
-      !options.values.empty(),
-      "JniFileSystem::openFileForWrite: file options is not empty, this is not currently supported");
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  jobject obj = env->CallObjectMethod(obj_, jniFileSystemOpenFileForWrite, createJString(env, path));
-  auto out = std::make_unique<JniWriteFile>(obj);
-  checkException(env);
-  return out;
-}
+  // path = "jni:/spillDir/pipelineId_driverId_operatorId-fileNo-ordinal";
+  // I think the spillDir is an unique string, need to confirm
+  FileStub stub;
+  std::unique_ptr<facebook::velox::WriteFile> writeFile;
 
-void gluten::JniFileSystem::remove(std::string_view path) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniFileSystemRemove, createJString(env, path));
-  checkException(env);
-}
-
-void gluten::JniFileSystem::rename(std::string_view oldPath, std::string_view newPath, bool overwrite) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniFileSystemRename, createJString(env, oldPath), createJString(env, newPath), overwrite);
-  checkException(env);
-}
-
-bool gluten::JniFileSystem::exists(std::string_view path) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  bool out = env->CallBooleanMethod(obj_, jniFileSystemExists, createJString(env, path));
-  checkException(env);
-  return out;
-}
-
-std::vector<std::string> gluten::JniFileSystem::list(std::string_view path) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  std::vector<std::string> out;
-  jobjectArray jarray = (jobjectArray)env->CallObjectMethod(obj_, jniFileSystemList, createJString(env, path));
-  jsize length = env->GetArrayLength(jarray);
-  for (jsize i = 0; i < length; ++i) {
-    jstring element = (jstring)env->GetObjectArrayElement(jarray, i);
-    std::string cElement = jStringToCString(env, element);
-    out.push_back(cElement);
+  size_t size = getFileSizeLimit(options);
+  auto handle = tryAllocHeapMemory(size);
+  if (handle.valid()) {
+    writeFile = std::make_unique<JniWriteFile>(handle);
+    stub.type = FileStub::HEAP;
+    stub.handle = handle;
+  } else {
+    auto filename = path.substr(kFileScheme.size()); // skip 'jni:'
+    writeFile = getLocalFileSystem()->openFileForWrite(filename);
+    stub.type = FileStub::DISK;
+    stub.filename = filename;
   }
-  checkException(env);
+
+  // add stub
+  {
+    std::lock_guard<std::mutex> lg(fileStubsMutex_);
+    auto result = fileStubs_.insert(std::make_pair(std::string(path), stub));
+    GLUTEN_CHECK(result.second, "JniFileSystem::openFileForWrite insert stub failed");
+  }
+
+  return writeFile;
+}
+
+void JniFileSystem::remove(std::string_view path) {
+  GLUTEN_CHECK(false, "JniFileSystem::remove TODO");
+}
+
+void JniFileSystem::rename(std::string_view oldPath, std::string_view newPath, bool overwrite) {
+  GLUTEN_CHECK(false, "JniFileSystem::rename TODO");
+}
+
+bool JniFileSystem::exists(std::string_view path) {
+  GLUTEN_CHECK(false, "JniFileSystem::exists TODO");
+  return false;
+}
+
+std::vector<std::string> JniFileSystem::list(std::string_view path) {
+  GLUTEN_CHECK(false, "JniFileSystem::list TODO");
+  std::vector<std::string> out;
   return out;
 }
 
-void gluten::JniFileSystem::mkdir(std::string_view path) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniFileSystemMkdir, createJString(env, path));
-  checkException(env);
+void JniFileSystem::mkdir(std::string_view path) {
+  GLUTEN_CHECK(false, "JniFileSystem::mkdir TODO");
 }
 
-void gluten::JniFileSystem::rmdir(std::string_view path) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->CallVoidMethod(obj_, jniFileSystemRmdir, createJString(env, path));
-  checkException(env);
+void JniFileSystem::rmdir(std::string_view path) {
+  // path = "jni:/spillDir"
+  // rethink: does path need to be transferred
+
+  // step1: remove files under spill dir
+  getLocalFileSystem()->rmdir(path);
+
+  // step2: free heap memories
+  {
+    std::lock_guard<std::mutex> lg(fileStubsMutex_);
+    for (auto x = fileStubs_.begin(); x != fileStubs_.end();) {
+      if (x->first.find_first_of(path) == 0) {
+        if (x->second.type == FileStub::HEAP) {
+          freeHeapMemory(x->second.handle);
+        }
+        x = fileStubs_.erase(x);
+      } else {
+        ++x;
+      }
+    }
+  }
 }
 
-std::function<bool(std::string_view)> gluten::JniFileSystem::schemeMatcher() {
+std::function<bool(std::string_view)> JniFileSystem::schemeMatcher() {
   return [](std::string_view filePath) { return filePath.find(kFileScheme) == 0; };
 }
 
 std::function<std::shared_ptr<
     facebook::velox::filesystems::FileSystem>(std::shared_ptr<const facebook::velox::Config>, std::string_view)>
-gluten::JniFileSystem::fileSystemGenerator() {
+JniFileSystem::fileSystemGenerator() {
   return [](std::shared_ptr<const facebook::velox::Config> properties, std::string_view filePath) {
-    JNIEnv* env;
-    attachCurrentThreadAsDaemonOrThrow(vm, &env);
-    jobject obj = env->CallStaticObjectMethod(jniFileSystemClass, jniGetFileSystem, createJString(env, filePath));
-    std::shared_ptr<FileSystem> lfs = std::make_shared<JniFileSystem>(obj, properties);
-    checkException(env);
-    return lfs;
+    return std::make_shared<JniFileSystem>(properties);
   };
 }
 
-void gluten::registerJniFileSystem() {
+void registerJniFileSystem() {
   facebook::velox::filesystems::registerFileSystem(
       JniFileSystem::schemeMatcher(), JniFileSystem::fileSystemGenerator());
 }
 
-gluten::JniFileSystem::JniFileSystem(jobject obj, std::shared_ptr<const facebook::velox::Config> config)
-    : FileSystem(config) {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  obj_ = env->NewGlobalRef(obj);
-  checkException(env);
-}
-
-gluten::JniFileSystem::~JniFileSystem() {
-  JNIEnv* env;
-  attachCurrentThreadAsDaemonOrThrow(vm, &env);
-  env->DeleteGlobalRef(obj_);
-  checkException(env);
-}
+} // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?

We will implement the priority logic in C++ by `JniFileSystem `.

Three member functions `openFileForRead` `openFileForWrite` `rmdir` are implemented first, and I added the `TODO` marks for @zhztheplayer to implement.

could you have a look for me?

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

