### PR TITLE
[GLUTEN-2862] [VL] Skip broken orc test

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Run CPP unit test
         run: |
           docker exec velox-ubuntu2004-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/cpp/build && \
-          ctest -V -E OrcTest'
+          ctest -V'
       # Cpp micro benchmarks will use generated files from unit test in backends-velox module.
       - name: Run micro benchmarks
         run: |

--- a/cpp/velox/tests/OrcTest.cc
+++ b/cpp/velox/tests/OrcTest.cc
@@ -163,6 +163,7 @@ void testReadOrc() {
 class OrcTest : public ::testing::Test {};
 
 TEST_F(OrcTest, testOrc) {
+  GTEST_SKIP() << "Issue 2862";
   testWriteOrc();
   testReadOrc();
   orcTestData.check();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip broken test and modify CI, after this patch, we can run `ctest -V` with no concern.

(Fixes: #2862)
