### PR TITLE
[GLUTEN-2422][CH] Fix parse nan/inf exception in RangeSelectorBuilder

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1642,6 +1642,15 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     }
   }
 
+  test("GLUTEN-2422 range bound with nan/inf") {
+    val sql =
+      """
+        |select a from values (1.0), (2.1), (null), (cast('NaN' as double)), (cast('inf' as double)),
+        | (cast('-inf' as double)) as data(a) order by a asc nulls last
+        |""".stripMargin
+    runQueryAndCompare(sql)(checkOperatorMatch[SortExecTransformer])
+  }
+
   test("GLUTEN-2243 empty projection") {
     val sql =
       """

--- a/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
+++ b/cpp-ch/local-engine/Shuffle/SelectorBuilder.h
@@ -76,6 +76,9 @@ private:
     void initRangeBlock(Poco::JSON::Array::Ptr range_bounds);
     void initActionsDAG(const DB::Block & block);
 
+    template <typename T>
+    void safeInsertFloatValue(const Poco::Dynamic::Var & field_value, DB::MutableColumnPtr & col);
+
     void computePartitionIdByBinarySearch(DB::Block & block, DB::IColumn::Selector & selector);
     int compareRow(
         const DB::Columns & columns,


### PR DESCRIPTION
## What changes were proposed in this pull request?
`field_value.convert<DB::Float64>()` will fail when field_value is special value like NaN/Inf.

We check it and insert the corresponding value.

(Fixes: \#2422)

## How was this patch tested?
UT
