### PR TITLE
[VL] Fix insistent SMJ params

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -38,7 +38,7 @@ import java.util.{ArrayList => JArrayList}
 
 import scala.collection.JavaConverters._
 
-/** Performs a hash join of two child relations by first shuffling the data using the join keys. */
+/** Performs a sort merge join of two child relations. */
 case class SortMergeJoinExecTransformer(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
@@ -212,12 +212,11 @@ case class SortMergeJoinExecTransformer(
     BackendsApiManager.getMetricsApiInstance.genSortMergeJoinTransformerMetricsUpdater(metrics)
 
   def genJoinParametersBuilder(): com.google.protobuf.Any.Builder = {
-    val (isSMJ, isNullAwareAntiJoin) = (0, 0)
+    val (isSMJ, isNullAwareAntiJoin) = (1, 0)
     // Start with "JoinParameters:"
     val joinParametersStr = new StringBuffer("JoinParameters:")
-    // isSMJ: 0 for SMJ, 1 for SHJ
+    // isSMJ: 0 for SHJ, 1 for SMJ
     // isNullAwareAntiJoin: 0 for false, 1 for true
-    // buildHashTableId: the unique id for the hash table of build plan
     joinParametersStr
       .append("isSMJ=")
       .append(isSMJ)

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/adaptive/GlutenAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/adaptive/GlutenAdaptiveQueryExecSuite.scala
@@ -890,7 +890,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
       df.collect()
       val plan = df.queryExecution.executedPlan
       assert(hasRepartitionShuffle(plan) == !optimizeOutRepartition)
-      val smj = findTopLevelSortMergeJoinTransform(plan)
+      val smj = findTopLevelSortMergeJoin(plan)
       assert(smj.length == 1)
       assert(smj.head.isSkewJoin == optimizeSkewJoin)
       val aqeReads = collect(smj.head) { case c: ColumnarAQEShuffleReadExec => c }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/GlutenAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/GlutenAdaptiveQueryExecSuite.scala
@@ -892,7 +892,7 @@ class GlutenAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQL
       df.collect()
       val plan = df.queryExecution.executedPlan
       assert(hasRepartitionShuffle(plan) == !optimizeOutRepartition)
-      val smj = findTopLevelSortMergeJoinTransform(plan)
+      val smj = findTopLevelSortMergeJoin(plan)
       assert(smj.length == 1)
       assert(smj.head.isSkewJoin == optimizeSkewJoin)
       val aqeReads = collect(smj.head) { case c: ColumnarAQEShuffleReadExec => c }


### PR DESCRIPTION
The plan `SortMergeJoinExec` is converted to `MergeJoin` in velox only when the param `isSMJ=1` instead of `0`
https://github.com/oap-project/velox/blob/8cffafc01fbd8ea453022540fea6df97aebd2c32/velox/substrait/SubstraitToVeloxPlan.cpp#L319