### PR TITLE
[GLUTEN-2504][VL] Support upload UDF libraries via --files and --archives

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
-          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -Prss -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,io.glutenproject.tags.UDFTest && \
+          mvn clean install -Pspark-3.2 -Pspark-ut -Pbackends-velox -Prss -DargLine="-Dspark.test.home=/opt/spark322" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,io.glutenproject.tags.UDFTest,io.glutenproject.tags.SkipTestTags && \
           mvn test -Pspark-3.2 -Pbackends-velox -DtagsToExclude=None -DtagsToInclude=io.glutenproject.tags.UDFTest'
       - name: Run CPP unit test
         run: |
@@ -231,7 +231,7 @@ jobs:
       - name: Build and Run unit test for Spark 3.3.1(other tests)
         run: |
           docker exec velox-ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
-          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -Pspark-ut -DargLine="-Dspark.test.home=/var/cache/spark33/spark331" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,io.glutenproject.tags.UDFTest && \
+          mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -Pspark-ut -DargLine="-Dspark.test.home=/var/cache/spark33/spark331" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,io.glutenproject.tags.UDFTest,io.glutenproject.tags.SkipTestTags && \
           mvn test -Pspark-3.3 -Pbackends-velox -DtagsToExclude=None -DtagsToInclude=io.glutenproject.tags.UDFTest'
       - name: Exit docker container
         if: ${{ always() }}

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -47,7 +47,8 @@ object BackendSettings extends BackendSettingsApi {
 
   val SHUFFLE_SUPPORTED_CODEC = Set("lz4", "zstd")
 
-  val GLUTEN_VELOX_UDF_LIBS = getBackendConfigPrefix() + ".udfLibraryPaths"
+  val GLUTEN_VELOX_UDF_LIB_PATHS = getBackendConfigPrefix() + ".udfLibraryPaths"
+  val GLUTEN_VELOX_DRIVER_UDF_LIB_PATHS = getBackendConfigPrefix() + ".driver.udfLibraryPaths"
 
   override def supportFileFormatRead(
       format: ReadFileFormat,
@@ -291,20 +292,7 @@ object BackendSettings extends BackendSettingsApi {
 
   override def shuffleSupportedCodec(): Set[String] = SHUFFLE_SUPPORTED_CODEC
 
-  private def resolveUdfConf(nativeConf: java.util.Map[String, String]): Unit = {
-    if (nativeConf.containsKey(GLUTEN_VELOX_UDF_LIBS)) {
-      val cachedLibraryPaths = UDFResolver.localLibraryPaths
-      if (cachedLibraryPaths.isEmpty) {
-        nativeConf.put(
-          GLUTEN_VELOX_UDF_LIBS,
-          UDFResolver.getAllLibraries(nativeConf.get(GLUTEN_VELOX_UDF_LIBS)).mkString(","))
-      } else {
-        nativeConf.put(GLUTEN_VELOX_UDF_LIBS, cachedLibraryPaths.mkString(","))
-      }
-    }
-  }
-
   override def resolveNativeConf(nativeConf: java.util.Map[String, String]): Unit = {
-    resolveUdfConf(nativeConf)
+    UDFResolver.resolveUdfConf(nativeConf)
   }
 }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -117,7 +117,9 @@ object UDFResolver extends Logging {
 
   def resolveUdfConf(conf: java.util.Map[String, String]): Unit = {
     if (isDriver) {
-      conf.put(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS, localLibraryPaths)
+      if (localLibraryPaths != null) {
+        conf.put(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS, localLibraryPaths)
+      }
     } else {
       val sparkConf = SparkEnv.get.conf
       Option(conf.get(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)) match {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -143,7 +143,9 @@ object UDFResolver extends Logging {
       Utils.unpack(source, dest)
     } catch {
       case e: Exception =>
-        throw new GlutenException(s"Unpack ${source.toString} failed.", e)
+        throw new GlutenException(
+          s"Unpack ${source.toString} failed. Please check if it is an archive.",
+          e)
     }
     dest
   }
@@ -193,11 +195,9 @@ object UDFResolver extends Logging {
   def loadAndGetFunctionDescriptions: Seq[(FunctionIdentifier, ExpressionInfo, FunctionBuilder)] = {
     val sparkContext = SparkContext.getActive.get
     val sparkConf = sparkContext.conf
-    val udfLibPaths = if (sparkConf.contains(BackendSettings.GLUTEN_VELOX_DRIVER_UDF_LIB_PATHS)) {
-      Some(sparkConf.get(BackendSettings.GLUTEN_VELOX_DRIVER_UDF_LIB_PATHS))
-    } else {
-      sparkConf.getOption(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS)
-    }
+    val udfLibPaths = sparkConf
+      .getOption(BackendSettings.GLUTEN_VELOX_DRIVER_UDF_LIB_PATHS)
+      .orElse(sparkConf.getOption(BackendSettings.GLUTEN_VELOX_UDF_LIB_PATHS))
 
     udfLibPaths match {
       case None =>

--- a/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
@@ -16,42 +16,106 @@
  */
 package io.glutenproject.expression
 
-import io.glutenproject.tags.UDFTest
+import io.glutenproject.tags.{SkipTestTags, UDFTest}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.GlutenQueryTest
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.{GlutenQueryTest, SparkSession}
+import org.apache.spark.sql.catalyst.plans.SQLHelper
 
-@UDFTest
-class VeloxUdfSuite extends GlutenQueryTest with SharedSparkSession {
+import java.nio.file.Paths
+
+abstract class VeloxUdfSuite extends GlutenQueryTest with SQLHelper {
+
+  protected val master: String
+
+  private var _spark: SparkSession = _
 
   // This property is used for unit tests.
   val UDFLibPathProperty: String = "velox.udf.lib.path"
 
-  private lazy val udfLibPath: String = System.getProperty(UDFLibPathProperty)
+  protected val udfLibPath: String =
+    sys.props.get(UDFLibPathProperty) match {
+      case Some(path) =>
+        path
+          .split(",")
+          .map(p => Paths.get(p).toAbsolutePath.toString)
+          .mkString(",")
+      case None =>
+        throw new IllegalArgumentException(
+          UDFLibPathProperty + s" cannot be null. You may set it by adding " +
+            s"-D$UDFLibPathProperty=" +
+            "/path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so")
+    }
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    sparkContext.setLogLevel("INFO")
-  }
-  override protected def sparkConf: SparkConf = {
-    if (udfLibPath == null) {
-      throw new IllegalArgumentException(
-        UDFLibPathProperty + s" cannot be null. You may set it by adding " +
-          s"-D$UDFLibPathProperty=" +
-          "/path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so")
+    if (_spark == null) {
+      _spark = SparkSession
+        .builder()
+        .master(master)
+        .config(sparkConf)
+        .getOrCreate()
     }
-    super.sparkConf
+
+    _spark.sparkContext.setLogLevel("info")
+  }
+
+  override protected def spark = _spark
+
+  protected def sparkConf: SparkConf = {
+    new SparkConf()
       .set("spark.plugins", "io.glutenproject.GlutenPlugin")
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
-      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", "libmyudf.so")
-      .set("spark.files", udfLibPath)
   }
 
   test("test udf") {
     val df = spark.sql("""select myudf1(1), myudf2(100L)""")
     df.collect().sameElements(Array(6, 105))
+  }
+}
+
+@UDFTest
+class VeloxUdfSuiteLocal extends VeloxUdfSuite {
+
+  override val master: String = "local[2]"
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", udfLibPath)
+  }
+}
+
+// Set below environment variables and VM options to run this test:
+// export SCALA_HOME=/usr/share/scala
+// export SPARK_SCALA_VERSION=2.12
+//
+// VM options:
+// -Dspark.test.home=${SPARK_HOME}
+// -Dgluten.package.jar=\
+// /path/to/gluten/package/target/gluten-package-${project.version}.jar
+// -Dvelox.udf.lib.path=\
+// /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
+@SkipTestTags
+class VeloxUdfSuiteCluster extends VeloxUdfSuite {
+
+  override val master: String = "local-cluster[2,2,1024]"
+
+  val GLUTEN_JAR: String = "gluten.package.jar"
+
+  private val glutenJar = sys.props.get(GLUTEN_JAR) match {
+    case Some(jar) => jar
+    case None =>
+      throw new IllegalArgumentException(
+        GLUTEN_JAR + s" cannot be null. You may set it by adding " +
+          s"-D$GLUTEN_JAR=" +
+          "/path/to/gluten/package/target/gluten-package-${project.version}.jar")
+  }
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths", udfLibPath)
+      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", udfLibPath)
+      .set("spark.driver.extraClassPath", glutenJar)
+      .set("spark.executor.extraClassPath", glutenJar)
   }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
@@ -33,7 +33,7 @@ abstract class VeloxUdfSuite extends GlutenQueryTest with SQLHelper {
   // This property is used for unit tests.
   val UDFLibPathProperty: String = "velox.udf.lib.path"
 
-  protected val udfLibPath: String =
+  protected lazy val udfLibPath: String =
     sys.props.get(UDFLibPathProperty) match {
       case Some(path) =>
         path
@@ -103,7 +103,7 @@ class VeloxUdfSuiteCluster extends VeloxUdfSuite {
 
   val GLUTEN_JAR: String = "gluten.package.jar"
 
-  private val glutenJar = sys.props.get(GLUTEN_JAR) match {
+  private lazy val glutenJar = sys.props.get(GLUTEN_JAR) match {
     case Some(jar) => jar
     case None =>
       throw new IllegalArgumentException(

--- a/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/expression/VeloxUdfSuite.scala
@@ -46,7 +46,8 @@ class VeloxUdfSuite extends GlutenQueryTest with SharedSparkSession {
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
-      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", udfLibPath)
+      .set("spark.gluten.sql.columnar.backend.velox.udfLibraryPaths", "libmyudf.so")
+      .set("spark.files", udfLibPath)
   }
 
   test("test udf") {

--- a/cpp/core/utils/StringUtil.cc
+++ b/cpp/core/utils/StringUtil.cc
@@ -39,7 +39,7 @@ std::vector<std::string> gluten::splitByDelim(const std::string& s, const char d
 }
 
 std::vector<std::string> gluten::splitPaths(const std::string& s) {
-  auto splits = splitByDelim(s, ':');
+  auto splits = splitByDelim(s, ',');
   std::vector<std::string> paths;
   for (auto i = 0; i < splits.size(); ++i) {
     if (!splits[i].empty()) {

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -55,7 +55,7 @@ It's recommended to use buildbundle-veloxbe.sh and build gluten in one script.
 **For x86_64 build**
 
 ```bash
-cd /path_to_gluten
+cd /path/to/gluten
 
 ## The script builds two jars for spark 3.2.2 and 3.3.1.
 ./dev/buildbundle-veloxbe.sh
@@ -70,39 +70,39 @@ cd /path_to_gluten
 ```bash
 export CPU_TARGET="aarch64"
 
-cd /path_to_gluten
+cd /path/to/gluten
 
 ./dev/builddeps-veloxbe.sh
 ```
 
 **Build Velox or Arrow separately**
 
-Scripts under `/path_to_gluten/ep/build-xxx/src` provide `get_xxx.sh` and `build_xxx.sh` to build Velox or Arrow separately, you could use these scripts with custom repo/branch/location.
+Scripts under `/path/to/gluten/ep/build-xxx/src` provide `get_xxx.sh` and `build_xxx.sh` to build Velox or Arrow separately, you could use these scripts with custom repo/branch/location.
 
 Velox can use pre-build arrow/parquet lib from ARROW_HOME parsed by --arrow_home to decrease build time.
 Gluten cpp module need a required VELOX_HOME parsed by --velox_home and an optional ARROW_HOME by --arrow_home, if you specify custom ep location, make sure these variables be passed correctly.
 
 ```bash
 ## fetch Arrow and compile
-cd /path_to_gluten/ep/build-arrow/src/
+cd /path/to/gluten/ep/build-arrow/src/
 ## you could use custom ep location by --arrow_home=custom_path, make sure specify --arrow_home in build_arrow.sh too.
 ./get_arrow.sh
 ./build_arrow.sh
 
 ## fetch Velox and compile
-cd /path_to_gluten/ep/build-velox/src/
+cd /path/to/gluten/ep/build-velox/src/
 ## you could use custom ep location by --velox_home=custom_path, make sure specify --velox_home in build_velox.sh too.
 ./get_velox.sh
 ## make sure specify --arrow_home or --velox_home if you have specified it in get_xxx.sh.
 ./build_velox.sh
 
 ## compile Gluten cpp module
-cd /path_to_gluten/cpp
+cd /path/to/gluten/cpp
 ## if you use custom velox_home or arrow_home, make sure specified here by --arrow_home or --velox_home 
 ./compile.sh --build_velox_backend=ON
 
 ## compile Gluten java module and create package jar
-cd /path_to_gluten
+cd /path/to/gluten
 # For spark3.2.x
 mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
 # For spark3.3.x
@@ -121,7 +121,7 @@ Hadoop hdfs support is ready via the [libhdfs3](https://github.com/apache/hawq/t
 To build Gluten with HDFS support, below command is suggested:
 
 ```bash
-cd /path_to_gluten
+cd /path/to/gluten
 ./dev/buildbundle-veloxbe.sh --enable_hdfs=ON
 ```
 
@@ -193,7 +193,7 @@ Velox supports S3 with the open source [AWS C++ SDK](https://github.com/aws/aws-
 A new build option for S3(enable_s3) is added. Below command is used to enable this feature
 
 ```
-cd /path_to_gluten
+cd /path/to/gluten
 ./dev/buildbundle-veloxbe.sh --enable_s3=ON
 ```
 
@@ -387,14 +387,14 @@ target_link_libraries(myudf PRIVATE ${VELOX_LIBRARY})
 
 Gluten loads the UDF libraries at runtime. You can upload UDF libraries via `--files` or `--archives`, and configure the libray paths using the provided Spark configuration, which accepts comma separated list of library paths.
 
-Note if running on Yarn client mode, the uploaded files are not reachable on driver side. You should copy those files to somewhere reachable for driver and set `spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths`. This configuration is also useful when the `udfLibraryPaths` is different between driver side and executor side.
+Note if running on Yarn client mode, the uploaded files are not reachable on driver side. Users should copy those files to somewhere reachable for driver and set `spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths`. This configuration is also useful when the `udfLibraryPaths` is different between driver side and executor side.
 
 - Use `--files`
 ```shell
 --files /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=libmyudf.so
 # Needed for Yarn client mode
---conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path_to_libmyudf.so
+--conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path/to/libmyudf.so
 ```
 
 - Use `--archives`
@@ -402,14 +402,14 @@ Note if running on Yarn client mode, the uploaded files are not reachable on dri
 --archives /path/to/udf_archives.zip#udf_archives
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=udf_archives
 # Needed for Yarn client mode
---conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path_to_udf_archives.zip
+--conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path/to/udf_archives.zip
 ```
 
-You can also specify the local or HDFS URIs to the UDF libraries or archives. Local URIs should exist on driver and every worker nodes.
-
 - Specify URI
+
+You can also specify the local or HDFS URIs to the UDF libraries or archives. Local URIs should exist on driver and every worker nodes.
 ```shell
---conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=hdfs://path_to_library_or_archive
+--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=hdfs://path/to/library_or_archive
 ```
 
 ## Try the example
@@ -449,7 +449,7 @@ sudo apt install -y autoconf automake g++ libnuma-dev libtool numactl unzip libd
 After the set-up, you can now build Gluten with HBM. Below command is used to enable this feature
 
 ```bash
-cd /path_to_gluten
+cd /path/to/gluten
 
 ## The script builds two jars for spark 3.2.2 and 3.3.1.
 ./dev/buildbundle-veloxbe.sh --enable_hbm=ON
@@ -479,12 +479,12 @@ This environment variable is required during building Gluten and running Spark a
 It's recommended to put it in .bashrc on Driver and Worker nodes.
 
 ```bash
-echo "export ICP_ROOT=/path_to_QAT_driver" >> ~/.bashrc
+echo "export ICP_ROOT=/path/to/QAT_driver" >> ~/.bashrc
 source ~/.bashrc
 
 # Also set for root if running as non-root user
 sudo su - 
-echo "export ICP_ROOT=/path_to_QAT_driver" >> ~/.bashrc
+echo "export ICP_ROOT=/path/to/QAT_driver" >> ~/.bashrc
 exit
 ```
 
@@ -539,7 +539,7 @@ exit
 4. After the setup, you are now ready to build Gluten with QAT. Use the command below to enable this feature:
 
 ```bash
-cd /path_to_gluten
+cd /path/to/gluten
 
 ## The script builds two jars for spark 3.2.2 and 3.3.1.
 ./dev/buildbundle-veloxbe.sh --enable_qat=ON
@@ -553,7 +553,7 @@ cd /path_to_gluten
 ## run as root
 ## Overwrite QAT configuration file.
 cd /etc
-for i in {0..7}; do echo "4xxx_dev$i.conf"; done | xargs -i cp -f /path_to_gluten/docs/qat/4x16.conf {}
+for i in {0..7}; do echo "4xxx_dev$i.conf"; done | xargs -i cp -f /path/to/gluten/docs/qat/4x16.conf {}
 ## Restart QAT after updating configuration files.
 adf_ctl restart
 ```
@@ -634,7 +634,7 @@ sudo chmod -R g+rw /dev/iax
 After the set-up, you can now build Gluten with QAT. Below command is used to enable this feature
 
 ```bash
-cd /path_to_gluten
+cd /path/to/gluten
 
 ## The script builds two jars for spark 3.2.2 and 3.3.1.
 ./dev/buildbundle-veloxbe.sh --enable_iaa=ON

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -385,10 +385,11 @@ target_link_libraries(myudf PRIVATE ${VELOX_LIBRARY})
 
 ## Using UDF in Gluten
 
-Gluten loads the UDF libraries at runtime. Users need to configure the libray paths using the provided Spark configuration, which accepts comma separated list of library paths
+Gluten loads the UDF libraries at runtime. Users can upload UDF libraries via `--files` or `--archives`, and configure the libray paths using the provided Spark configuration, which accepts comma separated list of library paths
 
 ```
---conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=/path/to/libmyudf1.so,/path/to/libmyudf2.so
+--archives /path/to/udf_archives.zip#udf_archives
+--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=udf_archives
 ```
 
 ## Try the example
@@ -397,7 +398,8 @@ We provided an Velox UDF example file [MyUDF.cpp](../../cpp/velox/udf/examples/M
 
 Start spark-shell or spark-sql with below configuration 
 ```
---conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=/path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
+--files /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
+--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=libmyudf.so
 ```
 Run query. The functions `myudf1` and `myudf2` increment the input value by a constant of 5
 ```

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -385,11 +385,31 @@ target_link_libraries(myudf PRIVATE ${VELOX_LIBRARY})
 
 ## Using UDF in Gluten
 
-Gluten loads the UDF libraries at runtime. Users can upload UDF libraries via `--files` or `--archives`, and configure the libray paths using the provided Spark configuration, which accepts comma separated list of library paths
+Gluten loads the UDF libraries at runtime. You can upload UDF libraries via `--files` or `--archives`, and configure the libray paths using the provided Spark configuration, which accepts comma separated list of library paths.
 
+Note if running on Yarn client mode, the uploaded files are not reachable on driver side. You should copy those files to somewhere reachable for driver and set `spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths`. This configuration is also useful when the `udfLibraryPaths` is different between driver side and executor side.
+
+- Use `--files`
+```shell
+--files /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
+--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=libmyudf.so
+# Needed for Yarn client mode
+--conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path_to_libmyudf.so
 ```
+
+- Use `--archives`
+```shell
 --archives /path/to/udf_archives.zip#udf_archives
 --conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=udf_archives
+# Needed for Yarn client mode
+--conf spark.gluten.sql.columnar.backend.velox.driver.udfLibraryPaths=file:///path_to_udf_archives.zip
+```
+
+You can also specify the local or HDFS URIs to the UDF libraries or archives. Local URIs should exist on driver and every worker nodes.
+
+- Specify URI
+```shell
+--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=hdfs://path_to_library_or_archive
 ```
 
 ## Try the example

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
@@ -90,4 +90,7 @@ trait BackendSettingsApi {
   def shuffleSupportedCodec(): Set[String]
 
   def needOutputSchemaForPlan(): Boolean = false
+
+  /** Apply necessary conversions before passing to native side */
+  def resolveNativeConf(nativeConf: java.util.Map[String, String]): Unit = {}
 }

--- a/gluten-data/src/main/java/io/glutenproject/init/JniInitialized.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/JniInitialized.java
@@ -35,6 +35,7 @@ public abstract class JniInitialized {
       String prefix = BackendsApiManager.getSettings().getBackendConfigPrefix();
       Map<String, String> nativeConfMap =
           GlutenConfig.getNativeBackendConf(prefix, SQLConf.get().getAllConfs());
+      BackendsApiManager.getSettings().resolveNativeConf(nativeConfMap);
       InitializerJniWrapper.initialize(JniUtils.toNativeConf(nativeConfMap));
     } catch (Exception e) {
       LOG.error("Error calling InitializerJniWrapper.initialize(...)", e);


### PR DESCRIPTION
This patch improves the native UDF support by allowing users to upload UDF libs via two Spark methods:
- `--files`
```
--files /path/to/gluten/cpp/build/velox/udf/examples/libmyudf.so
--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=libmyudf.so
```

- `--archives`
```
--archives /path/to/udf_archives.zip#udf_archives
--conf spark.gluten.sql.columnar.backend.velox.udfLibraryPaths=udf_archives
```

The documents are also updated with more detailed instrutions.
