### PR TITLE
[CH] optimize `get_json_object` by reusing intermediate data

### DIFF
--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -51,6 +51,7 @@ add_headers_and_sources(shuffle Shuffle)
 add_headers_and_sources(operator Operator)
 add_headers_and_sources(jni jni)
 add_headers_and_sources(aggregate_functions AggregateFunctions)
+add_headers_and_sources(local_columns Columns)
 
 include_directories(
         ${JNI_INCLUDE_DIRS}

--- a/cpp-ch/local-engine/Columns/DecodedJSONColumn.h
+++ b/cpp-ch/local-engine/Columns/DecodedJSONColumn.h
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <memory>
+#include <Columns/IColumn.h>
+#include <Common/JSONParsers/DummyJSONParser.h>
+#include <Common/JSONParsers/SimdJSONParser.h>
+#include "FormattedColumn.h"
+
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
+
+namespace local_engine
+{
+
+template<typename JSONParser>
+class JSONParserWrapper
+{
+public:
+    struct Element
+    {
+        /// For simdjson. the document is just a reference to the internal data of the
+        /// parser. So bind the document and the parser together.
+        JSONParser parser;
+        typename JSONParser::Element document;
+    };
+    using ElementPtr = std::shared_ptr<Element>;
+    JSONParserWrapper() = default;
+    ~JSONParserWrapper() = default;
+    inline ElementPtr decode(const StringRef & json_str)
+    {
+        auto element = std::make_shared<Element>();
+        if (element->parser.parse(json_str.toView(), element->document)) [[likely]]
+        {
+            return element;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+};
+
+using SimdJSONParserWrapper = JSONParserWrapper<DB::SimdJSONParser>;
+using SimdJSONColumn = FormattedColumn<SimdJSONParserWrapper>;
+
+using DummyJSONParserWrapper = JSONParserWrapper<DB::DummyJSONParser>;
+using DummyJSONColumn = FormattedColumn<DummyJSONParserWrapper>;
+
+template <typename JSONParser>
+const FormattedColumn<JSONParserWrapper<JSONParser>> * castToDecodedJSONColumn(DB::ColumnPtr column)
+{
+    return dynamic_cast<const FormattedColumn<JSONParserWrapper<JSONParser>> *>(column.get());
+}
+
+}

--- a/cpp-ch/local-engine/Columns/FormattedColumn.h
+++ b/cpp-ch/local-engine/Columns/FormattedColumn.h
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
+#include <Common/COW.h>
+#include <Common/Exception.h>
+#include <Common/PODArray_fwd.h>
+#include <Core/Field.h>
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
+}
+
+namespace local_engine
+{
+
+// Not a writable column. It's useful to share intemediate data between processors.
+template <typename Decoder>
+class FormattedColumn : public COWHelper<DB::IColumn, FormattedColumn<Decoder>>
+{
+public:
+    using Base = COWHelper<DB::IColumn, FormattedColumn<Decoder>>;
+    using Ptr = Base::Ptr;
+    using MutablePtr = Base::MutablePtr;
+    using DecoderPtr = std::shared_ptr<Decoder>;
+    using DecodedElement = Decoder::Element;
+    using DecodedElementPtr = std::shared_ptr<DecodedElement>;
+    using DecodedElementContainer = std::vector<DecodedElementPtr>;
+
+    DecodedElementPtr getDecodedElement(size_t row) const
+    {
+        assert(row < decoded_elements.size());
+        return decoded_elements[row];
+    }
+
+    const DB::IColumn & getNestedColumnRef() const { return *nested_column; }
+    const DB::ColumnPtr & getNestedColumnPtr() const { return nested_column; }
+
+    bool canBeInsideNullable() const override { return true; }
+
+private:
+    friend class COWHelper<DB::IColumn, FormattedColumn<Decoder>>;
+    DecoderPtr decoder;
+    Base::WrappedPtr nested_column;
+    DecodedElementContainer decoded_elements;
+
+    FormattedColumn() = default;
+    FormattedColumn(const FormattedColumn & other)
+        : decoder(other.decoder)
+        , nested_column(other.nested_column)
+    {
+    }
+
+    explicit FormattedColumn(DB::ColumnPtr nested_column_, DecoderPtr decoder_)
+        : decoder(decoder_)
+        , nested_column(nested_column_)
+    {
+        initializationDecode();
+    }
+
+    void initializationDecode()
+    {
+        size_t rows = nested_column->size();
+        decoded_elements.resize(rows);
+        for (size_t i = 0; i < rows; ++i)
+        {
+            decoded_elements[i] = decoder->decode(nested_column->getDataAt(i));
+        }
+    }
+
+    const char * getFamilyName() const override { return "Formatted"; }
+    std::string getName() const override { return "Formatted(" + nested_column->getName() + ")"; }
+    DB::TypeIndex getDataType() const override { return nested_column->getDataType(); }
+
+    DB::MutableColumnPtr cloneResized(size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support cloneResized.");
+    }
+
+    size_t size() const override
+    {
+        return nested_column->size();
+    }
+
+    DB::ColumnPtr cut(size_t, size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support cut.");
+    }
+
+    DB::ColumnPtr replicate(const DB::IColumn::Offsets &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support replicate.");
+    }
+
+    DB::ColumnPtr filter(const DB::IColumn::Filter &, ssize_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support filter.");
+    }
+
+    void expand(const DB::IColumn::Filter &, bool) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support expand");
+    }
+
+    DB::ColumnPtr permute(const DB::IColumn::Permutation &, size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support permute.");
+    }
+
+    DB::ColumnPtr index(const DB::IColumn &, size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support index.");
+    }
+
+    std::vector<DB::MutableColumnPtr> scatter(DB::IColumn::ColumnIndex,
+                                              const DB::IColumn::Selector &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Not support scatter.");
+    }
+
+    void getExtremes(DB::Field &, DB::Field &) const override {}
+
+    size_t byteSize() const override { return nested_column->byteSize(); }
+    size_t byteSizeAt(size_t n) const override { return nested_column->byteSizeAt(n); }
+    size_t allocatedBytes() const override { return nested_column->allocatedBytes(); }
+
+    DB::Field operator[](size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot get value from {}", getName());
+    }
+
+    void get(size_t, DB::Field &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot get value from {}", getName());
+    }
+
+    StringRef getDataAt(size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot get value from {}", getName());
+    }
+
+    bool isDefaultAt(size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "isDefaultAt is not implemented for {}", getName());
+    }
+
+    void insert(const DB::Field &) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot insert into {}", getName());
+    }
+
+    void insertDefault() override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot insert into {}", getName());
+    }
+
+    void insertFrom(const DB::IColumn &, size_t) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot insert into {}", getName());
+    }
+
+    void insertRangeFrom(const DB::IColumn &, size_t, size_t) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot insert into {}", getName());
+    }
+
+    void insertData(const char *, size_t) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot insert into {}", getName());
+    }
+
+    StringRef serializeValueIntoArena(size_t, DB::Arena &, char const *&, const UInt8 *) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot serializeValueIntoArena into {}", getName());
+    }
+
+    const char * deserializeAndInsertFromArena(const char *) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot deserializeAndInsertFromArena into {}", getName());
+    }
+
+    const char * skipSerializedInArena(const char *) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Cannot skipSerializedInArena into {}", getName());
+    }
+
+    void updateHashWithValue(size_t, SipHash &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "updateHashWithValue is not implemented for {}", getName());
+    }
+
+    void updateWeakHash32(DB::WeakHash32 &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "updateWeakHash32 is not implemented for {}", getName());
+    }
+
+    void updateHashFast(SipHash &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "updateHashFast is not implemented for {}", getName());
+    }
+
+    void popBack(size_t) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "popBack is not implemented for {}", getName());
+    }
+
+    int compareAt(size_t, size_t, const DB::IColumn &, int) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "compareAt is not implemented for {}", getName());
+    }
+
+    void compareColumn(const DB::IColumn &, size_t, DB::PaddedPODArray<UInt64> *, DB::PaddedPODArray<Int8> &, int, int) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "compareColumn is not implemented for {}", getName());
+    }
+
+    bool hasEqualValues() const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "hasEqualValues is not implemented for {}", getName());
+    }
+
+    void getPermutation(DB::IColumn::PermutationSortDirection, DB::IColumn::PermutationSortStability,
+                        size_t, int, DB::IColumn::Permutation &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "getPermutation is not implemented for {}", getName());
+    }
+
+    void updatePermutation(DB::IColumn::PermutationSortDirection, DB::IColumn::PermutationSortStability,
+                        size_t, int, DB::IColumn::Permutation &, DB::EqualRanges &) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "updatePermutation is not implemented for {}", getName());
+    }
+
+    void gather(DB::ColumnGathererStream &) override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Method gather is not supported for {}", getName());
+    }
+
+    double getRatioOfDefaultRows(double) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Method getRatioOfDefaultRows is not supported for {}", getName());
+    }
+
+    UInt64 getNumberOfDefaultRows() const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Method getNumberOfDefaultRows is not supported for {}", getName());
+    }
+
+    void getIndicesOfNonDefaultRows(DB::IColumn::Offsets &, size_t, size_t) const override
+    {
+        throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED, "Method getIndicesOfNonDefaultRows is not supported for {}", getName());
+    }
+};
+
+}

--- a/cpp-ch/local-engine/Functions/DecodeJSONStringFunction.cpp
+++ b/cpp-ch/local-engine/Functions/DecodeJSONStringFunction.cpp
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string>
+#include <Columns/DecodedJSONColumn.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Functions/FunctionFactory.h>
+#include <Interpreters/Context.h>
+#include "config.h"
+#include <Poco/Logger.h>
+#include <Common/logger_useful.h>
+
+
+namespace DB
+{
+namespace ErrorCodes
+{}
+}
+
+namespace local_engine
+{
+class DecodeJSONStringFunction : public DB::IFunction
+{
+public:
+    static constexpr auto name = "decodeJSONString";
+    static DB::FunctionPtr create(const DB::ContextPtr & context)
+    {
+        return std::make_shared<DecodeJSONStringFunction>(context);
+    }
+
+    explicit DecodeJSONStringFunction(DB::ContextPtr context_) : context(context_) {}
+    ~DecodeJSONStringFunction() override = default;
+
+    DB::String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 2; }
+    bool isVariadic() const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DB::DataTypesWithConstInfo & /*arguments*/) const override { return false; }
+
+    DB::DataTypePtr getReturnTypeImpl(const DB::ColumnsWithTypeAndName & arguments) const override
+    {
+        return arguments[0].type;
+    }
+
+    DB::ColumnPtr executeImpl(
+        const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const override
+    {
+#if USE_SIMDJSON
+        if (context->getSettingsRef().allow_simdjson)
+        {
+            return SimdJSONColumn::create(arguments[0].column, std::make_shared<SimdJSONParserWrapper>());
+        }
+#endif
+        auto decoder = std::make_shared<DummyJSONParserWrapper>();
+        return DummyJSONColumn::create(arguments[0].column, decoder);
+    }
+
+private:
+    DB::ContextPtr context;
+};
+
+REGISTER_FUNCTION(DecodeJSONStringFunction)
+{
+    factory.registerFunction<DecodeJSONStringFunction>();
+}
+}

--- a/cpp-ch/local-engine/Functions/SparkFunctionGetJsonObject.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionGetJsonObject.cpp
@@ -15,13 +15,187 @@
  * limitations under the License.
  */
 #include "SparkFunctionGetJsonObject.h"
+#include <Columns/FormattedColumn.h>
+#include <DataTypes/DataTypeString.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <Functions/JSONPath/ASTs/ASTJSONPath.h>
+#include <Functions/JSONPath/Generator/GeneratorJSONPath.h>
+#include <Functions/JSONPath/Parsers/ParserJSONPath.h>
+#include <Common/Exception.h>
+#include <Common/JSONParsers/DummyJSONParser.h>
+#include <Common/JSONParsers/RapidJSONParser.h>
+#include <Common/JSONParsers/SimdJSONParser.h>
 
+#include <Interpreters/Context.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <Parsers/IParser.h>
+#include <Parsers/Lexer.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <base/range.h>
+#include <Columns/DecodedJSONColumn.h>
+#include <Functions/FunctionSQLJSON.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+    extern const int TOO_FEW_ARGUMENTS_FOR_FUNCTION;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+}
 
 namespace local_engine
 {
+
+class FunctionSQLDecodedJSONHelpers
+{
+public:
+    template <typename Name, template <typename> typename Impl, class JSONParser>
+    class Executor
+    {
+    public:
+        static DB::ColumnPtr run(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows_count, uint32_t parse_depth, const DB::ContextPtr & context)
+        {
+            DB::MutableColumnPtr to{result_type->createColumn()};
+            to->reserve(input_rows_count);
+
+            if (arguments.size() < 2)
+            {
+                throw DB::Exception(DB::ErrorCodes::TOO_FEW_ARGUMENTS_FOR_FUNCTION, "JSONPath functions require at least 2 arguments");
+            }
+
+            const auto & json_column = arguments[0];
+            const auto * decoded_json_column = castToDecodedJSONColumn<JSONParser>(json_column.column);
+            if (!decoded_json_column)
+            {
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                                "JSONPath functions require first argument to be JSON of string, illegal type: {}",
+                                json_column.column->getName());
+            }
+
+            const auto & json_path_column = arguments[1];
+
+            if (!isString(json_path_column.type))
+            {
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                                "JSONPath functions require second argument "
+                                "to be JSONPath of type string, illegal type: {}", json_path_column.type->getName());
+            }
+            if (!isColumnConst(*json_path_column.column))
+            {
+                throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Second argument (JSONPath) must be constant string");
+            }
+
+            const DB::ColumnPtr & arg_jsonpath = json_path_column.column;
+            const auto * arg_jsonpath_const = typeid_cast<const DB::ColumnConst *>(arg_jsonpath.get());
+            const auto * arg_jsonpath_string = typeid_cast<const DB::ColumnString *>(arg_jsonpath_const->getDataColumnPtr().get());
+
+
+            /// Get data and offsets for 1 argument (JSONPath)
+            const DB::ColumnString::Chars & chars_path = arg_jsonpath_string->getChars();
+            const DB::ColumnString::Offsets & offsets_path = arg_jsonpath_string->getOffsets();
+
+            /// Prepare to parse 1 argument (JSONPath)
+            const char * query_begin = reinterpret_cast<const char *>(&chars_path[0]);
+            const char * query_end = query_begin + offsets_path[0] - 1;
+
+            /// Tokenize query
+            DB::Tokens tokens(query_begin, query_end);
+            /// Max depth 0 indicates that depth is not limited
+            DB::IParser::Pos token_iterator(tokens, parse_depth);
+
+            /// Parse query and create AST tree
+            DB::Expected expected;
+            DB::ASTPtr res;
+            DB::ParserJSONPath parser;
+            const bool parse_res = parser.parse(token_iterator, res, expected);
+            if (!parse_res)
+            {
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unable to parse JSONPath");
+            }
+
+            Impl<JSONParser> impl;
+            for (const auto i : collections::range(0, input_rows_count))
+            {
+                auto element = decoded_json_column->getDecodedElement(i);
+                if (!element) [[unlikely]]
+                {
+                    to->insertDefault();
+                }
+                else
+                {
+                    auto added_col = impl.insertResultToColumn(*to, element->document, res, context);
+                    if (!added_col)
+                    {
+                        to->insertDefault();
+                    }
+                }
+            }
+            return to;
+        }
+    };
+};
+
+template <typename Name, template <typename> typename Impl>
+class ExtendedFunctionSQLJSON : public DB::IFunction, DB::WithConstContext
+{
+public:
+    static DB::FunctionPtr create(DB::ContextPtr context_) { return std::make_shared<ExtendedFunctionSQLJSON>(context_); }
+    explicit ExtendedFunctionSQLJSON(DB::ContextPtr context_) : DB::WithConstContext(context_) { }
+
+    static constexpr auto name = Name::name;
+    String getName() const override { return Name::name; }
+    bool isVariadic() const override { return true; }
+    size_t getNumberOfArguments() const override { return 0; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+    DB::ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DB::DataTypesWithConstInfo & /*arguments*/) const override { return true; }
+
+    DB::DataTypePtr getReturnTypeImpl(const DB::ColumnsWithTypeAndName & arguments) const override
+    {
+        return Impl<DB::DummyJSONParser>::getReturnType(Name::name, arguments, getContext());
+    }
+
+    DB::ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        /// Choose JSONParser.
+        /// 1. Lexer(path) -> Tokens
+        /// 2. Create ASTPtr
+        /// 3. Parser(Tokens, ASTPtr) -> complete AST
+        /// 4. Execute functions: call getNextItem on generator and handle each item
+        unsigned parse_depth = static_cast<unsigned>(getContext()->getSettingsRef().max_parser_depth);
+        if (typeid_cast<const DB::ColumnString *>(arguments[0].column.get()))
+        {
+#if USE_SIMDJSON
+            if (getContext()->getSettingsRef().allow_simdjson)
+                return DB::FunctionSQLJSONHelpers::Executor<Name, Impl, DB::SimdJSONParser>::run(
+                    arguments, result_type, input_rows_count, parse_depth, getContext());
+#endif
+            return DB::FunctionSQLJSONHelpers::Executor<Name, Impl, DB::DummyJSONParser>::run(
+                arguments, result_type, input_rows_count, parse_depth, getContext());
+        }
+        else
+        {
+#if USE_SIMDJSON
+            if (getContext()->getSettingsRef().allow_simdjson && castToDecodedJSONColumn<DB::SimdJSONParser>(arguments[0].column))
+            {
+                return FunctionSQLDecodedJSONHelpers::Executor<Name, Impl, DB::SimdJSONParser>::run(
+                    arguments, result_type, input_rows_count, parse_depth, getContext());
+            }
+#endif
+            return FunctionSQLDecodedJSONHelpers::Executor<Name, Impl, DB::DummyJSONParser>::run(
+                arguments, result_type, input_rows_count, parse_depth, getContext());
+        }
+    }
+};
+
 REGISTER_FUNCTION(GetJsonObject)
 {
-    factory.registerFunction<DB::FunctionSQLJSON<GetJsonObject, GetJsonObjectImpl>>();
+    factory.registerFunction<ExtendedFunctionSQLJSON<GetJsonObject, GetJsonObjectImpl>>();
 }
 }

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/GetJSONObjectParser.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/GetJSONObjectParser.cpp
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Parser/FunctionParser.h>
+#include <Poco/Logger.h>
+#include <Common/Exception.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+}
+
+namespace local_engine
+{
+
+class GetJSONObjectParser : public FunctionParser
+{
+public:
+    static constexpr auto name = "get_json_object";
+
+    explicit GetJSONObjectParser(SerializedPlanParser * plan_parser_): FunctionParser(plan_parser_) {}
+    ~GetJSONObjectParser() override = default;
+
+    String getName() const override { return name; }
+protected:
+    String getCHFunctionName(const substrait::Expression_ScalarFunction &) const override
+    {
+        return name;
+    }
+
+    DB::ActionsDAG::NodeRawConstPtrs parseFunctionArguments(
+        const substrait::Expression_ScalarFunction & substrait_func,
+        const String & ch_func_name,
+        DB::ActionsDAGPtr & actions_dag) const override
+    {
+        const auto & args = substrait_func.arguments();
+        if (args.size() != 2)
+        {
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Function {} requires 2 arguments", ch_func_name);
+        }
+
+        const auto * json_column_node = parseExpression(actions_dag, args[0].value());
+        auto decoded_json_col_name = getDecodedJSONColumnName(json_column_node->result_name);
+        const auto * decoded_json_column_node = actions_dag->tryFindInOutputs(decoded_json_col_name);
+        if (!decoded_json_column_node)
+        {
+            // This extra-column should be removed later.
+            decoded_json_column_node = toFunctionNode(actions_dag, "decodeJSONString", decoded_json_col_name, {json_column_node});
+            actions_dag->addOrReplaceInOutputs(*decoded_json_column_node);
+            assert(decoded_json_column_node);
+        }
+        const auto * json_path_node = parseExpression(actions_dag, args[1].value());
+        return {decoded_json_column_node, json_path_node};
+    }
+
+private:
+    String getDecodedJSONColumnName(const String & json_column_name) const
+    {
+        return "Decode(" + json_column_name + ")";
+    }
+};
+
+static FunctionParserRegister<GetJSONObjectParser> register_get_json_object_parser;
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Extracting fields out from the same string is normal case. 
```SQL
select get_json_object(a, '$.a'), get_json_object(a, '$.b') from t
```
At present, `CH`  parse the original string repeatly for each field extracting. The parsing phase's overhead is high
![image](https://github.com/oap-project/gluten/assets/2599447/845ec410-e4b6-4bfc-8024-fb5cedb8eb11)

We try to reuse the intermediate data from json parsing in thi PR

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

