### PR TITLE
[GLUTEN-2723][CH] Improve Broadcast Join perfermance -- Part 1

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockOutputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/BlockOutputStream.java
@@ -28,13 +28,7 @@ public class BlockOutputStream implements Closeable {
   private final long instance;
   private final OutputStream outputStream;
 
-  private final byte[] buffer;
-
-  private final int bufferSize;
-
-  private final String defaultCompressionCodec;
-
-  private SQLMetric dataSize;
+  private final SQLMetric dataSize;
 
   private boolean isClosed = false;
 
@@ -54,16 +48,9 @@ public class BlockOutputStream implements Closeable {
       this.outputStream = outputStream;
       compressionEnable = false;
     }
-    this.defaultCompressionCodec = defaultCompressionCodec;
-    this.buffer = buffer;
-    this.bufferSize = bufferSize;
     this.instance =
         nativeCreate(
-            this.outputStream,
-            this.buffer,
-            this.defaultCompressionCodec,
-            compressionEnable,
-            this.bufferSize);
+            this.outputStream, buffer, defaultCompressionCodec, compressionEnable, bufferSize);
     this.dataSize = dataSize;
   }
 

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHStreamReader.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/CHStreamReader.java
@@ -23,25 +23,22 @@ import java.io.InputStream;
 public class CHStreamReader implements AutoCloseable {
   private final ShuffleInputStream inputStream;
   private long nativeShuffleReader;
-  private boolean compressed;
-  private int bufferSize;
-
-  public CHStreamReader(InputStream inputStream, int bufferSize) {
-    this(inputStream, false, false, bufferSize);
-  }
 
   public CHStreamReader(
       InputStream inputStream,
       boolean forceCompress,
       boolean isCustomizedShuffleCodec,
       int bufferSize) {
-    this.bufferSize = bufferSize;
-    this.inputStream =
+    this(
         CHShuffleReadStreamFactory.create(
-            inputStream, forceCompress, isCustomizedShuffleCodec, bufferSize);
-    this.compressed = this.inputStream.isCompressed();
+            inputStream, forceCompress, isCustomizedShuffleCodec, bufferSize),
+        bufferSize);
+  }
+
+  public CHStreamReader(ShuffleInputStream shuffleInputStream, int bufferSize) {
+    inputStream = shuffleInputStream;
     nativeShuffleReader =
-        createNativeShuffleReader(this.inputStream, this.compressed, this.bufferSize);
+        createNativeShuffleReader(this.inputStream, inputStream.isCompressed(), bufferSize);
   }
 
   private static native long createNativeShuffleReader(

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyNettyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/LowCopyNettyShuffleInputStream.java
@@ -21,25 +21,21 @@ import io.glutenproject.exception.GlutenException;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.PlatformDependent;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 public class LowCopyNettyShuffleInputStream implements ShuffleInputStream {
 
   private final InputStream in;
-  private final int bufferSize;
   private final boolean isCompressed;
 
-  private ByteBuf byteBuf;
+  private final ByteBuf byteBuf;
   private int readBytesCount = 0;
 
-  public LowCopyNettyShuffleInputStream(
-      InputStream in, ByteBuf byteBuf, int bufferSize, boolean isCompressed) {
+  public LowCopyNettyShuffleInputStream(InputStream in, ByteBuf byteBuf, boolean isCompressed) {
     // to prevent underlying netty buffer from being collected by GC
     this.in = in;
     this.byteBuf = byteBuf;
-    this.bufferSize = bufferSize;
     this.isCompressed = isCompressed;
   }
 
@@ -69,10 +65,10 @@ public class LowCopyNettyShuffleInputStream implements ShuffleInputStream {
 
   @Override
   public void close() {
-    try {
-      in.close();
-    } catch (IOException e) {
-      throw new GlutenException(e);
-    }
+    GlutenException.wrap(
+        () -> {
+          in.close();
+          return null;
+        });
   }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
@@ -75,11 +75,11 @@ public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
 
   @Override
   public void close() {
-    try {
-      in.close();
-      in = null;
-    } catch (IOException e) {
-      throw new GlutenException(e);
-    }
+    GlutenException.wrap(
+        () -> {
+          in.close();
+          in = null;
+          return null;
+        });
   }
 }

--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/OnHeapCopyShuffleInputStream.java
@@ -20,7 +20,6 @@ import io.glutenproject.exception.GlutenException;
 
 import io.netty.util.internal.PlatformDependent;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
@@ -30,7 +29,7 @@ public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
   private int bufferSize;
   private long bytesRead = 0L;
 
-  private byte[] buffer = null;
+  private byte[] buffer;
 
   public OnHeapCopyShuffleInputStream(InputStream in, int bufferSize, boolean isCompressed) {
     this.in = in;
@@ -41,26 +40,25 @@ public class OnHeapCopyShuffleInputStream implements ShuffleInputStream {
 
   @Override
   public long read(long destAddress, long maxReadSize) {
-    int maxReadSize32 = Math.toIntExact(maxReadSize);
-    if (maxReadSize32 > this.bufferSize) {
-      this.bufferSize = maxReadSize32;
-      this.buffer = new byte[this.bufferSize];
-    }
-    try {
-      // The code conducts copy as long as 'in' wraps off-heap data,
-      // which is about to be moved to heap
-      int read = in.read(buffer, 0, maxReadSize32);
-      if (read == -1 || read == 0) {
-        return 0;
-      }
-      // The code conducts copy, from heap to off-heap
-      // memCopyFromHeap(buffer, destAddress, read);
-      PlatformDependent.copyMemory(buffer, 0, destAddress, read);
-      bytesRead += read;
-      return read;
-    } catch (IOException e) {
-      throw new GlutenException(e);
-    }
+    return GlutenException.wrap(
+        () -> {
+          int maxReadSize32 = Math.toIntExact(maxReadSize);
+          if (maxReadSize32 > this.bufferSize) {
+            this.bufferSize = maxReadSize32;
+            this.buffer = new byte[this.bufferSize];
+          }
+          // The code conducts copy as long as 'in' wraps off-heap data,
+          // which is about to be moved to heap
+          int read = in.read(buffer, 0, maxReadSize32);
+          if (read == -1 || read == 0) {
+            return 0;
+          }
+          // The code conducts copy, from heap to off-heap
+          // memCopyFromHeap(buffer, destAddress, read);
+          PlatformDependent.copyMemory(buffer, 0, destAddress, read);
+          bytesRead += read;
+          return read;
+        });
   }
 
   @Override

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.storage;
 
-import io.glutenproject.backendsapi.clickhouse.CHBackendSettings;
 import io.glutenproject.exception.GlutenException;
 import io.glutenproject.vectorized.LowCopyFileSegmentShuffleInputStream;
 import io.glutenproject.vectorized.LowCopyNettyShuffleInputStream;
@@ -83,18 +82,6 @@ public final class CHShuffleReadStreamFactory {
   }
 
   private CHShuffleReadStreamFactory() {}
-
-  public static ShuffleInputStream create(byte[] allBatches) {
-    return create(allBatches, false, CHBackendSettings.customizeBufferSize());
-  }
-
-  public static ShuffleInputStream create(byte[] allBatches, boolean compressed) {
-    return create(allBatches, compressed, CHBackendSettings.customizeBufferSize());
-  }
-
-  public static ShuffleInputStream create(byte[] allBatches, int bufferSize) {
-    return create(allBatches, false, bufferSize);
-  }
 
   public static ShuffleInputStream create(byte[] allBatches, boolean compressed, int bufferSize) {
     return new OnHeapCopyShuffleInputStream(

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleReadStreamFactory.java
@@ -88,6 +88,10 @@ public final class CHShuffleReadStreamFactory {
     return create(allBatches, false, CHBackendSettings.customizeBufferSize());
   }
 
+  public static ShuffleInputStream create(byte[] allBatches, boolean compressed) {
+    return create(allBatches, compressed, CHBackendSettings.customizeBufferSize());
+  }
+
   public static ShuffleInputStream create(byte[] allBatches, int bufferSize) {
     return create(allBatches, false, bufferSize);
   }

--- a/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleWriteStreamFactory.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/storage/CHShuffleWriteStreamFactory.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.xerial.snappy.SnappyOutputStream;
 
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 
@@ -79,10 +80,12 @@ public final class CHShuffleWriteStreamFactory {
         out = (OutputStream) FIELD_LZ4BlockOutputStream_out.get(os);
       } else if (os instanceof LZFOutputStream) {
         out = (OutputStream) FIELD_LZFOutputStream_out.get(os);
+      } else if (os instanceof ByteArrayOutputStream) {
+        out = os;
       }
     } catch (IllegalAccessException e) {
       LOG.error("Can not get the field 'out' from compression output stream: ", e);
-      return out;
+      return null;
     }
     return out;
   }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHContextApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHContextApi.scala
@@ -50,10 +50,10 @@ class CHContextApi extends ContextApi with Logging {
 
     // Add configs
     conf.set(
-      s"${CHBackendSettings.getBackendConfigPrefix()}.runtime_config.timezone",
+      s"${CHBackendSettings.getBackendConfigPrefix}.runtime_config.timezone",
       conf.get("spark.sql.session.timeZone", TimeZone.getDefault.getID))
     conf.set(
-      s"${CHBackendSettings.getBackendConfigPrefix()}.runtime_config" +
+      s"${CHBackendSettings.getBackendConfigPrefix}.runtime_config" +
         s".local_engine.settings.log_processors_profiles",
       "true")
 

--- a/backends-clickhouse/src/main/scala/io/glutenproject/expression/CHExpressionTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/expression/CHExpressionTransformer.scala
@@ -300,7 +300,7 @@ case class CHTruncTimestampTransformer(
       timeZoneIgnore && timeZoneId.nonEmpty &&
       !timeZoneId.get.equalsIgnoreCase(
         SQLConf.get.getConfString(
-          s"${CHBackendSettings.getBackendConfigPrefix()}.runtime_config.timezone")
+          s"${CHBackendSettings.getBackendConfigPrefix}.runtime_config.timezone")
       )
     ) {
       throw new UnsupportedOperationException(

--- a/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CHColumnarBatchSerializer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CHColumnarBatchSerializer.scala
@@ -54,23 +54,16 @@ private class CHColumnarBatchSerializerInstance(
   extends SerializerInstance
   with Logging {
 
-  private lazy val isUseColumnarShufflemanager =
-    GlutenConfig.getConf.isUseColumnarShuffleManager
-  private lazy val customizeBufferSize = SparkEnv.get.conf.getInt(
-    CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE,
-    CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE_DEFAULT.toInt
-  )
-  private lazy val isCustomizedShuffleCodec = SparkEnv.get.conf.getBoolean(
-    CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE,
-    CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_SHUFFLE_CODEC_ENABLE_DEFAULT.toBoolean
-  )
   private lazy val compressionCodec =
     GlutenShuffleUtils.getCompressionCodec(SparkEnv.get.conf).toUpperCase(Locale.ROOT)
 
   override def deserializeStream(in: InputStream): DeserializationStream = {
     new DeserializationStream {
-
-      private var reader: CHStreamReader = _
+      private val reader: CHStreamReader = new CHStreamReader(
+        in,
+        GlutenConfig.getConf.isUseColumnarShuffleManager,
+        CHBackendSettings.useCustomizedShuffleCodec,
+        CHBackendSettings.customizeBufferSize)
       private var cb: ColumnarBatch = _
 
       private var numBatchesTotal: Long = _
@@ -91,35 +84,26 @@ private class CHColumnarBatchSerializerInstance(
 
       @throws(classOf[EOFException])
       override def readValue[T: ClassTag](): T = {
-        if (reader != null) {
-          if (cb != null) {
-            cb.close()
-            cb = null
-          }
-
-          var nativeBlock = reader.next()
-          while (nativeBlock.numRows() == 0) {
-            if (nativeBlock.numColumns() == 0) {
-              nativeBlock.close()
-              this.close()
-              throw new EOFException
-            }
-            nativeBlock = reader.next()
-          }
-          val numRows = nativeBlock.numRows()
-
-          numBatchesTotal += 1
-          numRowsTotal += numRows
-          cb = nativeBlock.toColumnarBatch
-          cb.asInstanceOf[T]
-        } else {
-          reader = new CHStreamReader(
-            in,
-            isUseColumnarShufflemanager,
-            isCustomizedShuffleCodec,
-            customizeBufferSize)
-          readValue()
+        if (cb != null) {
+          cb.close()
+          cb = null
         }
+
+        var nativeBlock = reader.next()
+        while (nativeBlock.numRows() == 0) {
+          if (nativeBlock.numColumns() == 0) {
+            nativeBlock.close()
+            this.close()
+            throw new EOFException
+          }
+          nativeBlock = reader.next()
+        }
+        val numRows = nativeBlock.numRows()
+
+        numBatchesTotal += 1
+        numRowsTotal += numRows
+        cb = nativeBlock.toColumnarBatch
+        cb.asInstanceOf[T]
       }
 
       override def readObject[T: ClassTag](): T = {
@@ -137,7 +121,7 @@ private class CHColumnarBatchSerializerInstance(
             cb.close()
             cb = null
           }
-          if (reader != null) reader.close()
+          reader.close()
           isClosed = true
         }
       }
@@ -145,15 +129,16 @@ private class CHColumnarBatchSerializerInstance(
   }
 
   override def serializeStream(out: OutputStream): SerializationStream = new SerializationStream {
-    private[this] var writeBuffer: Array[Byte] = new Array[Byte](customizeBufferSize)
+    private[this] var writeBuffer: Array[Byte] =
+      new Array[Byte](CHBackendSettings.customizeBufferSize)
     private[this] var dOut: BlockOutputStream =
       new BlockOutputStream(
         out,
         writeBuffer,
         dataSize,
-        isCustomizedShuffleCodec,
+        CHBackendSettings.useCustomizedShuffleCodec,
         compressionCodec,
-        customizeBufferSize
+        CHBackendSettings.customizeBufferSize
       )
 
     override def writeKey[T: ClassTag](key: T): SerializationStream = {

--- a/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CHColumnarBatchSerializer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CHColumnarBatchSerializer.scala
@@ -131,7 +131,7 @@ private class CHColumnarBatchSerializerInstance(
   override def serializeStream(out: OutputStream): SerializationStream = new SerializationStream {
     private[this] var writeBuffer: Array[Byte] =
       new Array[Byte](CHBackendSettings.customizeBufferSize)
-    private[this] var dOut: BlockOutputStream =
+    private[this] val dOut: BlockOutputStream =
       new BlockOutputStream(
         out,
         writeBuffer,

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -77,7 +77,7 @@ class CHColumnarShuffleWriter[K, V](
     internalCHWrite(records)
   }
 
-  def internalCHWrite(records: Iterator[Product2[K, V]]): Unit = {
+  private def internalCHWrite(records: Iterator[Product2[K, V]]): Unit = {
     val splitterJniWrapper: CHShuffleSplitterJniWrapper = jniWrapper
     if (!records.hasNext) {
       partitionLengths = new Array[Long](dep.partitioner.numPartitions)
@@ -187,7 +187,9 @@ class CHColumnarShuffleWriter[K, V](
     }
   }
 
-  private def closeCHSplitter(): Unit = jniWrapper.close(nativeSplitter)
+  private def closeCHSplitter(): Unit = {
+    jniWrapper.close(nativeSplitter)
+  }
 
   // VisibleForTesting
   def getPartitionLengths: Array[Long] = partitionLengths

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/joins/ClickHouseBuildSideRelation.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/joins/ClickHouseBuildSideRelation.scala
@@ -21,15 +21,13 @@ import io.glutenproject.execution.{BroadCastHashJoinContext, ColumnarNativeItera
 import io.glutenproject.utils.PlanNodesUtil
 import io.glutenproject.vectorized._
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.utils.CHExecUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
-import java.io.ByteArrayInputStream
+import org.apache.spark.storage.CHShuffleReadStreamFactory
 
 import scala.collection.JavaConverters._
 
@@ -40,11 +38,6 @@ case class ClickHouseBuildSideRelation(
     newBuildKeys: Seq[Expression] = Seq.empty)
   extends BuildSideRelation
   with Logging {
-
-  private lazy val customizeBufferSize = SparkEnv.get.conf.getInt(
-    CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE,
-    CHBackendSettings.GLUTEN_CLICKHOUSE_CUSTOMIZED_BUFFER_SIZE_DEFAULT.toInt
-  )
 
   override def deserialized: Iterator[ColumnarBatch] = Iterator.empty
 
@@ -61,12 +54,9 @@ case class ClickHouseBuildSideRelation(
           s"BHJ value size: " +
             s"${broadCastContext.buildHashTableId} = ${allBatches.length}")
         val storageJoinBuilder = new StorageJoinBuilder(
-          new OnHeapCopyShuffleInputStream(
-            new ByteArrayInputStream(allBatches),
-            customizeBufferSize,
-            false),
+          CHShuffleReadStreamFactory.create(allBatches),
           broadCastContext,
-          customizeBufferSize,
+          CHBackendSettings.customizeBufferSize,
           output.asJava,
           newBuildKeys.asJava
         )
@@ -91,8 +81,10 @@ case class ClickHouseBuildSideRelation(
   override def transform(key: Expression): Array[InternalRow] = {
     val allBatches = batches.flatten
     // native block reader
-    val input = new ByteArrayInputStream(allBatches)
-    val blockReader = new CHStreamReader(input, customizeBufferSize)
+    val blockReader =
+      new CHStreamReader(
+        CHShuffleReadStreamFactory.create(allBatches),
+        CHBackendSettings.customizeBufferSize)
     val broadCastIter = new Iterator[ColumnarBatch] {
       private var current: CHNativeBlock = _
 

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -22,9 +22,8 @@ import io.glutenproject.row.SparkRowInfo
 import io.glutenproject.vectorized._
 import io.glutenproject.vectorized.BlockSplitIterator.IteratorOptions
 
-import org.apache.spark.{ShuffleDependency, SparkEnv}
+import org.apache.spark.ShuffleDependency
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.IO_COMPRESSION_CODEC
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.ColumnarShuffleDependency
@@ -58,7 +57,7 @@ object CHExecUtil extends Logging {
   def toBytes(
       dataSize: SQLMetric,
       iter: Iterator[ColumnarBatch],
-      compressionCodec: Option[String] = Option(SparkEnv.get.conf.get(IO_COMPRESSION_CODEC)),
+      compressionCodec: Option[String] = Some("lz4"),
       bufferSize: Int = 4 << 10): Iterator[(Int, Array[Byte])] = {
     var count = 0
     val bos = new ByteArrayOutputStream()

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -22,8 +22,9 @@ import io.glutenproject.row.SparkRowInfo
 import io.glutenproject.vectorized._
 import io.glutenproject.vectorized.BlockSplitIterator.IteratorOptions
 
-import org.apache.spark.ShuffleDependency
+import org.apache.spark.{ShuffleDependency, SparkEnv}
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.IO_COMPRESSION_CODEC
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.ColumnarShuffleDependency
@@ -32,7 +33,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, BoundReference, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
 import org.apache.spark.sql.catalyst.plans.physical.{SinglePartition, _}
-import org.apache.spark.sql.execution.PartitionIdPassthrough
+import org.apache.spark.sql.execution.{PartitionIdPassthrough, SparkPlan}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLShuffleWriteMetricsReporter}
 import org.apache.spark.sql.internal.SQLConf
@@ -42,6 +43,8 @@ import org.apache.spark.util.MutablePair
 
 import io.substrait.proto.Type
 
+import java.io.ByteArrayOutputStream
+
 import scala.collection.JavaConverters._
 
 object CHExecUtil extends Logging {
@@ -50,6 +53,34 @@ object CHExecUtil extends Logging {
     val (datatype, nullable) =
       ConverterUtils.parseFromSubstraitType(Type.parseFrom(substraitType))
     datatype
+  }
+
+  def toBytes(
+      dataSize: SQLMetric,
+      iter: Iterator[ColumnarBatch],
+      compressionCodec: Option[String] = Option(SparkEnv.get.conf.get(IO_COMPRESSION_CODEC)),
+      bufferSize: Int = 4 << 10): Iterator[(Int, Array[Byte])] = {
+    var count = 0
+    val bos = new ByteArrayOutputStream()
+    val buffer = new Array[Byte](bufferSize) // 4K
+    val blockOutputStream =
+      compressionCodec
+        .map(new BlockOutputStream(bos, buffer, dataSize, true, _, bufferSize))
+        .getOrElse(new BlockOutputStream(bos, buffer, dataSize, false, "", bufferSize))
+    while (iter.hasNext) {
+      val batch = iter.next()
+      count += batch.numRows
+      blockOutputStream.write(batch)
+    }
+    blockOutputStream.flush()
+    blockOutputStream.close()
+    Iterator((count, bos.toByteArray))
+  }
+
+  def buildSideRDD(dataSize: SQLMetric, newChild: SparkPlan): RDD[(Int, Array[Byte])] = {
+    newChild
+      .executeColumnar()
+      .mapPartitionsInternal(iter => toBytes(dataSize, iter))
   }
 
   private def buildRangePartitionSampleRDD(
@@ -117,28 +148,29 @@ object CHExecUtil extends Logging {
       cbIter: Iterator[ColumnarBatch],
       options: IteratorOptions,
       records_written_metric: SQLMetric): CloseablePartitionedBlockIterator = {
-    val iter = new Iterator[Product2[Int, ColumnarBatch]] with AutoCloseable {
-      val splitIterator = new BlockSplitIterator(
-        cbIter
-          .map(
-            CHNativeBlock
-              .fromColumnarBatch(_)
-              .blockAddress()
-              .asInstanceOf[java.lang.Long])
-          .asJava,
-        options
-      )
-      override def hasNext: Boolean = splitIterator.hasNext
-      override def next(): Product2[Int, ColumnarBatch] = {
-        val nextBatch = splitIterator.next()
-        // need add rows before shuffle write, one block will convert to one row
-        // Because one is always added during shuffle write
-        // one line needs to be subtracted here
-        records_written_metric.add(nextBatch.numRows() - 1)
-        (splitIterator.nextPartitionId(), nextBatch)
-      };
-      override def close(): Unit = splitIterator.close();
-    }
+    val iter: Iterator[Product2[Int, ColumnarBatch]] with AutoCloseable =
+      new Iterator[Product2[Int, ColumnarBatch]] with AutoCloseable {
+        val splitIterator = new BlockSplitIterator(
+          cbIter
+            .map(
+              CHNativeBlock
+                .fromColumnarBatch(_)
+                .blockAddress()
+                .asInstanceOf[java.lang.Long])
+            .asJava,
+          options
+        )
+        override def hasNext: Boolean = splitIterator.hasNext
+        override def next(): Product2[Int, ColumnarBatch] = {
+          val nextBatch = splitIterator.next()
+          // need add rows before shuffle write, one block will convert to one row
+          // Because one is always added during shuffle write
+          // one line needs to be subtracted here
+          records_written_metric.add(nextBatch.numRows() - 1)
+          (splitIterator.nextPartitionId(), nextBatch)
+        }
+        override def close(): Unit = splitIterator.close()
+      }
     new CloseablePartitionedBlockIterator(iter)
   }
 

--- a/backends-clickhouse/src/test/resources/log4j.properties
+++ b/backends-clickhouse/src/test/resources/log4j.properties
@@ -44,7 +44,3 @@ log4j.logger.hive.ql.metadata.Hive=OFF
 # Parquet related logging
 log4j.logger.org.apache.parquet.CorruptStatistics=ERROR
 log4j.logger.parquet.CorruptStatistics=ERROR
-
-# CHBroadcastBuildSideCache
-log4j.additivity.io.glutenproject.execution.CHBroadcastBuildSideCache=true
-log4j.logger.io.glutenproject.execution.CHBroadcastBuildSideCache=DEBUG

--- a/backends-clickhouse/src/test/resources/log4j2.properties
+++ b/backends-clickhouse/src/test/resources/log4j2.properties
@@ -66,8 +66,3 @@ logger.parquet1.level = error
 
 logger.parquet2.name = parquet.CorruptStatistics
 logger.parquet2.level = error
-
-# CHBroadcastBuildSideCache
-logger.CHBroadcastBuildSideCache.name=io.glutenproject.execution.CHBroadcastBuildSideCache
-logger.CHBroadcastBuildSideCache.additivity=true
-logger.CHBroadcastBuildSideCache.level=debug

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/RemoveTopColumnarToRow.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/RemoveTopColumnarToRow.scala
@@ -14,27 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.vectorized;
+package org.apache.spark.sql.execution
 
-import io.glutenproject.execution.SparkRowIterator;
-import io.glutenproject.row.SparkRowInfo;
+import io.glutenproject.execution.ColumnarToRowExecBase
 
-public class CHBlockConverterJniWrapper {
+import org.apache.spark.sql.catalyst.rules.Rule
 
-  private CHBlockConverterJniWrapper() {
-    // utility class
+object RemoveTopColumnarToRow extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = plan match {
+    case plan: ColumnarToRowExecBase => plan.child
+    case _ => plan
   }
-
-  // for ch columnar -> spark row
-  public static native SparkRowInfo convertColumnarToRow(long blockAddress, int[] masks);
-
-  // for ch columnar -> spark row
-  public static native void freeMemory(long address, long size);
-
-  // for spark row -> ch columnar
-  public static native long convertSparkRowsToCHColumn(
-      SparkRowIterator iter, String[] names, byte[][] types);
-
-  // for spark row -> ch columnar
-  public static native void freeBlock(long blockAddress);
 }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHAggAndShuffleBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHAggAndShuffleBenchmark.scala
@@ -16,13 +16,10 @@
  */
 package org.apache.spark.sql.execution.benchmarks
 
-import io.glutenproject.GlutenConfig
 import io.glutenproject.execution.{FileSourceScanExecTransformer, ProjectExecTransformer, WholeStageTransformer}
 import io.glutenproject.sql.shims.SparkShimLoader
-import io.glutenproject.utils.UTSystemParameters
-import io.glutenproject.vectorized.JniLibLoader
 
-import org.apache.spark.{SparkConf, SparkEnv}
+import org.apache.spark.SparkEnv
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -31,7 +28,6 @@ import org.apache.spark.sql.execution.{ColumnarCollapseTransformStages, Columnar
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.execution.benchmarks.utils.FakeFileOutputStream
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
-import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseLog
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExchangeExec}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.ShuffleBlockId
@@ -57,8 +53,9 @@ import org.apache.spark.storage.ShuffleBlockId
  *     8. filter conditions (Optional);
  * }}}
  */
-object CHAggAndShuffleBenchmark extends SqlBasedBenchmark {
+object CHAggAndShuffleBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark {
 
+  protected lazy val appName = "CHAggAndShuffleBenchmark"
   protected lazy val thrdNum = "3"
   protected lazy val shufflePartition = "12"
   protected lazy val memorySize = "15G"
@@ -67,31 +64,10 @@ object CHAggAndShuffleBenchmark extends SqlBasedBenchmark {
   def beforeAll(): Unit = {}
 
   override def getSparkSession: SparkSession = {
-    beforeAll();
-    val conf = new SparkConf()
-      .setAppName("CHAggAndShuffleBenchmark")
-      .setIfMissing("spark.master", s"local[$thrdNum]")
-      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
-      .set(
-        "spark.sql.catalog.spark_catalog",
-        "org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog")
-      .set("spark.memory.offHeap.enabled", "true")
-      .set("spark.databricks.delta.maxSnapshotLineageLength", "20")
-      .set("spark.databricks.delta.snapshotPartitions", "1")
-      .set("spark.databricks.delta.properties.defaults.checkpointInterval", "5")
-      .set("spark.databricks.delta.stalenessLimit", "3600000")
-      .set("spark.gluten.sql.columnar.columnarToRow", "true")
-      .set("spark.gluten.sql.enable.native.validation", "false")
+    beforeAll()
+    val conf = getSparkcConf
       .set("spark.gluten.sql.columnar.separate.scan.rdd.for.ch", "false")
-      .set("spark.sql.adaptive.enabled", "false")
-      .setIfMissing(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
-      .setIfMissing("spark.memory.offHeap.size", offheapSize)
-      .setIfMissing("spark.sql.columnVector.offheap.enabled", "true")
       .setIfMissing("spark.sql.shuffle.partitions", shufflePartition)
-      .setIfMissing("spark.driver.memory", memorySize)
-      .setIfMissing("spark.executor.memory", memorySize)
-      .setIfMissing("spark.sql.files.maxPartitionBytes", "1G")
-      .setIfMissing("spark.sql.files.openCostInBytes", "1073741824")
       .setIfMissing("spark.shuffle.manager", "sort")
       .setIfMissing("spark.io.compression.codec", "SNAPPY")
 
@@ -332,7 +308,7 @@ object CHAggAndShuffleBenchmark extends SqlBasedBenchmark {
 
       val sparkFileScan = vanillaScanPlan.head
       val relation = sparkFileScan.relation
-      val readFile: (PartitionedFile) => Iterator[InternalRow] =
+      val readFile: PartitionedFile => Iterator[InternalRow] =
         relation.fileFormat.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,
@@ -452,17 +428,5 @@ object CHAggAndShuffleBenchmark extends SqlBasedBenchmark {
 
       sparkAllStagesBenchmark.run()
     }
-  }
-
-  override def afterAll(): Unit = {
-    ClickHouseLog.clearCache()
-    val libPath = spark.conf.get(
-      GlutenConfig.GLUTEN_LIB_PATH,
-      UTSystemParameters
-        .getClickHouseLibPath())
-    JniLibLoader.unloadFromPath(libPath)
-    // Wait for Ctrl+C, convenient for seeing Spark UI
-    Thread.sleep(600000)
-    super.afterAll()
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
@@ -16,17 +16,14 @@
  */
 package org.apache.spark.sql.execution.benchmarks
 
-import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.{FileSourceScanExecTransformer, WholeStageTransformContext}
 import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.PlanBuilder
-import io.glutenproject.utils.UTSystemParameters
-import io.glutenproject.vectorized.{CHBlockConverterJniWrapper, CHNativeBlock, JniLibLoader}
+import io.glutenproject.vectorized.{CHBlockConverterJniWrapper, CHNativeBlock}
 
-import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -35,7 +32,6 @@ import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
-import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseLog
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import com.google.common.collect.Lists
@@ -60,8 +56,9 @@ import scala.collection.JavaConverters._
  *     5. whether to run vanilla spark benchmarks;
  * }}}
  */
-object CHParquetReadBenchmark extends SqlBasedBenchmark {
+object CHParquetReadBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark {
 
+  protected lazy val appName = "CHParquetReadBenchmark"
   protected lazy val thrdNum = "1"
   protected lazy val memorySize = "4G"
   protected lazy val offheapSize = "4G"
@@ -69,30 +66,10 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark {
   def beforeAll(): Unit = {}
 
   override def getSparkSession: SparkSession = {
-    beforeAll();
-    val conf = new SparkConf()
-      .setAppName("CHParquetReadBenchmark")
-      .setIfMissing("spark.master", s"local[$thrdNum]")
-      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
-      .set(
-        "spark.sql.catalog.spark_catalog",
-        "org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog")
-      .set("spark.memory.offHeap.enabled", "true")
-      .setIfMissing("spark.memory.offHeap.size", offheapSize)
+    beforeAll()
+    val conf = getSparkcConf
       .setIfMissing("spark.sql.columnVector.offheap.enabled", "true")
-      .set("spark.databricks.delta.maxSnapshotLineageLength", "20")
-      .set("spark.databricks.delta.snapshotPartitions", "1")
-      .set("spark.databricks.delta.properties.defaults.checkpointInterval", "5")
-      .set("spark.databricks.delta.stalenessLimit", "3600000")
-      .set("spark.gluten.sql.columnar.columnarToRow", "true")
-      .setIfMissing(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
-      .set("spark.gluten.sql.enable.native.validation", "false")
       .set("spark.gluten.sql.columnar.separate.scan.rdd.for.ch", "true")
-      .set("spark.sql.adaptive.enabled", "false")
-      .setIfMissing("spark.driver.memory", memorySize)
-      .setIfMissing("spark.executor.memory", memorySize)
-      .setIfMissing("spark.sql.files.maxPartitionBytes", "1G")
-      .setIfMissing("spark.sql.files.openCostInBytes", "1073741824")
 
     SparkSession.builder.config(conf).getOrCreate()
   }
@@ -227,7 +204,7 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark {
       val fileScan = vanillaScanPlan.head
       val fileScanOutput = fileScan.output
       val relation = fileScan.relation
-      val readFile: (PartitionedFile) => Iterator[InternalRow] =
+      val readFile: PartitionedFile => Iterator[InternalRow] =
         relation.fileFormat.buildReaderWithPartitionValues(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,
@@ -274,15 +251,5 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark {
     }
 
     parquetReadBenchmark.run()
-  }
-
-  override def afterAll(): Unit = {
-    ClickHouseLog.clearCache()
-    val libPath = spark.conf.get(
-      GlutenConfig.GLUTEN_LIB_PATH,
-      UTSystemParameters
-        .getClickHouseLibPath())
-    JniLibLoader.unloadFromPath(libPath)
-    super.afterAll()
   }
 }

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHSqlBasedBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHSqlBasedBenchmark.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.benchmarks
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.utils.UTSystemParameters
+import io.glutenproject.vectorized.JniLibLoader
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseLog
+trait CHSqlBasedBenchmark extends SqlBasedBenchmark {
+
+  protected val appName: String
+  protected val thrdNum: String
+  protected val memorySize: String
+  protected val offheapSize: String
+  def getSparkcConf: SparkConf = {
+    val conf = new SparkConf()
+      .setAppName(appName)
+      .setIfMissing(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
+      .setIfMissing("spark.master", s"local[$thrdNum]")
+      .set("spark.plugins", "io.glutenproject.GlutenPlugin")
+      .set(
+        "spark.sql.catalog.spark_catalog",
+        "org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseSparkCatalog")
+      .set("spark.memory.offHeap.enabled", "true")
+      .set("spark.databricks.delta.maxSnapshotLineageLength", "20")
+      .set("spark.databricks.delta.snapshotPartitions", "1")
+      .set("spark.databricks.delta.properties.defaults.checkpointInterval", "5")
+      .set("spark.databricks.delta.stalenessLimit", "3600000")
+      .set("spark.gluten.sql.columnar.columnarToRow", "true")
+      .set("spark.gluten.sql.enable.native.validation", "false")
+      .set("spark.sql.adaptive.enabled", "false")
+      .setIfMissing("spark.memory.offHeap.size", offheapSize)
+      .setIfMissing("spark.sql.columnVector.offheap.enabled", "true")
+      .setIfMissing("spark.driver.memory", memorySize)
+      .setIfMissing("spark.executor.memory", memorySize)
+      .setIfMissing("spark.sql.files.maxPartitionBytes", "1G")
+      .setIfMissing("spark.sql.files.openCostInBytes", "1073741824")
+
+    conf
+  }
+
+  override def afterAll(): Unit = {
+    ClickHouseLog.clearCache()
+    val libPath = spark.conf.get(
+      GlutenConfig.GLUTEN_LIB_PATH,
+      UTSystemParameters
+        .getClickHouseLibPath())
+    JniLibLoader.unloadFromPath(libPath)
+    // Wait for Ctrl+C, convenient for seeing Spark UI
+    // Thread.sleep(600000)
+    super.afterAll()
+  }
+}

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHStorageJoinBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHStorageJoinBenchmark.scala
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.benchmarks
+
+import io.glutenproject.backendsapi.clickhouse.CHBackendSettings
+import io.glutenproject.utils.IteratorUtil
+import io.glutenproject.vectorized.{BlockOutputStream, CHBlockWriterJniWrapper, CHStreamReader}
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.io.CompressionCodec
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.BoundReference
+import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
+import org.apache.spark.sql.execution.{RemoveTopColumnarToRow, SparkPlan}
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.execution.joins.ClickHouseBuildSideRelation
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.storage.CHShuffleReadStreamFactory
+
+import java.io.{ByteArrayOutputStream, DataOutputStream}
+
+object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark {
+
+  protected lazy val appName = "CHStorageJoinBenchmark"
+  protected lazy val thrdNum = "2"
+  protected lazy val memorySize = "4G"
+  protected lazy val offheapSize = "4G"
+
+  override def getSparkSession: SparkSession = {
+
+    val conf = getSparkcConf
+      .set("spark.driver.maxResultSize", "0")
+    SparkSession.builder.config(conf).getOrCreate()
+  }
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+
+    val (parquetDir, readFileCnt, scanSchema, executedCnt, executedVanilla) =
+      if (mainArgs.isEmpty) {
+        ("/data/tpch-data/parquet/lineitem", 3, "l_orderkey,l_receiptdate", 5, true)
+      } else {
+        (mainArgs(0), mainArgs(1).toInt, mainArgs(2), mainArgs(3).toInt, mainArgs(4).toBoolean)
+      }
+
+    val chParquet = spark.sql(s"""
+                                 |select $scanSchema from parquet.`$parquetDir`
+                                 |
+                                 |""".stripMargin)
+
+    val benchmark = new Benchmark(
+      "CHStorageJoinBenchmark",
+      readFileCnt,
+      outputPerIteration = false,
+      output = output)
+    benchmark.addCase("mapPartitions", executedCnt) {
+      _ => createBroadcastRelation1(RemoveTopColumnarToRow(chParquet.queryExecution.executedPlan))
+    }
+    benchmark.addCase("map", executedCnt) {
+      _ => createBroadcastRelation2(RemoveTopColumnarToRow(chParquet.queryExecution.executedPlan))
+    }
+    benchmark.addCase("5", executedCnt) {
+      _ => createBroadcastRelation5(RemoveTopColumnarToRow(chParquet.queryExecution.executedPlan))
+    }
+    benchmark.addCase("6", executedCnt) {
+      _ => createBroadcastRelation6(RemoveTopColumnarToRow(chParquet.queryExecution.executedPlan))
+    }
+    benchmark.run()
+  }
+
+  def createBroadcastRelation1(child: SparkPlan): ClickHouseBuildSideRelation = {
+    val countsAndBytes = child
+      .executeColumnar()
+      .mapPartitions {
+        iter =>
+          var _numRows: Long = 0
+          // Use for reading bytes array from block
+          val blockNativeWriter = new CHBlockWriterJniWrapper()
+          while (iter.hasNext) {
+            val batch = iter.next
+            blockNativeWriter.write(batch)
+            _numRows += batch.numRows
+          }
+          Iterator((_numRows, blockNativeWriter.collectAsByteArray()))
+        // Iterator((_numRows, new Array[Byte](0)))
+      }
+      .collect
+    val count0 = countsAndBytes.map(_._1).sum
+    val batches = countsAndBytes.map(_._2)
+    val rawSize = batches.map(_.length).sum
+    val allBytes = batches.flatten
+    val count1 = iterateBatch(allBytes, compressed = false)
+    require(count0 == count1, s"count0: $count0, count1: $count1")
+    ClickHouseBuildSideRelation(
+      NoopBroadcastMode,
+      child.output,
+      allBytes,
+      Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
+  }
+
+  def createBroadcastRelation2(child: SparkPlan): ClickHouseBuildSideRelation = {
+    val countsAndBytes = child
+      .executeColumnar()
+      .map {
+        cb =>
+          val blockNativeWriter = new CHBlockWriterJniWrapper()
+          blockNativeWriter.write(cb)
+          (cb.numRows, blockNativeWriter.collectAsByteArray())
+      }
+      .collect
+    val count0 = countsAndBytes.map(_._1).sum
+    val batches = countsAndBytes.map(_._2)
+    val rawSize = batches.map(_.length).sum
+    val allBytes = batches.flatten
+    val count1 = iterateBatch(allBytes, compressed = false)
+    require(count0 == count1, s"count0: $count0, count1: $count1")
+    ClickHouseBuildSideRelation(
+      NoopBroadcastMode,
+      child.output,
+      allBytes,
+      Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
+  }
+
+//  def createBroadcastRelation3(child: SparkPlan): ClickHouseBuildSideRelation = {
+//    val countsAndBytes = child
+//      .executeColumnar()
+//      .map(cb => new SerializableColumnarBatch(cb))
+//      .collect
+//
+//    val batches = countsAndBytes.map(_.getBuffer)
+//    val rawSize = batches.map(_.length).sum
+//    ClickHouseBuildSideRelation(
+//      NoopBroadcastMode,
+//      child.output,
+//      batches,
+//      Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
+//  }
+
+  def createBroadcastRelation4(child: SparkPlan): ClickHouseBuildSideRelation = {
+    val countsAndBytes = child
+      .executeColumnar()
+      .mapPartitionsInternal {
+        iter =>
+          var count = 0
+          val codec = CompressionCodec.createCodec(SparkEnv.get.conf)
+          val bos = new ByteArrayOutputStream()
+          val out = new DataOutputStream(codec.compressedOutputStream(bos))
+          while (iter.hasNext) {
+            val batch = iter.next()
+            count += batch.numRows
+            val blockNativeWriter = new CHBlockWriterJniWrapper()
+            blockNativeWriter.write(batch)
+            val bytes = blockNativeWriter.collectAsByteArray()
+            out.writeInt(bytes.length)
+            out.write(bytes)
+          }
+          out.writeInt(-1)
+          out.flush()
+          out.close()
+          Iterator((count, bos.toByteArray))
+      }
+      .collect()
+    val batches = countsAndBytes.map(_._2)
+    val rawSize = batches.map(_.length).sum
+    val allBytes = batches.flatten
+    ClickHouseBuildSideRelation(
+      NoopBroadcastMode,
+      child.output,
+      allBytes,
+      Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
+  }
+
+  def createBroadcastRelation5(child: SparkPlan): ClickHouseBuildSideRelation = {
+    val dataSize = SQLMetrics.createSizeMetric(spark.sparkContext, "size of files read")
+
+    val countsAndBytes = child
+      .executeColumnar()
+      .mapPartitionsInternal {
+        iter =>
+          var count = 0
+          val bos = new ByteArrayOutputStream()
+          val buffer = new Array[Byte](4 << 10) // 4K
+          val dout = new BlockOutputStream(bos, buffer, dataSize, true, "lz4", buffer.length)
+          while (iter.hasNext) {
+            val batch = iter.next()
+            count += batch.numRows
+            dout.write(batch)
+          }
+          dout.flush()
+          dout.close()
+          Iterator((count, bos.toByteArray))
+      }
+      .collect()
+
+    val count0 = countsAndBytes.map(_._1).sum
+    val batches = countsAndBytes.map(_._2)
+    val rawSize = dataSize.value
+    val allBytes = batches.flatten
+    val count1 = iterateBatch(allBytes, compressed = true)
+    require(count0 == count1, s"count0: $count0, count1: $count1")
+    ClickHouseBuildSideRelation(
+      NoopBroadcastMode,
+      child.output,
+      allBytes,
+      Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
+  }
+
+  def createBroadcastRelation6(child: SparkPlan): ClickHouseBuildSideRelation = {
+    val dataSize = SQLMetrics.createSizeMetric(spark.sparkContext, "size of files read")
+
+    val countsAndBytes = child
+      .executeColumnar()
+      .map {
+        batch =>
+          val bos = new ByteArrayOutputStream()
+          val buffer = new Array[Byte](4 << 10) // 4K
+          val dout = new BlockOutputStream(bos, buffer, dataSize, true, "lz4", buffer.length)
+          dout.write(batch)
+          dout.flush()
+          dout.close()
+          (batch.numRows, bos.toByteArray)
+      }
+      .collect()
+
+    val count0 = countsAndBytes.map(_._1).sum
+    val batches = countsAndBytes.map(_._2)
+    val rawSize = dataSize.value
+    val allBytes = batches.flatten
+    val count1 = iterateBatch(batches.flatten, compressed = true)
+    require(count0 == count1, s"count0: $count0, count1: $count1")
+    ClickHouseBuildSideRelation(
+      NoopBroadcastMode,
+      child.output,
+      allBytes,
+      Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
+  }
+
+  def iterateBatch(array: Array[Byte], compressed: Boolean): Int = {
+    val blockReader =
+      new CHStreamReader(
+        CHShuffleReadStreamFactory.create(array, compressed),
+        CHBackendSettings.customizeBufferSize)
+    val broadCastIter: Iterator[ColumnarBatch] = IteratorUtil.createBatchIterator(blockReader)
+    broadCastIter.foldLeft(0) {
+      case (acc, batch) =>
+        acc + batch.numRows
+    }
+  }
+}
+
+/** NoopBroadcastMode does nothing. */
+case object NoopBroadcastMode extends BroadcastMode {
+  override def transform(rows: Array[InternalRow]): Any =
+    throw new UnsupportedOperationException("NoOPBroadcastMode.transform")
+  override def transform(rows: Iterator[InternalRow], sizeHint: Option[Long]): Any =
+    throw new UnsupportedOperationException("NoOPBroadcastMode.transform")
+  override def canonicalized: BroadcastMode =
+    throw new UnsupportedOperationException("NoOPBroadcastMode.canonicalized")
+}

--- a/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.cpp
+++ b/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.cpp
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 #include "BroadCastJoinBuilder.h"
-#include <jni.h>
 #include <Parser/SerializedPlanParser.h>
 #include <Parser/TypeParser.h>
+#include <Shuffle/ShuffleReader.h>
+#include <Storages/StorageJoinFromReadBuffer.h>
 #include <jni/SharedPointerWrapper.h>
 #include <jni/jni_common.h>
 #include <Poco/StringTokenizer.h>
@@ -78,8 +79,10 @@ namespace BroadCastJoinBuilder
         {
             try
             {
+                std::unique_ptr<ReadBuffer> in = std::make_unique<ReadBufferFromJavaInputStream>(context.input, context.io_buffer_size);
+                std::unique_ptr<ReadBuffer> compressed_in = createCompressedReadBuffer(in);
                 result = std::make_shared<StorageJoinFromReadBuffer>(
-                    std::make_unique<ReadBufferFromJavaInputStream>(context.input, context.io_buffer_size),
+                    *compressed_in,
                     context.key_names,
                     true,
                     SizeLimits(),
@@ -100,7 +103,8 @@ namespace BroadCastJoinBuilder
         ThreadFromGlobalPool build_thread(func);
         build_thread.join();
 
-        if(!result) {
+        if (!result)
+        {
             throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "create broadcast hash table {} failed.", key);
         }
 

--- a/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.cpp
+++ b/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.cpp
@@ -94,10 +94,16 @@ namespace BroadCastJoinBuilder
             catch (DB::Exception & e)
             {
                 LOG_ERROR(&Poco::Logger::get("BroadCastJoinBuilder"), "storage join create failed, {}", e.displayText());
+                result.reset();
             }
         };
         ThreadFromGlobalPool build_thread(func);
         build_thread.join();
+
+        if(!result) {
+            throw DB::Exception(ErrorCodes::LOGICAL_ERROR, "create broadcast hash table {} failed.", key);
+        }
+
         return result;
     }
 

--- a/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.h
+++ b/cpp-ch/local-engine/Builder/BroadCastJoinBuilder.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 #pragma once
-#include <Shuffle/ShuffleReader.h>
-#include <Storages/StorageJoinFromReadBuffer.h>
+#include <memory>
+#include <jni.h>
 
 // Forward Declarations
 struct JNIEnv_;
@@ -24,6 +24,7 @@ using JNIEnv = JNIEnv_;
 
 namespace local_engine
 {
+class StorageJoinFromReadBuffer;
 namespace BroadCastJoinBuilder
 {
 

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -86,6 +86,7 @@
 #include <Storages/CustomStorageMergeTree.h>
 #include <Storages/IStorage.h>
 #include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/StorageJoinFromReadBuffer.h>
 #include <Storages/StorageMergeTreeFactory.h>
 #include <Storages/SubstraitSource/SubstraitFileSource.h>
 #include <Storages/SubstraitSource/SubstraitFileSourceStep.h>

--- a/cpp-ch/local-engine/Shuffle/ShuffleReader.h
+++ b/cpp-ch/local-engine/Shuffle/ShuffleReader.h
@@ -16,14 +16,20 @@
  */
 #pragma once
 #include <jni.h>
-#include <Compression/CompressedReadBuffer.h>
 #include <Formats/NativeReader.h>
-#include <IO/ReadBuffer.h>
+#include <IO/BufferWithOwnMemory.h>
 #include <Common/BlockIterator.h>
 
+namespace DB
+{
+class CompressedReadBuffer;
+class NativeReader;
+}
 
 namespace local_engine
 {
+std::unique_ptr<DB::ReadBuffer> createCompressedReadBuffer(std::unique_ptr<DB::ReadBuffer> & in);
+
 class ReadBufferFromJavaInputStream;
 class ShuffleReader : BlockIterator
 {
@@ -33,10 +39,10 @@ public:
     ~ShuffleReader();
     static jclass input_stream_class;
     static jmethodID input_stream_read;
-    std::unique_ptr<DB::ReadBuffer> in;
 
 private:
-    std::unique_ptr<DB::CompressedReadBuffer> compressed_in;
+    std::unique_ptr<DB::ReadBuffer> in;
+    std::unique_ptr<DB::ReadBuffer> compressed_in;
     std::unique_ptr<DB::NativeReader> input_stream;
     DB::Block header;
 };

--- a/cpp-ch/local-engine/Shuffle/ShuffleWriter.cpp
+++ b/cpp-ch/local-engine/Shuffle/ShuffleWriter.cpp
@@ -17,6 +17,7 @@
 #include "ShuffleWriter.h"
 #include <Compression/CompressedWriteBuffer.h>
 #include <Compression/CompressionFactory.h>
+#include <Shuffle/WriteBufferFromJavaOutputStream.h>
 #include <boost/algorithm/string/case_conv.hpp>
 
 using namespace DB;

--- a/cpp-ch/local-engine/Shuffle/ShuffleWriter.h
+++ b/cpp-ch/local-engine/Shuffle/ShuffleWriter.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 #pragma once
+#include <jni.h>
 #include <Formats/NativeWriter.h>
-#include <Shuffle/WriteBufferFromJavaOutputStream.h>
 
 namespace local_engine
 {
@@ -30,8 +30,8 @@ public:
     void flush();
 
 private:
-    std::unique_ptr<DB::CompressedWriteBuffer> compressed_out;
-    std::unique_ptr<WriteBufferFromJavaOutputStream> write_buffer;
+    std::unique_ptr<DB::WriteBuffer> compressed_out;
+    std::unique_ptr<DB::WriteBuffer> write_buffer;
     std::unique_ptr<DB::NativeWriter> native_writer;
     bool compression_enable;
 };

--- a/cpp-ch/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
+++ b/cpp-ch/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
@@ -40,8 +40,8 @@ void WriteBufferFromJavaOutputStream::nextImpl()
 WriteBufferFromJavaOutputStream::WriteBufferFromJavaOutputStream(jobject output_stream_, jbyteArray buffer_, size_t customize_buffer_size)
 {
     GET_JNIENV(env)
-    buffer = static_cast<jbyteArray>(env->NewWeakGlobalRef(buffer_));
-    output_stream = env->NewWeakGlobalRef(output_stream_);
+    buffer = static_cast<jbyteArray>(env->NewGlobalRef(buffer_));
+    output_stream = env->NewGlobalRef(output_stream_);
     buffer_size = customize_buffer_size;
     CLEAN_JNIENV
 }
@@ -55,8 +55,8 @@ void WriteBufferFromJavaOutputStream::finalizeImpl()
 WriteBufferFromJavaOutputStream::~WriteBufferFromJavaOutputStream()
 {
     GET_JNIENV(env)
-    env->DeleteWeakGlobalRef(output_stream);
-    env->DeleteWeakGlobalRef(buffer);
+    env->DeleteGlobalRef(output_stream);
+    env->DeleteGlobalRef(buffer);
     CLEAN_JNIENV
 }
 }

--- a/cpp-ch/local-engine/Storages/StorageJoinFromReadBuffer.cpp
+++ b/cpp-ch/local-engine/Storages/StorageJoinFromReadBuffer.cpp
@@ -43,12 +43,7 @@ namespace local_engine
 
 void StorageJoinFromReadBuffer::restore()
 {
-    if (!in)
-    {
-        throw std::runtime_error("input reader buffer is not available");
-    }
-    ContextPtr ctx = nullptr;
-    NativeReader block_stream(*in, 0);
+    NativeReader block_stream(in, 0);
 
     ProfileInfo info;
     {
@@ -59,11 +54,10 @@ void StorageJoinFromReadBuffer::restore()
             join->addBlockToJoin(final_block, true);
         }
     }
-    in.reset();
 }
 
 StorageJoinFromReadBuffer::StorageJoinFromReadBuffer(
-    std::unique_ptr<DB::ReadBuffer> in_,
+    DB::ReadBuffer & in_,
     const Names & key_names_,
     bool use_nulls_,
     DB::SizeLimits limits_,
@@ -73,13 +67,7 @@ StorageJoinFromReadBuffer::StorageJoinFromReadBuffer(
     const ConstraintsDescription & constraints_,
     const String & comment,
     const bool overwrite_)
-    : key_names(key_names_)
-    , use_nulls(use_nulls_)
-    , limits(limits_)
-    , kind(kind_)
-    , strictness(strictness_)
-    , overwrite(overwrite_)
-    , in(std::move(in_))
+    : key_names(key_names_), use_nulls(use_nulls_), limits(limits_), kind(kind_), strictness(strictness_), overwrite(overwrite_), in(in_)
 {
     storage_metadata_.setColumns(columns_);
     storage_metadata_.setConstraints(constraints_);

--- a/cpp-ch/local-engine/Storages/StorageJoinFromReadBuffer.h
+++ b/cpp-ch/local-engine/Storages/StorageJoinFromReadBuffer.h
@@ -32,7 +32,7 @@ class StorageJoinFromReadBuffer
 {
 public:
     StorageJoinFromReadBuffer(
-        std::unique_ptr<DB::ReadBuffer> in_,
+        DB::ReadBuffer & in_,
         const DB::Names & key_names_,
         bool use_nulls_,
         DB::SizeLimits limits_,
@@ -73,6 +73,6 @@ private:
     std::shared_ptr<DB::TableJoin> table_join;
     DB::HashJoinPtr join;
 
-    std::unique_ptr<DB::ReadBuffer> in;
+    DB::ReadBuffer & in;
 };
 }

--- a/gluten-core/src/main/java/io/glutenproject/exception/GlutenException.java
+++ b/gluten-core/src/main/java/io/glutenproject/exception/GlutenException.java
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.exception;
 
+import java.util.concurrent.Callable;
+
 public class GlutenException extends RuntimeException {
 
   public GlutenException() {}
@@ -30,5 +32,13 @@ public class GlutenException extends RuntimeException {
 
   public GlutenException(Throwable cause) {
     super(cause);
+  }
+
+  public static <V> V wrap(Callable<V> callable) {
+    try {
+      return callable.call();
+    } catch (Exception e) {
+      throw new GlutenException(e);
+    }
   }
 }

--- a/gluten-ut/common/src/test/resources/log4j.properties
+++ b/gluten-ut/common/src/test/resources/log4j.properties
@@ -44,7 +44,3 @@ log4j.logger.hive.ql.metadata.Hive=OFF
 # Parquet related logging
 log4j.logger.org.apache.parquet.CorruptStatistics=ERROR
 log4j.logger.parquet.CorruptStatistics=ERROR
-
-# CHBroadcastBuildSideCache
-log4j.additivity.io.glutenproject.execution.CHBroadcastBuildSideCache=true
-log4j.logger.io.glutenproject.execution.CHBroadcastBuildSideCache=DEBUG

--- a/gluten-ut/common/src/test/resources/log4j2.properties
+++ b/gluten-ut/common/src/test/resources/log4j2.properties
@@ -66,8 +66,3 @@ logger.parquet1.level = error
 
 logger.parquet2.name = parquet.CorruptStatistics
 logger.parquet2.level = error
-
-# CHBroadcastBuildSideCache
-logger.CHBroadcastBuildSideCache.name=io.glutenproject.execution.CHBroadcastBuildSideCache
-logger.CHBroadcastBuildSideCache.additivity=true
-logger.CHBroadcastBuildSideCache.level=debug


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, when Broadcast size increased linearly, the  preformace degradates in a quadratic manner. 
![image](https://github.com/oap-project/gluten/assets/3688732/6268d328-ac0c-43f1-a9b5-0210b6e4e2dd)

One of reason is  we don't compress data when getting results from workers. This PR try **compression**.

(Fixes: \#2723)

## How was this patch tested?

Using existed UT

