### PR TITLE
[GLUTEN-2169][VL] enable aggregate push down - different data types test case

### DIFF
--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -759,14 +759,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenFileIndexSuite]
   enableSuite[GlutenFileMetadataStructSuite]
   enableSuite[GlutenParquetV1AggregatePushDownSuite]
-    // FIXME: yan
-    .exclude("aggregate push down - different data types")
   enableSuite[GlutenParquetV2AggregatePushDownSuite]
-    .exclude("aggregate push down - different data types")
   enableSuite[GlutenOrcV1AggregatePushDownSuite]
-    .exclude("aggregate push down - different data types")
   enableSuite[GlutenOrcV2AggregatePushDownSuite]
-    .exclude("aggregate push down - different data types")
   enableSuite[GlutenParquetCodecSuite]
     // Unsupported compression codec.
     .exclude("write and read - file source parquet - codec: lz4")


### PR DESCRIPTION
enable test case - aggregate push down - different data types for all parquet/orc/v1/v2 AggregatePushDownSuite
#2169 
