### PR TITLE
[CORE][VL] Fix memory leak of fallback storage

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ContextInitializer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ContextInitializer.scala
@@ -23,7 +23,6 @@ import io.glutenproject.execution.datasource.GlutenOrcWriterInjects
 import io.glutenproject.execution.datasource.GlutenParquetWriterInjects
 import io.glutenproject.execution.datasource.GlutenRowSplitter
 import io.glutenproject.expression.UDFMappings
-import io.glutenproject.init.JniTaskContext
 import io.glutenproject.utils._
 import io.glutenproject.vectorized.{JniLibLoader, JniWorkspace}
 
@@ -31,7 +30,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.datasources.velox.VeloxOrcWriterInjects
 import org.apache.spark.sql.execution.datasources.velox.VeloxParquetWriterInjects
 import org.apache.spark.sql.execution.datasources.velox.VeloxRowSplitter
-import org.apache.spark.util.TaskResource
+import org.apache.spark.util.{JniTaskContext, TaskResource}
 
 import org.apache.commons.lang3.StringUtils
 

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -134,6 +134,8 @@ class ColumnarToRowRDD(
             if (!hasNext && !closed) {
               jniWrapper.nativeClose(c2rId)
               closed = true
+
+              TaskResources.releaseCurrentResources()
             }
             hasNext
           }
@@ -183,7 +185,7 @@ class ColumnarToRowRDD(
             }
           }
         }
-        res.flatten
+        res.flatten.map(_.copy())
       }
   }
 

--- a/cpp/core/utils/TaskContext.cc
+++ b/cpp/core/utils/TaskContext.cc
@@ -57,6 +57,7 @@ void bindToTask(std::shared_ptr<void> object) {
     taskContextStorage->bind(object);
     return;
   }
+  GLUTEN_CHECK(false, "Force throw");
   // The fallback storage is used. Spark sometimes creates sub-threads from a task thread. For example,
   //   PythonRunner.scala:183 @ Spark3.2.2
   std::lock_guard<std::mutex> guard(fallbackStorageMutex);

--- a/cpp/core/utils/TaskContext.cc
+++ b/cpp/core/utils/TaskContext.cc
@@ -40,6 +40,8 @@ class TaskContextStorage {
 };
 
 thread_local std::unique_ptr<TaskContextStorage> taskContextStorage = nullptr;
+
+// TODO: Remove this and let related unmanaged resources be managed.
 std::unique_ptr<TaskContextStorage> fallbackStorage = std::make_unique<TaskContextStorage>();
 std::mutex fallbackStorageMutex;
 } // namespace
@@ -57,7 +59,6 @@ void bindToTask(std::shared_ptr<void> object) {
   }
   // The fallback storage is used. Spark sometimes creates sub-threads from a task thread. For example,
   //   PythonRunner.scala:183 @ Spark3.2.2
-  //   GlutenSubqueryBroadcastExec.scala:73 @6bce2c33
   std::lock_guard<std::mutex> guard(fallbackStorageMutex);
   std::cout << "Binding a shared object to fallback storage. This should only happen on sub-thread of a Spark task. "
             << std::endl;

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -32,6 +32,7 @@
 #include "compute/VeloxPlanConverter.h"
 #include "config/GlutenConfig.h"
 #include "utils/ArrowTypeUtils.h"
+#include "utils/TaskContext.h"
 #include "utils/exception.h"
 
 #include <thread>
@@ -216,6 +217,7 @@ int main(int argc, char** argv) {
 
   conf.insert({gluten::kSparkBatchSize, FLAGS_batch_size});
   initVeloxBackend(conf);
+  gluten::createTaskContextStorage();
 
   try {
     if (argc < 2) {
@@ -282,6 +284,7 @@ int main(int argc, char** argv) {
 
   ::benchmark::RunSpecifiedBenchmarks();
   ::benchmark::Shutdown();
+  gluten::deleteTaskContextStorage();
 
   return 0;
 }

--- a/gluten-core/src/main/java/io/glutenproject/init/InitializerJniWrapper.java
+++ b/gluten-core/src/main/java/io/glutenproject/init/InitializerJniWrapper.java
@@ -16,15 +16,15 @@
  */
 package io.glutenproject.init;
 
-class InitializerJniWrapper {
+public class InitializerJniWrapper {
 
   private InitializerJniWrapper() {}
 
   // For global context
-  static native void initialize(byte[] configPlan);
+  public static native void initialize(byte[] configPlan);
 
   // For local context
-  static native long makeTaskContext();
+  public static native long makeTaskContext();
 
-  static native void closeTaskContext(long handle);
+  public static native void closeTaskContext(long handle);
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/joins/BuildSideRelation.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/joins/BuildSideRelation.scala
@@ -27,10 +27,7 @@ trait BuildSideRelation extends Serializable {
   /** Deserialized relation from broadcasted value */
   def deserialized: Iterator[ColumnarBatch]
 
-  /**
-   * Transform columnar broadcasted value to Array[InternalRow] by key and distinct.
-   * @return
-   */
+  /** Transform columnar broadcasted value to Array[InternalRow] by key and distinct. */
   def transform(key: Expression): Array[InternalRow]
 
   /** Returns a read-only copy of this, to be safely used in current thread. */

--- a/gluten-core/src/main/scala/org/apache/spark/util/JniTaskContext.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/JniTaskContext.scala
@@ -23,16 +23,9 @@ class JniTaskContext extends TaskResource {
 
   private val handle: Long = InitializerJniWrapper.makeTaskContext()
 
-  private var close: Boolean = false
-
-  private val defaultPriority: Long = 10
-
   override def release(): Unit = {
-    if (!close) {
-      InitializerJniWrapper.closeTaskContext(handle)
-      close = true
-    }
+    InitializerJniWrapper.closeTaskContext(handle)
   }
 
-  override def priority(): Long = defaultPriority
+  override def priority(): Long = 10
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/JniTaskContext.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/JniTaskContext.scala
@@ -14,20 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.spark.util
 
-
-package io.glutenproject.init
-
-import org.apache.spark.util.TaskResource
+import _root_.io.glutenproject.init.InitializerJniWrapper
 
 // To make native task context work properly, register this resource type in ContextAPI
 class JniTaskContext extends TaskResource {
 
   private val handle: Long = InitializerJniWrapper.makeTaskContext()
 
+  private var close: Boolean = false
+
+  private val defaultPriority: Long = 10
+
   override def release(): Unit = {
-    InitializerJniWrapper.closeTaskContext(handle)
+    if (!close) {
+      InitializerJniWrapper.closeTaskContext(handle)
+      close = true
+    }
   }
 
-  override def priority(): Long = 10
+  override def priority(): Long = defaultPriority
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -43,12 +43,12 @@ object TaskResources extends TaskListener with Logging {
     new java.util.IdentityHashMap[TaskContext, TaskResourceRegistry]()
 
   // The fallback registry handles the case that the caller is not in a Spark task.
-  private val FALLBACK_REGISTRY = new TaskResourceRegistry()
+  //  private val FALLBACK_REGISTRY = new TaskResourceRegistry()
 
-  GlutenShutdownManager.addHook(
-    () => {
-      FALLBACK_REGISTRY.releaseAll()
-    })
+  //  GlutenShutdownManager.addHook(
+  //    () => {
+  //      FALLBACK_REGISTRY.releaseAll()
+  //    })
 
   def getLocalTaskContext(): TaskContext = {
     TaskContext.get()
@@ -60,10 +60,10 @@ object TaskResources extends TaskListener with Logging {
 
   private def getTaskResourceRegistry(): TaskResourceRegistry = {
     if (!inSparkTask()) {
-      logInfo(
+      logWarning(
         "Using the fallback instance of TaskResourceRegistry. " +
           "This should only happen when call is not from Spark task.")
-      return FALLBACK_REGISTRY
+      throw new IllegalStateException("Should not be here.")
     }
     val tc = getLocalTaskContext()
     RESOURCE_REGISTRIES.synchronized {

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -76,10 +76,9 @@ object TaskResources extends TaskListener with Logging {
           new TaskFailureListener {
             override def onTaskFailure(context: TaskContext, error: Throwable): Unit = {
               RESOURCE_REGISTRIES.synchronized {
+                // All queries were fallback
                 if (!RESOURCE_REGISTRIES.containsKey(tc)) {
-                  throw new IllegalStateException(
-                    "" +
-                      "TaskMemoryResourceRegistry is not initialized, this should not happen")
+                  return
                 }
                 val registry = RESOURCE_REGISTRIES.remove(context)
                 assert(
@@ -99,9 +98,7 @@ object TaskResources extends TaskListener with Logging {
           override def onTaskCompletion(context: TaskContext): Unit = {
             RESOURCE_REGISTRIES.synchronized {
               if (!RESOURCE_REGISTRIES.containsKey(tc)) {
-                throw new IllegalStateException(
-                  "" +
-                    "TaskMemoryResourceRegistry is not initialized, this should not happen")
+                return
               }
               val registry = RESOURCE_REGISTRIES.remove(context)
               assert(

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -57,6 +57,12 @@ public final class NativeMemoryAllocators {
     return INSTANCES.computeIfAbsent(type, NativeMemoryAllocators::new);
   }
 
+  /** Should ONLY be used in Spark Driver scope. */
+  public NativeMemoryAllocator globalInstance() {
+    return global;
+  }
+
+  /** Should ONLY be used in Spark Task scope. */
   public NativeMemoryAllocator contextInstance() {
     if (!TaskResources.inSparkTask()) {
       throw new IllegalStateException("Found computation not in a Spark Task!");

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -59,7 +59,7 @@ public final class NativeMemoryAllocators {
 
   public NativeMemoryAllocator contextInstance() {
     if (!TaskResources.inSparkTask()) {
-      return globalInstance();
+      throw new IllegalStateException("Found computation not in a Spark Task!");
     }
     final String id = NativeMemoryAllocatorManager.class + "-" + System.identityHashCode(global);
     return TaskResources.addResourceIfNotRegistered(
@@ -87,10 +87,6 @@ public final class NativeMemoryAllocators {
             spiller,
             global);
     return TaskResources.addAnonymousResource(manager).getManaged();
-  }
-
-  public NativeMemoryAllocator globalInstance() {
-    return global;
   }
 
   private static NativeMemoryAllocatorManager createNativeMemoryAllocatorManager(

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -34,6 +34,14 @@ public class ArrowBufferAllocators {
 
   private ArrowBufferAllocators() {}
 
+  private static final BufferAllocator GLOBAL = new RootAllocator();
+
+  /** Should ONLY be used in Spark Driver scope. */
+  public static BufferAllocator globalInstance() {
+    return GLOBAL;
+  }
+
+  /** Should ONLY be used in Spark Task scope. */
   public static BufferAllocator contextInstance() {
     if (!TaskResources.inSparkTask()) {
       throw new IllegalStateException("Found computation not in a Spark Task!");

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -34,15 +34,9 @@ public class ArrowBufferAllocators {
 
   private ArrowBufferAllocators() {}
 
-  private static final BufferAllocator GLOBAL = new RootAllocator(Long.MAX_VALUE);
-
-  public static BufferAllocator globalInstance() {
-    return GLOBAL;
-  }
-
   public static BufferAllocator contextInstance() {
     if (!TaskResources.inSparkTask()) {
-      return globalInstance();
+      throw new IllegalStateException("Found computation not in a Spark Task!");
     }
     String id = ArrowBufferAllocatorManager.class.toString();
     return TaskResources.addResourceIfNotRegistered(id, ArrowBufferAllocatorManager::new).managed;

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -90,16 +90,12 @@ case class ColumnarBuildSideRelation(
   override def asReadOnlyCopy(
       broadCastContext: BroadCastHashJoinContext): ColumnarBuildSideRelation = this
 
-  /**
-   * Transform columnar broadcast value to Array[InternalRow] by key and distinct.
-   * @return
-   */
+  /** Transform columnar broadcast value to Array[InternalRow] by key and distinct. */
   override def transform(key: Expression): Array[InternalRow] = {
     // convert batches: Array[Array[Byte]] to Array[InternalRow] by key and distinct.
 
     // These conversion happens in Driver, we need release all resources explicitly.
-    // TODO: Manage these resources more gracefully,
-    // or let this conversion happens in native whole stage.
+    // TODO: Manage these resources more gracefully.
     val glutenTaskContext = new JniTaskContext
     val serializeHandle = {
       val allocator = ArrowBufferAllocators.globalInstance()

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution
 
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.execution.BroadCastHashJoinContext
-import io.glutenproject.init.JniTaskContext
 import io.glutenproject.memory.alloc.NativeMemoryAllocators
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.utils.ArrowAbiUtil
@@ -32,7 +31,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkArrowUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.TaskResources
+import org.apache.spark.util.{JniTaskContext, TaskResources}
 
 import org.apache.arrow.c.ArrowSchema
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this patch, the resources which not tracked by Spark executor task will be managed in FALLBACK_REGISTRY(java side) and fallbackStorage(native side), however, these will be released when process exit, and may bring memory problem when running lots of query in one Spark application.

E.g. DPP subquery execution will submitted to another thread pool in Spark driver, Gluten need do c2r conversion in the same time. We add explicit release after conversion.
Some computation happens on another thread, such as PythonUDF, since Velox backend has not support PythonUDF, it will insert a c2r, this c2r will do conversion in PythonRunner writer thread. We add a check in c2r to find this case and release early.

