### PR TITLE
[GLUTEN-2520][CORE][VL][CH][UT] Refactor: unify java and scala license checker 

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -233,6 +233,9 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <configuration>
           <scala>
+            <scalafmt>
+              <file>${project.basedir}/../.scalafmt.conf</file>
+            </scalafmt>
             <includes>
               <include>src/main/scala/**/*.scala</include>
               <include>src/test/scala/**/*.scala</include>

--- a/backends-clickhouse/src/main/java/io/glutenproject/execution/ColumnarNativeIterator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/execution/ColumnarNativeIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.execution;
 
 import io.glutenproject.vectorized.CHColumnVector;

--- a/backends-clickhouse/src/main/java/io/glutenproject/execution/SparkRowIterator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/execution/SparkRowIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.execution;
 
 import java.nio.ByteBuffer;

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHManagedCHReservationListener.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHManagedCHReservationListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import io.glutenproject.memory.TaskMemoryMetrics;

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 /**

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocatorManager.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocatorManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import org.apache.spark.util.TaskResource;

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocatorManagerImpl.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocatorManagerImpl.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 public class CHNativeMemoryAllocatorManagerImpl implements CHNativeMemoryAllocatorManager {

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import io.glutenproject.memory.TaskMemoryMetrics;

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHReservationListener.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHReservationListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 public interface CHReservationListener {

--- a/backends-clickhouse/src/main/java/io/glutenproject/metrics/OperatorMetrics.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/metrics/OperatorMetrics.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.metrics;
 
 import io.glutenproject.substrait.AggregationParams;

--- a/backends-clickhouse/src/main/java/io/glutenproject/utils/SnowflakeIdWorker.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/utils/SnowflakeIdWorker.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.utils;
 
 import org.apache.spark.SparkEnv;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BatchIterator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BatchIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.metrics.IMetrics;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockOutputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockOutputStream.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.execution.metric.SQLMetric;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockSplitIterator.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockSplitIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHBlockConverterJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHBlockConverterJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.execution.SparkRowIterator;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHBlockWriterJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHBlockWriterJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHColumnVector.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHColumnVector.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.types.DataType;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHNativeBlock.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.execution.utils.CHExecUtil;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHShuffleSplitterJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHShuffleSplitterJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import java.io.IOException;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHStreamReader.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHStreamReader.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.storage.CHShuffleReadStreamFactory;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 /**

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/IteratorWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/IteratorWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import java.util.Iterator;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/SimpleExpressionEval.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/SimpleExpressionEval.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.execution.ColumnarNativeIterator;

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.execution.BroadCastHashJoinContext;

--- a/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/CHDatasourceJniWrapper.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/CHDatasourceJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql.execution.datasources;
 
 public class CHDatasourceJniWrapper {

--- a/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
+++ b/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.memory;
 
 import io.glutenproject.memory.TaskMemoryMetrics;

--- a/backends-velox/src/main/java/io/glutenproject/fs/JniFilesystem.java
+++ b/backends-velox/src/main/java/io/glutenproject/fs/JniFilesystem.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.fs;
 
 import org.apache.commons.lang3.NotImplementedException;

--- a/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.spark.sql.execution.datasources.velox;
 
 import io.glutenproject.init.JniInitialized;

--- a/backends-velox/src/main/java/io/glutenproject/udf/UdfJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/udf/UdfJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.udf;
 
 public class UdfJniWrapper {

--- a/backends-velox/src/test/java/io/glutenproject/tags/UDFTest.java
+++ b/backends-velox/src/test/java/io/glutenproject/tags/UDFTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.tags;
 
 import org.scalatest.TagAnnotation;

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.shuffle.gluten.celeborn;
 
 import org.apache.celeborn.client.LifecycleManager;

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -322,6 +322,13 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <scala>
+            <scalafmt>
+              <file>${project.basedir}/../.scalafmt.conf</file>
+            </scalafmt>
+          </scala>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>

--- a/gluten-core/src/main/java/io/glutenproject/memory/TaskMemoryMetrics.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/TaskMemoryMetrics.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/MemoryTarget.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/MemoryTarget.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.memtarget;
 
 // The naming convention "borrow" and "repay" are for preventing collisions with

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/OverAcquire.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/OverAcquire.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.memtarget;
 
 import com.google.common.base.Preconditions;

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.memtarget.spark;
 
 import io.glutenproject.memory.memtarget.MemoryTarget;

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/Spiller.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/Spiller.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.memtarget.spark;
 
 import org.apache.spark.memory.MemoryConsumer;

--- a/gluten-core/src/main/java/io/glutenproject/row/SparkRowInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/row/SparkRowInfo.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.row;
 
 public class SparkRowInfo {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/DllNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/DllNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.ddlplan;
 
 import io.substrait.proto.Dll;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/DllPlanNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/DllPlanNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.ddlplan;
 
 import io.substrait.proto.DllPlan;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.ddlplan;
 
 public class InsertOutputBuilder {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/InsertOutputNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.ddlplan;
 
 import com.google.protobuf.Any;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/InsertPlanNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/ddlplan/InsertPlanNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.ddlplan;
 
 import io.glutenproject.substrait.SubstraitContext;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/derivation/BinaryOPNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/derivation/BinaryOPNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.derivation;
 
 import io.substrait.proto.DerivationExpression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/derivation/DerivationExpressionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/derivation/DerivationExpressionBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.derivation;
 
 public class DerivationExpressionBuilder {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/derivation/DerivationExpressionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/derivation/DerivationExpressionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.derivation;
 
 import io.substrait.proto.DerivationExpression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/derivation/DerivationFP64TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/derivation/DerivationFP64TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.derivation;
 
 import io.substrait.proto.DerivationExpression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/BinaryLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/BinaryLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.BinaryTypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/BooleanLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/BooleanLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.BooleanTypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ByteLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ByteLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.I8TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/CastNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/CastNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/DateLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/DateLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.DateTypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/DecimalLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/DecimalLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeBuilder;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/DoubleLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/DoubleLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.FP64TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.expression.ConverterUtils;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/FloatLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/FloatLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.FP32TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/IfThenNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/IfThenNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/IntLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/IntLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.I32TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ListLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ListLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.ListNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/LiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/LiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/LongLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/LongLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.I64TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/MapLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/MapLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.MapNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/NullLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/NullLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ScalarFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ScalarFunctionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ShortLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ShortLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.I16TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/SingularOrListNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/SingularOrListNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.substrait.proto.Expression;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/StringLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/StringLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.StringTypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/StructLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/StructLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.*;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/TimestampLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/TimestampLiteralNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TimestampTypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/WindowFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/WindowFunctionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.expression;
 
 import io.glutenproject.substrait.type.TypeNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/extensions/AdvancedExtensionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/extensions/AdvancedExtensionNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.extensions;
 
 import com.google.protobuf.Any;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/extensions/ExtensionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/extensions/ExtensionBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.extensions;
 
 import com.google.protobuf.Any;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/extensions/FunctionMappingNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/extensions/FunctionMappingNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.extensions;
 
 import io.substrait.proto.SimpleExtensionDeclaration;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.plan;
 
 import io.glutenproject.substrait.SubstraitContext;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.plan;
 
 import io.glutenproject.substrait.extensions.AdvancedExtensionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/AggregateRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/AggregateRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.AggregateFunctionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExpandRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExpandRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 public class ExtensionTableBuilder {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import com.google.protobuf.Any;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/FilterRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/FilterRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/GenerateRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/GenerateRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/JoinRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import java.util.List;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.GlutenConfig;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ProjectRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ProjectRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.SubstraitContext;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.expression.ConverterUtils;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.substrait.proto.Rel;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/SortRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/SortRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.extensions.AdvancedExtensionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/WindowRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/WindowRelNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.rel;
 
 import io.glutenproject.substrait.expression.ExpressionNode;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/BinaryTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/BinaryTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/BooleanTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/BooleanTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/ColumnTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/ColumnTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.NamedStruct.ColumnType;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/DateTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/DateTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/DecimalTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/DecimalTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/FP32TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/FP32TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/FP64TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/FP64TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/FixedBinaryTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/FixedBinaryTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/FixedCharTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/FixedCharTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/I16TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/I16TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/I32TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/I32TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/I64TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/I64TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/I8TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/I8TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/StringTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/StringTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/StructNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/StructNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/TimestampTypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/TimestampTypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/TypeBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/TypeBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import java.util.ArrayList;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/TypeNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/TypeNode.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.substrait.type;
 
 import io.substrait.proto.Type;

--- a/gluten-core/src/main/java/io/glutenproject/test/TestStats.java
+++ b/gluten-core/src/main/java/io/glutenproject/test/TestStats.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.test;
 
 import java.util.*;

--- a/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidationInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/validate/NativePlanValidationInfo.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.validate;
 
 import java.util.Vector;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/GeneralInIterator.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/GeneralInIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/GeneralInIteratorV2.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/GeneralInIteratorV2.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/GeneralOutIterator.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/GeneralOutIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.metrics.IMetrics;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniLibLoader.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.util.GlutenShutdownManager;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/JniResourceHelper.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/JniResourceHelper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.slf4j.Logger;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/NativePartitioning.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/NativePartitioning.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import java.io.Serializable;

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/NativeSerializableObject.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/NativeSerializableObject.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 /** ArrowBufBuilder. */

--- a/gluten-core/src/main/java/io/glutenproject/vectorized/SplitResult.java
+++ b/gluten-core/src/main/java/io/glutenproject/vectorized/SplitResult.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 /** POJO to hold native split result */

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.columnarbatch;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.columnarbatch;
 
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators;

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/IndicatorVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/IndicatorVector.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.columnarbatch;
 
 import org.apache.spark.sql.types.DataTypes;

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/PlaceholderVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/PlaceholderVector.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.columnarbatch;
 
 import org.apache.spark.sql.types.DataTypes;

--- a/gluten-data/src/main/java/io/glutenproject/init/InitializerJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/InitializerJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.init;
 
 class InitializerJniWrapper {

--- a/gluten-data/src/main/java/io/glutenproject/init/JniInitialized.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/JniInitialized.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.init;
 
 import io.glutenproject.GlutenConfig;

--- a/gluten-data/src/main/java/io/glutenproject/init/JniUtils.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/JniUtils.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.init;
 
 import io.glutenproject.substrait.expression.ExpressionBuilder;

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/ManagedReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/ManagedReservationListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import io.glutenproject.memory.TaskMemoryMetrics;

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocator.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 /**

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocatorManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocatorManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import org.apache.spark.util.TaskResource;

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocatorManagerImpl.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocatorManagerImpl.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import org.apache.spark.util.TaskResources;

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 import io.glutenproject.memory.TaskMemoryMetrics;

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/ReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/ReservationListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.alloc;
 
 public interface ReservationListener {

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.arrowalloc;
 
 import io.glutenproject.memory.memtarget.spark.GlutenMemoryConsumer;

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ManagedAllocationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ManagedAllocationListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.memory.arrowalloc;
 
 import io.glutenproject.memory.TaskMemoryMetrics;

--- a/gluten-data/src/main/java/io/glutenproject/metrics/Metrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/metrics/Metrics.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.metrics;
 
 public class Metrics implements IMetrics {

--- a/gluten-data/src/main/java/io/glutenproject/metrics/OperatorMetrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/metrics/OperatorMetrics.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.metrics;
 
 public class OperatorMetrics implements IOperatorMetrics {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ArrowColumnVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ArrowColumnVector.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.arrow.vector.*;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ArrowWritableColumnVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ArrowWritableColumnVector.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchInIterator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchInIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.columnarbatch.ColumnarBatches;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchOutIterator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.columnarbatch.ColumnarBatches;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializeResult.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializeResult.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 public class ColumnarBatchSerializeResult {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializerJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializerJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/JniByteInputStream.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/JniByteInputStream.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 /** For being called from C++ code only. */

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/JniByteInputStreams.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/JniByteInputStreams.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import org.apache.spark.storage.BufferReleasingInputStream;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentJniByteInputStream.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentJniByteInputStream.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.netty.util.internal.PlatformDependent;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/LowCopyNettyJniByteInputStream.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/LowCopyNettyJniByteInputStream.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.netty.buffer.ByteBuf;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowInfo.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowInfo.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 public class NativeColumnarToRowInfo {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.GlutenConfig;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeRowToColumnarJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeRowToColumnarJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/OnHeapJniByteInputStream.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/OnHeapJniByteInputStream.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import java.io.IOException;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderMetrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderMetrics.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 public class ShuffleReaderMetrics {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;

--- a/gluten-ut/common/src/test/java/org/apache/spark/tags/ExtendedSQLTest.java
+++ b/gluten-ut/common/src/test/java/org/apache/spark/tags/ExtendedSQLTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.tags;
 
 import org.scalatest.TagAnnotation;

--- a/pom.xml
+++ b/pom.xml
@@ -690,6 +690,10 @@
               </importOrder>
 
               <removeUnusedImports />
+              <licenseHeader>
+                <content>${spotless.license.header}</content>
+                <delimiter>${spotless.delimiter}</delimiter>
+              </licenseHeader>
             </java>
             <scala>
               <scalafmt>

--- a/shims/spark32/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVectorShim.java
+++ b/shims/spark32/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVectorShim.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql.execution.vectorized;
 
 import org.apache.spark.sql.types.DataType;

--- a/shims/spark33/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVectorShim.java
+++ b/shims/spark33/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVectorShim.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.spark.sql.execution.vectorized;
 
 import org.apache.spark.sql.types.DataType;


### PR DESCRIPTION
## What changes were proposed in this pull request?

We now apply spotless for both java and scala, but missing java's license checker configuration.

This PR fix this issue.

(Fixes: \#2520)

## How was this patch tested?

Using existed UT
