### PR TITLE
[GLUTEN-2803][VL] Use a single native shuffle reader instance per Spark reducer task

### DIFF
--- a/cpp/core/compute/Backend.h
+++ b/cpp/core/compute/Backend.h
@@ -103,12 +103,11 @@ class Backend : public std::enable_shared_from_this<Backend> {
   }
 
   virtual std::shared_ptr<Reader> getShuffleReader(
-      std::shared_ptr<arrow::io::InputStream> in,
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
       std::shared_ptr<arrow::MemoryPool> pool,
       MemoryAllocator* allocator) {
-    return std::make_shared<Reader>(in, schema, options, pool);
+    return std::make_shared<Reader>(schema, options, pool);
   }
 
   virtual std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(

--- a/cpp/core/compute/ResultIterator.h
+++ b/cpp/core/compute/ResultIterator.h
@@ -25,10 +25,20 @@ namespace gluten {
 
 class Backend;
 
+// FIXME the code is tightly coupled with Velox plan execution. Should cleanup the abstraction for uses from
+//  other places.
 class ResultIterator {
  public:
   explicit ResultIterator(std::unique_ptr<ColumnarBatchIterator> iter, std::shared_ptr<Backend> backend = nullptr)
       : iter_(std::move(iter)), next_(nullptr), backend_(std::move(backend)) {}
+
+  // copy constructor and copy assignment (deleted)
+  ResultIterator(const ResultIterator& in) = delete;
+  ResultIterator& operator=(const ResultIterator&) = delete;
+
+  // move constructor and move assignment
+  ResultIterator(ResultIterator&& in) = default;
+  ResultIterator& operator=(ResultIterator&& in) = default;
 
   bool hasNext() {
     checkValid();

--- a/cpp/core/shuffle/reader.cc
+++ b/cpp/core/shuffle/reader.cc
@@ -24,51 +24,72 @@
 
 #include "ShuffleSchema.h"
 
+namespace {
+using namespace gluten;
+
+class ShuffleReaderOutStream : public ColumnarBatchIterator {
+ public:
+  ShuffleReaderOutStream(
+      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<arrow::io::InputStream>& in,
+      const ReaderOptions& options)
+      : options_(options), in_(in) {
+    GLUTEN_ASSIGN_OR_THROW(firstMessage_, arrow::ipc::ReadMessage(in_.get()))
+    if (firstMessage_ == nullptr) {
+      throw GlutenException("Failed to read message from shuffle.");
+    }
+    if (firstMessage_->type() == arrow::ipc::MessageType::SCHEMA) {
+      GLUTEN_ASSIGN_OR_THROW(writeSchema_, arrow::ipc::ReadSchema(*firstMessage_, nullptr))
+      firstMessageConsumed_ = true;
+    } else {
+      if (options.compression_type != arrow::Compression::UNCOMPRESSED) {
+        writeSchema_ = toCompressWriteSchema(*schema);
+      } else {
+        writeSchema_ = toWriteSchema(*schema);
+      }
+    }
+  }
+
+  std::shared_ptr<ColumnarBatch> next() override {
+    std::shared_ptr<arrow::RecordBatch> arrowBatch;
+    std::unique_ptr<arrow::ipc::Message> messageToRead;
+    if (!firstMessageConsumed_) {
+      messageToRead = std::move(firstMessage_);
+      firstMessageConsumed_ = true;
+    } else {
+      GLUTEN_ASSIGN_OR_THROW(messageToRead, arrow::ipc::ReadMessage(in_.get()))
+    }
+    if (messageToRead == nullptr) {
+      return nullptr;
+    }
+
+    GLUTEN_ASSIGN_OR_THROW(
+        arrowBatch, arrow::ipc::ReadRecordBatch(*messageToRead, writeSchema_, nullptr, options_.ipc_read_options))
+    std::shared_ptr<ColumnarBatch> glutenBatch = std::make_shared<ArrowColumnarBatch>(arrowBatch);
+    return glutenBatch;
+  }
+
+ private:
+  ReaderOptions options_;
+  std::shared_ptr<arrow::io::InputStream> in_;
+  std::shared_ptr<arrow::Schema> writeSchema_;
+  // TODO it's not reliable to infer schema from the first message, should finally drop this code
+  std::unique_ptr<arrow::ipc::Message> firstMessage_;
+  bool firstMessageConsumed_ = false;
+};
+} // namespace
+
 namespace gluten {
 
 ReaderOptions ReaderOptions::defaults() {
   return {};
 }
 
-Reader::Reader(
-    std::shared_ptr<arrow::io::InputStream> in,
-    std::shared_ptr<arrow::Schema> schema,
-    ReaderOptions options,
-    std::shared_ptr<arrow::MemoryPool> pool)
-    : pool_(pool), options_(std::move(options)), in_(std::move(in)) {
-  GLUTEN_ASSIGN_OR_THROW(firstMessage_, arrow::ipc::ReadMessage(in_.get()))
-  if (firstMessage_ == nullptr) {
-    throw GlutenException("Failed to read message from shuffle.");
-  }
-  if (firstMessage_->type() == arrow::ipc::MessageType::SCHEMA) {
-    GLUTEN_ASSIGN_OR_THROW(writeSchema_, arrow::ipc::ReadSchema(*firstMessage_, nullptr))
-    firstMessageConsumed_ = true;
-  } else {
-    if (options.compression_type != arrow::Compression::UNCOMPRESSED) {
-      writeSchema_ = toCompressWriteSchema(*schema);
-    } else {
-      writeSchema_ = toWriteSchema(*schema);
-    }
-  }
-}
+Reader::Reader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, std::shared_ptr<arrow::MemoryPool> pool)
+    : pool_(pool), options_(std::move(options)), schema_(schema) {}
 
-arrow::Result<std::shared_ptr<ColumnarBatch>> Reader::next() {
-  std::shared_ptr<arrow::RecordBatch> arrowBatch;
-  std::unique_ptr<arrow::ipc::Message> messageToRead;
-  if (!firstMessageConsumed_) {
-    messageToRead = std::move(firstMessage_);
-    firstMessageConsumed_ = true;
-  } else {
-    GLUTEN_ASSIGN_OR_THROW(messageToRead, arrow::ipc::ReadMessage(in_.get()))
-  }
-  if (messageToRead == nullptr) {
-    return nullptr;
-  }
-
-  GLUTEN_ASSIGN_OR_THROW(
-      arrowBatch, arrow::ipc::ReadRecordBatch(*messageToRead, writeSchema_, nullptr, options_.ipc_read_options))
-  std::shared_ptr<ColumnarBatch> glutenBatch = std::make_shared<ArrowColumnarBatch>(arrowBatch);
-  return glutenBatch;
+std::shared_ptr<ResultIterator> Reader::readStream(std::shared_ptr<arrow::io::InputStream> in) {
+  return std::make_shared<ResultIterator>(std::make_unique<ShuffleReaderOutStream>(schema_, in, options_));
 }
 
 arrow::Status Reader::close() {
@@ -77,6 +98,9 @@ arrow::Status Reader::close() {
 
 int64_t Reader::getDecompressTime() {
   return decompressTime_;
+}
+const std::shared_ptr<arrow::MemoryPool>& Reader::getPool() const {
+  return pool_;
 }
 
 } // namespace gluten

--- a/cpp/core/shuffle/reader.h
+++ b/cpp/core/shuffle/reader.h
@@ -22,6 +22,7 @@
 #include <arrow/ipc/message.h>
 #include <arrow/ipc/options.h>
 
+#include "compute/ResultIterator.h"
 #include "utils/compression.h"
 
 namespace gluten {
@@ -37,17 +38,16 @@ struct ReaderOptions {
 
 class Reader {
  public:
-  Reader(
-      std::shared_ptr<arrow::io::InputStream> in,
-      std::shared_ptr<arrow::Schema> schema,
-      ReaderOptions options,
-      std::shared_ptr<arrow::MemoryPool> pool);
+  Reader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, std::shared_ptr<arrow::MemoryPool> pool);
 
   virtual ~Reader() = default;
 
-  virtual arrow::Result<std::shared_ptr<ColumnarBatch>> next();
+  // FIXME iterator should be unique_ptr or un-copyable singleton
+  virtual std::shared_ptr<ResultIterator> readStream(std::shared_ptr<arrow::io::InputStream> in);
+
   arrow::Status close();
   int64_t getDecompressTime();
+  const std::shared_ptr<arrow::MemoryPool>& getPool() const;
 
  protected:
   std::shared_ptr<arrow::MemoryPool> pool_;
@@ -55,10 +55,7 @@ class Reader {
   ReaderOptions options_;
 
  private:
-  std::shared_ptr<arrow::io::InputStream> in_;
-  std::shared_ptr<arrow::Schema> writeSchema_;
-  std::unique_ptr<arrow::ipc::Message> firstMessage_;
-  bool firstMessageConsumed_ = false;
+  std::shared_ptr<arrow::Schema> schema_;
 };
 
 } // namespace gluten

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -68,14 +68,13 @@ class VeloxBackend final : public Backend {
   }
 
   std::shared_ptr<Reader> getShuffleReader(
-      std::shared_ptr<arrow::io::InputStream> in,
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
       std::shared_ptr<arrow::MemoryPool> pool,
       MemoryAllocator* allocator) override {
     auto veloxPool = asAggregateVeloxMemoryPool(allocator);
     auto ctxVeloxPool = veloxPool->addLeafChild("velox_shuffle_reader");
-    return std::make_shared<VeloxShuffleReader>(in, schema, options, pool, ctxVeloxPool);
+    return std::make_shared<VeloxShuffleReader>(schema, options, pool, ctxVeloxPool);
   }
 
   std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -25,13 +25,12 @@ namespace gluten {
 class VeloxShuffleReader final : public Reader {
  public:
   VeloxShuffleReader(
-      std::shared_ptr<arrow::io::InputStream> in,
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
       std::shared_ptr<arrow::MemoryPool> pool,
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool);
 
-  arrow::Result<std::shared_ptr<ColumnarBatch>> next() override;
+  std::shared_ptr<ResultIterator> readStream(std::shared_ptr<arrow::io::InputStream> in) override;
 
   // Visiable for testing
   static facebook::velox::RowVectorPtr readRowVector(

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
@@ -24,14 +24,13 @@ public class ShuffleReaderJniWrapper extends JniInitialized {
   private ShuffleReaderJniWrapper() {}
 
   public native long make(
-      JniByteInputStream jniIn,
       long cSchema,
       long allocatorId,
       String compressionType,
       String compressionCodecBackend,
       String compressionMode);
 
-  public native long next(long handle);
+  public native long readStream(long handle, JniByteInputStream jniIn);
 
   public native void populateMetrics(long handle, ShuffleReaderMetrics metrics);
 


### PR DESCRIPTION
A single shuffle reader instance in Gluten could hold one Velox memory pool that may reserve at least several MiBs data until Spark task ends. This could be a memory leak source in the case of large read amount.

In the patch we'll expand the shuffle reader scope to let one task create only a single shuffle reader instead of creating the reader per shuffle read fetch (which by default 48MiB).

Ideally this will decrease Gluten's overall Spark off-heap memory occupation.

A simple calculation:

Assuming shuffle read size is 1TiB, with 10 available Spark CPUs, read batch / buffer size is 4096 rows, 100 Byte per row:

Then the peak off-heap memory from shuffle reader (which could cause unnecessary spills even OOM when high):

Before:
1T / 48M * 4096 * 100B = 8.95 GiB

After:
10 * 4096 * 100B = 4 MiB

Note: the reserved Spark off-heap memory may already be released to OS, but not repaid to Spark. The main problem here we want to address is about the Spark off-heap counter. It's unrelated to high process RSS.


