### PR TITLE
Add spark round function

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -54,7 +54,8 @@ set(root_directory ${PROJECT_BINARY_DIR})
 get_filename_component(GLUTEN_HOME ${CMAKE_SOURCE_DIR} DIRECTORY)
 
 if (NOT DEFINED ARROW_HOME)
-  set(ARROW_HOME ${GLUTEN_HOME}/ep/build-velox/build/velox_ep/_build/release/third_party/arrow_ep)
+  string(TOLOWER ${CMAKE_BUILD_TYPE} cmake_build_type_lower)
+  set(ARROW_HOME ${GLUTEN_HOME}/ep/build-velox/build/velox_ep/_build/${cmake_build_type_lower}/third_party/arrow_ep)
 endif()
 
 #

--- a/cpp/velox/operators/functions/Arithmetic.h
+++ b/cpp/velox/operators/functions/Arithmetic.h
@@ -1,0 +1,38 @@
+#include <folly/CPortability.h>
+#include <stdint.h>
+#include <cmath>
+#include <type_traits>
+
+namespace gluten {
+template <typename T>
+struct RoundFunction {
+  template <typename TNum, typename TDecimals, bool alwaysRoundNegDec = false>
+  FOLLY_ALWAYS_INLINE TNum round(const TNum& number, const TDecimals& decimals = 0) {
+    static_assert(!std::is_same_v<TNum, bool> && "round not supported for bool");
+
+    if constexpr (std::is_integral_v<TNum>) {
+      if constexpr (alwaysRoundNegDec) {
+        if (decimals >= 0)
+          return number;
+      } else {
+        return number;
+      }
+    }
+    if (!std::isfinite(number)) {
+      return number;
+    }
+
+    double factor = std::pow(10, decimals);
+    static const TNum kInf = std::numeric_limits<TNum>::infinity();
+    if (number < 0) {
+      return (std::round(std::nextafter(number, -kInf) * factor * -1) / factor) * -1;
+    }
+    return std::round(std::nextafter(number, kInf) * factor) / factor;
+  }
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, const TInput& a, const int32_t b = 0) {
+    result = round(a, b);
+  }
+};
+} // namespace gluten

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 #include "RegistrationAllFunctions.h"
+#include "Arithmetic.h"
 #include "RowConstructor.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
@@ -26,6 +28,8 @@
 #include "velox/functions/sparksql/window/WindowFunctionsRegistration.h"
 
 using namespace facebook;
+using namespace facebook::velox;
+using namespace facebook::velox::functions;
 
 namespace gluten {
 
@@ -35,6 +39,17 @@ void registerCustomFunctions() {
       "row_constructor",
       std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{},
       std::make_unique<RowConstructor>());
+}
+
+// Register some functions that is not accepted by the community, but necessary for gluten.
+void registerFuntionsForGluten() {
+  registerUnaryNumeric<RoundFunction>({"round"});
+  registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});
+  registerFunction<RoundFunction, int16_t, int16_t, int32_t>({"round"});
+  registerFunction<RoundFunction, int32_t, int32_t, int32_t>({"round"});
+  registerFunction<RoundFunction, int64_t, int64_t, int32_t>({"round"});
+  registerFunction<RoundFunction, double, double, int32_t>({"round"});
+  registerFunction<RoundFunction, float, float, int32_t>({"round"});
 }
 
 void registerFunctionOverwrite() {
@@ -61,6 +76,7 @@ void registerAllFunctions() {
   velox::functions::window::sparksql::registerWindowFunctions("");
   // Using function overwrite to handle function names mismatch between Spark and Velox.
   registerFunctionOverwrite();
+  registerFuntionsForGluten();
 }
 
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?
 velox round presto function can not handle round(0.575,2) = 0.57 case.  we need add spark round function to fix tpcds q78 resuslt not match issue.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

