### PR TITLE
[VL] Celeborn shuffle writer should use compressed byte size

### DIFF
--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -253,15 +253,17 @@ class CelebornClient : public RssClient {
     env->DeleteGlobalRef(javaCelebornShuffleWriter_);
   }
 
-  void pushPartitonData(int32_t partitionId, char* bytes, int64_t size) {
+  int32_t pushPartitonData(int32_t partitionId, char* bytes, int64_t size) {
     JNIEnv* env;
     if (vm_->GetEnv(reinterpret_cast<void**>(&env), jniVersion) != JNI_OK) {
       throw gluten::GlutenException("JNIEnv was not attached to current thread");
     }
     jbyteArray array = env->NewByteArray(size);
     env->SetByteArrayRegion(array, 0, size, reinterpret_cast<jbyte*>(bytes));
-    env->CallIntMethod(javaCelebornShuffleWriter_, javaCelebornPushPartitionData_, partitionId, array);
+    jint celebornBytesSize =
+        env->CallIntMethod(javaCelebornShuffleWriter_, javaCelebornPushPartitionData_, partitionId, array);
     checkException(env);
+    return static_cast<int32_t>(celebornBytesSize);
   }
 
   JavaVM* vm_;

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
@@ -36,10 +36,10 @@ arrow::Status CelebornPartitionWriter::pushPartition(int32_t partitionId) {
   auto buffer = celebornBufferOs_->Finish();
   int32_t size = buffer->get()->size();
   char* dst = reinterpret_cast<char*>(buffer->get()->mutable_data());
-  celebornClient_->pushPartitonData(partitionId, dst, size);
+  int32_t celebornBytesSize = celebornClient_->pushPartitonData(partitionId, dst, size);
   shuffleWriter_->partitionCachedRecordbatch()[partitionId].clear();
   shuffleWriter_->setPartitionCachedRecordbatchSize(partitionId, 0);
-  shuffleWriter_->setPartitionLengths(partitionId, shuffleWriter_->partitionLengths()[partitionId] + size);
+  shuffleWriter_->setPartitionLengths(partitionId, shuffleWriter_->partitionLengths()[partitionId] + celebornBytesSize);
   return arrow::Status::OK();
 };
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr changes the partition lengths to use compressed byte size which follows the jvm client side behavior.

The partition lengths is very import that would affect AQE decision.

## How was this patch tested?

test manually

Before:
<img width="588" alt="image" src="https://github.com/oap-project/gluten/assets/12025282/d7565565-dac5-4880-8dc2-4bee26784722">

After:
<img width="554" alt="image" src="https://github.com/oap-project/gluten/assets/12025282/4e5ba788-9df9-4cde-9a1f-76e91eae101a">
