### PR TITLE
[GLUTEN-2860][CH] Support removing files cache for CH Backend

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseS3SourceSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseS3SourceSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.execution
+
+import org.apache.spark.SparkConf
+
+// Some sqls' line length exceeds 100
+// scalastyle:off line.size.limit
+
+class GlutenClickHouseS3SourceSuite extends GlutenClickHouseTPCHAbstractSuite {
+
+  override protected val resourcePath: String =
+    "../../../../gluten-core/src/test/resources/tpch-data"
+
+  override protected val tablesPath: String = basePath + "/tpch-data"
+  override protected val tpchQueries: String =
+    rootPath + "../../../../gluten-core/src/test/resources/tpch-queries"
+  override protected val queriesResults: String = rootPath + "queries-output"
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.io.compression.codec", "LZ4")
+      .set("spark.sql.shuffle.partitions", "5")
+      .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
+      .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
+      .set("spark.memory.offHeap.size", "4g")
+      // test with minio
+      .set("spark.hadoop.fs.s3a.access.key", "admin")
+      .set("spark.hadoop.fs.s3a.secret.key", "xxxxxx")
+      .set("spark.hadoop.fs.s3a.endpoint", "http://ip:port")
+      .set("spark.hadoop.fs.s3a.path.style.access", "true")
+      .set("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
+      .set("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+      .set("spark.gluten.sql.columnar.backend.ch.runtime_config.s3.local_cache.enabled", "true")
+      .set(
+        "spark.gluten.sql.columnar.backend.ch.runtime_config.s3.local_cache.cache_path",
+        "/data/gluten-ch-cache-dir")
+  }
+
+  override protected val createNullableTables = true
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createTPCHS3Tables()
+  }
+
+  protected def createTPCHS3Tables(): Unit = {
+    val s3TablePath = "s3a://gluten-test"
+
+    val nationData = s3TablePath + "/nation"
+    spark.sql(s"DROP TABLE IF EXISTS nation_s3")
+    spark.sql(s"""
+                 | CREATE TABLE IF NOT EXISTS nation_s3 (
+                 | n_nationkey bigint,
+                 | n_name      string,
+                 | n_regionkey bigint,
+                 | n_comment   string)
+                 | USING PARQUET LOCATION '$nationData'
+                 |""".stripMargin)
+
+    val supplierData = s3TablePath + "/supplier"
+    spark.sql(s"DROP TABLE IF EXISTS supplier_s3")
+    spark.sql(s"""
+                 | CREATE TABLE IF NOT EXISTS supplier_s3 (
+                 | s_suppkey   bigint,
+                 | s_name      string,
+                 | s_address   string,
+                 | s_nationkey bigint,
+                 | s_phone     string,
+                 | s_acctbal   double,
+                 | s_comment   string)
+                 | USING PARQUET LOCATION '$supplierData'
+                 |""".stripMargin)
+  }
+
+  // ignore this test case, because it needs the minio to test s3
+  ignore("test ch backend with s3") {
+    var currTime = System.currentTimeMillis()
+    // scalastyle:off println
+    println(s"currTime=$currTime")
+    // scalastyle:on println
+    spark.sparkContext.setLocalProperty(
+      "spark.gluten.sql.columnar.backend.ch." +
+        "runtime_settings.spark.kylin.local-cache.accept-cache-time",
+      currTime.toString)
+    spark
+      .sql("""
+             |select * from supplier_s3
+             |""".stripMargin)
+      .show(10, false)
+
+    Thread.sleep(5000)
+
+    // scalastyle:off println
+    println(s"currTime=$currTime")
+    // scalastyle:on println
+    spark.sparkContext.setLocalProperty(
+      "spark.gluten.sql.columnar.backend.ch." +
+        "runtime_settings.spark.kylin.local-cache.accept-cache-time",
+      currTime.toString)
+    spark
+      .sql("""
+             |select * from supplier_s3
+             |""".stripMargin)
+      .show(10, false)
+
+    Thread.sleep(5000)
+    currTime = System.currentTimeMillis()
+    // scalastyle:off println
+    println(s"currTime=$currTime")
+    // scalastyle:on println
+    spark.sparkContext.setLocalProperty(
+      "spark.gluten.sql.columnar.backend.ch." +
+        "runtime_settings.spark.kylin.local-cache.accept-cache-time",
+      currTime.toString)
+    spark
+      .sql("""
+             |select * from supplier_s3
+             |""".stripMargin)
+      .show(10, false)
+  }
+}
+// scalastyle:on line.size.limit

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -699,6 +699,8 @@ void BackendInitializerUtil::init(std::string * plan)
     applyGlobalConfigAndSettings(config, settings);
     LOG_INFO(logger, "Apply configuration and setting for global context.");
 
+    // clean static per_bucket_clients and shared_client before running local engine,
+    // in case of running the multiple gluten ut in one process
     ReadBufferBuilderFactory::instance().clean();
 
     std::call_once(

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -37,8 +37,6 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsConversion.h>
 #include <Functions/registerFunctions.h>
-#include <google/protobuf/util/json_util.h>
-#include <google/protobuf/wrappers.pb.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/SharedThreadPools.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
@@ -50,6 +48,8 @@
 #include <QueryPipeline/printPipeline.h>
 #include <Storages/Output/WriteBufferBuilder.h>
 #include <Storages/SubstraitSource/ReadBufferBuilder.h>
+#include <google/protobuf/util/json_util.h>
+#include <google/protobuf/wrappers.pb.h>
 #include <Poco/Logger.h>
 #include <Poco/Util/MapConfiguration.h>
 #include <Common/Config/ConfigProcessor.h>
@@ -122,7 +122,8 @@ DB::Block BlockUtil::buildHeader(const DB::NamesAndTypesList & names_types_list)
  * There is a special case with which we need be careful. In spark, struct/map/list are always
  * wrapped in Nullable, but this should not happen in clickhouse.
  */
-DB::Block BlockUtil::flattenBlock(const DB::Block & block, UInt64 flags, bool recursively, const std::unordered_set<size_t> & columns_to_skip_flatten)
+DB::Block
+BlockUtil::flattenBlock(const DB::Block & block, UInt64 flags, bool recursively, const std::unordered_set<size_t> & columns_to_skip_flatten)
 {
     DB::Block res;
 
@@ -500,7 +501,6 @@ DB::Context::ConfigurationPtr BackendInitializerUtil::initConfig(std::map<std::s
             // Apply spark.gluten.sql.columnar.backend.ch.runtime_config.* to config
             config->setString(key.substr(CH_RUNTIME_CONFIG_PREFIX.size()), value);
         }
-
     }
     return config;
 }
@@ -630,8 +630,7 @@ void BackendInitializerUtil::applyGlobalConfigAndSettings(DB::Context::Configura
     global_context->setSettings(settings);
 }
 
-void BackendInitializerUtil::updateNewSettings(
-    DB::ContextMutablePtr context, DB::Settings & settings)
+void BackendInitializerUtil::updateNewSettings(DB::ContextMutablePtr context, DB::Settings & settings)
 {
     context->setSettings(settings);
 }
@@ -738,6 +737,8 @@ void BackendInitializerUtil::updateConfig(DB::ContextMutablePtr context, std::st
 
 void BackendFinalizerUtil::finalizeGlobally()
 {
+    // Make sure client caches release before ClientCacheRegistry
+    ReadBufferBuilderFactory::instance().clean();
     auto & global_context = SerializedPlanParser::global_context;
     auto & shared_context = SerializedPlanParser::shared_context;
     if (global_context)
@@ -750,6 +751,11 @@ void BackendFinalizerUtil::finalizeGlobally()
 
 void BackendFinalizerUtil::finalizeSessionally()
 {
+}
+
+Int64 DateTimeUtil::currentTimeMillis()
+{
+    return timeInMilliseconds(std::chrono::system_clock::now());
 }
 
 }

--- a/cpp-ch/local-engine/Common/CHUtil.h
+++ b/cpp-ch/local-engine/Common/CHUtil.h
@@ -118,10 +118,10 @@ public:
     /// 2. session level resources like settings/configs, they can be initialized multiple times following the lifetime of executor/driver
     static void init(std::string * plan);
 
-    static void updateConfig(DB::ContextMutablePtr , std::string *);
+    static void updateConfig(DB::ContextMutablePtr, std::string *);
 
 
-   // use excel text parser
+    // use excel text parser
     inline static const std::string USE_EXCEL_PARSER = "use_excel_serialization";
     inline static const String CH_BACKEND_PREFIX = "spark.gluten.sql.columnar.backend.ch";
 
@@ -184,18 +184,20 @@ public:
 };
 
 // Ignore memory track, memory should free before IgnoreMemoryTracker deconstruction
-class IgnoreMemoryTracker {
+class IgnoreMemoryTracker
+{
 public:
-    explicit IgnoreMemoryTracker(size_t limit_):limit(limit_)
-    {
-        DB::CurrentThread::get().untracked_memory_limit += limit;
-    }
-    ~IgnoreMemoryTracker()
-    {
-        DB::CurrentThread::get().untracked_memory_limit -= limit;
-    }
+    explicit IgnoreMemoryTracker(size_t limit_) : limit(limit_) { DB::CurrentThread::get().untracked_memory_limit += limit; }
+    ~IgnoreMemoryTracker() { DB::CurrentThread::get().untracked_memory_limit -= limit; }
+
 private:
     size_t limit;
+};
+
+class DateTimeUtil
+{
+public:
+    static Int64 currentTimeMillis();
 };
 
 }

--- a/cpp-ch/local-engine/Common/FileCacheConcurrentMap.h
+++ b/cpp-ch/local-engine/Common/FileCacheConcurrentMap.h
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <shared_mutex>
+#include <unordered_map>
+
+#include <Interpreters/Cache/FileCache.h>
+#include <Interpreters/Cache/FileCacheKey.h>
+
+namespace local_engine
+{
+
+using Lock = std::shared_mutex;
+using WriteLock = std::unique_lock<Lock>;
+using ReadLock = std::shared_lock<Lock>;
+
+class FileCacheConcurrentMap
+{
+public:
+    void insert(const DB::FileCacheKey & key, const Int64 value)
+    {
+        WriteLock wLock(rw_locker);
+        map.emplace(key, value);
+    }
+
+    void
+    update_cache_time(const DB::FileCacheKey & key, const String & path, const Int64 accept_cache_time, const DB::FileCachePtr & file_cache)
+    {
+        WriteLock wLock(rw_locker);
+        // double check
+        auto it = map.find(key);
+        if (it != map.end())
+        {
+            if (it->second < accept_cache_time)
+            {
+                // will delete cache file immediately
+                file_cache->removePathIfExists(path);
+                // update cache time
+                map[key] = accept_cache_time;
+            }
+        }
+        else
+        {
+            // will delete cache file immediately
+            file_cache->removePathIfExists(path);
+            // set cache time
+            map.emplace(key, accept_cache_time);
+        }
+    }
+
+    std::optional<Int64> get(const DB::FileCacheKey & key)
+    {
+        ReadLock rLock(rw_locker);
+        auto it = map.find(key);
+        if (it == map.end())
+        {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    bool contain(const DB::FileCacheKey & key)
+    {
+        ReadLock rLock(rw_locker);
+        return map.contains(key);
+    }
+
+    void erase(const DB::FileCacheKey & key)
+    {
+        WriteLock wLock(rw_locker);
+        if (map.find(key) == map.end())
+        {
+            return;
+        }
+        map.erase(key);
+    }
+
+    void clear()
+    {
+        WriteLock wLock(rw_locker);
+        map.clear();
+    }
+
+    size_t size() const
+    {
+        ReadLock rLock(rw_locker);
+        return map.size();
+    }
+
+private:
+    std::unordered_map<DB::FileCacheKey, Int64> map;
+    mutable Lock rw_locker;
+};
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support to remove files cache by the specified cache time, which will be passed through parameter 'spark.gluten.sql.columnar.backend.ch.runtime_settings.spark.kylin.local-cache.accept-cache-time'.

Close #2860.

(Fixes: #2860)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

