### PR TITLE
[VL] Fix the issue of SubstraitToVeloxPlanConverter::createNotEqualFilter

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -105,7 +105,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
    * @param condition
    *   : the filter condition
    * @param child
-   *   : the chid of FilterExec
+   *   : the child of FilterExec
    * @return
    *   the transformer of FilterExec
    */

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
@@ -135,7 +135,7 @@ class SparkPlanExecHandler extends SparkPlanExecApi {
    * @param condition
    *   : the filter condition
    * @param child
-   *   : the chid of FilterExec
+   *   : the child of FilterExec
    * @return
    *   the transformer of FilterExec
    */

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -619,9 +619,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
 core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::SortRel& sortRel) {
   auto childNode = convertSingleInput<::substrait::SortRel>(sortRel);
-
   auto [sortingKeys, sortingOrders] = processSortField(sortRel.sorts(), childNode->outputType());
-
   return std::make_shared<core::OrderByNode>(
       nextPlanNodeId(), sortingKeys, sortingOrders, false /*isPartial*/, childNode);
 }
@@ -821,11 +819,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
     // Separate the filters to be two parts. The subfield part can be
     // pushed down.
-    std::vector<::substrait::Expression_ScalarFunction> subfieldFunctions;
-    std::vector<::substrait::Expression_SingularOrList> subfieldrOrLists;
-
-    std::vector<::substrait::Expression_ScalarFunction> remainingFunctions;
-    std::vector<::substrait::Expression_SingularOrList> remainingrOrLists;
+    std::vector<::substrait::Expression_ScalarFunction> subfieldFunctions, remainingFunctions;
+    std::vector<::substrait::Expression_SingularOrList> subfieldrOrLists, remainingrOrLists;
 
     separateFilters(
         rangeRecorders,
@@ -1017,7 +1012,7 @@ void SubstraitToVeloxPlanConverter::flattenConditions(
   auto typeCase = substraitFilter.rex_type_case();
   switch (typeCase) {
     case ::substrait::Expression::RexTypeCase::kScalarFunction: {
-      auto sFunc = substraitFilter.scalar_function();
+      const auto& sFunc = substraitFilter.scalar_function();
       auto filterNameSpec = SubstraitParser::findFunctionSpec(functionMap_, sFunc.function_reference());
       // TODO: Only and relation is supported here.
       if (SubstraitParser::getSubFunctionName(filterNameSpec) == "and") {
@@ -1118,7 +1113,7 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::createSubfieldFi
     columnToFilterInfo[idx];
   }
 
-  // Construct the FilterInfo for the related column.
+  // process scalarFunctions
   for (const auto& scalarFunction : scalarFunctions) {
     auto filterNameSpec = SubstraitParser::findFunctionSpec(functionMap_, scalarFunction.function_reference());
     auto filterName = SubstraitParser::getSubFunctionName(filterNameSpec);
@@ -1127,16 +1122,13 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::createSubfieldFi
       VELOX_CHECK(scalarFunction.arguments().size() == 1);
       auto expr = scalarFunction.arguments()[0].value();
       if (expr.has_scalar_function()) {
-        // Set its chid to filter info with reverse enabled.
-        setFilterMap(scalarFunction.arguments()[0].value().scalar_function(), inputTypeList, columnToFilterInfo, true);
+        // Set its child to filter info with reverse enabled.
+        setFilterInfo(scalarFunction.arguments()[0].value().scalar_function(), inputTypeList, columnToFilterInfo, true);
       } else {
         // TODO: support push down of Not In.
         VELOX_NYI("Scalar function expected.");
       }
-      continue;
-    }
-
-    if (filterName == sOr) {
+    } else if (filterName == sOr) {
       VELOX_CHECK(scalarFunction.arguments().size() == 2);
       VELOX_CHECK(std::all_of(
           scalarFunction.arguments().cbegin(),
@@ -1144,26 +1136,27 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::createSubfieldFi
           [](const ::substrait::FunctionArgument& arg) {
             return arg.value().has_scalar_function() || arg.value().has_singular_or_list();
           }));
-      // Set the chidren functions to filter info. They should be
+
+      // Set the children functions to filter info. They should be
       // effective to the same field.
       for (const auto& arg : scalarFunction.arguments()) {
-        auto expr = arg.value();
+        const auto& expr = arg.value();
         if (expr.has_scalar_function()) {
-          setFilterMap(arg.value().scalar_function(), inputTypeList, columnToFilterInfo);
+          setFilterInfo(arg.value().scalar_function(), inputTypeList, columnToFilterInfo);
         } else if (expr.has_singular_or_list()) {
-          setSingularListValues(expr.singular_or_list(), columnToFilterInfo);
+          setFilterInfo(expr.singular_or_list(), columnToFilterInfo);
         } else {
           VELOX_NYI("Scalar function or SingularOrList expected.");
         }
       }
-      continue;
+    } else {
+      setFilterInfo(scalarFunction, inputTypeList, columnToFilterInfo);
     }
-
-    setFilterMap(scalarFunction, inputTypeList, columnToFilterInfo);
   }
 
+  // process singularOrLists
   for (const auto& list : singularOrLists) {
-    setSingularListValues(list, columnToFilterInfo);
+    setFilterInfo(list, columnToFilterInfo);
   }
 
   return mapToFilters(inputNameList, inputTypeList, columnToFilterInfo);
@@ -1208,21 +1201,21 @@ bool SubstraitToVeloxPlanConverter::fieldOrWithLiteral(
 
 bool SubstraitToVeloxPlanConverter::childrenFunctionsOnSameField(
     const ::substrait::Expression_ScalarFunction& function) {
-  // Get the column indices of the chidren functions.
+  // Get the column indices of the children functions.
   std::vector<int32_t> colIndices;
   for (const auto& arg : function.arguments()) {
     if (arg.value().has_scalar_function()) {
-      auto scalarFunction = arg.value().scalar_function();
+      const auto& scalarFunction = arg.value().scalar_function();
       for (const auto& param : scalarFunction.arguments()) {
         if (param.value().has_selection()) {
-          auto field = param.value().selection();
+          const auto& field = param.value().selection();
           VELOX_CHECK(field.has_direct_reference());
           int32_t colIdx = SubstraitParser::parseReferenceSegment(field.direct_reference());
           colIndices.emplace_back(colIdx);
         }
       }
     } else if (arg.value().has_singular_or_list()) {
-      auto singularOrList = arg.value().singular_or_list();
+      const auto& singularOrList = arg.value().singular_or_list();
       int32_t colIdx = getColumnIndexFromSingularOrList(singularOrList);
       colIndices.emplace_back(colIdx);
     } else {
@@ -1257,7 +1250,7 @@ bool SubstraitToVeloxPlanConverter::canPushdownNot(
     const ::substrait::Expression_ScalarFunction& scalarFunction,
     std::unordered_map<uint32_t, RangeRecorder>& rangeRecorders) {
   VELOX_CHECK(scalarFunction.arguments().size() == 1, "Only one arg is expected for Not.");
-  auto notArg = scalarFunction.arguments()[0];
+  const auto& notArg = scalarFunction.arguments()[0];
   if (!notArg.value().has_scalar_function()) {
     // Not for a Boolean Literal or Or List is not supported curretly.
     // It can be pushed down with an AlwaysTrue or AlwaysFalse Range.
@@ -1283,7 +1276,7 @@ bool SubstraitToVeloxPlanConverter::canPushdownNot(
 bool SubstraitToVeloxPlanConverter::canPushdownOr(
     const ::substrait::Expression_ScalarFunction& scalarFunction,
     std::unordered_map<uint32_t, RangeRecorder>& rangeRecorders) {
-  // OR Conditon whose chidren functions are on different columns is not
+  // OR Conditon whose children functions are on different columns is not
   // supported to be pushed down.
   if (!childrenFunctionsOnSameField(scalarFunction)) {
     return false;
@@ -1306,7 +1299,7 @@ bool SubstraitToVeloxPlanConverter::canPushdownOr(
         return false;
       }
     } else if (arg.value().has_singular_or_list()) {
-      auto singularOrList = arg.value().singular_or_list();
+      const auto& singularOrList = arg.value().singular_or_list();
       if (!canPushdownSingularOrList(singularOrList, true)) {
         return false;
       }
@@ -1348,7 +1341,22 @@ void SubstraitToVeloxPlanConverter::separateFilters(
   for (const auto& scalarFunction : scalarFunctions) {
     auto filterNameSpec = SubstraitParser::findFunctionSpec(functionMap_, scalarFunction.function_reference());
     auto filterName = SubstraitParser::getSubFunctionName(filterNameSpec);
-    if (filterName != sNot && filterName != sOr) {
+
+    // Check whether NOT and OR functions can be pushed down.
+    // If yes, the scalar function will be added into the subfield functions.
+    if (filterName == sNot) {
+      if (canPushdownNot(scalarFunction, rangeRecorders)) {
+        subfieldFunctions.emplace_back(scalarFunction);
+      } else {
+        remainingFunctions.emplace_back(scalarFunction);
+      }
+    } else if (filterName == sOr) {
+      if (canPushdownOr(scalarFunction, rangeRecorders)) {
+        subfieldFunctions.emplace_back(scalarFunction);
+      } else {
+        remainingFunctions.emplace_back(scalarFunction);
+      }
+    } else {
       // Check if the condition is supported to be pushed down.
       uint32_t fieldIdx;
       if (canPushdownCommonFunction(scalarFunction, filterName, fieldIdx) &&
@@ -1357,22 +1365,6 @@ void SubstraitToVeloxPlanConverter::separateFilters(
       } else {
         remainingFunctions.emplace_back(scalarFunction);
       }
-      continue;
-    }
-
-    // Check whether NOT and OR functions can be pushed down.
-    // If yes, the scalar function will be added into the subfield functions.
-    bool supported = false;
-    if (filterName == sNot) {
-      supported = canPushdownNot(scalarFunction, rangeRecorders);
-    } else if (filterName == sOr) {
-      supported = canPushdownOr(scalarFunction, rangeRecorders);
-    }
-
-    if (supported) {
-      subfieldFunctions.emplace_back(scalarFunction);
-    } else {
-      remainingFunctions.emplace_back(scalarFunction);
     }
   }
 }
@@ -1422,52 +1414,51 @@ bool SubstraitToVeloxPlanConverter::RangeRecorder::setCertainRangeForFunction(
 
 void SubstraitToVeloxPlanConverter::setColumnFilterInfo(
     const std::string& filterName,
-    uint32_t colIdx,
     std::optional<variant> literalVariant,
-    bool reverse,
-    std::unordered_map<uint32_t, FilterInfo>& columnToFilterInfo) {
+    FilterInfo& columnFilterInfo,
+    bool reverse) {
   if (filterName == sIsNotNull) {
     if (reverse) {
       VELOX_NYI("Reverse not supported for filter name '{}'", filterName);
     }
-    columnToFilterInfo[colIdx].forbidsNull();
+    columnFilterInfo.forbidsNull();
   } else if (filterName == sGte) {
     if (reverse) {
-      columnToFilterInfo[colIdx].setUpper(literalVariant, true);
+      columnFilterInfo.setUpper(literalVariant, true);
     } else {
-      columnToFilterInfo[colIdx].setLower(literalVariant, false);
+      columnFilterInfo.setLower(literalVariant, false);
     }
   } else if (filterName == sGt) {
     if (reverse) {
-      columnToFilterInfo[colIdx].setUpper(literalVariant, false);
+      columnFilterInfo.setUpper(literalVariant, false);
     } else {
-      columnToFilterInfo[colIdx].setLower(literalVariant, true);
+      columnFilterInfo.setLower(literalVariant, true);
     }
   } else if (filterName == sLte) {
     if (reverse) {
-      columnToFilterInfo[colIdx].setLower(literalVariant, true);
+      columnFilterInfo.setLower(literalVariant, true);
     } else {
-      columnToFilterInfo[colIdx].setUpper(literalVariant, false);
+      columnFilterInfo.setUpper(literalVariant, false);
     }
   } else if (filterName == sLt) {
     if (reverse) {
-      columnToFilterInfo[colIdx].setLower(literalVariant, false);
+      columnFilterInfo.setLower(literalVariant, false);
     } else {
-      columnToFilterInfo[colIdx].setUpper(literalVariant, true);
+      columnFilterInfo.setUpper(literalVariant, true);
     }
   } else if (filterName == sEqual) {
     if (reverse) {
-      columnToFilterInfo[colIdx].setNotValue(literalVariant);
+      columnFilterInfo.setNotValue(literalVariant);
     } else {
-      columnToFilterInfo[colIdx].setLower(literalVariant, false);
-      columnToFilterInfo[colIdx].setUpper(literalVariant, false);
+      columnFilterInfo.setLower(literalVariant, false);
+      columnFilterInfo.setUpper(literalVariant, false);
     }
   } else {
     VELOX_NYI("setColumnFilterInfo not supported for filter name '{}'", filterName);
   }
 }
 
-void SubstraitToVeloxPlanConverter::setFilterMap(
+void SubstraitToVeloxPlanConverter::setFilterInfo(
     const ::substrait::Expression_ScalarFunction& scalarFunction,
     const std::vector<TypePtr>& inputTypeList,
     std::unordered_map<uint32_t, FilterInfo>& columnToFilterInfo,
@@ -1514,14 +1505,14 @@ void SubstraitToVeloxPlanConverter::setFilterMap(
 
   // Set the extracted bound to the specific column.
   uint32_t colIdxVal = colIdx.value();
-  auto inputType = inputTypeList[colIdxVal];
   std::optional<variant> val;
+
+  auto inputType = inputTypeList[colIdxVal];
   switch (inputType->kind()) {
     case TypeKind::INTEGER:
       if (substraitLit) {
         val = variant(substraitLit.value().i32());
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
       break;
     case TypeKind::BIGINT:
       if (substraitLit) {
@@ -1534,31 +1525,31 @@ void SubstraitToVeloxPlanConverter::setFilterMap(
           val = variant(substraitLit.value().i64());
         }
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
+      break;
+    case TypeKind::REAL:
+      if (substraitLit) {
+        val = variant(substraitLit.value().fp32());
+      }
       break;
     case TypeKind::DOUBLE:
       if (substraitLit) {
         val = variant(substraitLit.value().fp64());
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
       break;
     case TypeKind::BOOLEAN:
       if (substraitLit) {
         val = variant(substraitLit.value().boolean());
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
       break;
     case TypeKind::VARCHAR:
       if (substraitLit) {
         val = variant(substraitLit.value().string());
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
       break;
     case TypeKind::DATE:
       if (substraitLit) {
         val = variant(Date(substraitLit.value().date()));
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
       break;
     case TypeKind::HUGEINT:
       if (substraitLit) {
@@ -1571,11 +1562,12 @@ void SubstraitToVeloxPlanConverter::setFilterMap(
           VELOX_NYI("TypeKind::HUGEINT only support inputType LongDecimal");
         }
       }
-      setColumnFilterInfo(functionName, colIdxVal, val, reverse, columnToFilterInfo);
       break;
     default:
       VELOX_NYI("Subfield filters creation not supported for input type '{}'", inputType);
   }
+
+  setColumnFilterInfo(functionName, val, columnToFilterInfo[colIdxVal], reverse);
 }
 
 template <TypeKind KIND, typename FilterType>
@@ -1594,7 +1586,6 @@ void SubstraitToVeloxPlanConverter::createNotEqualFilter(
       true, /*upperUnbounded*/
       false, /*upperExclusive*/
       nullAllowed); /*nullAllowed*/
-  colFilters.emplace_back(std::move(lowerFilter));
 
   // Value < upper
   std::unique_ptr<FilterType> upperFilter = std::make_unique<RangeType>(
@@ -1605,7 +1596,10 @@ void SubstraitToVeloxPlanConverter::createNotEqualFilter(
       false, /*upperUnbounded*/
       true, /*upperExclusive*/
       nullAllowed); /*nullAllowed*/
+
+  // keep this emplace_back order
   colFilters.emplace_back(std::move(upperFilter));
+  colFilters.emplace_back(std::move(lowerFilter));
 }
 
 template <TypeKind KIND>
@@ -1731,6 +1725,7 @@ void SubstraitToVeloxPlanConverter::setSubfieldFilter(
             dynamic_cast<common::BigintRange*>(b.get())->lower();
       });
     }
+
     filters[common::Subfield(inputName, true)] = std::make_unique<MultiRangeType>(std::move(colFilters), nullAllowed);
   }
 }
@@ -1769,10 +1764,10 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
     using MultiRangeType = typename RangeTraits<KIND>::MultiRangeType;
 
     // Handle 'in' filter.
-    if (filterInfo.valuesVector_.size() > 0) {
+    if (filterInfo.values_.size() > 0) {
       // To filter out null is a default behaviour of Spark IN expression.
       nullAllowed = false;
-      setInFilter<KIND>(filterInfo.valuesVector_, nullAllowed, inputName, filters);
+      setInFilter<KIND>(filterInfo.values_, nullAllowed, inputName, filters);
       // Currently, In cannot coexist with other filter conditions
       // due to multirange is in 'OR' relation but 'AND' is needed.
       VELOX_CHECK(rangeSize == 0, "LowerBounds or upperBounds conditons cannot be supported after IN filter.");
@@ -1801,7 +1796,6 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
       return;
     }
 
-    // Handle other filter ranges.
     NativeType lowerBound;
     if constexpr (KIND == facebook::velox::TypeKind::BIGINT) {
       if (inputType->isShortDecimal()) {
@@ -1824,11 +1818,10 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
       upperBound = getMax<NativeType>();
     }
 
-    bool lowerUnbounded = true;
-    bool upperUnbounded = true;
-    bool lowerExclusive = false;
-    bool upperExclusive = false;
+    bool lowerUnbounded = true, upperUnbounded = true;
+    bool lowerExclusive = false, upperExclusive = false;
 
+    // Handle other filter ranges.
     for (uint32_t idx = 0; idx < rangeSize; idx++) {
       if (idx < filterInfo.lowerBounds_.size() && filterInfo.lowerBounds_[idx]) {
         lowerUnbounded = false;
@@ -1922,6 +1915,7 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::mapToFilters(
         VELOX_NYI("Subfield filters creation not supported for input type '{}'", inputType);
     }
   }
+
   return filters;
 }
 
@@ -1983,7 +1977,7 @@ bool SubstraitToVeloxPlanConverter::canPushdownSingularOrList(
   VELOX_CHECK(singularOrList.options_size() > 0, "At least one option is expected.");
   // Check whether the value is field.
   bool hasField = singularOrList.value().has_selection();
-  auto options = singularOrList.options();
+  const auto& options = singularOrList.options();
   for (const auto& option : options) {
     VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
     auto type = option.literal().literal_type_case();
@@ -2019,7 +2013,7 @@ uint32_t SubstraitToVeloxPlanConverter::getColumnIndexFromSingularOrList(
   return SubstraitParser::parseReferenceSegment(selection.direct_reference());
 }
 
-void SubstraitToVeloxPlanConverter::setSingularListValues(
+void SubstraitToVeloxPlanConverter::setFilterInfo(
     const ::substrait::Expression_SingularOrList& singularOrList,
     std::unordered_map<uint32_t, FilterInfo>& columnToFilterInfo) {
   VELOX_CHECK(singularOrList.options_size() > 0, "At least one option is expected.");
@@ -2027,7 +2021,7 @@ void SubstraitToVeloxPlanConverter::setSingularListValues(
   uint32_t colIdx = getColumnIndexFromSingularOrList(singularOrList);
 
   // Get the value list.
-  auto options = singularOrList.options();
+  const auto& options = singularOrList.options();
   std::vector<variant> variants;
   variants.reserve(options.size());
   for (const auto& option : options) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1821,8 +1821,10 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
       upperBound = getMax<NativeType>();
     }
 
-    bool lowerUnbounded = true, upperUnbounded = true;
-    bool lowerExclusive = false, upperExclusive = false;
+    bool lowerUnbounded = true;
+    bool upperUnbounded = true;
+    bool lowerExclusive = false;
+    bool upperExclusive = false;
 
     // Handle other filter ranges.
     for (uint32_t idx = 0; idx < rangeSize; idx++) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -140,7 +140,7 @@ bool SubstraitToVeloxPlanValidator::validateExtractExpr(const std::vector<core::
   auto functionArg = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(params[0]);
   if (functionArg) {
     // Get the function argument.
-    auto variant = functionArg->value();
+    const auto& variant = functionArg->value();
     if (!variant.hasValue()) {
       logValidateMsg("native validation failed due to: Value expected in variant in ExtractExpr.");
       return false;
@@ -489,7 +489,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   }
 
   // Validate supported aggregate functions.
-  std::unordered_set<std::string> unsupportedFuncs = {"collect_list", "collect_set"};
+  static const std::unordered_set<std::string> unsupportedFuncs = {"collect_list", "collect_set"};
   for (const auto& funcSpec : funcSpecs) {
     auto funcName = SubstraitParser::getSubFunctionName(funcSpec);
     if (unsupportedFuncs.find(funcName) != unsupportedFuncs.end()) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -68,12 +68,6 @@ class SubstraitToVeloxPlanValidator {
     return validateLog_;
   }
 
-  void dumpValidateLog() const {
-    for (auto& log : validateLog_) {
-      std::cout << log << std::endl;
-    }
-  }
-
  private:
   /// A memory pool used for function validation.
   memory::MemoryPool* pool_;

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -75,7 +75,7 @@ trait SparkPlanExecApi {
    * @param condition
    *   : the filter condition
    * @param child
-   *   : the chid of FilterExec
+   *   : the child of FilterExec
    * @return
    *   the transformer of FilterExec
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

we will create two range filters for `createNotEqualFilter`, the `lowerFilter` and the `upperFilter`, the`NotEqual` will be transferred to `[minLower, value) || (value, maxUpper]`.

the `lowerFilter` represents the range `(value, maxUpper]`, and the `upperFilter` represents the range `[minLower, value)`.

then add `lowerFilter` first and add `upperFilter` second, which makes the multi-range filters violate the check rules in `BigintMultiRange::BigintMultiRange()`.

we can swap the adding to fix it.

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

