### PR TITLE
[GLUTEN-2391][FOLLOWUP] Fix hive scan miss do validation

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteForHiveSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteForHiveSuite.scala
@@ -113,4 +113,11 @@ class VeloxParquetWriteForHiveSuite extends GlutenQueryTest with SQLTestUtils {
         }
     }
   }
+
+  test("select plain hive table") {
+    withTable("t") {
+      sql("CREATE TABLE t AS SELECT 1 as c")
+      checkAnswer(sql("SELECT * FROM t"), Row(1))
+    }
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -175,6 +175,11 @@ class HiveTableScanExecTransformer(
   }
 
   override protected def doValidateInternal(): ValidationResult = {
+    val validationResult = super.doValidateInternal()
+    if (!validationResult.isValid) {
+      return validationResult
+    }
+
     val tableMeta = relation.tableMeta
     val planOutput = output.asInstanceOf[Seq[AttributeReference]]
     var hasComplexType = false
@@ -198,7 +203,7 @@ class HiveTableScanExecTransformer(
             if (!hasComplexType) {
               ValidationResult.ok
             } else {
-              ValidationResult.notOk("Hive scan is not defined")
+              ValidationResult.notOk("does not support complex type")
             }
         }
       case _ => ValidationResult.notOk("Hive scan is not defined")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr is a followup of https://github.com/oap-project/gluten/pull/2392.

Add back the file format validation and native validation. Otherwise, such query will fail:

```sql
CREATE TABLE t AS SELECT 1 as c
SELECT * FROM t
```

```
Caused by: java.lang.RuntimeException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: ReaderFactory is not registered for format unknown
```

(Fixes: \#2391)

## How was this patch tested?

add test
