### PR TITLE
[GLUTEN-2762] [VL] Release shuffle reader memory early to decrease peek memory usage

### DIFF
--- a/cpp/core/memory/ArrowMemoryPool.cc
+++ b/cpp/core/memory/ArrowMemoryPool.cc
@@ -61,7 +61,7 @@ int64_t ArrowMemoryPool::num_allocations() const {
 }
 
 std::string ArrowMemoryPool::backend_name() const {
-  return "gluten allocator";
+  return "gluten arrow allocator";
 }
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -321,6 +321,10 @@ VeloxShuffleReader::VeloxShuffleReader(
 arrow::Result<std::shared_ptr<ColumnarBatch>> VeloxShuffleReader::next() {
   ARROW_ASSIGN_OR_RAISE(auto batch, Reader::next());
   if (batch == nullptr) {
+    // Some empty batch has not been released here, so check is needed.
+    if (veloxPool_->currentBytes() == 0 || veloxPool_->reservedBytes() == 0) {
+      veloxPool_->shrinkManaged(veloxPool_.get(), veloxPool_->capacity());
+    }
     return nullptr;
   }
   auto rb = std::dynamic_pointer_cast<ArrowColumnarBatch>(batch)->getRecordBatch();

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -322,7 +322,7 @@ arrow::Result<std::shared_ptr<ColumnarBatch>> VeloxShuffleReader::next() {
   ARROW_ASSIGN_OR_RAISE(auto batch, Reader::next());
   if (batch == nullptr) {
     // Some empty batch has not been released here, so check is needed.
-    if (veloxPool_->currentBytes() == 0 || veloxPool_->reservedBytes() == 0) {
+    if (veloxPool_->currentBytes() == 0 && veloxPool_->reservedBytes() == 0) {
       veloxPool_->shrinkManaged(veloxPool_.get(), veloxPool_->capacity());
     }
     return nullptr;


### PR DESCRIPTION
## What changes were proposed in this pull request?

We found some query has high task peek memory usage after integrate memory arbitrator, e.g. before this patch, TPCDS sf1000 q4 use 2.4GiB peek memory in its biggest stage, after this patch, it use 384MiB instead.

And this patch only fix shuffle reader memory usage which is the most huge part, there still some memory consumers need release early to decrease peek usage, will fix these in followup patches.

(Fixes: #2762)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

