### PR TITLE
[CORE] Pass caller name to GlutenMemoryConsumer to identify fine-grained memory usage

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
@@ -60,7 +60,7 @@ public abstract class CHNativeMemoryAllocators {
     if (!TaskResources.isResourceRegistered(id)) {
       final CHNativeMemoryAllocatorManager manager =
           createNativeMemoryAllocatorManager(
-              "contextInstance",
+              "ContextInstance",
               TaskResources.getLocalTaskContext().taskMemoryManager(),
               Spiller.NO_OP,
               TaskResources.getSharedMetrics());

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
@@ -40,11 +40,12 @@ public abstract class CHNativeMemoryAllocators {
   private static final CHNativeMemoryAllocator GLOBAL = CHNativeMemoryAllocator.getDefault();
 
   private static CHNativeMemoryAllocatorManager createNativeMemoryAllocatorManager(
+      String name,
       TaskMemoryManager taskMemoryManager, Spiller spiller, TaskMemoryMetrics taskMemoryMetrics) {
 
     CHManagedCHReservationListener rl =
         new CHManagedCHReservationListener(
-            new GlutenMemoryConsumer(taskMemoryManager, spiller), taskMemoryMetrics);
+            new GlutenMemoryConsumer(name, taskMemoryManager, spiller), taskMemoryMetrics);
     return new CHNativeMemoryAllocatorManagerImpl(CHNativeMemoryAllocator.createListenable(rl));
   }
 
@@ -57,6 +58,7 @@ public abstract class CHNativeMemoryAllocators {
     if (!TaskResources.isResourceRegistered(id)) {
       final CHNativeMemoryAllocatorManager manager =
           createNativeMemoryAllocatorManager(
+              "contextInstance",
               TaskResources.getLocalTaskContext().taskMemoryManager(),
               Spiller.NO_OP,
               TaskResources.getSharedMetrics());
@@ -69,13 +71,14 @@ public abstract class CHNativeMemoryAllocators {
     return CHNativeMemoryAllocator.getDefaultForUT();
   }
 
-  public static CHNativeMemoryAllocator createSpillable(Spiller spiller) {
+  public static CHNativeMemoryAllocator createSpillable(String name, Spiller spiller) {
     if (!TaskResources.inSparkTask()) {
       throw new IllegalStateException("spiller must be used in a Spark task");
     }
 
     final CHNativeMemoryAllocatorManager manager =
         createNativeMemoryAllocatorManager(
+            name,
             TaskResources.getLocalTaskContext().taskMemoryManager(),
             spiller,
             TaskResources.getSharedMetrics());

--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
@@ -41,7 +41,9 @@ public abstract class CHNativeMemoryAllocators {
 
   private static CHNativeMemoryAllocatorManager createNativeMemoryAllocatorManager(
       String name,
-      TaskMemoryManager taskMemoryManager, Spiller spiller, TaskMemoryMetrics taskMemoryMetrics) {
+      TaskMemoryManager taskMemoryManager,
+      Spiller spiller,
+      TaskMemoryMetrics taskMemoryMetrics) {
 
     CHManagedCHReservationListener rl =
         new CHManagedCHReservationListener(

--- a/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
+++ b/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
@@ -50,7 +50,8 @@ public class TestTaskMemoryManagerSuite {
 
     listener =
         new CHManagedCHReservationListener(
-            new GlutenMemoryConsumer("test", taskMemoryManager, Spiller.NO_OP), new TaskMemoryMetrics());
+            new GlutenMemoryConsumer("test", taskMemoryManager, Spiller.NO_OP),
+            new TaskMemoryMetrics());
 
     manager = new CHNativeMemoryAllocatorManagerImpl(new CHNativeMemoryAllocator(-1L, listener));
   }

--- a/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
+++ b/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
@@ -50,7 +50,7 @@ public class TestTaskMemoryManagerSuite {
 
     listener =
         new CHManagedCHReservationListener(
-            new GlutenMemoryConsumer(taskMemoryManager, Spiller.NO_OP), new TaskMemoryMetrics());
+            new GlutenMemoryConsumer("test", taskMemoryManager, Spiller.NO_OP), new TaskMemoryMetrics());
 
     manager = new CHNativeMemoryAllocatorManagerImpl(new CHNativeMemoryAllocator(-1L, listener));
   }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
@@ -242,7 +242,9 @@ class SparkPlanExecHandler extends SparkPlanExecApi {
             val handleArray = input.map(ColumnarBatches.getNativeHandle).toArray
             val serializeResult = ColumnarBatchSerializerJniWrapper.INSTANCE.serialize(
               handleArray,
-              NativeMemoryAllocators.getDefault.contextInstance().getNativeInstanceId)
+              NativeMemoryAllocators.getDefault
+                .contextInstance("BroadcastRelation")
+                .getNativeInstanceId)
             input.foreach(ColumnarBatches.release)
             Iterator((serializeResult.getNumRows, serializeResult.getSerialized))
           }

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -76,7 +76,9 @@ case class RowToVeloxColumnarExec(child: SparkPlan)
               ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
               jniWrapper.init(
                 cSchema.memoryAddress(),
-                NativeMemoryAllocators.getDefault.contextInstance().getNativeInstanceId)
+                NativeMemoryAllocators.getDefault
+                  .contextInstance("RowToColumnar")
+                  .getNativeInstanceId)
             } finally {
               cSchema.close()
             }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarToRowExec.scala
@@ -118,7 +118,7 @@ class ColumnarToRowRDD(
         val jniWrapper = new NativeColumnarToRowJniWrapper()
         var closed = false
         val c2rId = jniWrapper.nativeColumnarToRowInit(
-          NativeMemoryAllocators.getDefault().contextInstance().getNativeInstanceId)
+          NativeMemoryAllocators.getDefault().contextInstance("ColumnarToRow").getNativeInstanceId)
 
         TaskResources.addRecycler(s"ColumnarToRow_$c2rId", 100) {
           if (!closed) {

--- a/gluten-celeborn/src/main/scala/org/apache/spark/shuffle/CelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/src/main/scala/org/apache/spark/shuffle/CelebornColumnarBatchSerializer.scala
@@ -88,7 +88,7 @@ private class CelebornColumnarBatchSerializerInstance(
         val handle = ShuffleReaderJniWrapper.INSTANCE.make(
           jniByteInputStream,
           cSchema.memoryAddress(),
-          NativeMemoryAllocators.getDefault().contextInstance.getNativeInstanceId,
+          NativeMemoryAllocators.getDefault().contextInstance("ShuffleReader").getNativeInstanceId,
           compressionCodec,
           compressionCodecBackend
         )

--- a/gluten-celeborn/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedColumnarShuffleWriter.scala
@@ -125,6 +125,7 @@ class CelebornHashBasedColumnarShuffleWriter[K, V](
             NativeMemoryAllocators
               .getDefault()
               .create(
+                "CelebornShuffleWriter",
                 0.0d,
                 new Spiller() {
                   override def spill(size: Long, trigger: MemoryConsumer): Long = {

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
@@ -46,7 +46,10 @@ public class GlutenMemoryConsumer extends MemoryConsumer implements MemoryTarget
 
   public long acquire(long size) {
     assert size > 0;
-    return acquireMemory(size);
+    long acquired = acquireMemory(size);
+    if (acquired < size) {
+      this.taskMemoryManager.showMemoryUsage();
+    }
   }
 
   public long free(long size) {

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
@@ -50,6 +50,7 @@ public class GlutenMemoryConsumer extends MemoryConsumer implements MemoryTarget
     if (acquired < size) {
       this.taskMemoryManager.showMemoryUsage();
     }
+    return acquired;
   }
 
   public long free(long size) {

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/spark/GlutenMemoryConsumer.java
@@ -27,9 +27,12 @@ import org.apache.spark.util.TaskResources;
 public class GlutenMemoryConsumer extends MemoryConsumer implements MemoryTarget {
   private final Spiller spiller;
 
-  public GlutenMemoryConsumer(TaskMemoryManager taskMemoryManager, Spiller spiller) {
+  private final String name;
+
+  public GlutenMemoryConsumer(String name, TaskMemoryManager taskMemoryManager, Spiller spiller) {
     super(taskMemoryManager, taskMemoryManager.pageSizeBytes(), MemoryMode.OFF_HEAP);
     this.spiller = spiller;
+    this.name = name;
   }
 
   @Override
@@ -66,5 +69,10 @@ public class GlutenMemoryConsumer extends MemoryConsumer implements MemoryTarget
   @Override
   public long bytes() {
     return getUsed();
+  }
+
+  @Override
+  public String toString() {
+    return "GlutenMemoryConsumer-" + name;
   }
 }

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -63,8 +63,8 @@ public final class NativeMemoryAllocators {
     if (!TaskResources.inSparkTask()) {
       return globalInstance();
     }
-    final String id = NativeMemoryAllocatorManager.class + "-"
-        + System.identityHashCode(global) + "-" + name;
+    final String id =
+        NativeMemoryAllocatorManager.class + "-" + System.identityHashCode(global) + "-" + name;
     return TaskResources.addResourceIfNotRegistered(
             id,
             () ->

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -57,16 +57,18 @@ public final class NativeMemoryAllocators {
     return INSTANCES.computeIfAbsent(type, NativeMemoryAllocators::new);
   }
 
-  public NativeMemoryAllocator contextInstance() {
+  // TODO: When remove fallback storage and ensure all allocator are in Spark task scope,
+  //  we could remove this method and use create.
+  public NativeMemoryAllocator contextInstance(String name) {
     if (!TaskResources.inSparkTask()) {
       return globalInstance();
     }
-    final String id = NativeMemoryAllocatorManager.class + "-" + System.identityHashCode(global);
+    final String id = NativeMemoryAllocatorManager.class + "-" + System.identityHashCode(global) + "-" + name;
     return TaskResources.addResourceIfNotRegistered(
             id,
             () ->
                 createNativeMemoryAllocatorManager(
-                    "contextInstance",
+                    name,
                     TaskResources.getLocalTaskContext().taskMemoryManager(),
                     TaskResources.getSharedMetrics(),
                     0.0D,

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -63,7 +63,8 @@ public final class NativeMemoryAllocators {
     if (!TaskResources.inSparkTask()) {
       return globalInstance();
     }
-    final String id = NativeMemoryAllocatorManager.class + "-" + System.identityHashCode(global) + "-" + name;
+    final String id = NativeMemoryAllocatorManager.class + "-"
+        + System.identityHashCode(global) + "-" + name;
     return TaskResources.addResourceIfNotRegistered(
             id,
             () ->

--- a/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/alloc/NativeMemoryAllocators.java
@@ -66,6 +66,7 @@ public final class NativeMemoryAllocators {
             id,
             () ->
                 createNativeMemoryAllocatorManager(
+                    "contextInstance",
                     TaskResources.getLocalTaskContext().taskMemoryManager(),
                     TaskResources.getSharedMetrics(),
                     0.0D,
@@ -74,13 +75,14 @@ public final class NativeMemoryAllocators {
         .getManaged();
   }
 
-  public NativeMemoryAllocator create(double overAcquiredRatio, Spiller spiller) {
+  public NativeMemoryAllocator create(String name, double overAcquiredRatio, Spiller spiller) {
     if (!TaskResources.inSparkTask()) {
       throw new IllegalStateException("Spiller must be used in a Spark task");
     }
 
     final NativeMemoryAllocatorManager manager =
         createNativeMemoryAllocatorManager(
+            name,
             TaskResources.getLocalTaskContext().taskMemoryManager(),
             TaskResources.getSharedMetrics(),
             overAcquiredRatio,
@@ -94,12 +96,13 @@ public final class NativeMemoryAllocators {
   }
 
   private static NativeMemoryAllocatorManager createNativeMemoryAllocatorManager(
+      String name,
       TaskMemoryManager taskMemoryManager,
       TaskMemoryMetrics taskMemoryMetrics,
       double overAcquiredRatio,
       Spiller spiller,
       NativeMemoryAllocator delegated) {
-    MemoryTarget target = new GlutenMemoryConsumer(taskMemoryManager, spiller);
+    MemoryTarget target = new GlutenMemoryConsumer(name, taskMemoryManager, spiller);
     if (overAcquiredRatio != 0.0D) {
       target =
           new OverAcquire(

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -54,7 +54,9 @@ public class ArrowBufferAllocators {
     private final AllocationListener listener =
         new ManagedAllocationListener(
             new GlutenMemoryConsumer(
-                TaskResources.getLocalTaskContext().taskMemoryManager(), Spiller.NO_OP),
+                "ArrowContextInstance",
+                TaskResources.getLocalTaskContext().taskMemoryManager(),
+                Spiller.NO_OP),
             TaskResources.getSharedMetrics());
     private final BufferAllocator managed = new RootAllocator(listener, Long.MAX_VALUE);
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -68,6 +68,7 @@ public class NativePlanEvaluator {
     final long allocId =
         NativeMemoryAllocators.getDefault()
             .create(
+                "WholeStageIterator",
                 GlutenConfig.getConf().veloxOverAcquiredMemoryRatio(),
                 (size, trigger) -> {
                   ColumnarBatchOutIterator instance =

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -98,7 +98,7 @@ private class ColumnarBatchSerializerInstance(
         val handle = ShuffleReaderJniWrapper.INSTANCE.make(
           jniByteInputStream,
           cSchema.memoryAddress(),
-          NativeMemoryAllocators.getDefault().contextInstance.getNativeInstanceId,
+          NativeMemoryAllocators.getDefault().contextInstance("ShuffleReader").getNativeInstanceId,
           compressionCodec,
           compressionCodecBackend
         )

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -138,6 +138,7 @@ class ColumnarShuffleWriter[K, V](
             NativeMemoryAllocators
               .getDefault()
               .create(
+                "ShuffleWriter",
                 0.0d,
                 new Spiller() {
                   override def spill(size: Long, trigger: MemoryConsumer): Long = {

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -57,7 +57,9 @@ case class ColumnarBuildSideRelation(
         ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
         val handle = ColumnarBatchSerializerJniWrapper.INSTANCE.init(
           cSchema.memoryAddress(),
-          NativeMemoryAllocators.getDefault.contextInstance().getNativeInstanceId)
+          NativeMemoryAllocators.getDefault
+            .contextInstance("BuildSideRelation#BatchSerializer")
+            .getNativeInstanceId)
         cSchema.close()
         handle
       }
@@ -105,7 +107,9 @@ case class ColumnarBuildSideRelation(
       ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
       val handle = ColumnarBatchSerializerJniWrapper.INSTANCE.init(
         cSchema.memoryAddress(),
-        NativeMemoryAllocators.getDefault.contextInstance().getNativeInstanceId)
+        NativeMemoryAllocators.getDefault
+          .contextInstance("BuildSideRelation#BatchSerializer")
+          .getNativeInstanceId)
       cSchema.close()
       handle
     }
@@ -121,7 +125,10 @@ case class ColumnarBuildSideRelation(
     // Convert columnar to Row.
     val jniWrapper = new NativeColumnarToRowJniWrapper()
     val c2rId = jniWrapper.nativeColumnarToRowInit(
-      NativeMemoryAllocators.getDefault().contextInstance().getNativeInstanceId)
+      NativeMemoryAllocators
+        .getDefault()
+        .contextInstance("BuildSideRelation#ColumnarToRow")
+        .getNativeInstanceId)
     var batchId = 0
     val iterator = if (batches.length > 0) {
       val res: Iterator[Iterator[InternalRow]] = new Iterator[Iterator[InternalRow]] {

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -45,7 +45,10 @@ object ExecUtil {
     var info: NativeColumnarToRowInfo = null
     val batchHandle = ColumnarBatches.getNativeHandle(batch)
     val instanceId = jniWrapper.nativeColumnarToRowInit(
-      NativeMemoryAllocators.getDefault().contextInstance().getNativeInstanceId)
+      NativeMemoryAllocators
+        .getDefault()
+        .contextInstance("ExecUtil#ColumnarToRow")
+        .getNativeInstanceId)
     info = jniWrapper.nativeColumnarToRowConvert(batchHandle, instanceId)
 
     new Iterator[InternalRow] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When call TaskMemoryManager#showMemoryUsage, it will print all memory consumer's used memory, use caller's name would helpful to debug.

Before
```
TaskMemoryManager: Memory used in task 87
TaskMemoryManager: Acquired by io.glutenproject.memory.memtarget.spark.GlutenMemoryConsumer@39c93f4e: 478.0 MiB
TaskMemoryManager: Acquired by io.glutenproject.memory.memtarget.spark.GlutenMemoryConsumer@27db450c: 23.6 MiB
TaskMemoryManager: Acquired by io.glutenproject.memory.memtarget.spark.GlutenMemoryConsumer@1b80a18a: 8.0 MiB
```
After
```
TaskMemoryManager: Memory used in task 88
TaskMemoryManager: Acquired by GlutenMemoryConsumer-ContextInstance: 478.0 MiB
TaskMemoryManager: Acquired by GlutenMemoryConsumer-WholeStageIterator: 23.6 MiB
TaskMemoryManager: Acquired by GlutenMemoryConsumer-ArrowContextInstance: 8.0 MiB
```
