### PR TITLE
[VL] Support empty dataframe write

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution
 
 import io.glutenproject.execution.WholeStageTransformerSuite
+
 import org.apache.spark.sql.functions.lit
 
 class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
@@ -105,12 +106,13 @@ class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
   }
 
   test("parquet write with empty dataframe") {
-    withTempPath { f =>
-      val df = spark.emptyDataFrame.select(lit(1).as("i"))
-      df.write.format("velox").save(f.getCanonicalPath)
-      val res = spark.read.parquet(f.getCanonicalPath)
-      checkAnswer(res, Nil)
-      assert(res.schema.asNullable == df.schema.asNullable)
+    withTempPath {
+      f =>
+        val df = spark.emptyDataFrame.select(lit(1).as("i"))
+        df.write.format("velox").save(f.getCanonicalPath)
+        val res = spark.read.parquet(f.getCanonicalPath)
+        checkAnswer(res, Nil)
+        assert(res.schema.asNullable == df.schema.asNullable)
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -14,7 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.execution
+package org.apache.spark.sql.execution
+
+import io.glutenproject.execution.WholeStageTransformerSuite
+import org.apache.spark.sql.functions.lit
 
 class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
   override protected val backend: String = "velox"
@@ -98,6 +101,16 @@ class VeloxParquetWriteSuite extends WholeStageTransformerSuite {
           .bucketBy(7, "p")
           .saveAsTable("bucket")
       }
+    }
+  }
+
+  test("parquet write with empty dataframe") {
+    withTempPath { f =>
+      val df = spark.emptyDataFrame.select(lit(1).as("i"))
+      df.write.format("velox").save(f.getCanonicalPath)
+      val res = spark.read.parquet(f.getCanonicalPath)
+      checkAnswer(res, Nil)
+      assert(res.schema.asNullable == df.schema.asNullable)
     }
   }
 }

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/NetEase/gluten-velox
+VELOX_BRANCH=empty-parquet
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -2,8 +2,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/NetEase/gluten-velox
-VELOX_BRANCH=empty-parquet
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the write data is empty, we should write a valid parquet file rather than an empty file.

```shell
val df = spark.emptyDataFrame.select(lit(1).as("i"))
df.write.format("velox").save("test3")
```

before:
![image](https://github.com/oap-project/gluten/assets/12025282/6d305fab-98d0-48d9-83bf-666cafad0c9d)

after:
![image](https://github.com/oap-project/gluten/assets/12025282/ac2fd180-1763-421c-a995-4aa33234be5d)

## How was this patch tested?

Add test
