### PR TITLE
[GLUTEN-2703][CH] get_json_object result's format is wrong when there is only one result

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -96,7 +96,8 @@ class GlutenFunctionValidateSuite extends WholeStageTransformerSuite {
         Row(1.011, 4, "{\"a 2\":\"b\"}"),
         Row(1.011, 5, "{\"a_2\":\"b\"}"),
         Row(1.011, 5, "{\"a\":\"b\", \"x\":{\"i\":1}}"),
-        Row(1.011, 5, "{\"a\":\"b\", \"x\":{\"i\":2}}")
+        Row(1.011, 5, "{\"a\":\"b\", \"x\":{\"i\":2}}"),
+        Row(1.011, 5, "{\"a\":1, \"x\":{\"i\":2}}")
       ))
     val dfParquet = spark.createDataFrame(data, schema)
     dfParquet

--- a/cpp-ch/local-engine/Functions/SparkFunctionGetJsonObject.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionGetJsonObject.h
@@ -111,7 +111,7 @@ public:
                 final_out_str = std::string_view(output_str_view.data() + 1, output_str_view.size() - 2);
             }
             else
-                final_out_str = std::string_view(output_str);
+                final_out_str = output_str_view;
         }
         else
         {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixex : #2703 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

