### PR TITLE
[GLUTEN-2638][VL]fix s3 endpoint configuration

### DIFF
--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -171,9 +171,13 @@ void VeloxInitializer::init(const std::unordered_map<std::string, std::string>& 
         {"hive.s3.aws-secret-key", awsSecretKey},
     });
   }
-
+  // Only need to set s3 endpoint when not use instance credentials.
+  if (useInstanceCredentials != "true") {
+    s3Config.insert({
+        {"hive.s3.endpoint", awsEndpoint},
+    });
+  }
   s3Config.insert({
-      {"hive.s3.endpoint", awsEndpoint},
       {"hive.s3.ssl.enabled", sslEnabled},
       {"hive.s3.path-style-access", pathStyleAccess},
   });

--- a/docs/get-started/VeloxS3.md
+++ b/docs/get-started/VeloxS3.md
@@ -31,6 +31,7 @@ S3 also provides other methods for accessing, you can also use instance credenti
 ```
 spark.hadoop.fs.s3a.use.instance.credentials true
 ```
+Note that in this case, "spark.hadoop.fs.s3a.endpoint" won't take affect as Gluten will use the endpoint set during instance creation.
 
 ## Configuring S3 IAM roles
 You can also use iam role credentials by setting the following configurations. Instance credentials have higher priority than iam credentials.


### PR DESCRIPTION
## What changes were proposed in this pull request?

allow s3 endpoint  set only when not use instance credentials.

(Fixes: [issue-2638](https://github.com/oap-project/gluten/issues/2638))

## How was this patch tested?

verified on aws s3.

