### PR TITLE
[VL] Move orc decimal filters to the remaining filter list in native scan

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1324,8 +1324,8 @@ void SubstraitToVeloxPlanConverter::separateFilters(
     const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
     std::vector<::substrait::Expression_SingularOrList>& subfieldOrLists,
     std::vector<::substrait::Expression_SingularOrList>& remainingOrLists,
-    std::vector<TypePtr>& veloxTypeList,
-    dwio::common::FileFormat format) {
+    const std::vector<TypePtr>& veloxTypeList,
+    const dwio::common::FileFormat& format) {
   for (const auto& singularOrList : singularOrLists) {
     if (!canPushdownSingularOrList(singularOrList)) {
       remainingOrLists.emplace_back(singularOrList);
@@ -1342,6 +1342,7 @@ void SubstraitToVeloxPlanConverter::separateFilters(
   for (const auto& scalarFunction : scalarFunctions) {
     auto filterNameSpec = SubstraitParser::findFunctionSpec(functionMap_, scalarFunction.function_reference());
     auto filterName = SubstraitParser::getSubFunctionName(filterNameSpec);
+    // Add all decimal filters to remaining functions because their pushdown are not supported
     if (format == dwio::common::FileFormat::ORC && scalarFunction.arguments().size() > 0) {
       auto value = scalarFunction.arguments().at(0).value();
       if (value.has_selection()) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1342,7 +1342,7 @@ void SubstraitToVeloxPlanConverter::separateFilters(
   for (const auto& scalarFunction : scalarFunctions) {
     auto filterNameSpec = SubstraitParser::findFunctionSpec(functionMap_, scalarFunction.function_reference());
     auto filterName = SubstraitParser::getSubFunctionName(filterNameSpec);
-    // Add all decimal filters to remaining functions because their pushdown are not supported
+    // Add all decimal filters to remaining functions because their pushdown are not supported.
     if (format == dwio::common::FileFormat::ORC && scalarFunction.arguments().size() > 0) {
       auto value = scalarFunction.arguments().at(0).value();
       if (value.has_selection()) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -350,7 +350,9 @@ class SubstraitToVeloxPlanConverter {
       std::vector<::substrait::Expression_ScalarFunction>& remainingFunctions,
       const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
       std::vector<::substrait::Expression_SingularOrList>& subfieldrOrLists,
-      std::vector<::substrait::Expression_SingularOrList>& remainingrOrLists);
+      std::vector<::substrait::Expression_SingularOrList>& remainingrOrLists,
+      std::vector<TypePtr>& veloxTypeList,
+      dwio::common::FileFormat format);
 
   /// Returns whether a function can be pushed down.
   static bool canPushdownCommonFunction(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -351,8 +351,8 @@ class SubstraitToVeloxPlanConverter {
       const std::vector<::substrait::Expression_SingularOrList>& singularOrLists,
       std::vector<::substrait::Expression_SingularOrList>& subfieldrOrLists,
       std::vector<::substrait::Expression_SingularOrList>& remainingrOrLists,
-      std::vector<TypePtr>& veloxTypeList,
-      dwio::common::FileFormat format);
+      const std::vector<TypePtr>& veloxTypeList,
+      const dwio::common::FileFormat& format);
 
   /// Returns whether a function can be pushed down.
   static bool canPushdownCommonFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?
At present, the orc filter of velox does not support decimal and timestamp. If the filter of decimal and timestamp is pushed down to scan, the task will directly fail. If scan fallback is set, serious performance regression will be caused. Therefore, it is currently necessary to push down only the types supported by the orc filter.

## How was this patch tested?
TPCDS  q33

