### PR TITLE
[VL](Refactor) Making SubstraitParser's methods as static members 

### DIFF
--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -47,7 +47,7 @@ static inline jmethodID getStaticMethodId(JNIEnv* env, jclass thisClass, const c
   return ret;
 }
 
-static jmethodID getStaticMethodIdOrError(JNIEnv* env, jclass thisClass, const char* name, const char* sig) {
+static inline jmethodID getStaticMethodIdOrError(JNIEnv* env, jclass thisClass, const char* name, const char* sig) {
   jmethodID ret = getStaticMethodId(env, thisClass, name, sig);
   if (ret == nullptr) {
     std::string errorMessage =
@@ -132,7 +132,7 @@ static inline void checkException(JNIEnv* env) {
   }
 }
 
-static jmethodID getMethodIdOrError(JNIEnv* env, jclass thisClass, const char* name, const char* sig) {
+static inline jmethodID getMethodIdOrError(JNIEnv* env, jclass thisClass, const char* name, const char* sig) {
   jmethodID ret = getMethodId(env, thisClass, name, sig);
   if (ret == nullptr) {
     std::string errorMessage = "Unable to find method " + std::string(name) + " within signature" + std::string(sig);
@@ -141,7 +141,7 @@ static jmethodID getMethodIdOrError(JNIEnv* env, jclass thisClass, const char* n
   return ret;
 }
 
-static jclass createGlobalClassReferenceOrError(JNIEnv* env, const char* className) {
+static inline jclass createGlobalClassReferenceOrError(JNIEnv* env, const char* className) {
   jclass globalClass = createGlobalClassReference(env, className);
   if (globalClass == nullptr) {
     std::string errorMessage = "Unable to CreateGlobalClassReferenceOrError for" + std::string(className);

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -112,8 +112,6 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::ReadRel& sread) {
     throw std::runtime_error("Invalid input iterator.");
   }
 
-  SubstraitParser substraitParser;
-
   // Get the input schema of this iterator.
   uint64_t colNum = 0;
   std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> subTypeList;
@@ -122,7 +120,7 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::ReadRel& sread) {
     // Input names is not used. Instead, new input/output names will be created
     // because the ValueStreamNode in Velox does not support name change.
     colNum = baseSchema.names().size();
-    subTypeList = substraitParser.parseNamedStruct(baseSchema);
+    subTypeList = SubstraitParser::parseNamedStruct(baseSchema);
   }
 
   std::vector<std::string> outNames;

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -27,15 +27,6 @@ using namespace facebook;
 
 namespace gluten {
 
-namespace {
-void registerCustomFunctions() {
-  velox::exec::registerVectorFunction(
-      "row_constructor",
-      std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{},
-      std::make_unique<RowConstructor>());
-}
-} // anonymous namespace
-
 void registerAllFunctions() {
   // The registration order matters. Spark sql functions are registered after
   // presto sql functions to overwrite the registration for same named functions.

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -41,29 +41,29 @@ class SubstraitParser {
   };
 
   /// Used to parse Substrait NamedStruct.
-  std::vector<std::shared_ptr<SubstraitType>> parseNamedStruct(const ::substrait::NamedStruct& namedStruct);
+  static std::vector<std::shared_ptr<SubstraitType>> parseNamedStruct(const ::substrait::NamedStruct& namedStruct);
 
   /// Used to parse partition columns from Substrait NamedStruct.
-  std::vector<bool> parsePartitionColumns(const ::substrait::NamedStruct& namedStruct);
+  static std::vector<bool> parsePartitionColumns(const ::substrait::NamedStruct& namedStruct);
 
   /// Parse Substrait Type.
-  std::shared_ptr<SubstraitType> parseType(const ::substrait::Type& substraitType);
+  static std::shared_ptr<SubstraitType> parseType(const ::substrait::Type& substraitType);
 
   // Parse substraitType type such as i32.
-  std::string parseType(const std::string& substraitType);
+  static std::string parseType(const std::string& substraitType);
 
   /// Parse Substrait ReferenceSegment.
-  int32_t parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment);
+  static int32_t parseReferenceSegment(const ::substrait::Expression::ReferenceSegment& refSegment);
 
   /// Make names in the format of {prefix}_{index}.
-  std::vector<std::string> makeNames(const std::string& prefix, int size);
+  static std::vector<std::string> makeNames(const std::string& prefix, int size);
 
   /// Make node name in the format of n{nodeId}_{colIdx}.
   static std::string makeNodeName(int nodeId, int colIdx);
 
   /// Get the column index from a node name in the format of
   /// n{nodeId}_{colIdx}.
-  int getIdxFromNodeName(const std::string& nodeName);
+  static int getIdxFromNodeName(const std::string& nodeName);
 
   /// Find the Substrait function name according to the function id
   /// from a pre-constructed function map. The function specification can be
@@ -72,75 +72,40 @@ class SubstraitParser {
   /// Currently, the input types in the function specification are not used. But
   /// in the future, they should be used for the validation according the
   /// specifications in Substrait yaml files.
-  const std::string& findFunctionSpec(const std::unordered_map<uint64_t, std::string>& functionMap, uint64_t id) const;
+  static std::string findFunctionSpec(const std::unordered_map<uint64_t, std::string>& functionMap, uint64_t id);
 
   /// Extracts the function name for a function from specified compound name.
   /// When the input is a simple name, it will be returned.
-  std::string getSubFunctionName(const std::string& functionSpec) const;
+  static std::string getSubFunctionName(const std::string& functionSpec);
 
   /// This function is used get the types from the compound name.
-  void getSubFunctionTypes(const std::string& subFuncSpec, std::vector<std::string>& types) const;
+  static void getSubFunctionTypes(const std::string& subFuncSpec, std::vector<std::string>& types);
 
   /// Used to find the Velox function name according to the function id
   /// from a pre-constructed function map.
-  std::string findVeloxFunction(const std::unordered_map<uint64_t, std::string>& functionMap, uint64_t id) const;
+  static std::string findVeloxFunction(const std::unordered_map<uint64_t, std::string>& functionMap, uint64_t id);
 
   /// Map the Substrait function keyword into Velox function keyword.
-  std::string mapToVeloxFunction(const std::string& substraitFunction, bool isDecimal) const;
+  static std::string mapToVeloxFunction(const std::string& substraitFunction, bool isDecimal);
 
   /// @brief Return whether a config is set as true in AdvancedExtension
   /// optimization.
   /// @param extension Substrait advanced extension.
   /// @param config the key string of a config.
   /// @return Whether the config is set as true.
-  bool configSetInOptimization(const ::substrait::extensions::AdvancedExtension& extension, const std::string& config)
-      const;
+  static bool configSetInOptimization(const ::substrait::extensions::AdvancedExtension&, const std::string& config);
 
  private:
   /// A map used for mapping Substrait function keywords into Velox functions'
   /// keywords. Key: the Substrait function keyword, Value: the Velox function
   /// keyword. For those functions with different names in Substrait and Velox,
   /// a mapping relation should be added here.
-  std::unordered_map<std::string, std::string> substraitVeloxFunctionMap_ = {
-      {"is_not_null", "isnotnull"}, /*Spark functions.*/
-      {"is_null", "isnull"},
-      {"equal", "equalto"},
-      {"equal_null_safe", "equalnullsafe"},
-      {"lt", "lessthan"},
-      {"lte", "lessthanorequal"},
-      {"gt", "greaterthan"},
-      {"gte", "greaterthanorequal"},
-      {"not_equal", "notequalto"},
-      {"char_length", "length"},
-      {"strpos", "instr"},
-      {"ends_with", "endswith"},
-      {"starts_with", "startswith"},
-      {"datediff", "date_diff"},
-      {"named_struct", "row_constructor"},
-      {"bit_or", "bitwise_or_agg"},
-      {"bit_or_merge", "bitwise_or_agg_merge"},
-      {"bit_and", "bitwise_and_agg"},
-      {"bit_and_merge", "bitwise_and_agg_merge"},
-      {"collect_set", "array_distinct"},
-      {"modulus", "mod"} /*Presto functions.*/};
+  static std::unordered_map<std::string, std::string> substraitVeloxFunctionMap_;
 
   // The map is uesd for mapping substrait type.
   // Key: type in function name.
   // Value: substrait type name.
-  const std::unordered_map<std::string, std::string> typeMap_ = {
-      {"bool", "BOOLEAN"},
-      {"i8", "TINYINT"},
-      {"i16", "SMALLINT"},
-      {"i32", "INTEGER"},
-      {"i64", "BIGINT"},
-      {"fp32", "REAL"},
-      {"fp64", "DOUBLE"},
-      {"date", "DATE"},
-      {"ts", "TIMESTAMP"},
-      {"str", "VARCHAR"},
-      {"vbin", "VARBINARY"},
-      {"decShort", "SHORT_DECIMAL"},
-      {"decLong", "LONG_DECIMAL"}};
+  static const std::unordered_map<std::string, std::string> typeMap_;
 };
 
 } // namespace gluten

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.h
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.h
@@ -93,10 +93,6 @@ class SubstraitVeloxExprConverter {
   /// Memory pool.
   memory::MemoryPool* pool_;
 
-  /// The Substrait parser used to convert Substrait representations into
-  /// recognizable representations.
-  SubstraitParser substraitParser_;
-
   /// The map storing the relations between the function id and the function
   /// name.
   std::unordered_map<uint64_t, std::string> functionMap_;

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -497,10 +497,6 @@ class SubstraitToVeloxPlanConverter {
   /// depends on other input nodes.
   std::unordered_map<uint64_t, std::shared_ptr<const core::PlanNode>> inputNodesMap_;
 
-  /// The Substrait parser used to convert Substrait representations into
-  /// recognizable representations.
-  SubstraitParser substraitParser_;
-
   /// The Expression converter used to convert Substrait representations into
   /// Velox expressions.
   std::unique_ptr<SubstraitVeloxExprConverter> exprConverter_;

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -81,9 +81,6 @@ class SubstraitToVeloxPlanValidator {
   /// A converter used to convert Substrait plan into Velox's plan node.
   SubstraitToVeloxPlanConverter planConverter_;
 
-  /// A parser used to convert Substrait plan into recognizable representations.
-  SubstraitParser substraitParser_;
-
   /// An expression converter used to convert Substrait representations into
   /// Velox expressions.
   std::unique_ptr<SubstraitVeloxExprConverter> exprConverter_;

--- a/cpp/velox/tests/FunctionTest.cc
+++ b/cpp/velox/tests/FunctionTest.cc
@@ -38,8 +38,6 @@ class FunctionTest : public ::testing::Test {
 
   std::shared_ptr<memory::MemoryPool> pool_ = memory::addDefaultLeafMemoryPool();
 
-  std::shared_ptr<gluten::SubstraitParser> substraitParser_ = std::make_shared<gluten::SubstraitParser>();
-
   std::shared_ptr<gluten::SubstraitToVeloxPlanConverter> planConverter_ =
       std::make_shared<gluten::SubstraitToVeloxPlanConverter>(pool_.get());
 };
@@ -47,11 +45,11 @@ class FunctionTest : public ::testing::Test {
 TEST_F(FunctionTest, makeNames) {
   std::string prefix = "n";
   int size = 0;
-  std::vector<std::string> names = substraitParser_->makeNames(prefix, size);
+  std::vector<std::string> names = SubstraitParser::makeNames(prefix, size);
   ASSERT_EQ(names.size(), size);
 
   size = 5;
-  names = substraitParser_->makeNames(prefix, size);
+  names = SubstraitParser::makeNames(prefix, size);
   ASSERT_EQ(names.size(), size);
   for (int i = 0; i < size; i++) {
     std::string expected = "n_" + std::to_string(i);
@@ -60,13 +58,13 @@ TEST_F(FunctionTest, makeNames) {
 }
 
 TEST_F(FunctionTest, makeNodeName) {
-  std::string nodeName = substraitParser_->makeNodeName(1, 0);
+  std::string nodeName = SubstraitParser::makeNodeName(1, 0);
   ASSERT_EQ(nodeName, "n1_0");
 }
 
 TEST_F(FunctionTest, getIdxFromNodeName) {
   std::string nodeName = "n1_0";
-  int index = substraitParser_->getIdxFromNodeName(nodeName);
+  int index = SubstraitParser::getIdxFromNodeName(nodeName);
   ASSERT_EQ(index, 0);
 }
 
@@ -181,15 +179,15 @@ TEST_F(FunctionTest, setVectorFromVariants) {
 
 TEST_F(FunctionTest, getFunctionType) {
   std::vector<std::string> types;
-  substraitParser_->getSubFunctionTypes("sum:opt_i32", types);
+  SubstraitParser::getSubFunctionTypes("sum:opt_i32", types);
   ASSERT_EQ("i32", types[0]);
 
   types.clear();
-  substraitParser_->getSubFunctionTypes("sum:i32", types);
+  SubstraitParser::getSubFunctionTypes("sum:i32", types);
   ASSERT_EQ("i32", types[0]);
 
   types.clear();
-  substraitParser_->getSubFunctionTypes("sum:opt_str_str", types);
+  SubstraitParser::getSubFunctionTypes("sum:opt_str_str", types);
   ASSERT_EQ(2, types.size());
   ASSERT_EQ("str", types[0]);
   ASSERT_EQ("str", types[1]);

--- a/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
+++ b/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
@@ -32,14 +32,12 @@ class VeloxToSubstraitTypeTest : public ::testing::Test {
 
     google::protobuf::Arena arena;
     auto substraitType = typeConvertor_->toSubstraitType(arena, type);
-    auto sameType = toVeloxType(substraitParser_->parseType(substraitType)->type);
+    auto sameType = toVeloxType(SubstraitParser::parseType(substraitType)->type);
     ASSERT_TRUE(sameType->kindEquals(type))
         << "Expected: " << type->toString() << ", but got: " << sameType->toString();
   }
 
   std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
-
-  std::shared_ptr<SubstraitParser> substraitParser_ = std::make_shared<SubstraitParser>();
 };
 
 TEST_F(VeloxToSubstraitTypeTest, basic) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

the `SubstraitParser` takes only read-only two map members, so we can change them to `static` data members, and make the member methods as static members.

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

