### PR TITLE
[CORE] Change default value to 0.0D of spark.gluten.sql.columnar.backend.velox.overAcquiredMemoryRatio

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -976,7 +976,7 @@ object GlutenConfig {
         "allocated memory as backup to avoid OOM")
       .doubleConf
       .checkValue(d => d >= 0.0d, "Over-acquired ratio should be larger than or equals 0")
-      .createWithDefault(0.3d)
+      .createWithDefault(0.0d)
 
   val COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD =
     buildConf("spark.gluten.sql.columnar.backend.ch.spillThreshold")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This should be an advance config for user who knows what they want in memory management.

Let's change its default value to 0.0D as OverAcquire class described.
