### PR TITLE
[GLUTEN-2836][VL] Fix: memory usage problems caused by complex type

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -196,8 +196,9 @@ class VeloxShuffleWriter final : public ShuffleWriter {
       std::shared_ptr<PartitionWriterCreator> partitionWriterCreator,
       const ShuffleWriterOptions& options)
       : ShuffleWriter(numPartitions, partitionWriterCreator, std::move(options)),
-        veloxPool_(defaultLeafVeloxMemoryPool()),
-        arena_(std::make_unique<facebook::velox::StreamArena>(veloxPool_.get())) {}
+        veloxPool_(defaultLeafVeloxMemoryPool()) {
+    arenas_.resize(numPartitions);
+  }
 
   arrow::Status init();
 
@@ -344,7 +345,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   std::shared_ptr<const facebook::velox::RowType> complexWriteType_;
 
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
-  std::unique_ptr<facebook::velox::StreamArena> arena_;
+  std::vector<std::unique_ptr<facebook::velox::StreamArena>> arenas_;
 
   std::unique_ptr<facebook::velox::serializer::presto::PrestoVectorSerde> serde_ =
       std::make_unique<facebook::velox::serializer::presto::PrestoVectorSerde>();


### PR DESCRIPTION
Complex types of data will only be released when the shufflewriter is released, even if this part of the data has been stored in a RecordBatch This change allows each partition to have a StreamArena, so that after converting to RecordBatch, the memory in StreamArena can be freed immediately


