### PR TITLE
[VL] Change celeborn-client-spark dep scope to provided

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -288,7 +288,7 @@ jobs:
           mkdir /opt/hadoop && chmod 777 /opt/hadoop && cp apache-celeborn-0.3.0-incubating-bin/spark/celeborn-client-spark-3-shaded_2.12-0.3.0-incubating.jar /opt/hadoop/ && \
           echo -e "celeborn.worker.flusher.threads 32\nceleborn.worker.storage.dirs /opt\nceleborn.worker.monitor.disk.enabled false" > apache-celeborn-0.3.0-incubating-bin/conf/celeborn-defaults.conf && \
           bash apache-celeborn-0.3.0-incubating-bin/sbin/start-master.sh && bash apache-celeborn-0.3.0-incubating-bin/sbin/start-worker.sh && \
-          cd /opt/gluten/tools/gluten-it && mvn clean install -Pspark-3.2 \
+          cd /opt/gluten/tools/gluten-it && mvn clean install -Pspark-3.2,rss \
           && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox-with-celeborn --benchmark-type=h --error-on-memleak --disable-aqe --extra-conf=spark.driver.extraClassPath=/opt/hadoop/* \
             --extra-conf=spark.executor.extraClassPath=/opt/hadoop/* --off-heap-size=20g -s=1.0 --threads=16 --iterations=1 \

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ target/
 *.iml
 
 **/target/**
+**/dependency-reduced-pom.xml
 
 # logs
 *.log

--- a/gluten-celeborn/pom.xml
+++ b/gluten-celeborn/pom.xml
@@ -18,7 +18,7 @@
       <groupId>org.apache.celeborn</groupId>
       <artifactId>celeborn-client-spark-${spark.major.version}-shaded_${scala.binary.version}</artifactId>
       <version>${celeborn.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>

--- a/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
@@ -43,6 +43,8 @@ object Constants {
     .set("spark.sql.parquet.enableVectorizedReader", "true")
     .set("spark.plugins", "io.glutenproject.GlutenPlugin")
     .set("spark.shuffle.manager", "org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager")
+    .set("spark.driver.extraClassPath", "/opt/hadoop/*")
+    .set("spark.executor.extraClassPath", "/opt/hadoop/*")
     .set("spark.celeborn.shuffle.writer", "hash")
     .set("spark.celeborn.push.replicate.enabled", "false")
     .set("spark.shuffle.service.enabled", "false")

--- a/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
@@ -45,6 +45,7 @@ object Constants {
     .set("spark.shuffle.manager", "org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager")
     .set("spark.celeborn.shuffle.writer", "hash")
     .set("spark.celeborn.push.replicate.enabled", "false")
+    .set("spark.celeborn.client.shuffle.compression.codec", "none")
     .set("spark.shuffle.service.enabled", "false")
     .set("spark.sql.adaptive.localShuffleReader.enabled", "false")
     .set("spark.dynamicAllocation.enabled", "false")

--- a/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
+++ b/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/Constants.scala
@@ -43,8 +43,6 @@ object Constants {
     .set("spark.sql.parquet.enableVectorizedReader", "true")
     .set("spark.plugins", "io.glutenproject.GlutenPlugin")
     .set("spark.shuffle.manager", "org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager")
-    .set("spark.driver.extraClassPath", "/opt/hadoop/*")
-    .set("spark.executor.extraClassPath", "/opt/hadoop/*")
     .set("spark.celeborn.shuffle.writer", "hash")
     .set("spark.celeborn.push.replicate.enabled", "false")
     .set("spark.shuffle.service.enabled", "false")

--- a/tools/gluten-it/package/pom.xml
+++ b/tools/gluten-it/package/pom.xml
@@ -92,4 +92,21 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>rss</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.celeborn</groupId>
+          <artifactId>celeborn-client-spark-${spark.major.version}-shaded_${scala.binary.version}</artifactId>
+          <version>${celeborn.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -21,6 +21,8 @@
     <spark32.version>3.2.2</spark32.version>
     <spark33.version>3.3.1</spark33.version>
     <scala.binary.version>2.12</scala.binary.version>
+    <spark.major.version>3</spark.major.version>
+    <celeborn.version>0.3.0-incubating</celeborn.version>
     <gluten.version>1.1.0-SNAPSHOT</gluten.version>
     <guava.version>32.0.1-jre</guava.version>
     <tpch.version>1.1</tpch.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change `celeborn-client-spark-3_2.12` scope from compile to provided.

It's likely that the user put the Celeborn client jar into `SPAKR_HOME/jars` when he/she uses Celeborn as Remote Shuffle Service, and the Gluten jar should not include duplicate Celeborn classes. Further, it's likely that the user maintains internal versions of Celeborn/Gluten, separating should be good than bundling them into one.

BTW, it's not a good practice to include everything in a fat jar without proper class relocation.

## How was this patch tested?

manual tests.

```
➜  gluten git:(main) mvn clean package -DskipTests -pl :gluten-package -am -Pbackends-velox,spark-3.3,rss
➜  gluten git:(main) ll package/target/gluten-velox-bundle-spark3.3_2.12-pop_22.04-1.1.0-SNAPSHOT.jar
-rw-rw-r-- 1 chengpan chengpan 68M Jul 31 12:33 package/target/gluten-velox-bundle-spark3.3_2.12-pop_22.04-1.1.0-SNAPSHOT.jar
```

```
➜  gluten git:(celeborn-provided) mvn clean package -DskipTests -pl :gluten-package -am -Pbackends-velox,spark-3.3,rss
➜  gluten git:(celeborn-provided) ll package/target/gluten-velox-bundle-spark3.3_2.12-pop_22.04-1.1.0-SNAPSHOT.jar    
-rw-rw-r-- 1 chengpan chengpan 57M Jul 31 12:28 package/target/gluten-velox-bundle-spark3.3_2.12-pop_22.04-1.1.0-SNAPSHOT.jar
```