### PR TITLE
[GLUTEN-2625][VL] Fix: Velox shuffle reader / Velox Parquet data-source memory leak 

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -47,7 +47,7 @@ VeloxColumnarBatchSerializer::VeloxColumnarBatchSerializer(
   // serializeColumnarBatches don't need rowType_
   if (cSchema != nullptr) {
     rowType_ = asRowType(importFromArrow(*cSchema));
-    ArrowSchemaRelease(cSchema);
+    ArrowSchemaRelease(cSchema); // otherwise the c schema leaks memory
   }
   serde_ = std::make_unique<serializer::presto::PrestoVectorSerde>();
 }

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -26,7 +26,7 @@ VeloxRowToColumnarConverter::VeloxRowToColumnarConverter(
     struct ArrowSchema* cSchema,
     std::shared_ptr<memory::MemoryPool> memoryPool)
     : RowToColumnarConverter(), pool_(memoryPool) {
-  rowType_ = importFromArrow(*cSchema);
+  rowType_ = importFromArrow(*cSchema); // otherwise the c schema leaks memory
   ArrowSchemaRelease(cSchema);
 }
 

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -63,14 +63,6 @@ void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::str
         "The file path is not local or hdfs when writing data with parquet format in velox backend!");
   }
 
-  ArrowSchema cSchema{};
-  arrow::Status status = arrow::ExportSchema(*(schema_.get()), &cSchema);
-  if (!status.ok()) {
-    throw std::runtime_error("Failed to export arrow cSchema.");
-  }
-
-  type_ = velox::importFromArrow(cSchema);
-
   if (sparkConfs.find(kParquetBlockSize) != sparkConfs.end()) {
     maxRowGroupBytes_ = static_cast<int64_t>(stoi(sparkConfs.find(kParquetBlockSize)->second));
   }

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -20,6 +20,7 @@
 #include <arrow/array/array_binary.h>
 
 #include "memory/VeloxColumnarBatch.h"
+#include "utils/ArrowTypeUtils.h"
 #include "utils/compression.h"
 #include "utils/macros.h"
 #include "velox/serializers/PrestoSerializer.h"
@@ -314,9 +315,7 @@ VeloxShuffleReader::VeloxShuffleReader(
     std::shared_ptr<arrow::MemoryPool> pool,
     std::shared_ptr<memory::MemoryPool> veloxPool)
     : Reader(in, schema, options, pool), veloxPool_(std::move(veloxPool)) {
-  ArrowSchema cSchema;
-  GLUTEN_THROW_NOT_OK(arrow::ExportSchema(*schema, &cSchema));
-  rowType_ = asRowType(importFromArrow(cSchema));
+  rowType_ = asRowType(gluten::fromArrowSchema(schema));
 }
 
 arrow::Result<std::shared_ptr<ColumnarBatch>> VeloxShuffleReader::next() {

--- a/cpp/velox/utils/ArrowTypeUtils.h
+++ b/cpp/velox/utils/ArrowTypeUtils.h
@@ -23,7 +23,7 @@
 
 namespace gluten {
 
-// FIXME: The namings should emphasis on "Velox" as well
+// FIXME: The namings should emphasize "Velox" as well
 void toArrowSchema(const facebook::velox::TypePtr& rowType, struct ArrowSchema* out);
 
 std::shared_ptr<arrow::Schema> toArrowSchema(const facebook::velox::TypePtr& rowType);

--- a/cpp/velox/utils/ArrowTypeUtils.h
+++ b/cpp/velox/utils/ArrowTypeUtils.h
@@ -23,8 +23,11 @@
 
 namespace gluten {
 
+// FIXME: The namings should emphasis on "Velox" as well
 void toArrowSchema(const facebook::velox::TypePtr& rowType, struct ArrowSchema* out);
 
 std::shared_ptr<arrow::Schema> toArrowSchema(const facebook::velox::TypePtr& rowType);
+
+facebook::velox::TypePtr fromArrowSchema(const std::shared_ptr<arrow::Schema>& schema);
 
 } // namespace gluten

--- a/cpp/velox/utils/VeloxArrowUtils.cc
+++ b/cpp/velox/utils/VeloxArrowUtils.cc
@@ -36,7 +36,7 @@ arrow::Status MyMemoryPool::Allocate(int64_t size, int64_t alignment, uint8_t** 
   if (bytes_allocated() + size > capacity_) {
     return arrow::Status::OutOfMemory("malloc of size ", size, " failed");
   }
-  RETURN_NOT_OK(pool_->Allocate(size, out));
+  RETURN_NOT_OK(pool_->Allocate(size, alignment, out));
   stats_.UpdateAllocatedBytes(size);
   return arrow::Status::OK();
 }
@@ -46,13 +46,13 @@ arrow::Status MyMemoryPool::Reallocate(int64_t oldSize, int64_t newSize, int64_t
     return arrow::Status::OutOfMemory("malloc of size ", newSize, " failed");
   }
   // auto old_ptr = *ptr;
-  RETURN_NOT_OK(pool_->Reallocate(oldSize, newSize, ptr));
+  RETURN_NOT_OK(pool_->Reallocate(oldSize, newSize, alignment, ptr));
   stats_.UpdateAllocatedBytes(newSize - oldSize);
   return arrow::Status::OK();
 }
 
 void MyMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
-  pool_->Free(buffer, size);
+  pool_->Free(buffer, size, alignment);
   stats_.UpdateAllocatedBytes(-size);
 }
 


### PR DESCRIPTION
This patch fixed the memory leaks: the arrow schema is not correctly released on shuffle reader.

This resolves #2625 