### PR TITLE
[GLUTEN-2740][CORE] Gluten endpoint should supports ipv6

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
@@ -33,8 +33,8 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
 
   private val driverHost = conf.get(config.DRIVER_HOST_ADDRESS.key, "localhost")
   private val driverPort = conf.getInt(config.DRIVER_PORT.key, 7077)
-  private val driverUrl =
-    s"spark://${GlutenRpcConstants.GLUTEN_DRIVER_ENDPOINT_NAME}@$driverHost:$driverPort"
+  private val rpcAddress = RpcAddress(driverHost, driverPort)
+  private val driverUrl = RpcEndpointAddress(rpcAddress, GlutenRpcConstants.GLUTEN_DRIVER_ENDPOINT_NAME).toString
 
   @volatile var driverEndpointRef: RpcEndpointRef = null
 

--- a/gluten-core/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
@@ -34,7 +34,8 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
   private val driverHost = conf.get(config.DRIVER_HOST_ADDRESS.key, "localhost")
   private val driverPort = conf.getInt(config.DRIVER_PORT.key, 7077)
   private val rpcAddress = RpcAddress(driverHost, driverPort)
-  private val driverUrl = RpcEndpointAddress(rpcAddress, GlutenRpcConstants.GLUTEN_DRIVER_ENDPOINT_NAME).toString
+  private val driverUrl =
+    RpcEndpointAddress(rpcAddress, GlutenRpcConstants.GLUTEN_DRIVER_ENDPOINT_NAME).toString
 
   @volatile var driverEndpointRef: RpcEndpointRef = null
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Gluten endpoint address should be constructed using Spark buildin `RpcEndpointAddress` constructor, so that it can work on ipv6 env.

(Fixes: \#2740)

