### PR TITLE
[VL] Compatible with CELEBORN-798

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -21,6 +21,7 @@ on:
       - '.github/**'
       - 'pom.xml'
       - 'backends-velox/**'
+      - 'gluten-celeborn/**'
       - 'gluten-core/**'
       - 'gluten-data/**'
       - 'gluten-ut/**'

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -21,6 +21,7 @@ import io.glutenproject.exception.GlutenException;
 import org.apache.celeborn.client.LifecycleManager;
 import org.apache.celeborn.client.ShuffleClient;
 import org.apache.celeborn.common.CelebornConf;
+import org.apache.celeborn.common.identity.UserIdentifier;
 import org.apache.celeborn.common.protocol.ShuffleMode;
 import org.apache.spark.*;
 import org.apache.spark.shuffle.*;
@@ -32,6 +33,7 @@ import org.apache.spark.shuffle.sort.ColumnarShuffleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CelebornShuffleManager implements ShuffleManager {
@@ -93,14 +95,49 @@ public class CelebornShuffleManager implements ShuffleManager {
       synchronized (this) {
         if (lifecycleManager == null) {
           lifecycleManager = new LifecycleManager(appUniqueId, celebornConf);
-          shuffleClient =
-              ShuffleClient.get(
-                  appUniqueId,
-                  lifecycleManager.getHost(),
-                  lifecycleManager.getPort(),
-                  celebornConf,
-                  lifecycleManager.getUserIdentifier(),
-                  true);
+          try {
+            try {
+              Method method =
+                  ShuffleClient.class.getDeclaredMethod(
+                      "get",
+                      String.class,
+                      String.class,
+                      int.class,
+                      CelebornConf.class,
+                      UserIdentifier.class);
+              shuffleClient =
+                  (ShuffleClient)
+                      method.invoke(
+                          null,
+                          appUniqueId,
+                          lifecycleManager.getHost(),
+                          Integer.valueOf(lifecycleManager.getPort()),
+                          celebornConf,
+                          lifecycleManager.getUserIdentifier());
+            } catch (NoSuchMethodException noMethod) {
+              Method method =
+                  ShuffleClient.class.getDeclaredMethod(
+                      "get",
+                      String.class,
+                      String.class,
+                      int.class,
+                      CelebornConf.class,
+                      UserIdentifier.class,
+                      boolean.class);
+              shuffleClient =
+                  (ShuffleClient)
+                      method.invoke(
+                          null,
+                          appUniqueId,
+                          lifecycleManager.getHost(),
+                          Integer.valueOf(lifecycleManager.getPort()),
+                          celebornConf,
+                          lifecycleManager.getUserIdentifier(),
+                          Boolean.TRUE);
+            }
+          } catch (ReflectiveOperationException rethrow) {
+            throw new RuntimeException(rethrow);
+          }
         }
       }
     }

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -98,6 +98,7 @@ public class CelebornShuffleManager implements ShuffleManager {
           try {
             try {
               Method method =
+                  // for Celeborn 0.3.0, see CELEBORN-798
                   ShuffleClient.class.getDeclaredMethod(
                       "get",
                       String.class,
@@ -116,6 +117,7 @@ public class CelebornShuffleManager implements ShuffleManager {
                           lifecycleManager.getUserIdentifier());
             } catch (NoSuchMethodException noMethod) {
               Method method =
+                  // for Celeborn 0.3.1 and above, see CELEBORN-804
                   ShuffleClient.class.getDeclaredMethod(
                       "get",
                       String.class,

--- a/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
+++ b/gluten-celeborn/src/main/java/org/apache/spark/shuffle/gluten/celeborn/CelebornShuffleManager.java
@@ -98,7 +98,7 @@ public class CelebornShuffleManager implements ShuffleManager {
           try {
             try {
               Method method =
-                  // for Celeborn 0.3.0, see CELEBORN-798
+                  // for Celeborn 0.3.1 and above, see CELEBORN-804
                   ShuffleClient.class.getDeclaredMethod(
                       "get",
                       String.class,
@@ -117,7 +117,7 @@ public class CelebornShuffleManager implements ShuffleManager {
                           lifecycleManager.getUserIdentifier());
             } catch (NoSuchMethodException noMethod) {
               Method method =
-                  // for Celeborn 0.3.1 and above, see CELEBORN-804
+                  // for Celeborn 0.3.0, see CELEBORN-798
                   ShuffleClient.class.getDeclaredMethod(
                       "get",
                       String.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?

CELEBORN-798 was merged into Celeborn 0.3.0, but was reverted and replaced by CELEBORN-804 in 0.3.1, it changes the method signature of `ShuffleClient#get` which introduces a compatible issue on the Gluten side.

This patch aims to use reflection to tackle the issue.

```
23/08/01 15:06:06 ERROR ExecuteStatement: Error operating ExecuteStatement: 
java.lang.NoSuchMethodError: org.apache.celeborn.client.ShuffleClient.get(Ljava/lang/String;Ljava/lang/String;ILorg/apache/celeborn/common/CelebornConf;Lorg/apache/celeborn/common/identity/UserIdentifier;Z)Lorg/apache/celeborn/client/ShuffleClient;
	at org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager.initializeLifecycleManager(CelebornShuffleManager.java:97)
	at org.apache.spark.shuffle.gluten.celeborn.CelebornShuffleManager.registerShuffle(CelebornShuffleManager.java:117)
	at org.apache.spark.ShuffleDependency.<init>(Dependency.scala:103)
	at org.apache.spark.shuffle.ColumnarShuffleDependency.<init>(ColumnarShuffleDependency.scala:62)
	at org.apache.spark.sql.execution.utils.ExecUtil$.genShuffleDependency(ExecUtil.scala:197)
	at io.glutenproject.backendsapi.velox.SparkPlanExecHandler.genShuffleDependency(SparkPlanExecHandler.scala:182)
	at org.apache.spark.sql.execution.ColumnarShuffleExchangeExec$.prepareShuffleDependency(ColumnarShuffleExchangeExec.scala:186)
	at org.apache.spark.sql.execution.ColumnarShuffleExchangeExec.columnarShuffleDependency$lzycompute(ColumnarShuffleExchangeExec.scala:82)
	at org.apache.spark.sql.execution.ColumnarShuffleExchangeExec.columnarShuffleDependency(ColumnarShuffleExchangeExec.scala:74)
	at org.apache.spark.sql.execution.ColumnarShuffleExchangeExec.mapOutputStatisticsFuture$lzycompute(ColumnarShuffleExchangeExec.scala:64)
	at org.apache.spark.sql.execution.ColumnarShuffleExchangeExec.mapOutputStatisticsFuture(ColumnarShuffleExchangeExec.scala:60)
	at org.apache.spark.sql.execution.exchange.ShuffleExchangeLike.$anonfun$submitShuffleJob$1(ShuffleExchangeExec.scala:68)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:232)
```

## How was this patch tested?

The current CI should cover the reflection invocation code path of Celeborn client 0.3.0.
