### PR TITLE
[GLUTEN-2796][VL] Set default session time zone if not explicitly set by user

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -29,7 +29,9 @@ const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
-const std::string kSessionTimezone = "spark.gluten.sql.session.timeZone";
+const std::string kSessionTimezone = "spark.sql.session.timeZone";
+
+const std::string kDefaultSessionTimezone = "spark.gluten.sql.session.timeZone.default";
 
 const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
 

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -29,7 +29,7 @@ const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
-const std::string kSessionTimezone = "spark.sql.session.timeZone";
+const std::string kSessionTimezone = "spark.gluten.sql.session.timeZone";
 
 const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -289,8 +289,7 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
     configs[velox::core::QueryConfig::kCastToIntByTruncate] = std::to_string(true);
     // To align with Spark's behavior, allow decimal in casting string to int.
     configs[velox::core::QueryConfig::kCastIntAllowDecimal] = std::to_string(true);
-    // Uses nullopt as default, expecting it is always set. If not, an exception will be thrown.
-    auto defaultTimezone = getConfigValue(confMap_, kDefaultSessionTimezone, std::nullopt);
+    auto defaultTimezone = getConfigValue(confMap_, kDefaultSessionTimezone, "");
     configs[velox::core::QueryConfig::kSessionTimezone] = getConfigValue(confMap_, kSessionTimezone, defaultTimezone);
     // Adjust timestamp according to the above configured session timezone.
     configs[velox::core::QueryConfig::kAdjustTimestampToTimezone] = std::to_string(true);

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -289,7 +289,9 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
     configs[velox::core::QueryConfig::kCastToIntByTruncate] = std::to_string(true);
     // To align with Spark's behavior, allow decimal in casting string to int.
     configs[velox::core::QueryConfig::kCastIntAllowDecimal] = std::to_string(true);
-    configs[velox::core::QueryConfig::kSessionTimezone] = getConfigValue(confMap_, kSessionTimezone, "");
+    // Uses nullopt as default, expecting it is always set. If not, an exception will be thrown.
+    auto defaultTimezone = getConfigValue(confMap_, kDefaultSessionTimezone, std::nullopt);
+    configs[velox::core::QueryConfig::kSessionTimezone] = getConfigValue(confMap_, kSessionTimezone, defaultTimezone);
     // Adjust timestamp according to the above configured session timezone.
     configs[velox::core::QueryConfig::kAdjustTimestampToTimezone] = std::to_string(true);
 

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject
 
+import io.glutenproject.GlutenConfig.GLUTEN_SESSION_LOCAL_TIMEZONE_KEY
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.events.GlutenBuildInfoEvent
@@ -151,11 +152,11 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
     }
     // Session's local time zone must be set. If not explicitly set by user, its default
     // value (detected for the platform) is used, consistent with spark.
-    if (!conf.contains(SQLConf.SESSION_LOCAL_TIMEZONE.key)) {
-      conf.set(
+    conf.set(
+      GLUTEN_SESSION_LOCAL_TIMEZONE_KEY,
+      conf.get(
         SQLConf.SESSION_LOCAL_TIMEZONE.key,
-        SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
-    }
+        SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString))
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)
     conf.set(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY, offHeapSize.toString)
     // FIXME Is this calculation always reliable ? E.g. if dynamic allocation is enabled

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject
 
-import io.glutenproject.GlutenConfig.GLUTEN_SESSION_LOCAL_TIMEZONE_KEY
+import io.glutenproject.GlutenConfig.GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY
 import io.glutenproject.GlutenPlugin.{GLUTEN_SESSION_EXTENSION_NAME, SPARK_SESSION_EXTS_KEY}
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.events.GlutenBuildInfoEvent
@@ -152,11 +152,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
     }
     // Session's local time zone must be set. If not explicitly set by user, its default
     // value (detected for the platform) is used, consistent with spark.
-    conf.set(
-      GLUTEN_SESSION_LOCAL_TIMEZONE_KEY,
-      conf.get(
-        SQLConf.SESSION_LOCAL_TIMEZONE.key,
-        SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString))
+    conf.set(GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY, SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)
     conf.set(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY, offHeapSize.toString)
     // FIXME Is this calculation always reliable ? E.g. if dynamic allocation is enabled

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -32,7 +32,7 @@ import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.{GlutenDriverEndpoint, GlutenExecutorEndpoint}
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.execution.ui.GlutenEventUtils
-import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.utils.ExpressionUtil
 import org.apache.spark.util.{SparkResourcesUtil, TaskResources}
 
@@ -148,6 +148,13 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
     // off-heap bytes
     if (!conf.contains(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)) {
       throw new UnsupportedOperationException(s"${GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY} is not set")
+    }
+    // Session's local time zone must be set. If not explicitly set by user, its default
+    // value (detected for the platform) is used, consistent with spark.
+    if (!conf.contains(SQLConf.SESSION_LOCAL_TIMEZONE.key)) {
+      conf.set(
+        SQLConf.SESSION_LOCAL_TIMEZONE.key,
+        SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
     }
     val offHeapSize = conf.getSizeAsBytes(GlutenConfig.GLUTEN_OFFHEAP_SIZE_KEY)
     conf.set(GlutenConfig.GLUTEN_OFFHEAP_SIZE_IN_BYTES_KEY, offHeapSize.toString)

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -350,6 +350,11 @@ object GlutenConfig {
   val GLUTEN_EXTENDED_EXPRESSION_TRAN_CONF =
     "spark.gluten.sql.columnar.extended.expressions.transformer"
 
+  // A mirror property to Spark's spark.sql.session.timeZone. With this independent property, we
+  // can avoid some Spark UT failure where a specific session time zone is used by just setting
+  // the default time zone.
+  val GLUTEN_SESSION_LOCAL_TIMEZONE_KEY = "spark.gluten.sql.session.timeZone"
+
   // Principal of current user
   val GLUTEN_UGI_USERNAME = "spark.gluten.ugi.username"
   // Tokens of current user, split by `\0`
@@ -388,7 +393,7 @@ object GlutenConfig {
       GLUTEN_SAVE_DIR,
       GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY,
       GLUTEN_MAX_BATCH_SIZE_KEY,
-      SQLConf.SESSION_LOCAL_TIMEZONE.key
+      GLUTEN_SESSION_LOCAL_TIMEZONE_KEY
     )
     keys.forEach(
       k => {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -350,10 +350,9 @@ object GlutenConfig {
   val GLUTEN_EXTENDED_EXPRESSION_TRAN_CONF =
     "spark.gluten.sql.columnar.extended.expressions.transformer"
 
-  // A mirror property to Spark's spark.sql.session.timeZone. With this independent property, we
-  // can avoid some Spark UT failure where a specific session time zone is used by just setting
-  // the default time zone.
-  val GLUTEN_SESSION_LOCAL_TIMEZONE_KEY = "spark.gluten.sql.session.timeZone"
+  // This is an internal config property set by Gluten. It is used to hold default session timezone
+  // and will be really used by Gluten only if `spark.sql.session.timeZone` is not set.
+  val GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY = "spark.gluten.sql.session.timeZone.default"
 
   // Principal of current user
   val GLUTEN_UGI_USERNAME = "spark.gluten.ugi.username"
@@ -393,7 +392,8 @@ object GlutenConfig {
       GLUTEN_SAVE_DIR,
       GLUTEN_TASK_OFFHEAP_SIZE_IN_BYTES_KEY,
       GLUTEN_MAX_BATCH_SIZE_KEY,
-      GLUTEN_SESSION_LOCAL_TIMEZONE_KEY
+      SQLConf.SESSION_LOCAL_TIMEZONE.key,
+      GLUTEN_DEFAULT_SESSION_TIMEZONE_KEY
     )
     keys.forEach(
       k => {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -394,6 +394,12 @@ object GlutenConfig {
       k => {
         if (conf.contains(k)) {
           nativeConfMap.put(k, conf(k))
+        } else {
+          // Session's local time zone must be set. If not explicitly set by user,
+          // its default value is used, consistent with spark.
+          if (k.equals(SQLConf.SESSION_LOCAL_TIMEZONE.key)) {
+            nativeConfMap.put(k, SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
+          }
         }
       })
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -394,12 +394,6 @@ object GlutenConfig {
       k => {
         if (conf.contains(k)) {
           nativeConfMap.put(k, conf(k))
-        } else {
-          // Session's local time zone must be set. If not explicitly set by user,
-          // its default value is used, consistent with spark.
-          if (k.equals(SQLConf.SESSION_LOCAL_TIMEZONE.key)) {
-            nativeConfMap.put(k, SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
-          }
         }
       })
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR, we introduced a gluten config key to hold default session time zone, which will be used if spark config (spark.sql.session.timeZone) is not explicitly set by user (this handling is quite consistent with spark's).

(Fixes: \#2796)

## How was this patch tested?

Will refactor native config by introducing a dedicated class to hold properties. Will then add native tests for validation.  

