### PR TITLE
[GLUTEN-2375][CH] Fix split function runtime exception in CH

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -482,4 +482,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
   enableSuite[GlutenStringFunctionsSuite]
     .include("initcap function")
     .include("string concat_ws")
+    .include("string split function with no limit")
+    .include("string split function with limit explicitly set to 0")
+    .include("string split function with negative limit")
+    .include("string split function with positive limit")
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#2375) 

Current solution is falling back when some corner cases are not supported by CH. 

TODO: 
- align spark split and ch splitByRegexp when limit > 0
- align spark split and ch splitByRegexp when regexp is not literal 