### PR TITLE
[GLUTEN-2604][VL] Fix github dependabot alert for Spark version

### DIFF
--- a/tools/gluten-it/README.md
+++ b/tools/gluten-it/README.md
@@ -16,14 +16,13 @@ See official Gluten build guidance https://github.com/oap-project/gluten#how-to-
 
 ### 2. Install and run gluten-it with Spark version
 
-> Note: Support Spark 3.2 and Spark 3.3 only
-
 ```sh
 cd gluten/tools/gluten-it
-mvn clean package -Pspark-3.2
+mvn clean package -P{Spark-Version}
 sbin/gluten-it.sh
 ```
 
+> Note: *Spark-Version* support *spark-3.2* and *spark-3.3* only
 
 ## Usage
 

--- a/tools/gluten-it/README.md
+++ b/tools/gluten-it/README.md
@@ -14,13 +14,16 @@ https://github.com/oap-project/gluten
 
 See official Gluten build guidance https://github.com/oap-project/gluten#how-to-use-gluten
 
-### 2. Install and run gluten-it
+### 2. Install and run gluten-it with Spark version
+
+> Note: Support Spark 3.2 and Spark 3.3 only
 
 ```sh
 cd gluten/tools/gluten-it
-mvn clean package
+mvn clean package -Pspark-3.2
 sbin/gluten-it.sh
 ```
+
 
 ## Usage
 

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -92,9 +92,6 @@
   <profiles>
     <profile>
       <id>spark-3.2</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>${spark32.version}</spark.version>
       </properties>
@@ -122,6 +119,34 @@
       <id>spark-3.3</id>
       <properties>
         <spark.version>${spark33.version}</spark.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_${scala.binary.version}</artifactId>
+          <version>${spark.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.protobuf</groupId>
+              <artifactId>protobuf-java</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_${scala.binary.version}</artifactId>
+          <version>${spark.version}</version>
+          <type>test-jar</type>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>spark-3.4</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.version>3.4.0</spark.version>
       </properties>
       <dependencies>
         <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix dependabot alert


```
Apache Spark vulnerable to Improper Privilege Management

Upgrade org.apache.spark:spark-core_2.12 to fix [1 Dependabot alert](https://github.com/oap-project/gluten/security/dependabot?q=is%3Aopen+package%3Aorg.apache.spark%3Aspark-core_2.12+manifest%3Atools%2Fgluten-it%2Fpom.xml+has%3Apatch) in [tools/gluten-it/pom.xml](https://github.com/oap-project/gluten/blob/-/tools/gluten-it/pom.xml)
Upgrade org.apache.spark:spark-core_2.12 to version 3.4.0 or later.

In Apache Spark versions prior to 3.4.0, applications using spark-submit can specify a proxy-user to run as, limiting privileges. The application can execute code with the privileges of the submitting user, however, by providing malicious configuration-related classes on the classpath. This affects architectures relying on proxy-user, for example those using Apache Livy to manage submitted applications.

Update to Apache Spark 3.4.0 or later, and ensure that spark.submit.proxyUser.allowCustomClasspathInClusterMode is set to its
default of "false", and is not overridden by submitted applications.

```
## How was this patch tested?

Use exist UTs

