### PR TITLE
[VL] Remove shuffle write schema option

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -55,7 +55,6 @@ class CHColumnarShuffleWriter[K, V](
     GlutenShuffleUtils.getCompressionCodec(conf).toUpperCase(Locale.ROOT)
   private val preferSpill = GlutenConfig.getConf.columnarShufflePreferSpill
   private val spillThreshold = GlutenConfig.getConf.chColumnarShuffleSpillThreshold
-  private val writeSchema = GlutenConfig.getConf.columnarShuffleWriteSchema
   private val jniWrapper = new CHShuffleSplitterJniWrapper
   // Are we in the process of stopping? Because map tasks can call stop() with success = true
   // and then call stop() with success = false if they get an exception, we want to make sure

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -739,7 +739,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jstring localDirsJstr,
     jboolean preferEvict,
     jlong memoryManagerId,
-    jboolean writeSchema,
     jboolean writeEOS,
     jlong firstBatchHandle,
     jlong taskAttemptId,
@@ -802,7 +801,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
       throw gluten::GlutenException(std::string("Shuffle DataFile can't be null"));
     }
 
-    shuffleWriterOptions.write_schema = writeSchema;
     shuffleWriterOptions.write_eos = writeEOS;
     shuffleWriterOptions.prefer_evict = preferEvict;
 

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -315,9 +315,7 @@ arrow::Status PreferCachePartitionWriter::stop() {
       auto partitionSpillInfo = spills_[i].partitionSpillInfos[spillInfoOffsets[i]];
       // 5. read if partition exists in the spilled file and write to the final file
       if (partitionSpillInfo.partitionId == pid) { // A hit
-        if (firstWrite) {
-          firstWrite = false;
-        }
+        firstWrite = false;
         ARROW_ASSIGN_OR_RAISE(auto raw, spilledFiles[i]->ReadAt(partitionSpillInfo.start, partitionSpillInfo.length));
         RETURN_NOT_OK(dataFileOs_->Write(raw));
         // Goto next partition in this spillInfo
@@ -327,9 +325,7 @@ arrow::Status PreferCachePartitionWriter::stop() {
     // 6. Write cached batches
     auto cachedPayloadSize = shuffleWriter_->partitionCachedRecordbatchSize()[pid];
     if (cachedPayloadSize > 0) {
-      if (firstWrite) {
-        firstWrite = false;
-      }
+      firstWrite = false;
       RETURN_NOT_OK(flushCachedPayloads(dataFileOs_.get(), shuffleWriter_->partitionCachedRecordbatch()[pid]));
       // clearCache();
       shuffleWriter_->partitionCachedRecordbatch()[pid].clear();
@@ -338,9 +334,7 @@ arrow::Status PreferCachePartitionWriter::stop() {
     // 7. Write the last payload.
     ARROW_ASSIGN_OR_RAISE(auto rb, shuffleWriter_->createArrowRecordBatchFromBuffer(pid, true));
     if (rb) {
-      if (firstWrite) {
-        firstWrite = false;
-      }
+      firstWrite = false;
       // Record rawPartitionLength and flush the last payload.
       TIME_NANO_START(lastPayloadCompressTime)
       ARROW_ASSIGN_OR_RAISE(auto lastPayload, shuffleWriter_->createArrowIpcPayload(*rb, false));

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -83,20 +83,6 @@ class PreferCachePartitionWriter : public LocalPartitionWriterBase {
  private:
   arrow::Status clearResource() override;
 
-  // TODO: helper methods
-  arrow::Status writeSchemaPayload(arrow::io::OutputStream* os) {
-    std::shared_ptr<arrow::ipc::IpcPayload> payload;
-    if (shuffleWriter_->options().compression_type == arrow::Compression::type::UNCOMPRESSED) {
-      ARROW_ASSIGN_OR_RAISE(payload, getSchemaPayload(shuffleWriter_->writeSchema()));
-    } else {
-      ARROW_ASSIGN_OR_RAISE(payload, getSchemaPayload(shuffleWriter_->compressWriteSchema()));
-    }
-    int32_t metadataLength = 0; // unused
-    RETURN_NOT_OK(
-        arrow::ipc::WriteIpcPayload(*payload, shuffleWriter_->options().ipc_write_options, os, &metadataLength));
-    return arrow::Status::OK();
-  }
-
   arrow::Status flushCachedPayload(
       arrow::io::OutputStream* os,
       std::shared_ptr<arrow::ipc::IpcPayload>& payload,

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -44,7 +44,6 @@ struct ShuffleWriterOptions {
   CodecBackend codec_backend = CodecBackend::NONE;
   CompressionMode compression_mode = CompressionMode::BUFFER;
   bool prefer_evict = false;
-  bool write_schema = false;
   bool buffered_write = false;
   bool write_eos = true;
 

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -119,7 +119,6 @@ class BenchmarkShuffleSplit {
     options.buffered_write = true;
     options.offheap_per_task = 128 * 1024 * 1024 * 1024L;
     options.prefer_evict = FLAGS_prefer_evict;
-    options.write_schema = false;
     options.memory_pool = pool;
     options.partitioning_name = "rr";
 

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -321,7 +321,7 @@ void getUncompressedBuffers(
   }
 }
 
-RowVectorPtr readRowVectorInternal(
+RowVectorPtr readRowVector(
     const arrow::RecordBatch& batch,
     RowTypePtr rowType,
     CodecBackend codecBackend,
@@ -375,7 +375,7 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
     auto batch = in_.next();
     auto rb = std::dynamic_pointer_cast<ArrowColumnarBatch>(batch)->getRecordBatch();
     int64_t decompressTime = 0LL;
-    auto vp = readRowVectorInternal(
+    auto vp = readRowVector(
         *rb,
         rowType_,
         options_.codec_backend,
@@ -416,17 +416,6 @@ std::shared_ptr<ResultIterator> VeloxShuffleReader::readStream(std::shared_ptr<a
       rowType_,
       [this](int64_t decompressionTime) { this->decompressTime_ += decompressionTime; },
       *wrappedIn));
-}
-
-RowVectorPtr VeloxShuffleReader::readRowVector(
-    const arrow::RecordBatch& batch,
-    RowTypePtr rowType,
-    CodecBackend codecBackend,
-    CompressionMode compressionMode,
-    int64_t& decompressTime,
-    arrow::MemoryPool* arrowPool,
-    memory::MemoryPool* pool) {
-  return readRowVectorInternal(batch, rowType, codecBackend, compressionMode, decompressTime, arrowPool, pool);
 }
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -32,16 +32,6 @@ class VeloxShuffleReader final : public Reader {
 
   std::shared_ptr<ResultIterator> readStream(std::shared_ptr<arrow::io::InputStream> in) override;
 
-  // Visiable for testing
-  static facebook::velox::RowVectorPtr readRowVector(
-      const arrow::RecordBatch& batch,
-      facebook::velox::RowTypePtr rowType,
-      CodecBackend codecBackend,
-      CompressionMode compressionMode,
-      int64_t& decompressTime,
-      arrow::MemoryPool* arrowPool,
-      facebook::velox::memory::MemoryPool* pool);
-
  private:
   facebook::velox::RowTypePtr rowType_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -67,12 +67,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
         subDirsPerLocalDir,
         localDirs,
         preferEvict,
-<<<<<<< HEAD
         memoryManagerId,
-        writeSchema,
-=======
-        memoryPoolId,
->>>>>>> remove shuffle write_schema
         writeEOS,
         handle,
         taskAttemptId,
@@ -116,12 +111,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
         0,
         null,
         true,
-<<<<<<< HEAD
         memoryManagerId,
-        false,
-=======
-        memoryPoolId,
->>>>>>> remove shuffle write_schema
         true,
         handle,
         taskAttemptId,
@@ -143,12 +133,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
       int subDirsPerLocalDir,
       String localDirs,
       boolean preferEvict,
-<<<<<<< HEAD
       long memoryManagerId,
-      boolean writeSchema,
-=======
-      long memoryPoolId,
->>>>>>> remove shuffle write_schema
       boolean writeEOS,
       long handle,
       long taskAttemptId,

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -51,7 +51,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
       String localDirs,
       boolean preferEvict,
       long memoryManagerId,
-      boolean writeSchema,
       boolean writeEOS,
       long handle,
       long taskAttemptId) {
@@ -68,8 +67,12 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
         subDirsPerLocalDir,
         localDirs,
         preferEvict,
+<<<<<<< HEAD
         memoryManagerId,
         writeSchema,
+=======
+        memoryPoolId,
+>>>>>>> remove shuffle write_schema
         writeEOS,
         handle,
         taskAttemptId,
@@ -113,8 +116,12 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
         0,
         null,
         true,
+<<<<<<< HEAD
         memoryManagerId,
         false,
+=======
+        memoryPoolId,
+>>>>>>> remove shuffle write_schema
         true,
         handle,
         taskAttemptId,
@@ -136,8 +143,12 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
       int subDirsPerLocalDir,
       String localDirs,
       boolean preferEvict,
+<<<<<<< HEAD
       long memoryManagerId,
       boolean writeSchema,
+=======
+      long memoryPoolId,
+>>>>>>> remove shuffle write_schema
       boolean writeEOS,
       long handle,
       long taskAttemptId,

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -48,10 +48,8 @@ class ColumnarBatchSerializer(
   extends Serializer
   with Serializable {
 
-  // if don't write schema and EOS in shuffle writer, then the erializer supports relocation
-  private val supportsRelocation =
-    !GlutenConfig.getConf.columnarShuffleWriteSchema &&
-      !GlutenConfig.getConf.columnarShuffleWriteEOS
+  // if don't write EOS in shuffle writer, then the serializer supports relocation
+  private val supportsRelocation = !GlutenConfig.getConf.columnarShuffleWriteEOS
 
   /** Creates a new [[SerializerInstance]]. */
   override def newInstance(): SerializerInstance = {

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -76,8 +76,6 @@ class ColumnarShuffleWriter[K, V](
 
   private val preferSpill = GlutenConfig.getConf.columnarShufflePreferSpill
 
-  private val writeSchema = GlutenConfig.getConf.columnarShuffleWriteSchema
-
   private val writeEOS = GlutenConfig.getConf.columnarShuffleWriteEOS
 
   private val jniWrapper = new ShuffleWriterJniWrapper
@@ -157,7 +155,6 @@ class ColumnarShuffleWriter[K, V](
                 }
               )
               .getNativeInstanceId,
-            writeSchema,
             writeEOS,
             handle,
             taskContext.taskAttemptId()

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -121,8 +121,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def columnarShufflePreferSpill: Boolean = conf.getConf(COLUMNAR_SHUFFLE_PREFER_SPILL_ENABLED)
 
-  def columnarShuffleWriteSchema: Boolean = conf.getConf(COLUMNAR_SHUFFLE_WRITE_SCHEMA_ENABLED)
-
   def columnarShuffleWriteEOS: Boolean = conf.getConf(COLUMNAR_SHUFFLE_WRITE_EOS_ENABLED)
 
   def columnarShuffleCodec: Option[String] = conf.getConf(COLUMNAR_SHUFFLE_CODEC)
@@ -735,12 +733,6 @@ object GlutenConfig {
         "Whether to spill the partition buffers when buffers are full. " +
           "If false, the partition buffers will be cached in memory first, " +
           "and the cached buffers will be spilled when reach maximum memory.")
-      .booleanConf
-      .createWithDefault(false)
-
-  val COLUMNAR_SHUFFLE_WRITE_SCHEMA_ENABLED =
-    buildConf("spark.gluten.sql.columnar.shuffle.writeSchema")
-      .internal()
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
This option is default false, the true mode is only used in test code, and not suggest to change to the true mode.
If switch to true mode, shuffle will write serialized schema firstly, for some small batch, it is a high load. And we can get correct schema from spark plan when constructing ShuffleReader.

Refactor the test code to remove write_schema option.