### PR TITLE
[VL] Fix TPCDS Q83 fallback

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -90,6 +90,9 @@ add_compile_options(-Wno-error=unused-variable)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   add_compile_options(-Wno-error=unused-but-set-variable)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
+    add_compile_options(-Wno-error=maybe-uninitialized)
+  endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # Experimental
   add_compile_options(-Wno-implicit-int-float-conversion)

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -294,15 +294,15 @@ std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::lite
   VELOX_CHECK_GE(literals.size(), 0, "List should have at least one item.");
   std::optional<TypePtr> literalType = std::nullopt;
   for (const auto& literal : literals) {
-    auto veloxVariant = toVeloxExpr(literal)->value();
+    auto veloxVariant = toVeloxExpr(literal);
     if (!literalType.has_value()) {
-      literalType = veloxVariant.inferType();
+      literalType = veloxVariant->type();
     }
-    variants.emplace_back(veloxVariant);
+    variants.emplace_back(veloxVariant->value());
   }
   VELOX_CHECK(literalType.has_value(), "Type expected.");
   auto varArray = variant::array(variants);
-  ArrayVectorPtr arrayVector = variantArrayToVector(varArray.inferType(), varArray.array(), pool_);
+  ArrayVectorPtr arrayVector = variantArrayToVector(ARRAY(literalType.value()), varArray.array(), pool_);
   // Wrap the array vector into constant vector.
   auto constantVector = BaseVector::wrapInConstant(1 /*length*/, 0 /*index*/, arrayVector);
   return std::make_shared<const core::ConstantTypedExpr>(constantVector);


### PR DESCRIPTION
Fixes validation failure due to DATE IN expression.
>native check failure:native validation failed due to: validation fails for FilterRel expression, Scalar function in not registered with arguments: (DATE, ARRAY<INTEGER>).

Before:
![image](https://github.com/oap-project/gluten/assets/52736607/fedf8e1c-0b33-4019-8b92-3cf8f087fc99)

After:
![image](https://github.com/oap-project/gluten/assets/52736607/c2e47852-e0c8-49c6-a1a2-74aab8565d2d)
