### PR TITLE
[VL] Patch for JniFileSystem PR #2481

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/fs/OnHeapFileSystem.java
+++ b/backends-velox/src/main/java/io/glutenproject/fs/OnHeapFileSystem.java
@@ -53,7 +53,7 @@ public class OnHeapFileSystem implements JniFilesystem {
     // FIXME: This is rough. JVM heap can still be filled out by other threads
     //   after passing this check.
     long freeMemory = Runtime.getRuntime().freeMemory();
-    return freeMemory > size;
+    return (freeMemory * 0.75) > size;
   }
 
   private void ensureExist(String path) {

--- a/cpp/velox/jni/JniFileSystem.h
+++ b/cpp/velox/jni/JniFileSystem.h
@@ -24,8 +24,6 @@
 
 namespace gluten {
 
-void registerJniFileSystem();
-
 // Register JNI-or-local (or JVM-over-local, as long as it describes what happens here)
 //   file system. maxFileSize is necessary (!= 0) because we use this size to decide
 //   whether a new file can fit in JVM heap, otherwise we write it via local fs directly.


### PR DESCRIPTION
## What changes were proposed in this pull request?

modify `isCapableForNewFile0`
rename `RemovePathProtocol` to `FileSystemWrapper`
delete useless function `registerJniFileSystem`

[PR 2481](https://github.com/oap-project/gluten/pull/2481)


(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

