### PR TITLE
[GLUTEN-2673][CH] Fallback when lpad/rpad third arg is non-literal

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -88,6 +88,28 @@ case class SubstringIndexValidator() extends FunctionValidator {
   }
 }
 
+case class StringLPadValidator() extends FunctionValidator {
+  override def doValidate(expr: Expression): Boolean = {
+    val lpad = expr.asInstanceOf[StringLPad]
+    if (!lpad.pad.isInstanceOf[Literal]) {
+      return false
+    }
+
+    true
+  }
+}
+
+case class StringRPadValidator() extends FunctionValidator {
+  override def doValidate(expr: Expression): Boolean = {
+    val rpad = expr.asInstanceOf[StringRPad]
+    if (!rpad.pad.isInstanceOf[Literal]) {
+      return false
+    }
+
+    true
+  }
+}
+
 object CHExpressionUtil {
 
   final val CH_AGGREGATE_FUNC_BLACKLIST: Map[String, FunctionValidator] = Map(
@@ -102,6 +124,8 @@ object CHExpressionUtil {
     GET_JSON_OBJECT -> GetJsonObjectValidator(),
     ARRAYS_OVERLAP -> DefaultValidator(),
     SPLIT -> StringSplitValidator(),
-    SUBSTRING_INDEX -> SubstringIndexValidator()
+    SUBSTRING_INDEX -> SubstringIndexValidator(),
+    LPAD -> StringLPadValidator(),
+    RPAD -> StringRPadValidator()
   )
 }

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -267,7 +267,6 @@ class ClickHouseTestSettings extends BackendTestSettings {
       "translate",
       "INSTR",
       "LOCATE",
-      "LPAD/RPAD",
       "REPEAT",
       "length for string / binary",
       "SPARK-40213: ascii for Latin-1 Supplement characters",
@@ -483,4 +482,5 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .include("string split function with negative limit")
     .include("string split function with positive limit")
     .include("string substring_index function")
+    .include("string padding functions")
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#2673)
