### PR TITLE
[VL] Disable Velox spill file truncating by default

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -955,7 +955,7 @@ object GlutenConfig {
       .internal()
       .doc("The maximum size of a single spill file created")
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("0MB")
+      .createWithDefaultString("1GB")
 
   val COLUMNAR_VELOX_SPILL_FILE_SYSTEM =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillFileSystem")

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -955,7 +955,7 @@ object GlutenConfig {
       .internal()
       .doc("The maximum size of a single spill file created")
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("20MB")
+      .createWithDefaultString("0MB")
 
   val COLUMNAR_VELOX_SPILL_FILE_SYSTEM =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillFileSystem")


### PR DESCRIPTION
This is a hot fix to disable spill truncating to avoid possible performance regression by too many small files.