### PR TITLE
[VL] gluten-it-parameterized: Change delimiter '->' to ':' to avoid escaping '>' in shell

### DIFF
--- a/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Parameterized.java
@@ -61,7 +61,7 @@ public class Parameterized implements Callable<Integer> {
   @CommandLine.Option(names = {"-d", "--dim"}, description = "Set a series of dimensions consisting of possible config options, example: -d=offheap->1g,spark.memory.offHeap.enabled=true,spark.memory.offHeap.size=1g")
   private String[] dims = new String[0];
 
-  private static final Pattern dimPattern1 = Pattern.compile("([\\w-]+)->([\\w-]+)((?:,[^=,]+=[^=,]+)+)");
+  private static final Pattern dimPattern1 = Pattern.compile("([\\w-]+):([\\w-]+)((?:,[^=,]+=[^=,]+)+)");
   private static final Pattern dimPattern2 = Pattern.compile("([\\w-]+)((?:,[^=,]+=[^=,]+)+)");
 
   @Override


### PR DESCRIPTION
After the change, '->' should be ':' in `parameterized` integration testing.

For example: 

```sh
sbin/gluten-it.sh parameterized \
--local \
--threads=8 \
--benchmark-type=ds \
-s=100 \
--queries=q95 \
--iterations=1 \
--shuffle-partitions=8 \
--enable-ui \
--enable-history \
-m=OffHeapExecutionMemory \
-d=offheap:3g,spark.memory.offHeap.size=3g \ # note ":" is used here rather than '->'
-d=offheap:4g,spark.memory.offHeap.size=4g \
--extra-conf=spark.gluten.sql.columnar.backend.velox.spillStrategy=auto \
--extra-conf=spark.gluten.sql.columnar.backend.velox.spillFileSystem=local \
--extra-conf=spark.executor.userClassPathFirst=true
```