### PR TITLE
[GLUTEN-2182][VL][FOLLOWUP] Add BUILD_EXAMPLES flag

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
-          mkdir build && cd build && cmake -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON .. && make -j'
+          mkdir build && cd build && cmake -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARKS=ON .. && make -j'
       - name: Build and run unit test for Spark 3.2.2(other tests)
         run: |
           docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
@@ -226,7 +226,7 @@ jobs:
         run: |
           docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
-          mkdir build && cd build && cmake .. && make -j'
+          mkdir build && cd build && cmake -DBUILD_EXAMPLES=ON .. && make -j'
       - name: Build and Run unit test for Spark 3.3.1(other tests)
         run: |
           docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -39,6 +39,7 @@ project(gluten)
 
 option(BUILD_VELOX_BACKEND "Build Velox backend" ON)
 option(BUILD_TESTS "Build Tests" OFF)
+option(BUILD_EXAMPLES "Build Examples" OFF)
 option(BUILD_BENCHMARKS "Build Benchmarks" OFF)
 option(BUILD_PROTOBUF "Build Protobuf from Source" OFF)
 option(BUILD_JEMALLOC "Build Jemalloc from Source" OFF)

--- a/cpp/compile.sh
+++ b/cpp/compile.sh
@@ -19,6 +19,7 @@ set -exu
 BUILD_TYPE=release
 BUILD_VELOX_BACKEND=OFF
 BUILD_TESTS=OFF
+BUILD_EXAMPLES=OFF
 BUILD_BENCHMARKS=OFF
 BUILD_JEMALLOC=OFF
 BUILD_PROTOBUF=OFF
@@ -50,6 +51,10 @@ for arg in "$@"; do
     ;;
   --build_tests=*)
     BUILD_TESTS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --build_examples=*)
+    BUILD_EXAMPLES=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
   --build_benchmarks=*)
@@ -109,6 +114,7 @@ echo "VELOX_HOME=${VELOX_HOME}"
 echo "BUILD_TYPE=${BUILD_TYPE}"
 echo "BUILD_VELOX_BACKEND=${BUILD_VELOX_BACKEND}"
 echo "BUILD_TESTS=${BUILD_TESTS}"
+echo "BUILD_EXAMPLES=${BUILD_EXAMPLES}"
 echo "BUILD_BENCHMARKS=${BUILD_BENCHMARKS}"
 echo "BUILD_JEMALLOC=${BUILD_JEMALLOC}"
 echo "ENABLE_HBM=${ENABLE_HBM}"
@@ -123,6 +129,7 @@ mkdir build
 cd build
 cmake .. \
   -DBUILD_TESTS=${BUILD_TESTS} \
+  -DBUILD_EXAMPLES=${BUILD_EXAMPLES} \
   -DARROW_HOME=${ARROW_HOME} \
   -DBUILD_JEMALLOC=${BUILD_JEMALLOC} \
   -DBUILD_VELOX_BACKEND=${BUILD_VELOX_BACKEND} \

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -338,4 +338,6 @@ if(ENABLE_S3)
   target_link_libraries(velox PUBLIC ${AWSSDK_LIBRARIES})
 endif()
 
-add_subdirectory(udf/examples)
+if(BUILD_EXAMPLES)
+  add_subdirectory(udf/examples)
+endif()

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -10,6 +10,7 @@ CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 GLUTEN_DIR="$CURRENT_DIR/.."
 BUILD_TYPE=Release
 BUILD_TESTS=OFF
+BUILD_EXAMPLES=OFF
 BUILD_BENCHMARKS=OFF
 BUILD_JEMALLOC=OFF
 BUILD_PROTOBUF=ON
@@ -32,6 +33,10 @@ do
         ;;
         --build_tests=*)
         BUILD_TESTS=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --build_examples=*)
+        BUILD_EXAMPLES=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         --build_benchmarks=*)
@@ -115,6 +120,6 @@ rm -rf build
 mkdir build
 cd build
 cmake -DBUILD_VELOX_BACKEND=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-      -DBUILD_TESTS=$BUILD_TESTS -DBUILD_BENCHMARKS=$BUILD_BENCHMARKS -DBUILD_JEMALLOC=$BUILD_JEMALLOC \
+      -DBUILD_TESTS=$BUILD_TESTS -DBUILD_EXAMPLES=$BUILD_EXAMPLES -DBUILD_BENCHMARKS=$BUILD_BENCHMARKS -DBUILD_JEMALLOC=$BUILD_JEMALLOC \
       -DENABLE_HBM=$ENABLE_HBM -DENABLE_QAT=$ENABLE_QAT -DENABLE_IAA=$ENABLE_IAA -DENABLE_S3=$ENABLE_S3 -DENABLE_HDFS=$ENABLE_HDFS ..
 make -j


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is a followup of https://github.com/oap-project/gluten/pull/2427 to avoid compiling example code.

(Fixes: \#2182)

## How was this patch tested?

test locally:

```shell
./dev/buildbundle-veloxbe.sh --skip_build_ep=ON --enable_hdfs=ON --build_type=Debug --build_examples=ON
./dev/buildbundle-veloxbe.sh --skip_build_ep=ON --enable_hdfs=ON --build_type=Debug --build_examples=OFF
```
