### PR TITLE
[GLUTEN-2785][CH] Optimize the setting of lib path

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHContextApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHContextApi.scala
@@ -34,19 +34,25 @@ import org.apache.spark.sql.execution.datasources.v1.CHRowSplitter
 
 import org.apache.commons.lang3.StringUtils
 
+import java.nio.file.Paths
 import java.util
 import java.util.TimeZone
 
 class CHContextApi extends ContextApi with Logging {
 
-  override def initialize(conf: SparkConf): Unit = {
+  override def initialize(conf: SparkConf, isDriver: Boolean): Unit = {
     val libPath = conf.get(GlutenConfig.GLUTEN_LIB_PATH, StringUtils.EMPTY)
     if (StringUtils.isBlank(libPath)) {
       throw new IllegalArgumentException(
         "Please set spark.gluten.sql.columnar.libpath to enable clickhouse backend")
     }
+    val realLibPath = if (isDriver || conf.get("spark.master").contains("local")) {
+      libPath
+    } else {
+      Paths.get(libPath).getFileName.toString
+    }
     // Path based load. Ignore all other loadees.
-    JniLibLoader.loadFromPath(libPath, true)
+    JniLibLoader.loadFromPath(realLibPath, true)
 
     // Add configs
     conf.set(

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ContextInitializer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ContextInitializer.scala
@@ -101,7 +101,7 @@ class ContextInitializer extends ContextApi {
     Seq(() => new JniTaskContext())
   }
 
-  override def initialize(conf: SparkConf): Unit = {
+  override def initialize(conf: SparkConf, isDriver: Boolean): Unit = {
     val workspace = JniWorkspace.getDefault
     val loader = workspace.libLoader
 

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -69,7 +69,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
     setPredefinedConfigs(sc, conf)
     // Initialize Backends API
     BackendsApiManager.initialize()
-    BackendsApiManager.getContextApiInstance.initialize(conf)
+    BackendsApiManager.getContextApiInstance.initialize(conf, true)
     GlutenDriverEndpoint.glutenDriverEndpointRef = (new GlutenDriverEndpoint).self
     GlutenListenerFactory.addToSparkListenerBus(sc)
     ExpressionMappings.expressionExtensionTransformer =
@@ -193,7 +193,7 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
     // Initialize Backends API
     // TODO categorize the APIs by driver's or executor's
     BackendsApiManager.initialize()
-    BackendsApiManager.getContextApiInstance.initialize(conf)
+    BackendsApiManager.getContextApiInstance.initialize(conf, false)
 
     executorEndpoint = new GlutenExecutorEndpoint(ctx.executorID(), conf)
   }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ContextApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ContextApi.scala
@@ -22,7 +22,7 @@ import org.apache.spark.util.TaskResource
 import java.util
 
 trait ContextApi {
-  def initialize(conf: SparkConf): Unit = {}
+  def initialize(conf: SparkConf, isDriver: Boolean): Unit = {}
 
   def shutdown(): Unit = {}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we configure the library(libch.so) path using `spark.gluten.sql.columnar.libpath`.

When running in yarn mode, the library will be uploaded to the YARN container's working directory using `--files`, which leads to a situation where we must set the libpath as `./libch.so` in order to load the lib on the executor side. This also means that we need to set it in the same way on the driver side, which restricts the storage path of the library.

The patch fixes the loading path of the library on the executor side in yarn mode to be the filename of the library.

(Fixes: \#2785)

## How was this patch tested?

manual tests
