### PR TITLE
[VL] Refactor SubstraitToVeloxPlanConverter by using vector instead of unordered_map

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -344,7 +344,7 @@ class SubstraitToVeloxPlanConverter {
   /// and remaining functions to be handled by the remainingFilter in
   /// HiveConnector.
   void separateFilters(
-      std::unordered_map<uint32_t, RangeRecorder>& rangeRecorders,
+      std::vector<RangeRecorder>& rangeRecorders,
       const std::vector<::substrait::Expression_ScalarFunction>& scalarFunctions,
       std::vector<::substrait::Expression_ScalarFunction>& subfieldFunctions,
       std::vector<::substrait::Expression_ScalarFunction>& remainingFunctions,
@@ -361,12 +361,12 @@ class SubstraitToVeloxPlanConverter {
   /// Returns whether a NOT function can be pushed down.
   bool canPushdownNot(
       const ::substrait::Expression_ScalarFunction& scalarFunction,
-      std::unordered_map<uint32_t, RangeRecorder>& rangeRecorders);
+      std::vector<RangeRecorder>& rangeRecorders);
 
   /// Returns whether a OR function can be pushed down.
   bool canPushdownOr(
       const ::substrait::Expression_ScalarFunction& scalarFunction,
-      std::unordered_map<uint32_t, RangeRecorder>& rangeRecorders);
+      std::vector<RangeRecorder>& rangeRecorders);
 
   /// Returns whether a SingularOrList can be pushed down.
   static bool canPushdownSingularOrList(
@@ -383,13 +383,13 @@ class SubstraitToVeloxPlanConverter {
   void setFilterInfo(
       const ::substrait::Expression_ScalarFunction& scalarFunction,
       const std::vector<TypePtr>& inputTypeList,
-      std::unordered_map<uint32_t, FilterInfo>& columnToFilterInfo,
+      std::vector<FilterInfo>& columnToFilterInfo,
       bool reverse = false);
 
   /// Extract SingularOrList and set it to the filter info map.
   void setFilterInfo(
       const ::substrait::Expression_SingularOrList& singularOrList,
-      std::unordered_map<uint32_t, FilterInfo>& columnToFilterInfo);
+      std::vector<FilterInfo>& columnToFilterInfo);
 
   /// Extract SingularOrList and returns the field index.
   static uint32_t getColumnIndexFromSingularOrList(const ::substrait::Expression_SingularOrList&);
@@ -442,7 +442,7 @@ class SubstraitToVeloxPlanConverter {
   connector::hive::SubfieldFilters mapToFilters(
       const std::vector<std::string>& inputNameList,
       const std::vector<TypePtr>& inputTypeList,
-      std::unordered_map<uint32_t, FilterInfo> columnToFilterInfo);
+      std::vector<FilterInfo>& columnToFilterInfo);
 
   /// Convert subfield functions into subfieldFilters to
   /// be used in Hive Connector.


### PR DESCRIPTION
## What changes were proposed in this pull request?

two advantages of using `vector` in this situation:
1. vector is faster and more efficient than unordered_map
2. vector doesn't need to use a loop to construct

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

