### PR TITLE
[GLUTEN-2733][CORE][CH] Implementation of the automatic-resource-management pattern

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/NativeFileScanColumnarRDD.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/NativeFileScanColumnarRDD.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.metrics.GlutenTimeMetric
 import io.glutenproject.vectorized.{CHNativeExpressionEvaluator, CloseableCHColumnBatchIterator, GeneralInIterator, GeneralOutIterator}
 
 import org.apache.spark.{Partition, SparkContext, SparkException, TaskContext}
@@ -24,6 +25,7 @@ import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+import java.util
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
 class NativeFileScanColumnarRDD(
@@ -37,21 +39,19 @@ class NativeFileScanColumnarRDD(
   override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
     val inputPartition = castNativePartition(split)
 
-    val startNs = System.nanoTime()
-    val transKernel = new CHNativeExpressionEvaluator()
-    val inBatchIters = new java.util.ArrayList[GeneralInIterator]()
-    val resIter: GeneralOutIterator =
-      transKernel.createKernelWithBatchIterator(inputPartition.plan, inBatchIters, false)
-    scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+    val resIter: GeneralOutIterator = GlutenTimeMetric.millis(scanTime) {
+      _ =>
+        val transKernel = new CHNativeExpressionEvaluator()
+        val inBatchIters = new util.ArrayList[GeneralInIterator]()
+        transKernel.createKernelWithBatchIterator(inputPartition.plan, inBatchIters, false)
+    }
     TaskContext.get().addTaskCompletionListener[Unit](_ => resIter.close())
-    val iter = new Iterator[Any] {
+    val iter: Iterator[ColumnarBatch] = new Iterator[ColumnarBatch] {
       var scanTotalTime = 0L
       var scanTimeAdded = false
 
       override def hasNext: Boolean = {
-        val startNs = System.nanoTime()
-        val res = resIter.hasNext
-        scanTotalTime += System.nanoTime() - startNs
+        val res = GlutenTimeMetric.withNanoTime(resIter.hasNext)(t => scanTotalTime += t)
         if (!res && !scanTimeAdded) {
           scanTime += NANOSECONDS.toMillis(scanTotalTime)
           scanTimeAdded = true
@@ -59,16 +59,16 @@ class NativeFileScanColumnarRDD(
         res
       }
 
-      override def next(): Any = {
-        val startNs = System.nanoTime()
-        val cb = resIter.next()
-        numOutputRows += cb.numRows()
-        numOutputBatches += 1
-        scanTotalTime += System.nanoTime() - startNs
-        cb
+      override def next(): ColumnarBatch = {
+        GlutenTimeMetric.withNanoTime {
+          val cb = resIter.next()
+          numOutputRows += cb.numRows()
+          numOutputBatches += 1
+          cb
+        }(t => scanTotalTime += t)
       }
     }
-    new CloseableCHColumnBatchIterator(iter.asInstanceOf[Iterator[ColumnarBatch]])
+    new CloseableCHColumnBatchIterator(iter)
   }
 
   private def castNativePartition(split: Partition): BaseGlutenPartition = split match {

--- a/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CloseableCHColumnBatchIterator.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/vectorized/CloseableCHColumnBatchIterator.scala
@@ -16,6 +16,8 @@
  */
 package io.glutenproject.vectorized
 
+import io.glutenproject.metrics.GlutenTimeMetric
+
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -32,14 +34,12 @@ class CloseableCHColumnBatchIterator(
     pipelineTime: Option[SQLMetric] = None)
   extends Iterator[ColumnarBatch]
   with Logging {
-  var cb: ColumnarBatch = null
+  var cb: ColumnarBatch = _
   var scanTime = 0L
   var scanTimeAdded = false
 
   override def hasNext: Boolean = {
-    val beforeTime = System.nanoTime()
-    val res = itr.hasNext
-    scanTime += System.nanoTime() - beforeTime
+    val res = GlutenTimeMetric.withNanoTime(itr.hasNext)(t => scanTime += t)
     if (!res && pipelineTime.nonEmpty && !scanTimeAdded) {
       pipelineTime.foreach(t => t += TimeUnit.NANOSECONDS.toMillis(scanTime))
       scanTimeAdded = true
@@ -50,14 +50,17 @@ class CloseableCHColumnBatchIterator(
   TaskContext.get().addTaskCompletionListener[Unit] {
     _ =>
       closeCurrentBatch()
-      if (itr.isInstanceOf[AutoCloseable]) itr.asInstanceOf[AutoCloseable].close()
+      itr match {
+        case closeable: AutoCloseable => closeable.close()
+        case _ =>
+      }
   }
 
   override def next(): ColumnarBatch = {
-    val beforeTime = System.nanoTime()
-    closeCurrentBatch()
-    cb = itr.next()
-    scanTime += System.nanoTime() - beforeTime
+    cb = GlutenTimeMetric.withNanoTime {
+      closeCurrentBatch()
+      itr.next()
+    }(t => scanTime += t)
     cb
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -20,7 +20,7 @@ import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.extension.ValidationResult
-import io.glutenproject.metrics.MetricsUpdater
+import io.glutenproject.metrics.{GlutenTimeMetric, MetricsUpdater}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.ReadRelNode
@@ -38,8 +38,7 @@ import org.apache.spark.util.collection.BitSet
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import scala.collection.JavaConverters
-import scala.collection.mutable.HashMap
+import scala.collection.{mutable, JavaConverters}
 
 class FileSourceScanExecTransformer(
     @transient relation: HadoopFsRelation,
@@ -64,12 +63,12 @@ class FileSourceScanExecTransformer(
   with BasicScanExecTransformer {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
-  @transient override lazy val metrics =
+  @transient override lazy val metrics: Map[String, SQLMetric] =
     BackendsApiManager.getMetricsApiInstance
       .genFileSourceScanTransformerMetrics(sparkContext) ++ staticMetrics
 
   /** SQL metrics generated only for scans using dynamic partition pruning. */
-  protected lazy val staticMetrics =
+  private lazy val staticMetrics =
     if (partitionFilters.exists(FileSourceScanExecTransformer.isDynamicPruningFilter)) {
       Map(
         "staticFilesNum" -> SQLMetrics.createMetric(sparkContext, "static number of files read"),
@@ -117,7 +116,7 @@ class FileSourceScanExecTransformer(
 
   override def equals(other: Any): Boolean = other match {
     case that: FileSourceScanExecTransformer =>
-      (that.canEqual(this)) && super.equals(that)
+      that.canEqual(this) && super.equals(that)
     case _ => false
   }
 
@@ -166,7 +165,7 @@ class FileSourceScanExecTransformer(
 
   // The codes below are copied from FileSourceScanExec in Spark,
   // all of them are private.
-  protected lazy val driverMetrics: HashMap[String, Long] = HashMap.empty
+  protected lazy val driverMetrics: mutable.HashMap[String, Long] = mutable.HashMap.empty
 
   /**
    * Send the driver-side metrics. Before calling this function, selectedPartitions has been
@@ -200,16 +199,14 @@ class FileSourceScanExecTransformer(
 
   @transient override lazy val selectedPartitions: Array[PartitionDirectory] = {
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
-    val startTime = System.nanoTime()
-    val ret =
-      relation.location.listFiles(
-        partitionFilters.filterNot(FileSourceScanExecTransformer.isDynamicPruningFilter),
-        dataFilters)
-    setFilesNumAndSizeMetric(ret, true)
-    val timeTakenMs =
-      NANOSECONDS.toMillis((System.nanoTime() - startTime) + optimizerMetadataTimeNs)
-    driverMetrics("metadataTime") = timeTakenMs
-    ret
+    GlutenTimeMetric.withNanoTime {
+      val ret =
+        relation.location.listFiles(
+          partitionFilters.filterNot(FileSourceScanExecTransformer.isDynamicPruningFilter),
+          dataFilters)
+      setFilesNumAndSizeMetric(ret, static = true)
+      ret
+    }(t => driverMetrics("metadataTime") = NANOSECONDS.toMillis(t + optimizerMetadataTimeNs))
   }.toArray
 
   // We can only determine the actual partitions at runtime when a dynamic partition filter is
@@ -233,23 +230,22 @@ class FileSourceScanExecTransformer(
           }
         case _ =>
       }
-      val startTime = System.nanoTime()
-      // call the file index for the files matching all filters except dynamic partition filters
-      val predicate = dynamicPartitionFilters.reduce(And)
-      val partitionColumns = relation.partitionSchema
-      val boundPredicate = Predicate.create(
-        predicate.transform {
-          case a: AttributeReference =>
-            val index = partitionColumns.indexWhere(a.name == _.name)
-            BoundReference(index, partitionColumns(index).dataType, nullable = true)
-        },
-        Nil
-      )
-      val ret = selectedPartitions.filter(p => boundPredicate.eval(p.values))
-      setFilesNumAndSizeMetric(ret, false)
-      val timeTakenMs = (System.nanoTime() - startTime) / 1000 / 1000
-      driverMetrics("pruningTime") = timeTakenMs
-      ret
+      GlutenTimeMetric.withMillisTime {
+        // call the file index for the files matching all filters except dynamic partition filters
+        val predicate = dynamicPartitionFilters.reduce(And)
+        val partitionColumns = relation.partitionSchema
+        val boundPredicate = Predicate.create(
+          predicate.transform {
+            case a: AttributeReference =>
+              val index = partitionColumns.indexWhere(a.name == _.name)
+              BoundReference(index, partitionColumns(index).dataType, nullable = true)
+          },
+          Nil
+        )
+        val ret = selectedPartitions.filter(p => boundPredicate.eval(p.values))
+        setFilesNumAndSizeMetric(ret, static = false)
+        ret
+      }(t => driverMetrics("pruningTime") = t)
     } else {
       selectedPartitions
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -16,18 +16,19 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.GlutenConfig
+import io.glutenproject.{GlutenConfig, GlutenNumaBindingInfo}
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.exception.GlutenException
 import io.glutenproject.expression._
 import io.glutenproject.extension.GlutenPlan
-import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
+import io.glutenproject.metrics.{GlutenTimeMetric, MetricsUpdater, NoopMetricsUpdater}
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
 import io.glutenproject.substrait.rel.RelNode
 import io.glutenproject.utils.SubstraitPlanPrinterUtil
 
+import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
@@ -86,12 +87,12 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
   // For WholeStageCodegen-like operator, only pipeline time will be handled in graph plotting.
   // See SparkPlanGraph.scala:205 for reference.
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
-  @transient override lazy val metrics =
+  @transient override lazy val metrics: Map[String, SQLMetric] =
     BackendsApiManager.getMetricsApiInstance.genWholeStageTransformerMetrics(sparkContext)
 
-  val sparkConf = sparkContext.getConf
-  val numaBindingInfo = GlutenConfig.getConf.numaBindingInfo
-  val substraitPlanLogLevel = GlutenConfig.getConf.substraitPlanLogLevel
+  val sparkConf: SparkConf = sparkContext.getConf
+  val numaBindingInfo: GlutenNumaBindingInfo = GlutenConfig.getConf.numaBindingInfo
+  val substraitPlanLogLevel: String = GlutenConfig.getConf.substraitPlanLogLevel
 
   private var planJson: String = ""
 
@@ -133,9 +134,9 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
       append,
       verbose,
       prefix,
-      false,
+      addSuffix = false,
       maxFields,
-      printNodeId,
+      printNodeId = printNodeId,
       indent)
     if (verbose && planJson.nonEmpty) {
       append(prefix + "Substrait plan:\n")
@@ -254,23 +255,21 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
         throw new GlutenException(
           "The partition length of all the scan transformer are not the same.")
       }
-      val startTime = System.nanoTime()
-      val wsCxt = doWholeStageTransform()
+      val (wsCxt, substraitPlanPartitions) = GlutenTimeMetric.withMillisTime {
+        val wsCxt = doWholeStageTransform()
 
-      // the file format for each scan exec
-      val fileFormats = basicScanExecTransformers.map(ConverterUtils.getFileFormat)
+        // the file format for each scan exec
+        val fileFormats = basicScanExecTransformers.map(ConverterUtils.getFileFormat)
 
-      // generate each partition of all scan exec
-      val substraitPlanPartitions = (0 until partitionLength).map(
-        i => {
-          val currentPartitions = allScanPartitions.map(_(i))
-          BackendsApiManager.getIteratorApiInstance
-            .genFilePartition(i, currentPartitions, allScanPartitionSchemas, fileFormats, wsCxt)
-        })
-
-      logOnLevel(
-        substraitPlanLogLevel,
-        s"Generating the Substrait plan took: ${System.nanoTime() - startTime} ns.")
+        // generate each partition of all scan exec
+        val substraitPlanPartitions = (0 until partitionLength).map(
+          i => {
+            val currentPartitions = allScanPartitions.map(_(i))
+            BackendsApiManager.getIteratorApiInstance
+              .genFilePartition(i, currentPartitions, allScanPartitionSchemas, fileFormats, wsCxt)
+          })
+        (wsCxt, substraitPlanPartitions)
+      }(t => logOnLevel(substraitPlanLogLevel, s"Generating the Substrait plan took: $t ms."))
 
       new GlutenWholeStageColumnarRDD(
         sparkContext,
@@ -284,7 +283,7 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
           wsCxt.substraitContext.registeredJoinParams,
           wsCxt.substraitContext.registeredAggregationParams
         ),
-        materializeAtLast
+        materializeAtLast()
       )
     } else {
 
@@ -295,13 +294,9 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
        *      GlutenDataFrameAggregateSuite) in these cases, separate RDDs takes care of SCAN as a
        *      result, genFinalStageIterator rather than genFirstStageIterator will be invoked
        */
-      val startTime = System.nanoTime()
-      val resCtx = doWholeStageTransform()
-
-      logOnLevel(
-        substraitPlanLogLevel,
-        s"Generating the Substrait plan took: ${System.nanoTime() - startTime} ns.")
-
+      val resCtx = GlutenTimeMetric.withMillisTime(doWholeStageTransform()) {
+        t => logOnLevel(substraitPlanLogLevel, s"Generating the Substrait plan took: $t ms.")
+      }
       new WholeStageZippedPartitionsRDD(
         sparkContext,
         genFinalNewRDDsForBroadcast(inputRDDs),
@@ -316,7 +311,7 @@ case class WholeStageTransformer(child: SparkPlan)(val transformStageId: Int)
           resCtx.substraitContext.registeredJoinParams,
           resCtx.substraitContext.registeredAggregationParams
         ),
-        materializeAtLast
+        materializeAtLast()
       )
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -21,6 +21,7 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar._
+import io.glutenproject.metrics.GlutenTimeMetric
 import io.glutenproject.utils.{ColumnarShuffleUtil, LogLevelUtil, PhysicalPlanSelector}
 
 import org.apache.spark.api.python.EvalPythonExecTransformer
@@ -52,7 +53,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
   val columnarConf: GlutenConfig = GlutenConfig.getConf
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
-  val reuseSubquery = isAdaptiveContext && conf.subqueryReuseEnabled
+  val reuseSubquery: Boolean = isAdaptiveContext && conf.subqueryReuseEnabled
 
   /**
    * Insert a Project as the new child of Shuffle to calculate the hash expressions.
@@ -214,7 +215,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
           AddTransformHintRule().apply(
             ProjectExec(plan.child.output ++ projectExpressions, plan.child)))
         var newExprs = Seq[Expression]()
-        for (i <- 0 to exprs.size - 1) {
+        for (i <- exprs.indices) {
           val pos = newExpressionsPosition(i)
           newExprs = newExprs :+ project.output(pos)
         }
@@ -234,7 +235,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
           AddTransformHintRule().apply(
             ProjectExec(plan.child.output ++ projectExpressions, plan.child)))
         var newOrderings = Seq[SortOrder]()
-        for (i <- 0 to orderings.size - 1) {
+        for (i <- orderings.indices) {
           val oldOrdering = orderings(i)
           val pos = newExpressionsPosition(i)
           val ordering = SortOrder(
@@ -610,7 +611,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
 // into native implementations.
 case class TransformPostOverrides(session: SparkSession, isAdaptiveContext: Boolean)
   extends Rule[SparkPlan] {
-  val columnarConf = GlutenConfig.getConf
+  val columnarConf: GlutenConfig = GlutenConfig.getConf
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   def transformColumnarToRowExec(plan: ColumnarToRowExec): SparkPlan = {
@@ -708,7 +709,7 @@ case class ColumnarOverrideRules(session: SparkSession)
   with Logging
   with LogLevelUtil {
 
-  lazy val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
+  private lazy val transformPlanLogLevel = GlutenConfig.getConf.transformPlanLogLevel
   @transient private lazy val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   // Tracks whether the columnar rule is called through AQE.
@@ -716,18 +717,18 @@ case class ColumnarOverrideRules(session: SparkSession)
   // This is an empirical value, may need to be changed for supporting other versions of spark.
   private val aqeStackTraceIndex = 13
 
-  lazy val wholeStageFallbackThreshold = GlutenConfig.getConf.wholeStageFallbackThreshold
+  private lazy val wholeStageFallbackThreshold = GlutenConfig.getConf.wholeStageFallbackThreshold
 
-  lazy val queryFallbackThreshold = GlutenConfig.getConf.queryFallbackThreshold
+  private lazy val queryFallbackThreshold = GlutenConfig.getConf.queryFallbackThreshold
 
   // for fallback policy
-  lazy val fallbackPolicy = GlutenConfig.getConf.fallbackPolicy
+  private lazy val fallbackPolicy = GlutenConfig.getConf.fallbackPolicy
 
   private var originalPlan: SparkPlan = _
   // Do not create rules in class initialization as we should access SQLConf
   // while creating the rules. At this time SQLConf may not be there yet.
 
-  def preOverrides(): List[SparkSession => Rule[SparkPlan]] = {
+  private def preOverrides(): List[SparkSession => Rule[SparkPlan]] = {
     val tagBeforeTransformHitsRules = if (this.isAdaptiveContext) {
       // When AQE is supported, rules are applied in ColumnarQueryStagePrepOverrides
       List.empty
@@ -748,7 +749,7 @@ case class ColumnarOverrideRules(session: SparkSession)
       SparkUtil.extendedColumnarRules(session, GlutenConfig.getConf.extendedColumnarPreRules)
   }
 
-  def postOverrides(): List[SparkSession => Rule[SparkPlan]] =
+  private def postOverrides(): List[SparkSession => Rule[SparkPlan]] =
     List(
       (s: SparkSession) => TransformPostOverrides(s, this.isAdaptiveContext),
       (s: SparkSession) => VanillaColumnarPlanOverrides(s)) :::
@@ -758,8 +759,6 @@ case class ColumnarOverrideRules(session: SparkSession)
 
   override def preColumnarTransitions: Rule[SparkPlan] = plan =>
     PhysicalPlanSelector.maybe(session, plan) {
-      var overridden: SparkPlan = plan
-      val startTime = System.nanoTime()
       val traceElements = Thread.currentThread.getStackTrace
       assert(
         traceElements.length > aqeStackTraceIndex,
@@ -773,38 +772,24 @@ case class ColumnarOverrideRules(session: SparkSession)
         AdaptiveSparkPlanExec.getClass.getName)
       // Holds the original plan for possible entire fallback.
       originalPlan = plan
-      logOnLevel(
-        transformPlanLogLevel,
-        s"preColumnarTransitions preOverriden plan:\n${plan.toString}")
-      preOverrides().foreach {
-        r =>
-          overridden = r(session)(overridden)
-          planChangeLogger.logRule(r(session).ruleName, plan, overridden)
-      }
-      logOnLevel(
-        transformPlanLogLevel,
-        s"preColumnarTransitions afterOverriden plan:\n${overridden.toString}")
-      logOnLevel(
-        transformPlanLogLevel,
-        s"preTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
-      overridden
+      transformPlan(preOverrides(), plan, "pre")
     }
 
-  def fallbackWholeStage(plan: SparkPlan): Boolean = {
+  private def fallbackWholeStage(plan: SparkPlan): Boolean = {
     if (wholeStageFallbackThreshold < 0) {
       return false
     }
     countFallbacks(plan) >= wholeStageFallbackThreshold
   }
 
-  def fallbackWholeQuery(plan: SparkPlan): Boolean = {
+  private def fallbackWholeQuery(plan: SparkPlan): Boolean = {
     if (queryFallbackThreshold < 0) {
       return false
     }
     countFallbacks(plan) >= queryFallbackThreshold
   }
 
-  def countFallbacks(plan: SparkPlan): Int = {
+  private def countFallbacks(plan: SparkPlan): Int = {
     var fallbacks = 0
     def countFallback(plan: SparkPlan): Unit = {
       plan match {
@@ -819,7 +804,7 @@ case class ColumnarOverrideRules(session: SparkSession)
           fallbacks = fallbacks + 1
         case _ =>
       }
-      plan.children.map(p => countFallback(p))
+      plan.children.foreach(p => countFallback(p))
     }
     countFallback(plan)
     fallbacks
@@ -829,7 +814,7 @@ case class ColumnarOverrideRules(session: SparkSession)
    * Ported from ApplyColumnarRulesAndInsertTransitions of Spark. Inserts an transition to columnar
    * formatted data.
    */
-  def insertRowToColumnar(plan: SparkPlan): SparkPlan = {
+  private def insertRowToColumnar(plan: SparkPlan): SparkPlan = {
     if (!plan.supportsColumnar) {
       // The tree feels kind of backwards
       // Columnar Processing will start here, so transition from row to columnar
@@ -860,7 +845,7 @@ case class ColumnarOverrideRules(session: SparkSession)
   }
 
   // Just for test use.
-  def enableAdaptiveContext: Unit = {
+  def enableAdaptiveContext(): Unit = {
     isAdaptiveContext = true
   }
 
@@ -868,30 +853,33 @@ case class ColumnarOverrideRules(session: SparkSession)
     PhysicalPlanSelector.maybe(session, plan) {
       if (fallbackPolicy == "query" && !isAdaptiveContext && fallbackWholeQuery(plan)) {
         logWarning("Fall back to run the query due to unsupported operator!")
-        insertTransitions(originalPlan, false)
+        insertTransitions(originalPlan, outputsColumnar = false)
       } else if (fallbackPolicy == "stage" && isAdaptiveContext && fallbackWholeStage(plan)) {
         logWarning("Fall back the plan due to meeting the whole stage fallback threshold!")
-        insertTransitions(originalPlan, false)
+        insertTransitions(originalPlan, outputsColumnar = false)
       } else {
-        logOnLevel(
-          transformPlanLogLevel,
-          s"postColumnarTransitions preOverriden plan:\n${plan.toString}")
-        var overridden: SparkPlan = plan
-        val startTime = System.nanoTime()
-        postOverrides().foreach {
-          r =>
-            overridden = r(session)(overridden)
-            planChangeLogger.logRule(r(session).ruleName, plan, overridden)
-        }
-        logOnLevel(
-          transformPlanLogLevel,
-          s"postColumnarTransitions afterOverriden plan:\n${overridden.toString}")
-        logOnLevel(
-          transformPlanLogLevel,
-          s"postTransform SparkPlan took: ${(System.nanoTime() - startTime) / 1000000.0} ms.")
-        overridden
+        transformPlan(postOverrides(), plan, "post")
       }
     }
+  private def transformPlan(
+      getRules: List[SparkSession => Rule[SparkPlan]],
+      plan: SparkPlan,
+      step: String) = GlutenTimeMetric.withMillisTime {
+    logOnLevel(
+      transformPlanLogLevel,
+      s"${step}ColumnarTransitions preOverriden plan:\n${plan.toString}")
+    val overridden = getRules.foldLeft(plan) {
+      (p, getRule) =>
+        val rule = getRule(session)
+        val newPlan = rule(p)
+        planChangeLogger.logRule(rule.ruleName, p, newPlan)
+        newPlan
+    }
+    logOnLevel(
+      transformPlanLogLevel,
+      s"${step}ColumnarTransitions afterOverriden plan:\n${overridden.toString}")
+    overridden
+  }(t => logOnLevel(transformPlanLogLevel, s"${step}Transform SparkPlan took: $t ms."))
 }
 
 object ColumnarOverrides extends GlutenSparkExtensionsInjector {

--- a/gluten-core/src/main/scala/io/glutenproject/metrics/GlutenTimeMetric.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/metrics/GlutenTimeMetric.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.metrics
+
+import io.glutenproject.utils.Arm
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+import java.util.concurrent.TimeUnit
+
+class GlutenTimeMetric(val metric: SQLMetric, timeConvert: Long => Long) extends AutoCloseable {
+  private val start = System.nanoTime()
+
+  override def close(): Unit = {
+    val time = System.nanoTime() - start
+    metric.add(timeConvert(time))
+  }
+}
+object GlutenTimeMetric {
+  def nano[V](metric: SQLMetric)(block: GlutenTimeMetric => V): V =
+    Arm.withResource(new GlutenTimeMetric(metric, t => t))(block)
+  def millis[V](metric: SQLMetric)(block: GlutenTimeMetric => V): V =
+    Arm.withResource(new GlutenTimeMetric(metric, t => TimeUnit.NANOSECONDS.toMillis(t)))(block)
+
+  def withNanoTime[U](block: => U)(nanoTime: Long => Unit): U = {
+    val start = System.nanoTime()
+    val result = block
+    nanoTime(System.nanoTime() - start)
+    result
+  }
+  def withMillisTime[U](block: => U)(millisTime: Long => Unit): U =
+    withNanoTime(block)(t => millisTime(TimeUnit.NANOSECONDS.toMillis(t)))
+}

--- a/gluten-core/src/main/scala/io/glutenproject/utils/Arm.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/Arm.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils
+
+/** Implementation of the automatic-resource-management pattern */
+object Arm {
+
+  /** Executes the provided code block and then closes the resource */
+  def withResource[T <: AutoCloseable, V](r: T)(block: T => V): V = {
+    try {
+      block(r)
+    } finally {
+      r.close()
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR impelments automatic-resource-management pattern. For `SQLMetric`, we can use the following code to reduce duplicated codes:
```scala
val result = GlutenTimeMetric.millis(longMetric("collectTime")) { _ => 
 ...
}
```

I also implement a convenient utility `GlutenTimeMetric.withMillisTime` and `GlutenTimeMetric.withNanoTime`

### other improvement

I removed duplicate codes of `postColumnarTransitions` and `preColumnarTransitions`, extracting into a common method `transformPlan`, rewriting the following `foreach`

```scala
      preOverrides().foreach {
        r =>
          overridden = r(session)(overridden)
          planChangeLogger.logRule(r(session).ruleName, plan, overridden)
      }
```
Actually, The above `foreach`  is `fold`
```scala
    val overridden = getRules.foldLeft(plan) {
      (p, getRule) =>
        val rule = getRule(session)
        val newPlan = rule(p)
        planChangeLogger.logRule(rule.ruleName, p, newPlan)
        newPlan
    }
```
(Fixes: \#2733)

## How was this patch tested?
Using Existed UT.

