### PR TITLE
[Core][CH] Refactor: Introuce GlutenException and impelment automatic-resource-management pattern

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -233,6 +233,9 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <configuration>
           <scala>
+            <scalafmt>
+              <file>${project.basedir}/../.scalafmt.conf</file>
+            </scalafmt>
             <includes>
               <include>src/main/scala/**/*.scala</include>
               <include>src/test/scala/**/*.scala</include>

--- a/backends-clickhouse/src/main/java/io/glutenproject/utils/SnowflakeIdWorker.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/utils/SnowflakeIdWorker.java
@@ -17,6 +17,8 @@
 
 package io.glutenproject.utils;
 
+import io.glutenproject.exception.GlutenException;
+
 import org.apache.spark.SparkEnv;
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseConfig;
 
@@ -72,7 +74,7 @@ public class SnowflakeIdWorker {
     long timestamp = timeGen();
 
     if (timestamp < lastTimestamp) {
-      throw new RuntimeException(
+      throw new GlutenException(
           String.format(
               "Clock moved backwards.  Refusing to generate id for %d milliseconds",
               lastTimestamp - timestamp));

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
@@ -17,6 +17,8 @@
 
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import org.apache.spark.sql.execution.utils.CHExecUtil;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -30,7 +32,7 @@ public class CHNativeBlock {
 
   public static CHNativeBlock fromColumnarBatch(ColumnarBatch batch) {
     if (batch.numCols() == 0 || !(batch.column(0) instanceof CHColumnVector)) {
-      throw new RuntimeException(
+      throw new GlutenException(
           "Unexpected ColumnarBatch: "
               + (batch.numCols() == 0
                   ? "0 column"

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeExpressionEvaluator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeExpressionEvaluator.java
@@ -31,7 +31,6 @@ import io.substrait.proto.Plan;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.internal.SQLConf;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +80,7 @@ public class CHNativeExpressionEvaluator {
   // Used by WholeStageTransform to create the native computing pipeline and
   // return a columnar result iterator.
   public GeneralOutIterator createKernelWithBatchIterator(
-      Plan wsPlan, List<GeneralInIterator> iterList) throws RuntimeException, IOException {
+      Plan wsPlan, List<GeneralInIterator> iterList) {
     long allocId = CHNativeMemoryAllocators.contextInstance().getNativeInstanceId();
     long handle =
         jniWrapper.nativeCreateKernelWithIterator(
@@ -99,8 +98,7 @@ public class CHNativeExpressionEvaluator {
 
   // Only for UT.
   public GeneralOutIterator createKernelWithBatchIterator(
-      long allocId, byte[] wsPlan, List<GeneralInIterator> iterList)
-      throws RuntimeException, IOException {
+      long allocId, byte[] wsPlan, List<GeneralInIterator> iterList) {
     long handle =
         jniWrapper.nativeCreateKernelWithIterator(
             allocId,
@@ -119,7 +117,7 @@ public class CHNativeExpressionEvaluator {
     return planNode.toByteArray();
   }
 
-  private GeneralOutIterator createOutIterator(long nativeHandle) throws IOException {
+  private GeneralOutIterator createOutIterator(long nativeHandle) {
     return new BatchIterator(nativeHandle);
   }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -19,13 +19,10 @@ package io.glutenproject.vectorized;
 
 /**
  * This class is implemented in JNI. This provides the Java interface to invoke functions in JNI.
- * This file is used to generated the .h files required for jni. Avoid all external dependencies in
+ * This file is used to generate the .h files required for jni. Avoid all external dependencies in
  * this file.
  */
 public class ExpressionEvaluatorJniWrapper {
-
-  /** Wrapper for native API. */
-  public ExpressionEvaluatorJniWrapper() {}
 
   /** Call initNative to initialize native computing. */
   native void nativeInitNative(byte[] confAsPlan);
@@ -48,8 +45,7 @@ public class ExpressionEvaluatorJniWrapper {
    * @return iterator instance id
    */
   public native long nativeCreateKernelWithIterator(
-      long allocatorId, byte[] wsPlan, GeneralInIterator[] batchItr, byte[] confArray)
-      throws RuntimeException;
+      long allocatorId, byte[] wsPlan, GeneralInIterator[] batchItr, byte[] confArray);
 
   /**
    * Closes the projector referenced by nativeHandler.

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentShuffleInputStream.java
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import io.netty.util.internal.PlatformDependent;
 import org.apache.spark.network.util.LimitedInputStream;
 import org.apache.spark.storage.CHShuffleReadStreamFactory;
@@ -54,7 +56,7 @@ public class LowCopyFileSegmentShuffleInputStream implements ShuffleInputStream 
           (FileInputStream)
               CHShuffleReadStreamFactory.FIELD_FilterInputStream_in.get(this.limitedInputStream);
     } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
     channel = fin.getChannel();
   }
@@ -77,7 +79,7 @@ public class LowCopyFileSegmentShuffleInputStream implements ShuffleInputStream 
       left -= bytes;
       return bytes;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 
@@ -97,7 +99,7 @@ public class LowCopyFileSegmentShuffleInputStream implements ShuffleInputStream 
       channel.close();
       in.close();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyNettyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyNettyShuffleInputStream.java
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.PlatformDependent;
 
@@ -70,7 +72,7 @@ public class LowCopyNettyShuffleInputStream implements ShuffleInputStream {
     try {
       in.close();
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -57,7 +59,7 @@ public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
       bytesRead += read;
       return read;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 
@@ -77,7 +79,7 @@ public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
       in.close();
       in = null;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
@@ -17,6 +17,7 @@
 
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
 import io.glutenproject.execution.BroadCastHashJoinContext;
 import io.glutenproject.expression.ConverterUtils;
 import io.glutenproject.expression.ConverterUtils$;
@@ -119,7 +120,7 @@ public class StorageJoinBuilder implements AutoCloseable {
     try {
       in.close();
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 }

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.storage;
 
+import io.glutenproject.exception.GlutenException;
 import io.glutenproject.vectorized.LowCopyFileSegmentShuffleInputStream;
 import io.glutenproject.vectorized.LowCopyNettyShuffleInputStream;
 import io.glutenproject.vectorized.OnHeapCopyShuffleInputStream;
@@ -75,7 +76,7 @@ public final class CHShuffleReadStreamFactory {
       FIELD_LZFInputStream_in = LZFInputStream.class.getDeclaredField("_inputStream");
       FIELD_LZFInputStream_in.setAccessible(true);
     } catch (NoSuchFieldException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 
@@ -179,7 +180,6 @@ public final class CHShuffleReadStreamFactory {
     InputStream wrapped;
     try {
       wrapped = (InputStream) FIELD_FilterInputStream_in.get(lin);
-      long left = ((long) FIELD_LimitedInputStream_left.get(lin));
     } catch (IllegalAccessException e) {
       LOG.error("Can not get the fields from LimitedInputStream: ", e);
       return null;

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleWriteStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleWriteStreamFactory.java
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.storage;
 
+import io.glutenproject.exception.GlutenException;
+
 import com.github.luben.zstd.ZstdOutputStreamNoFinalizer;
 import com.ning.compress.lzf.LZFOutputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
@@ -28,6 +30,8 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 
 public final class CHShuffleWriteStreamFactory {
+
+  private CHShuffleWriteStreamFactory() {}
 
   private static final Logger LOG = LoggerFactory.getLogger(CHShuffleWriteStreamFactory.class);
 
@@ -53,7 +57,7 @@ public final class CHShuffleWriteStreamFactory {
       FIELD_LZFOutputStream_out = LZFOutputStream.class.getSuperclass().getDeclaredField("out");
       FIELD_LZFOutputStream_out.setAccessible(true);
     } catch (NoSuchFieldException e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/NativeFileScanColumnarRDD.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/NativeFileScanColumnarRDD.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.metrics.GlutenTimeMetric
 import io.glutenproject.vectorized.{CHNativeExpressionEvaluator, CloseableCHColumnBatchIterator, GeneralInIterator, GeneralOutIterator}
 
 import org.apache.spark.{Partition, SparkContext, SparkException, TaskContext}
@@ -24,6 +25,7 @@ import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+import java.util
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
 class NativeFileScanColumnarRDD(
@@ -37,21 +39,21 @@ class NativeFileScanColumnarRDD(
   override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
     val inputPartition = castNativePartition(split)
 
-    val startNs = System.nanoTime()
-    val transKernel = new CHNativeExpressionEvaluator()
-    val inBatchIters = new java.util.ArrayList[GeneralInIterator]()
-    val resIter: GeneralOutIterator =
-      transKernel.createKernelWithBatchIterator(inputPartition.plan, inBatchIters)
-    scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+    val resIter: GeneralOutIterator = GlutenTimeMetric.millis(scanTime) {
+      _ =>
+        val transKernel = new CHNativeExpressionEvaluator()
+        val inBatchIters = new util.ArrayList[GeneralInIterator]()
+        transKernel.createKernelWithBatchIterator(inputPartition.plan, inBatchIters)
+    }
+
     TaskContext.get().addTaskCompletionListener[Unit](_ => resIter.close())
-    val iter = new Iterator[Any] {
+    val iter: Iterator[ColumnarBatch] = new Iterator[ColumnarBatch] {
       var scanTotalTime = 0L
       var scanTimeAdded = false
 
       override def hasNext: Boolean = {
-        val startNs = System.nanoTime()
-        val res = resIter.hasNext
-        scanTotalTime += System.nanoTime() - startNs
+        val res = GlutenTimeMetric.withNanoTime(resIter.hasNext)(t => scanTotalTime += t)
+
         if (!res && !scanTimeAdded) {
           scanTime += NANOSECONDS.toMillis(scanTotalTime)
           scanTimeAdded = true
@@ -59,16 +61,14 @@ class NativeFileScanColumnarRDD(
         res
       }
 
-      override def next(): Any = {
-        val startNs = System.nanoTime()
-        val cb = resIter.next()
+      override def next(): ColumnarBatch = {
+        val cb = GlutenTimeMetric.withNanoTime(resIter.next())(t => scanTotalTime += t)
         numOutputRows += cb.numRows()
         numOutputBatches += 1
-        scanTotalTime += System.nanoTime() - startNs
         cb
       }
     }
-    new CloseableCHColumnBatchIterator(iter.asInstanceOf[Iterator[ColumnarBatch]])
+    new CloseableCHColumnBatchIterator(iter)
   }
 
   private def castNativePartition(split: Partition): BaseGlutenPartition = split match {

--- a/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CloseableCHColumnBatchIterator.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CloseableCHColumnBatchIterator.scala
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.vectorized
 
+import io.glutenproject.metrics.GlutenTimeMetric
+
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -32,14 +34,12 @@ class CloseableCHColumnBatchIterator(
     pipelineTime: Option[SQLMetric] = None)
   extends Iterator[ColumnarBatch]
   with Logging {
-  var cb: ColumnarBatch = null
+  var cb: ColumnarBatch = _
   var scanTime = 0L
   var scanTimeAdded = false
 
   override def hasNext: Boolean = {
-    val beforeTime = System.nanoTime()
-    val res = itr.hasNext
-    scanTime += System.nanoTime() - beforeTime
+    val res = GlutenTimeMetric.withNanoTime(itr.hasNext)(t => scanTime += t)
     if (!res && pipelineTime.nonEmpty && !scanTimeAdded) {
       pipelineTime.foreach(t => t += TimeUnit.NANOSECONDS.toMillis(scanTime))
       scanTimeAdded = true
@@ -50,14 +50,17 @@ class CloseableCHColumnBatchIterator(
   TaskContext.get().addTaskCompletionListener[Unit] {
     _ =>
       closeCurrentBatch()
-      if (itr.isInstanceOf[AutoCloseable]) itr.asInstanceOf[AutoCloseable].close()
+      itr match {
+        case closeable: AutoCloseable => closeable.close()
+        case _ =>
+      }
   }
 
   override def next(): ColumnarBatch = {
-    val beforeTime = System.nanoTime()
-    closeCurrentBatch()
-    cb = itr.next()
-    scanTime += System.nanoTime() - beforeTime
+    cb = GlutenTimeMetric.withNanoTime {
+      closeCurrentBatch()
+      itr.next()
+    }(t => scanTime += t)
     cb
   }
 

--- a/cpp-ch/local-engine/jni/jni_error.cpp
+++ b/cpp-ch/local-engine/jni/jni_error.cpp
@@ -44,7 +44,7 @@ void JniErrorsGlobalState::destroy(JNIEnv * env)
 void JniErrorsGlobalState::initialize(JNIEnv * env_)
 {
     io_exception_class = CreateGlobalExceptionClassReference(env_, "Ljava/io/IOException;");
-    runtime_exception_class = CreateGlobalExceptionClassReference(env_, "Ljava/lang/RuntimeException;");
+    runtime_exception_class = CreateGlobalExceptionClassReference(env_, "Lio/glutenproject/exception/GlutenException;");
     unsupportedoperation_exception_class = CreateGlobalExceptionClassReference(env_, "Ljava/lang/UnsupportedOperationException;");
     illegal_access_exception_class = CreateGlobalExceptionClassReference(env_, "Ljava/lang/IllegalAccessException;");
     illegal_argument_exception_class = CreateGlobalExceptionClassReference(env_, "Ljava/lang/IllegalArgumentException;");

--- a/gluten-core/src/main/java/io/glutenproject/exception/GlutenException.java
+++ b/gluten-core/src/main/java/io/glutenproject/exception/GlutenException.java
@@ -1,0 +1,18 @@
+package io.glutenproject.exception;
+
+public class GlutenException extends RuntimeException {
+
+  public GlutenException() {}
+
+  public GlutenException(String message) {
+    super(message);
+  }
+
+  public GlutenException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public GlutenException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
@@ -17,6 +17,8 @@
 
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import org.apache.spark.util.GlutenShutdownManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,8 +58,8 @@ import scala.runtime.BoxedUnit;
 public class JniLibLoader {
   private static final Logger LOG = LoggerFactory.getLogger(JniLibLoader.class);
 
-  public static Set<String> LOADED_LIBRARY_PATHS = new HashSet<>();
-  public static Set<String> REQUIRE_UNLOAD_LIBRARY_PATHS = new LinkedHashSet<>();
+  private static final Set<String> LOADED_LIBRARY_PATHS = new HashSet<>();
+  private static final Set<String> REQUIRE_UNLOAD_LIBRARY_PATHS = new LinkedHashSet<>();
 
   static {
     GlutenShutdownManager.addHookForLibUnloading(
@@ -97,8 +99,7 @@ public class JniLibLoader {
   public static void loadFromPath(String libPath, boolean requireUnload) {
     final File file = new File(libPath);
     if (!file.isFile() || !file.exists()) {
-      throw new RuntimeException(
-          "library at path: " + libPath + " is not a file or does not exist");
+      throw new GlutenException("library at path: " + libPath + " is not a file or does not exist");
     }
     loadFromPath0(file.getAbsolutePath(), requireUnload);
   }
@@ -208,7 +209,7 @@ public class JniLibLoader {
         return this;
       } catch (Exception e) {
         abort();
-        throw new RuntimeException(e);
+        throw new GlutenException(e);
       }
     }
 
@@ -218,7 +219,7 @@ public class JniLibLoader {
         return this;
       } catch (Exception e) {
         abort();
-        throw new RuntimeException(e);
+        throw new GlutenException(e);
       }
     }
 
@@ -229,7 +230,7 @@ public class JniLibLoader {
         return this;
       } catch (Exception e) {
         abort();
-        throw new RuntimeException(e);
+        throw new GlutenException(e);
       }
     }
 
@@ -250,7 +251,7 @@ public class JniLibLoader {
                     return Stream.of(
                         new LoadAction(req.libName, req.linkName, req.requireUnload, file));
                   } catch (IOException ex) {
-                    throw new RuntimeException(ex);
+                    throw new GlutenException(ex);
                   }
                 })
             .collect(Collectors.toList())
@@ -262,7 +263,7 @@ public class JniLibLoader {
                     loadedLibraries.add(e.libName);
                     LOG.info("Successfully loaded library {}", e.libName);
                   } catch (Exception ex) {
-                    throw new RuntimeException(ex);
+                    throw new GlutenException(ex);
                   }
                 });
       } finally {
@@ -300,7 +301,7 @@ public class JniLibLoader {
         try {
           Files.copy(is, temp.toPath());
         } catch (Exception e) {
-          throw new RuntimeException(e);
+          throw new GlutenException(e);
         }
       }
       return temp;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniResourceHelper.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniResourceHelper.java
@@ -17,6 +17,8 @@
 
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +30,6 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
@@ -101,10 +102,10 @@ public class JniResourceHelper {
     }
     final String folderToLoad = "";
     URL url = new URL("jar:file:" + sourceJar + "!/");
-    final URLConnection urlConnection = (JarURLConnection) url.openConnection();
-    File workDir_handler = new File(workDir + "/tmp");
-    if (!workDir_handler.exists()) {
-      workDir_handler.mkdirs();
+    final URLConnection urlConnection = url.openConnection();
+    File workDirHandler = new File(workDir + "/tmp");
+    if (!workDirHandler.exists()) {
+      workDirHandler.mkdirs();
     }
 
     if (urlConnection instanceof JarURLConnection) {
@@ -127,12 +128,11 @@ public class JniResourceHelper {
       if (((Objects.equals(jarPath, "") && !oneEntry.getName().contains("META-INF"))
               || (oneEntry.getName().startsWith(jarPath + "/")))
           && !oneEntry.isDirectory()) {
-        int rm_length = jarPath.length() == 0 ? 0 : jarPath.length() + 1;
-        Path dest_path = Paths.get(destPath + "/" + oneEntry.getName().substring(rm_length));
-        if (Files.exists(dest_path)) {
+        int rmLength = jarPath.isEmpty() ? 0 : jarPath.length() + 1;
+        if (Files.exists(Paths.get(destPath + "/" + oneEntry.getName().substring(rmLength)))) {
           continue;
         }
-        File destFile = new File(destPath + "/" + oneEntry.getName().substring(rm_length));
+        File destFile = new File(destPath + "/" + oneEntry.getName().substring(rmLength));
         File parentFile = destFile.getParentFile();
         if (parentFile != null) {
           parentFile.mkdirs();
@@ -177,7 +177,7 @@ public class JniResourceHelper {
       LOG.info("Successfully extracted headers to work directory {}", workDir);
       headersExtracted = true;
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 
@@ -199,7 +199,7 @@ public class JniResourceHelper {
                 LOG.info("Successfully extracted jar {} to work directory {}", jar, workDir);
                 jarExtracted.add(jar);
               } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new GlutenException(e);
               }
             });
   }

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniWorkspace.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniWorkspace.java
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.vectorized;
 
+import io.glutenproject.exception.GlutenException;
+
 import org.apache.spark.util.SparkDirectoryUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +48,7 @@ public class JniWorkspace {
       this.jniResourceHelper = new JniResourceHelper(workDir);
       LOG.info("JNI workspace {} created in root directory {}", workDir, rootDir);
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 
@@ -58,7 +60,7 @@ public class JniWorkspace {
               .getAbsolutePath();
       return createOrGet(tempRoot);
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new GlutenException(e);
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BroadcastBuildSideRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BroadcastBuildSideRDD.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenException
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
@@ -34,7 +35,7 @@ case class BroadcastBuildSideRDD(
 
   override def getPartitions: Array[Partition] = {
     if (numPartitions < 0) {
-      throw new RuntimeException(s"Invalid number of partitions: $numPartitions.")
+      throw new GlutenException(s"Invalid number of partitions: $numPartitions.")
     }
     Array.tabulate(numPartitions)(i => BroadcastBuildSideRDDPartition(i))
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -18,6 +18,7 @@ package io.glutenproject.execution
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.exception.GlutenException
 import io.glutenproject.expression._
 import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
@@ -240,7 +241,7 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
       val allScanPartitionSchemas = basicScanExecTransformers.map(_.getPartitionSchemas)
       val partitionLength = allScanPartitions.head.size
       if (allScanPartitions.exists(_.size != partitionLength)) {
-        throw new RuntimeException(
+        throw new GlutenException(
           "The partition length of all the scan transformer are not the same.")
       }
       val startTime = System.nanoTime()
@@ -261,7 +262,7 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
 
       logOnLevel(
         substraitPlanLogLevel,
-        s"Generating the Substrait plan took: ${(System.nanoTime() - startTime)} ns.")
+        s"Generating the Substrait plan took: ${System.nanoTime() - startTime} ns.")
 
       new GlutenWholeStageColumnarRDD(
         sparkContext,
@@ -291,7 +292,7 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
       logOnLevel(substraitPlanLogLevel, s"Generating substrait plan:\n$planJson")
       logOnLevel(
         substraitPlanLogLevel,
-        s"Generating the Substrait plan took: ${(System.nanoTime() - startTime)} ns.")
+        s"Generating the Substrait plan took: ${System.nanoTime() - startTime} ns.")
 
       new WholeStageZippedPartitionsRDD(
         sparkContext,
@@ -356,7 +357,7 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
     // Get the number of partitions from a non-broadcast RDD.
     val nonBroadcastRDD = rddSeq.find(rdd => !rdd.isInstanceOf[BroadcastBuildSideRDD])
     if (nonBroadcastRDD.isEmpty) {
-      throw new RuntimeException("At least one RDD should not being BroadcastBuildSideRDD")
+      throw new GlutenException("At least one RDD should not being BroadcastBuildSideRDD")
     }
     rddSeq.map {
       case broadcastRDD: BroadcastBuildSideRDD =>

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -21,6 +21,7 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar._
+import io.glutenproject.metrics.GlutenTimeMetric
 import io.glutenproject.utils.{ColumnarShuffleUtil, LogLevelUtil, PhysicalPlanSelector}
 
 import org.apache.spark.api.python.EvalPythonExecTransformer
@@ -44,6 +45,8 @@ import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 import org.apache.spark.util.SparkUtil
 
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
 // This rule will conduct the conversion from Spark plan to the plan transformer.
 case class TransformPreOverrides(isAdaptiveContext: Boolean)
   extends Rule[SparkPlan]
@@ -51,7 +54,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
   val columnarConf: GlutenConfig = GlutenConfig.getConf
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
-  val reuseSubquery = isAdaptiveContext && conf.subqueryReuseEnabled
+  val reuseSubquery: Boolean = isAdaptiveContext && conf.subqueryReuseEnabled
 
   /**
    * Insert a Project as the new child of Shuffle to calculate the hash expressions.
@@ -213,7 +216,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
           AddTransformHintRule().apply(
             ProjectExec(plan.child.output ++ projectExpressions, plan.child)))
         var newExprs = Seq[Expression]()
-        for (i <- 0 to exprs.size - 1) {
+        for (i <- exprs.indices) {
           val pos = newExpressionsPosition(i)
           newExprs = newExprs :+ project.output(pos)
         }
@@ -233,7 +236,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
           AddTransformHintRule().apply(
             ProjectExec(plan.child.output ++ projectExpressions, plan.child)))
         var newOrderings = Seq[SortOrder]()
-        for (i <- 0 to orderings.size - 1) {
+        for (i <- orderings.indices) {
           val oldOrdering = orderings(i)
           val pos = newExpressionsPosition(i)
           val ordering = SortOrder(
@@ -587,7 +590,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
 // into native implementations.
 case class TransformPostOverrides(session: SparkSession, isAdaptiveContext: Boolean)
   extends Rule[SparkPlan] {
-  val columnarConf = GlutenConfig.getConf
+  val columnarConf: GlutenConfig = GlutenConfig.getConf
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   def transformColumnarToRowExec(plan: ColumnarToRowExec): SparkPlan = {
@@ -685,7 +688,7 @@ case class ColumnarOverrideRules(session: SparkSession)
   with Logging
   with LogLevelUtil {
 
-  lazy val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
+  private lazy val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
   @transient private lazy val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   // Tracks whether the columnar rule is called through AQE.
@@ -693,12 +696,12 @@ case class ColumnarOverrideRules(session: SparkSession)
   // This is an empirical value, may need to be changed for supporting other versions of spark.
   private val aqeStackTraceIndex = 13
 
-  lazy val wholeStageFallbackThreshold = GlutenConfig.getConf.wholeStageFallbackThreshold
+  private lazy val wholeStageFallbackThreshold = GlutenConfig.getConf.wholeStageFallbackThreshold
 
-  lazy val queryFallbackThreshold = GlutenConfig.getConf.queryFallbackThreshold
+  private lazy val queryFallbackThreshold = GlutenConfig.getConf.queryFallbackThreshold
 
   // for fallback policy
-  lazy val fallbackPolicy = GlutenConfig.getConf.fallbackPolicy
+  private lazy val fallbackPolicy = GlutenConfig.getConf.fallbackPolicy
 
   private var originalPlan: SparkPlan = _
   // Do not create rules in class initialization as we should access SQLConf
@@ -736,34 +739,37 @@ case class ColumnarOverrideRules(session: SparkSession)
   override def preColumnarTransitions: Rule[SparkPlan] = plan =>
     PhysicalPlanSelector.maybe(session, plan) {
       var overridden: SparkPlan = plan
-      val startTime = System.nanoTime()
-      val traceElements = Thread.currentThread.getStackTrace
-      assert(
-        traceElements.length > aqeStackTraceIndex,
-        s"The number of stack trace elements is expected to be more than $aqeStackTraceIndex")
-      // ApplyColumnarRulesAndInsertTransitions is called by either QueryExecution or
-      // AdaptiveSparkPlanExec. So by checking the stack trace, we can know whether
-      // columnar rule will be applied in adaptive execution context. This part of code
-      // needs to be carefully checked when supporting higher versions of spark to make
-      // sure the calling stack has not been changed.
-      this.isAdaptiveContext = traceElements(aqeStackTraceIndex).getClassName.equals(
-        AdaptiveSparkPlanExec.getClass.getName)
-      // Holds the original plan for possible entire fallback.
-      originalPlan = plan
-      logOnLevel(
-        transformPlanLogLevel,
-        s"preColumnarTransitions preOverriden plan:\n${plan.toString}")
-      preOverrides().foreach {
-        r =>
-          overridden = r(session)(overridden)
-          planChangeLogger.logRule(r(session).ruleName, plan, overridden)
+      GlutenTimeMetric.withNanoTime {
+        val traceElements = Thread.currentThread.getStackTrace
+        assert(
+          traceElements.length > aqeStackTraceIndex,
+          s"The number of stack trace elements is expected to be more than $aqeStackTraceIndex")
+        // ApplyColumnarRulesAndInsertTransitions is called by either QueryExecution or
+        // AdaptiveSparkPlanExec. So by checking the stack trace, we can know whether
+        // columnar rule will be applied in adaptive execution context. This part of code
+        // needs to be carefully checked when supporting higher versions of spark to make
+        // sure the calling stack has not been changed.
+        this.isAdaptiveContext = traceElements(aqeStackTraceIndex).getClassName.equals(
+          AdaptiveSparkPlanExec.getClass.getName)
+        // Holds the original plan for possible entire fallback.
+        originalPlan = plan
+        logOnLevel(
+          transformPlanLogLevel,
+          s"preColumnarTransitions preOverriden plan:\n${plan.toString}")
+        preOverrides().foreach {
+          r =>
+            overridden = r(session)(overridden)
+            planChangeLogger.logRule(r(session).ruleName, plan, overridden)
+        }
+        logOnLevel(
+          transformPlanLogLevel,
+          s"preColumnarTransitions afterOverriden plan:\n${overridden.toString}")
+      } {
+        t =>
+          logOnLevel(
+            transformPlanLogLevel,
+            s"preTransform SparkPlan took: ${NANOSECONDS.toMillis(t)} ms.")
       }
-      logOnLevel(
-        transformPlanLogLevel,
-        s"preColumnarTransitions afterOverriden plan:\n${overridden.toString}")
-      logOnLevel(
-        transformPlanLogLevel,
-        s"preTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
       overridden
     }
 
@@ -796,7 +802,7 @@ case class ColumnarOverrideRules(session: SparkSession)
           fallbacks = fallbacks + 1
         case _ =>
       }
-      plan.children.map(p => countFallback(p))
+      plan.children.foreach(p => countFallback(p))
     }
     countFallback(plan)
     fallbacks
@@ -837,7 +843,7 @@ case class ColumnarOverrideRules(session: SparkSession)
   }
 
   // Just for test use.
-  def enableAdaptiveContext: Unit = {
+  def enableAdaptiveContext(): Unit = {
     isAdaptiveContext = true
   }
 
@@ -845,27 +851,30 @@ case class ColumnarOverrideRules(session: SparkSession)
     PhysicalPlanSelector.maybe(session, plan) {
       if (fallbackPolicy == "query" && !isAdaptiveContext && fallbackWholeQuery(plan)) {
         logWarning("Fall back to run the query due to unsupported operator!")
-        insertTransitions(originalPlan, false)
+        insertTransitions(originalPlan, outputsColumnar = false)
       } else if (fallbackPolicy == "stage" && isAdaptiveContext && fallbackWholeStage(plan)) {
         logWarning("Fall back the plan due to meeting the whole stage fallback threshold!")
-        insertTransitions(originalPlan, false)
+        insertTransitions(originalPlan, outputsColumnar = false)
       } else {
         logOnLevel(
           transformPlanLogLevel,
           s"postColumnarTransitions preOverriden plan:\n${plan.toString}")
         var overridden: SparkPlan = plan
-        val startTime = System.nanoTime()
-        postOverrides().foreach {
-          r =>
-            overridden = r(session)(overridden)
-            planChangeLogger.logRule(r(session).ruleName, plan, overridden)
+        GlutenTimeMetric.withNanoTime {
+          postOverrides().foreach {
+            r =>
+              overridden = r(session)(overridden)
+              planChangeLogger.logRule(r(session).ruleName, plan, overridden)
+          }
+          logOnLevel(
+            transformPlanLogLevel,
+            s"postColumnarTransitions afterOverriden plan:\n${overridden.toString}")
+        } {
+          t =>
+            logOnLevel(
+              transformPlanLogLevel,
+              s"postTransform SparkPlan took: ${NANOSECONDS.toMillis(t)} ms.")
         }
-        logOnLevel(
-          transformPlanLogLevel,
-          s"postColumnarTransitions afterOverriden plan:\n${overridden.toString}")
-        logOnLevel(
-          transformPlanLogLevel,
-          s"postTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
         overridden
       }
     }

--- a/gluten-core/src/main/scala/io/glutenproject/glutenproject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/glutenproject.scala
@@ -16,6 +16,8 @@
  */
 package io
 
+import io.glutenproject.exception.GlutenException
+
 import java.util.Properties
 
 import scala.util.Try
@@ -27,7 +29,7 @@ package object glutenproject {
       Thread.currentThread().getContextClassLoader.getResourceAsStream(buildFile)
 
     if (buildFileStream == null) {
-      throw new RuntimeException(s"Can not load the core build file: $buildFile")
+      throw new GlutenException(s"Can not load the core build file: $buildFile")
     }
 
     val unknown = "<unknown>"

--- a/gluten-core/src/main/scala/io/glutenproject/metrics/GlutenTimeMetric.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/metrics/GlutenTimeMetric.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.metrics
+
+import io.glutenproject.utils.Arm
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+import java.util.concurrent.TimeUnit
+
+class GlutenTimeMetric(val metric: SQLMetric, timeConvert: Long => Long) extends AutoCloseable {
+  private val start = System.nanoTime()
+
+  override def close(): Unit = {
+    val time = System.nanoTime() - start
+    metric.add(timeConvert(time))
+  }
+}
+object GlutenTimeMetric {
+  def nano[V](metric: SQLMetric)(block: GlutenTimeMetric => V): V =
+    Arm.withResource(new GlutenTimeMetric(metric, t => t))(block)
+  def millis[V](metric: SQLMetric)(block: GlutenTimeMetric => V): V =
+    Arm.withResource(new GlutenTimeMetric(metric, t => TimeUnit.NANOSECONDS.toMillis(t)))(block)
+
+  def withNanoTime[U](block: => U)(nanoTime: Long => Unit): U = {
+    val start = System.nanoTime()
+    val result = block
+    nanoTime(System.nanoTime() - start)
+    result
+  }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/utils/Arm.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/Arm.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils
+
+/** Implementation of the automatic-resource-management pattern */
+object Arm {
+
+  /** Executes the provided code block and then closes the resource */
+  def withResource[T <: AutoCloseable, V](r: T)(block: T => V): V = {
+    try {
+      block(r)
+    } finally {
+      r.close()
+    }
+  }
+}

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 
+import _root_.io.glutenproject.exception.GlutenException
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
 
@@ -39,7 +40,7 @@ object SparkDirectoryUtil extends Logging {
             try FileUtils.forceDelete(localDir)
             catch {
               case e: Exception =>
-                throw new RuntimeException(e)
+                throw new GlutenException(e)
             }
           })
         logInfo(s"Created local directory at $localDir")

--- a/gluten-core/src/test/scala/org/apache/spark/sql/TestUtils.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/sql/TestUtils.scala
@@ -16,13 +16,15 @@
  */
 package org.apache.spark.sql
 
+import io.glutenproject.exception.GlutenException
+
 import org.apache.spark.sql.test.SQLTestUtils
 
 object TestUtils {
   def compareAnswers(actual: Seq[Row], expected: Seq[Row], sort: Boolean = false): Unit = {
     val result = SQLTestUtils.compareAnswers(actual, expected, sort)
     if (result.isDefined) {
-      throw new RuntimeException("Failed to compare answer" + result.get)
+      throw new GlutenException("Failed to compare answer" + result.get)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have some code quality issues:

1.  `RuntimeException` is used when we need throw an expcetion, this PR introuces `GlutenException`. We can improve error meesage in the future.
2. Timing logic is cumbersome, we can see the following codes in many palces, this PR impelments automatic-resource-management pattern.

``` scala
val startTime = System.nanoTime()
...
logOnLevel(
   transformPlanLogLevel,
   s"preTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
```


## How was this patch tested?
Using Existed UTs

