### PR TITLE
[CORE] Do not catch errors during plan validation

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -694,9 +694,9 @@ case class HashAggregateExecTransformer(
               throw new UnsupportedOperationException(s"$other is not supported.")
           }
         case _ =>
-          Preconditions.checkState(
-            functionInputAttributes.size == 1,
-            "Only one input attribute is expected.")
+          if (functionInputAttributes.size != 1) {
+            throw new UnsupportedOperationException("Only one input attribute is expected.")
+          }
           val childNodes = new util.ArrayList[ExpressionNode](
             functionInputAttributes.toList
               .map(

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.execution
 
+import com.google.common.base.Preconditions
 import io.glutenproject.execution.VeloxAggregateFunctionsBuilder.{veloxFourIntermediateTypes, veloxSixIntermediateTypes, veloxThreeIntermediateTypes}
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
@@ -25,17 +26,14 @@ import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionB
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.GlutenDecimalUtil
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DataType, DecimalType, DoubleType, LongType, StructField, StructType}
-
 import com.google.protobuf.Any
 
 import java.util
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -693,7 +691,7 @@ case class HashAggregateExecTransformer(
               throw new UnsupportedOperationException(s"$other is not supported.")
           }
         case _ =>
-          assert(functionInputAttributes.size == 1, "Only one input attribute is expected.")
+          Preconditions.checkArgument(functionInputAttributes.size == 1, "Only one input attribute is expected.")
           val childNodes = new util.ArrayList[ExpressionNode](
             functionInputAttributes.toList
               .map(

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -16,23 +16,26 @@
  */
 package io.glutenproject.execution
 
-import com.google.protobuf.Any
 import io.glutenproject.execution.VeloxAggregateFunctionsBuilder.{veloxFourIntermediateTypes, veloxSixIntermediateTypes, veloxThreeIntermediateTypes}
-import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.expression._
+import io.glutenproject.expression.ConverterUtils.FunctionConfig
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode, ScalarFunctionNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
-import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.utils.GlutenDecimalUtil
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
+import com.google.protobuf.Any
+
 import java.util
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -16,27 +16,23 @@
  */
 package io.glutenproject.execution
 
+import com.google.protobuf.Any
 import io.glutenproject.execution.VeloxAggregateFunctionsBuilder.{veloxFourIntermediateTypes, veloxSixIntermediateTypes, veloxThreeIntermediateTypes}
-import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
+import io.glutenproject.expression._
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
-import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode, ScalarFunctionNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
+import io.glutenproject.substrait.{AggregationParams, SubstraitContext}
 import io.glutenproject.utils.GlutenDecimalUtil
-
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{BooleanType, DataType, DecimalType, DoubleType, LongType, StructField, StructType}
-
-import com.google.common.base.Preconditions
-import com.google.protobuf.Any
+import org.apache.spark.sql.types._
 
 import java.util
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -691,7 +691,8 @@ case class HashAggregateExecTransformer(
               throw new UnsupportedOperationException(s"$other is not supported.")
           }
         case _ =>
-          Preconditions.checkArgument(functionInputAttributes.size == 1, "Only one input attribute is expected.")
+          Preconditions.checkState(functionInputAttributes.size == 1,
+            "Only one input attribute is expected.")
           val childNodes = new util.ArrayList[ExpressionNode](
             functionInputAttributes.toList
               .map(

--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package io.glutenproject.execution
 
-import com.google.common.base.Preconditions
 import io.glutenproject.execution.VeloxAggregateFunctionsBuilder.{veloxFourIntermediateTypes, veloxSixIntermediateTypes, veloxThreeIntermediateTypes}
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
@@ -26,14 +25,18 @@ import io.glutenproject.substrait.expression.{AggregateFunctionNode, ExpressionB
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.GlutenDecimalUtil
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DataType, DecimalType, DoubleType, LongType, StructField, StructType}
+
+import com.google.common.base.Preconditions
 import com.google.protobuf.Any
 
 import java.util
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -691,7 +694,8 @@ case class HashAggregateExecTransformer(
               throw new UnsupportedOperationException(s"$other is not supported.")
           }
         case _ =>
-          Preconditions.checkState(functionInputAttributes.size == 1,
+          Preconditions.checkState(
+            functionInputAttributes.size == 1,
             "Only one input attribute is expected.")
           val childNodes = new util.ArrayList[ExpressionNode](
             functionInputAttributes.toList

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -69,7 +69,7 @@ trait GlutenPlan extends SparkPlan with LogLevelUtil {
       }
       res
     } catch {
-      case e: Throwable =>
+      case e: Exception =>
         TestStats.addFallBackClassName(this.getClass.toString)
         logValidationMessage(s"Validation failed with exception for plan: $nodeName, due to:", e)
         ValidationResult.notOk(e.getMessage)


### PR DESCRIPTION
We shouldn't catch Java/Scala errors during validation since:

1. Errors can lead to invalid state (e.g. load shared library failed, load class failed)
2. All errors should be addressed in development phase, catching them hides potential code bugs

Instead, we should only catch exceptions (although Exception is still too general for indicating a validation failure) at the moment.