### PR TITLE
[DOC][VL] Add libhdfs short-circuit read doc back

### DIFF
--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -144,6 +144,28 @@ cp /path/to/hdfs-client.xml hdfs-client.xml
 --files hdfs-client.xml
 ```
 
+One typical deployment on Spark/HDFS cluster is to enable [short-circuit reading](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/ShortCircuitLocalReads.html). Short-circuit reads provide a substantial performance boost to many applications.
+
+By default libhdfs3 does not set the default hdfs domain socket path to support HDFS short-circuit read. If this feature is required in HDFS setup, users may need to setup the domain socket path correctly by patching the libhdfs3 source code or by setting the correct config environment. In Gluten the short-circuit domain socket path is set to "/var/lib/hadoop-hdfs/dn_socket" in [build_velox.sh](https://github.com/oap-project/gluten/blob/main/ep/build-velox/src/build_velox.sh) So we need to make sure the folder existed and user has write access as below script.
+
+```
+sudo mkdir -p /var/lib/hadoop-hdfs/
+sudo chown <sparkuser>:<sparkuser> /var/lib/hadoop-hdfs/
+```
+
+You also need to add configuration to the "hdfs-site.xml" as below:
+
+```
+<property>
+   <name>dfs.client.read.shortcircuit</name>
+   <value>true</value>
+</property>
+<property>
+   <name>dfs.domain.socket.path</name>
+   <value>/var/lib/hadoop-hdfs/dn_socket</value>
+</property>
+```
+
 ### Kerberos support
 
 Here are two steps to enable kerberos.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add back libhdfs short-circuit reading introduction, which can speed up performance.  PR:https://github.com/oap-project/gluten/pull/2050 just deleted it. 

## How was this patch tested?
Just doc update. 


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

