### PR TITLE
[GLUTEN-2394][VL]bug: fix wrong schema issue in velox parquet writer

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetWriteSuite.scala
@@ -50,6 +50,7 @@ class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
             val parquetDf = spark.read
               .format("parquet")
               .load(f.getCanonicalPath)
+            assert(df.schema.equals(parquetDf.schema))
             checkAnswer(parquetDf, df)
           }
         }

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -109,7 +109,7 @@ void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::str
   std::unordered_map<std::string, std::string> configData({{velox::core::QueryConfig::kDataBufferGrowRatio, "2"}});
   auto queryCtx = std::make_shared<velox::core::QueryCtx>(nullptr, configData);
 
-  parquetWriter_ = std::make_unique<velox::parquet::Writer>(std::move(sink_), writeOption, pool_);
+  parquetWriter_ = std::make_unique<velox::parquet::Writer>(std::move(sink_), writeOption, pool_, schema_);
 }
 
 void VeloxParquetDatasource::inspectSchema(struct ArrowSchema* out) {

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/JkSelf/velox.git
-VELOX_BRANCH=parquet-writer-schema
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/JkSelf/velox.git
+VELOX_BRANCH=parquet-writer-schema
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR pass the schema from java side to velox parquet writer and ensure the written parquet file has the right schema info.

(https://github.com/oap-project/gluten/issues/2394)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

