### PR TITLE
[VL] Making resource management conform to our cpp CodingGuideLines

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -86,8 +86,9 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
 
   auto veloxPool = asAggregateVeloxMemoryPool(allocator);
   auto ctxPool = veloxPool->addAggregateChild("result_iterator", facebook::velox::memory::MemoryReclaimer::create());
-  auto veloxPlanConverter = std::make_unique<VeloxPlanConverter>(inputIters_, sessionConf);
-  veloxPlan_ = veloxPlanConverter->toVeloxPlan(substraitPlan_);
+
+  VeloxPlanConverter veloxPlanConverter(inputIters_, sessionConf);
+  veloxPlan_ = veloxPlanConverter.toVeloxPlan(substraitPlan_);
 
   // Scan node can be required.
   std::vector<std::shared_ptr<SplitInfo>> scanInfos;
@@ -95,7 +96,7 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
   std::vector<velox::core::PlanNodeId> streamIds;
 
   // Separate the scan ids and stream ids, and get the scan infos.
-  getInfoAndIds(veloxPlanConverter->splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
+  getInfoAndIds(veloxPlanConverter.splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
   if (scanInfos.size() == 0) {
     // Source node is not required.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -34,6 +34,7 @@
 #include "shuffle/reader.h"
 
 namespace gluten {
+
 // This class is used to convert the Substrait plan into Velox plan.
 class VeloxBackend final : public Backend {
  public:

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -24,6 +24,7 @@
 #include "velox/core/PlanNode.h"
 
 namespace gluten {
+
 // This class is used to convert the Substrait plan into Velox plan.
 class VeloxPlanConverter {
  public:
@@ -34,7 +35,7 @@ class VeloxPlanConverter {
   std::shared_ptr<const facebook::velox::core::PlanNode> toVeloxPlan(::substrait::Plan& substraitPlan);
 
   const std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfos() {
-    return subVeloxPlanConverter_->splitInfos();
+    return substraitVeloxPlanConverter_.splitInfos();
   }
 
  private:
@@ -63,11 +64,10 @@ class VeloxPlanConverter {
   std::string nextPlanNodeId();
 
   int planNodeId_ = 0;
+
   std::vector<std::shared_ptr<ResultIterator>> inputIters_;
 
-  std::shared_ptr<SubstraitParser> subParser_ = std::make_shared<SubstraitParser>();
-
-  std::shared_ptr<SubstraitVeloxPlanConverter> subVeloxPlanConverter_;
+  SubstraitToVeloxPlanConverter substraitVeloxPlanConverter_;
 };
 
 } // namespace gluten

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -59,7 +59,7 @@ class SubstraitParser {
   std::vector<std::string> makeNames(const std::string& prefix, int size);
 
   /// Make node name in the format of n{nodeId}_{colIdx}.
-  std::string makeNodeName(int nodeId, int colIdx);
+  static std::string makeNodeName(int nodeId, int colIdx);
 
   /// Get the column index from a node name in the format of
   /// n{nodeId}_{colIdx}.

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.h
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.h
@@ -95,7 +95,7 @@ class SubstraitVeloxExprConverter {
 
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.
-  std::shared_ptr<SubstraitParser> subParser_ = std::make_shared<SubstraitParser>();
+  SubstraitParser substraitParser_;
 
   /// The map storing the relations between the function id and the function
   /// name.

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -23,6 +23,7 @@
 #include "velox/core/PlanNode.h"
 
 namespace gluten {
+
 struct SplitInfo {
   /// Whether the split comes from arrow array stream node.
   bool isStream = false;
@@ -47,13 +48,14 @@ struct SplitInfo {
 };
 
 /// This class is used to convert the Substrait plan into Velox plan.
-class SubstraitVeloxPlanConverter {
+class SubstraitToVeloxPlanConverter {
  public:
-  SubstraitVeloxPlanConverter(
+  SubstraitToVeloxPlanConverter(
       memory::MemoryPool* pool,
       const std::unordered_map<std::string, std::string>& confMap = {},
       bool validationMode = false)
       : pool_(pool), confMap_(confMap), validationMode_(validationMode) {}
+
   /// Used to convert Substrait ExpandRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& expandRel);
 
@@ -497,11 +499,11 @@ class SubstraitVeloxPlanConverter {
 
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.
-  std::shared_ptr<SubstraitParser> subParser_{std::make_shared<SubstraitParser>()};
+  SubstraitParser substraitParser_;
 
   /// The Expression converter used to convert Substrait representations into
   /// Velox expressions.
-  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
+  std::unique_ptr<SubstraitVeloxExprConverter> exprConverter_;
 
   /// Memory pool.
   memory::MemoryPool* pool_;

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -25,7 +25,8 @@ namespace gluten {
 /// a Substrait plan is supported in Velox.
 class SubstraitToVeloxPlanValidator {
  public:
-  SubstraitToVeloxPlanValidator(memory::MemoryPool* pool, core::ExecCtx* execCtx) : pool_(pool), execCtx_(execCtx) {}
+  SubstraitToVeloxPlanValidator(memory::MemoryPool* pool, core::ExecCtx* execCtx)
+      : pool_(pool), execCtx_(execCtx), planConverter_(pool_, confMap_, true) {}
 
   /// Used to validate whether the computing of this Limit is supported.
   bool validate(const ::substrait::FetchRel& fetchRel);
@@ -63,7 +64,7 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Plan is supported.
   bool validate(const ::substrait::Plan& plan);
 
-  std::vector<std::string> getValidateLog() {
+  const std::vector<std::string>& getValidateLog() const {
     return validateLog_;
   }
 
@@ -78,15 +79,14 @@ class SubstraitToVeloxPlanValidator {
   std::unordered_map<std::string, std::string> confMap_ = {};
 
   /// A converter used to convert Substrait plan into Velox's plan node.
-  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<SubstraitVeloxPlanConverter>(pool_, confMap_, true);
+  SubstraitToVeloxPlanConverter planConverter_;
 
   /// A parser used to convert Substrait plan into recognizable representations.
-  std::shared_ptr<SubstraitParser> subParser_ = std::make_shared<SubstraitParser>();
+  SubstraitParser substraitParser_;
 
   /// An expression converter used to convert Substrait representations into
   /// Velox expressions.
-  std::shared_ptr<SubstraitVeloxExprConverter> exprConverter_;
+  std::unique_ptr<SubstraitVeloxExprConverter> exprConverter_;
 
   std::vector<std::string> validateLog_;
 

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.h
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.h
@@ -97,6 +97,4 @@ class VeloxToSubstraitExprConvertor {
   SubstraitExtensionCollectorPtr extensionCollector_;
 };
 
-using VeloxToSubstraitExprConvertorPtr = std::shared_ptr<VeloxToSubstraitExprConvertor>;
-
 } // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitPlan.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.cc
@@ -63,7 +63,7 @@ namespace {
   // Construct the extension colllector.
   extensionCollector_ = std::make_shared<SubstraitExtensionCollector>();
   // Construct the expression converter.
-  exprConvertor_ = std::make_shared<VeloxToSubstraitExprConvertor>(extensionCollector_);
+  exprConvertor_ = std::move(std::make_unique<VeloxToSubstraitExprConvertor>(extensionCollector_));
 
   auto substraitPlan = google::protobuf::Arena::CreateMessage<::substrait::Plan>(&arena);
 

--- a/cpp/velox/substrait/VeloxToSubstraitPlan.h
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.h
@@ -100,7 +100,7 @@ class VeloxToSubstraitPlanConvertor {
 
   /// The Expression converter used to convert Velox representations into
   /// Substrait expressions.
-  VeloxToSubstraitExprConvertorPtr exprConvertor_;
+  std::unique_ptr<VeloxToSubstraitExprConvertor> exprConvertor_;
 
   /// The Type converter used to conver velox representation into Substrait
   /// type.

--- a/cpp/velox/tests/FunctionTest.cc
+++ b/cpp/velox/tests/FunctionTest.cc
@@ -40,8 +40,8 @@ class FunctionTest : public ::testing::Test {
 
   std::shared_ptr<gluten::SubstraitParser> substraitParser_ = std::make_shared<gluten::SubstraitParser>();
 
-  std::shared_ptr<gluten::SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<gluten::SubstraitVeloxPlanConverter>(pool_.get());
+  std::shared_ptr<gluten::SubstraitToVeloxPlanConverter> planConverter_ =
+      std::make_shared<gluten::SubstraitToVeloxPlanConverter>(pool_.get());
 };
 
 TEST_F(FunctionTest, makeNames) {

--- a/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanConversionTest.cc
@@ -40,7 +40,7 @@ namespace gluten {
 class Substrait2VeloxPlanConversionTest : public exec::test::HiveConnectorTestBase {
  protected:
   std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>> makeSplits(
-      const SubstraitVeloxPlanConverter& converter,
+      const SubstraitToVeloxPlanConverter& converter,
       std::shared_ptr<const core::PlanNode> planNode) {
     const auto& splitInfos = converter.splitInfos();
     auto leafPlanNodeIds = planNode->leafPlanNodeIds();
@@ -71,8 +71,8 @@ class Substrait2VeloxPlanConversionTest : public exec::test::HiveConnectorTestBa
   }
 
   std::shared_ptr<exec::test::TempDirectoryPath> tmpDir_{exec::test::TempDirectoryPath::create()};
-  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<SubstraitVeloxPlanConverter>(memoryPool_.get());
+  std::shared_ptr<SubstraitToVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitToVeloxPlanConverter>(memoryPool_.get());
 
  private:
   std::shared_ptr<memory::MemoryPool> memoryPool_{memory::addDefaultLeafMemoryPool()};

--- a/cpp/velox/tests/Substrait2VeloxPlanValidatorTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxPlanValidatorTest.cc
@@ -36,8 +36,8 @@ using namespace facebook::velox::exec;
 namespace gluten {
 class Substrait2VeloxPlanValidatorTest : public exec::test::HiveConnectorTestBase {
  protected:
-  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<SubstraitVeloxPlanConverter>(memoryPool_.get());
+  std::shared_ptr<SubstraitToVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitToVeloxPlanConverter>(memoryPool_.get());
 
   bool validatePlan(std::string file) {
     std::string subPlanPath = FilePathGenerator::getDataFilePath(file);

--- a/cpp/velox/tests/Substrait2VeloxValuesNodeConversionTest.cc
+++ b/cpp/velox/tests/Substrait2VeloxValuesNodeConversionTest.cc
@@ -41,8 +41,8 @@ TEST_F(Substrait2VeloxValuesNodeConversionTest, valuesNode) {
   ::substrait::Plan substraitPlan;
   JsonToProtoConverter::readFromFile(planPath, substraitPlan);
   std::unordered_map<std::string, std::string> sessionConf = {};
-  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<SubstraitVeloxPlanConverter>(pool_.get(), sessionConf, true);
+  std::shared_ptr<SubstraitToVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitToVeloxPlanConverter>(pool_.get(), sessionConf, true);
   auto veloxPlan = planConverter_->toVeloxPlan(substraitPlan);
 
   RowVectorPtr expectedData = makeRowVector(

--- a/cpp/velox/tests/VeloxSubstraitRoundTripTest.cc
+++ b/cpp/velox/tests/VeloxSubstraitRoundTripTest.cc
@@ -66,8 +66,8 @@ class VeloxSubstraitRoundTripTest : public OperatorTestBase {
     google::protobuf::Arena arena;
     auto substraitPlan = veloxConvertor_->toSubstrait(arena, plan);
     std::unordered_map<std::string, std::string> sessionConf = {};
-    std::shared_ptr<SubstraitVeloxPlanConverter> substraitConverter_ =
-        std::make_shared<SubstraitVeloxPlanConverter>(pool_.get(), sessionConf, true);
+    std::shared_ptr<SubstraitToVeloxPlanConverter> substraitConverter_ =
+        std::make_shared<SubstraitToVeloxPlanConverter>(pool_.get(), sessionConf, true);
 
     // Convert Substrait Plan to the same Velox Plan.
     auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
@@ -87,8 +87,8 @@ class VeloxSubstraitRoundTripTest : public OperatorTestBase {
     google::protobuf::Arena arena;
     auto substraitPlan = veloxConvertor_->toSubstrait(arena, plan);
     std::unordered_map<std::string, std::string> sessionConf = {};
-    std::shared_ptr<SubstraitVeloxPlanConverter> substraitConverter_ =
-        std::make_shared<SubstraitVeloxPlanConverter>(pool_.get(), sessionConf, true);
+    std::shared_ptr<SubstraitToVeloxPlanConverter> substraitConverter_ =
+        std::make_shared<SubstraitToVeloxPlanConverter>(pool_.get(), sessionConf, true);
     // Convert Substrait Plan to the same Velox Plan.
     auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. prefer to use local objects than dynamic new objects
2. prefer unique_ptr to shared_ptr, shared_ptr should be used to represent shared semantic
3. prefer using general member data than smart pointer member data unless we need support copy semantic

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

