### PR TITLE
[GLUTEN-2684][CORE][HOTFIX]: disable Spark-36726 parquet reading tests temporarily on Spark 3.3

### DIFF
--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -678,6 +678,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("vectorized reader: required array with required elements")
     .exclude("vectorized reader: required array with optional elements")
     .exclude("vectorized reader: required array with legacy format")
+    .exclude("SPARK-36726: test incorrect Parquet row group file offset")
   enableSuite[GlutenParquetV1PartitionDiscoverySuite]
     // Timezone is not supported yet.
     .exclude("Resolve type conflicts - decimals, dates and timestamps in partition column")


### PR DESCRIPTION
Temporarily disable test case "SPARK-36726: test incorrect Parquet row group file offset" in GlutenParquetIOSuite for Spark33