### PR TITLE
[CORE] Fix a potential issue in hive table scan when DPP is used

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -724,7 +724,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       val newChild = exchange.child match {
         // get WholeStageTransformer directly
         case c2r: ColumnarToRowExecBase => c2r.child
-        // in case of fallbacking
+        // in fallback case
         case codeGen: WholeStageCodegenExec =>
           if (codeGen.child.isInstanceOf[ColumnarToRowExec]) {
             val wholeStageTransformer = exchange.find(_.isInstanceOf[WholeStageTransformer])

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -284,6 +284,8 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
         applyScanTransformer(plan)
       case plan: FileSourceScanExec =>
         applyScanTransformer(plan)
+      case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
+        applyScanTransformer(plan)
       case plan: CoalesceExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         CoalesceExecTransformer(plan.numPartitions, replaceWithTransformerPlan(plan.child))
@@ -572,6 +574,20 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
         TransformHints.tagNotTransformable(newSource, validationResult.reason.get)
         newSource
       }
+    case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
+      // TODO: Add DynamicPartitionPruningHiveScanSuite.scala
+      val newPartitionFilters: Seq[Expression] = ExpressionConverter.transformDynamicPruningExpr(
+        HiveTableScanExecTransformer.getpartitionFilters(plan),
+        reuseSubquery)
+      val hiveTableScanExecTransformer =
+        BackendsApiManager.getSparkPlanExecApiInstance.genHiveTableScanExecTransformer(plan)
+      val validateResult = hiveTableScanExecTransformer.doValidate()
+      if (validateResult.isValid) {
+        return hiveTableScanExecTransformer
+      }
+      val newSource = HiveTableScanExecTransformer.copyWith(plan, newPartitionFilters)
+      TransformHints.tagNotTransformable(newSource, validateResult.reason.get)
+      newSource
     case other =>
       throw new UnsupportedOperationException(s"${other.getClass.toString} is not supported.")
   }

--- a/gluten-core/src/main/scala/io/glutenproject/utils/QueryPlanSelector.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/QueryPlanSelector.scala
@@ -46,18 +46,17 @@ abstract class QueryPlanSelector[T <: QueryPlan[_]] extends Logging {
   protected def validate(plan: T): Boolean
 
   private[this] def shouldUseGluten(session: SparkSession, plan: T): Boolean = {
+    val glutenEnabled = session.conf
+      .get(GlutenConfig.GLUTEN_ENABLE_KEY, GlutenConfig.GLUTEN_ENABLE_BY_DEFAULT.toString)
+      .toBoolean
     if (log.isDebugEnabled) {
+      logDebug(s"shouldUseGluten: $glutenEnabled")
       logDebug(
         s"=========================\n" +
           s"running shouldUseGluten from:\n${stackTrace()}\n" +
           s"plan:\n${plan.treeString}\n" +
           "=========================")
     }
-    val glutenEnabled = session.conf
-      .get(GlutenConfig.GLUTEN_ENABLE_KEY, GlutenConfig.GLUTEN_ENABLE_BY_DEFAULT.toString)
-      .toBoolean
-    logInfo(s"shouldUseGluten: $glutenEnabled")
-
     glutenEnabled & validate(plan)
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -265,6 +265,16 @@ object HiveTableScanExecTransformer {
     plan.isInstanceOf[HiveTableScanExec]
   }
 
+  def getpartitionFilters(plan: SparkPlan): Seq[Expression] = {
+    plan.asInstanceOf[HiveTableScanExec].partitionPruningPred
+  }
+
+  def copyWith(plan: SparkPlan, newPartitionFilters: Seq[Expression]): SparkPlan = {
+    val hiveTableScanExec = plan.asInstanceOf[HiveTableScanExec]
+    hiveTableScanExec.copy(partitionPruningPred = newPartitionFilters)(sparkSession =
+      hiveTableScanExec.session)
+  }
+
   def validate(plan: SparkPlan): ValidationResult = {
     plan match {
       case hiveTableScan: HiveTableScanExec =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -104,7 +104,7 @@ class HiveTableScanExecTransformer(
     doExecuteColumnarInternal()
   }
 
-  private lazy val filteredPartitions: Seq[Seq[InputPartition]] = {
+  @transient private lazy val filteredPartitions: Seq[Seq[InputPartition]] = {
     scan match {
       case Some(fileScan) =>
         val dataSourceFilters = partitionPruningPred.flatMap {


### PR DESCRIPTION
The filter pruning expression of hive table scan may come from DPP. We need to do the check and transform for the pruning expression, the corresponding subqueryBroadcast and the possible re-used broadcast exchange. Otherwise, a mismatched subqueryBroadcast can be used and cause hash relation cast issues.

## How was this patch tested?
No regression issue in spark UTs.

