### PR TITLE
[VL] Minor refactor for ColumnarBatchSerializer

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -245,11 +245,11 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
   }
 
   /**
-   * Generate ColumnarBatchSerializer for ColumnarShuffleExchangeExec.
+   * Generate ColumnarShuffleSerializer for ColumnarShuffleExchangeExec.
    *
    * @return
    */
-  override def createColumnarBatchSerializer(
+  override def createColumnarShuffleSerializer(
       schema: StructType,
       metrics: Map[String, SQLMetric]): Serializer = {
     new CHColumnarBatchSerializer(

--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -23,7 +23,7 @@
 #include "memory/ColumnarBatch.h"
 #include "operators/c2r/ColumnarToRow.h"
 #include "operators/r2c/RowToColumnar.h"
-#include "operators/serializer/ColumnarBatchSerializer.h"
+#include "operators/serializer/ColumnarBatchSerde.h"
 #include "operators/writer/Datasource.h"
 #include "shuffle/ShuffleWriter.h"
 #include "shuffle/reader.h"
@@ -111,10 +111,8 @@ class Backend : public std::enable_shared_from_this<Backend> {
     return std::make_shared<Reader>(in, schema, options, pool);
   }
 
-  virtual std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(
-      MemoryAllocator* allocator,
-      struct ArrowSchema* cSchema) {
-    throw GlutenException("Not implement getColumnarBatchSerializer");
+  virtual std::shared_ptr<ColumnarBatchSerde> getColumnarBatchSerde(MemoryAllocator* allocator) {
+    throw GlutenException("Not implement getColumnarBatchSerde");
   }
 
   std::unordered_map<std::string, std::string> getConfMap() {

--- a/cpp/core/operators/serializer/ColumnarBatchSerde.h
+++ b/cpp/core/operators/serializer/ColumnarBatchSerde.h
@@ -17,25 +17,23 @@
 
 #pragma once
 
+#include <arrow/c/abi.h>
+
+#include "ColumnarBatchSerializer.h"
 #include "memory/ColumnarBatch.h"
-#include "operators/serializer/ColumnarBatchSerde.h"
-#include "velox/serializers/PrestoSerializer.h"
+#include "memory/MemoryAllocator.h"
 
 namespace gluten {
 
-class VeloxColumnarBatchSerializer final : public ColumnarBatchSerializer {
+class ColumnarBatchSerde {
  public:
-  VeloxColumnarBatchSerializer(
-      std::shared_ptr<facebook::velox::memory::MemoryPool>,
-      std::shared_ptr<arrow::MemoryPool>);
+  ColumnarBatchSerde() = default;
 
-  std::shared_ptr<arrow::Buffer> serializeColumnarBatches(
-      const std::vector<std::shared_ptr<ColumnarBatch>>& batches) override;
+  virtual std::shared_ptr<ColumnarBatchSerializer> createSerializer() = 0;
 
- private:
-  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
-  std::unique_ptr<facebook::velox::serializer::presto::PrestoVectorSerde> serde_;
-  std::shared_ptr<arrow::MemoryPool> arrowPool_;
+  virtual void initDeserializer(struct ArrowSchema* cSchema) = 0;
+
+  virtual std::shared_ptr<ColumnarBatch> deserialize(uint8_t* data, int32_t size) = 0;
 };
 
 } // namespace gluten

--- a/cpp/core/operators/serializer/ColumnarBatchSerializer.h
+++ b/cpp/core/operators/serializer/ColumnarBatchSerializer.h
@@ -17,26 +17,16 @@
 
 #pragma once
 
-#include <arrow/c/abi.h>
-
 #include "memory/ColumnarBatch.h"
 
 namespace gluten {
 
 class ColumnarBatchSerializer {
  public:
-  ColumnarBatchSerializer(std::shared_ptr<arrow::MemoryPool> arrowPool, struct ArrowSchema* cSchema)
-      : arrowPool_(std::move(arrowPool)) {}
-
-  virtual ~ColumnarBatchSerializer() = default;
+  ColumnarBatchSerializer() = default;
 
   virtual std::shared_ptr<arrow::Buffer> serializeColumnarBatches(
       const std::vector<std::shared_ptr<ColumnarBatch>>& batches) = 0;
-
-  virtual std::shared_ptr<ColumnarBatch> deserialize(uint8_t* data, int32_t size) = 0;
-
- protected:
-  std::shared_ptr<arrow::MemoryPool> arrowPool_;
 };
 
 } // namespace gluten

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -235,6 +235,7 @@ set(VELOX_SRCS
     compute/VeloxPlanConverter.cc
     operators/functions/RegistrationAllFunctions.cc
     operators/serializer/VeloxColumnarToRowConverter.cc
+    operators/serializer/VeloxColumnarBatchSerde.cc
     operators/serializer/VeloxColumnarBatchSerializer.cc
     operators/serializer/VeloxRowToColumnarConverter.cc
     operators/writer/VeloxParquetDatasource.cc

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -132,13 +132,11 @@ std::shared_ptr<ShuffleWriter> VeloxBackend::makeShuffleWriter(
   return shuffle_writer;
 }
 
-std::shared_ptr<ColumnarBatchSerializer> VeloxBackend::getColumnarBatchSerializer(
-    MemoryAllocator* allocator,
-    struct ArrowSchema* cSchema) {
+std::shared_ptr<ColumnarBatchSerde> VeloxBackend::getColumnarBatchSerde(MemoryAllocator* allocator) {
   auto arrowPool = asArrowMemoryPool(allocator);
   auto veloxPool = asAggregateVeloxMemoryPool(allocator);
-  auto ctxVeloxPool = veloxPool->addLeafChild("velox_columnar_batch_serializer");
-  return std::make_shared<VeloxColumnarBatchSerializer>(arrowPool, ctxVeloxPool, cSchema);
+  auto ctxVeloxPool = veloxPool->addLeafChild("velox_columnar_batch_serde");
+  return std::make_shared<VeloxColumnarBatchSerde>(ctxVeloxPool, arrowPool);
 }
 
 } // namespace gluten

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -25,7 +25,7 @@
 
 #include "WholeStageResultIterator.h"
 #include "compute/Backend.h"
-#include "operators/serializer/VeloxColumnarBatchSerializer.h"
+#include "operators/serializer/VeloxColumnarBatchSerde.h"
 #include "operators/serializer/VeloxColumnarToRowConverter.h"
 #include "operators/writer/VeloxParquetDatasource.h"
 #include "shuffle/ShuffleWriter.h"
@@ -78,9 +78,7 @@ class VeloxBackend final : public Backend {
     return std::make_shared<VeloxShuffleReader>(in, schema, options, pool, ctxVeloxPool);
   }
 
-  std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(
-      MemoryAllocator* allocator,
-      struct ArrowSchema* cSchema) override;
+  std::shared_ptr<ColumnarBatchSerde> getColumnarBatchSerde(MemoryAllocator* allocator) override;
 
   std::shared_ptr<const facebook::velox::core::PlanNode> getVeloxPlan() {
     return veloxPlan_;

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerde.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerde.cc
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VeloxColumnarBatchSerde.h"
+
+#include "VeloxColumnarBatchSerializer.h"
+#include "memory/ArrowMemoryPool.h"
+#include "memory/VeloxColumnarBatch.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/arrow/Bridge.h"
+
+using namespace facebook::velox;
+
+namespace gluten {
+
+namespace {
+std::unique_ptr<ByteStream> toByteStream(uint8_t* data, int32_t size) {
+  auto byteStream = std::make_unique<ByteStream>();
+  ByteRange byteRange{data, size, 0};
+  byteStream->resetInput({byteRange});
+  return byteStream;
+}
+} // namespace
+
+VeloxColumnarBatchSerde::VeloxColumnarBatchSerde(
+    std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool,
+    std::shared_ptr<arrow::MemoryPool> arrowPool)
+    : ColumnarBatchSerde(), arrowPool_(std::move(arrowPool)), veloxPool_(std::move(veloxPool)) {}
+
+std::shared_ptr<ColumnarBatchSerializer> VeloxColumnarBatchSerde::createSerializer() {
+  return std::make_shared<VeloxColumnarBatchSerializer>(veloxPool_, arrowPool_);
+}
+
+void VeloxColumnarBatchSerde::initDeserializer(struct ArrowSchema* cSchema) {
+  rowType_ = asRowType(importFromArrow(*cSchema));
+  ArrowSchemaRelease(cSchema); // otherwise the c schema leaks memory
+  serde_ = std::make_unique<serializer::presto::PrestoVectorSerde>();
+}
+
+std::shared_ptr<ColumnarBatch> VeloxColumnarBatchSerde::deserialize(uint8_t* data, int32_t size) {
+  RowVectorPtr result;
+  auto byteStream = toByteStream(data, size);
+  serde_->deserialize(byteStream.get(), veloxPool_.get(), rowType_, &result, /* serdeOptions */ nullptr);
+  return std::make_shared<VeloxColumnarBatch>(result);
+}
+} // namespace gluten

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerde.h
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerde.h
@@ -17,25 +17,29 @@
 
 #pragma once
 
+#include <arrow/c/abi.h>
+
 #include "memory/ColumnarBatch.h"
 #include "operators/serializer/ColumnarBatchSerde.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 namespace gluten {
 
-class VeloxColumnarBatchSerializer final : public ColumnarBatchSerializer {
+class VeloxColumnarBatchSerde final : public ColumnarBatchSerde {
  public:
-  VeloxColumnarBatchSerializer(
-      std::shared_ptr<facebook::velox::memory::MemoryPool>,
-      std::shared_ptr<arrow::MemoryPool>);
+  VeloxColumnarBatchSerde(std::shared_ptr<facebook::velox::memory::MemoryPool>, std::shared_ptr<arrow::MemoryPool>);
 
-  std::shared_ptr<arrow::Buffer> serializeColumnarBatches(
-      const std::vector<std::shared_ptr<ColumnarBatch>>& batches) override;
+  std::shared_ptr<ColumnarBatchSerializer> createSerializer() override;
+
+  void initDeserializer(struct ArrowSchema* cSchema) override;
+
+  std::shared_ptr<ColumnarBatch> deserialize(uint8_t* data, int32_t size) override;
 
  private:
-  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
-  std::unique_ptr<facebook::velox::serializer::presto::PrestoVectorSerde> serde_;
   std::shared_ptr<arrow::MemoryPool> arrowPool_;
+  std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
+  facebook::velox::RowTypePtr rowType_;
+  std::unique_ptr<facebook::velox::serializer::presto::PrestoVectorSerde> serde_;
 };
 
 } // namespace gluten

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -100,7 +100,7 @@ case class ColumnarShuffleExchangeExec(
 
   // super.stringArgs ++ Iterator(output.map(o => s"${o}#${o.dataType.simpleString}"))
   val serializer: Serializer = BackendsApiManager.getSparkPlanExecApiInstance
-    .createColumnarBatchSerializer(schema, metrics)
+    .createColumnarShuffleSerializer(schema, metrics)
 
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerdeJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerdeJniWrapper.java
@@ -18,17 +18,16 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.init.JniInitialized;
 
-public class ColumnarBatchSerializerJniWrapper extends JniInitialized {
+public class ColumnarBatchSerdeJniWrapper extends JniInitialized {
 
-  public static final ColumnarBatchSerializerJniWrapper INSTANCE =
-      new ColumnarBatchSerializerJniWrapper();
+  public static final ColumnarBatchSerdeJniWrapper INSTANCE = new ColumnarBatchSerdeJniWrapper();
 
-  private ColumnarBatchSerializerJniWrapper() {}
+  private ColumnarBatchSerdeJniWrapper() {}
 
   public native ColumnarBatchSerializeResult serialize(long[] handles, long allocId);
 
   // Return the native ColumnarBatchSerializer handle
-  public native long init(long cSchema, long allocId);
+  public native long initDeserializer(long cSchema, long allocId);
 
   public native long deserialize(long handle, byte[] data);
 

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarShuffleSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarShuffleSerializer.scala
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer
 
 import scala.reflect.ClassTag
 
-class ColumnarBatchSerializer(
+class ColumnarShuffleSerializer(
     schema: StructType,
     readBatchNumRows: SQLMetric,
     numOutputRows: SQLMetric,
@@ -56,13 +56,13 @@ class ColumnarBatchSerializer(
 
   /** Creates a new [[SerializerInstance]]. */
   override def newInstance(): SerializerInstance = {
-    new ColumnarBatchSerializerInstance(schema, readBatchNumRows, numOutputRows, decompressTime)
+    new ColumnarShuffleSerializerInstance(schema, readBatchNumRows, numOutputRows, decompressTime)
   }
 
   override def supportsRelocationOfSerializedObjects: Boolean = supportsRelocation
 }
 
-private class ColumnarBatchSerializerInstance(
+private class ColumnarShuffleSerializerInstance(
     schema: StructType,
     readBatchNumRows: SQLMetric,
     numOutputRows: SQLMetric,


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Rename ColumnarBatchSerializer to ColumnarShuffleSerializer, avoid use confused name with ColumnarBatchSerializerJniWrapper.
2. Rename ColumnarBatchSerializer to ColumnarBatchSerde, refactor API to separate serializer and deserializer.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

