### PR TITLE
[CH] Minor fix : fix build issue due to https://github.com/ClickHouse/ClickHouse/pull/53180

### DIFF
--- a/cpp-ch/local-engine/jni/jni_error.cpp
+++ b/cpp-ch/local-engine/jni/jni_error.cpp
@@ -82,7 +82,6 @@ void JniErrorsGlobalState::throwException(
     if (exception_class)
     {
         std::string error_msg = message + "\n" + stack_trace;
-        std::cerr << "Re-throwing a java exception for native exception..." << std::endl;
         env->ThrowNew(exception_class, error_msg.c_str());
     }
     else


### PR DESCRIPTION
In this PR https://github.com/ClickHouse/ClickHouse/pull/53180,  clickhouse remove redundant `<iostream>` for improving building speed.

In `jni_error.cpp`, we use std::cerr incorrlectly, let's remove it