### PR TITLE
[VL] Fix hash aggregate fail with mixed supported and unsupported aggregate functions

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
@@ -17,7 +17,6 @@
 package io.glutenproject.execution
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.Row
 
 class VeloxAggregateFunctionsSuite extends WholeStageTransformerSuite {
 
@@ -654,10 +653,5 @@ class VeloxAggregateFunctionsSuite extends WholeStageTransformerSuite {
         assert(
           getExecutedPlan(df).count(plan => plan.isInstanceOf[HashAggregateExecTransformer]) >= 2)
     }
-  }
-
-  test("mixed supported and unsupported aggregate functions") {
-    val df = spark.sql("SELECT a, collect_set(b/b), max(b) FROM testData2 group by a")
-    checkAnswer(df, Row(1, Array(1.0), 2) :: Row(2, Array(1.0), 2) :: Row(3, Array(1.0), 2) :: Nil)
   }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.execution
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
 
 class VeloxAggregateFunctionsSuite extends WholeStageTransformerSuite {
 
@@ -653,5 +654,10 @@ class VeloxAggregateFunctionsSuite extends WholeStageTransformerSuite {
         assert(
           getExecutedPlan(df).count(plan => plan.isInstanceOf[HashAggregateExecTransformer]) >= 2)
     }
+  }
+
+  test("mixed supported and unsupported aggregate functions") {
+    val df = spark.sql("SELECT a, collect_set(b/b), max(b) FROM testData2 group by a")
+    checkAnswer(df, Row(1, Array(1.0), 2) :: Row(2, Array(1.0), 2) :: Row(3, Array(1.0), 2) :: Nil)
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -19,7 +19,10 @@ package org.apache.spark.sql
 import io.glutenproject.execution.HashAggregateExecBaseTransformer
 
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
+import org.apache.spark.sql.expressions.Aggregator
 import org.apache.spark.sql.functions._
+
+import java.lang.{Long => JLong}
 
 class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenSQLTestsTrait {
 
@@ -202,17 +205,21 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
   }
 
   test("mixed supported and unsupported aggregate functions") {
-    val df = spark.sql("SELECT a, collect_set(b), max(b) FROM testData2 group by a")
-    try {
-      checkAnswer(
-        df,
-        Row(1, Array(1, 2), 2) :: Row(2, Array(1, 2), 2) :: Row(3, Array(1, 2), 2) :: Nil)
-    } catch {
-      case _: Exception =>
-        // set is not determined
-        checkAnswer(
-          df,
-          Row(1, Array(2, 1), 2) :: Row(2, Array(2, 1), 2) :: Row(3, Array(2, 1), 2) :: Nil)
+    withUserDefinedFunction(("udaf_sum", true)) {
+      spark.udf.register(
+        "udaf_sum",
+        udaf(new Aggregator[JLong, JLong, JLong] {
+          override def zero: JLong = 0
+          override def reduce(b: JLong, a: JLong): JLong = a + b
+          override def merge(b1: JLong, b2: JLong): JLong = b1 + b2
+          override def finish(reduction: JLong): JLong = reduction
+          override def bufferEncoder: Encoder[JLong] = Encoders.LONG
+          override def outputEncoder: Encoder[JLong] = Encoders.LONG
+        })
+      )
+
+      val df = spark.sql("SELECT a, udaf_sum(b), max(b) FROM testData2 group by a")
+      checkAnswer(df, Row(1, 3, 2) :: Row(2, 3, 2) :: Row(3, 3, 2) :: Nil)
     }
   }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -200,4 +200,19 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
           _.isInstanceOf[HashAggregateExecBaseTransformer]).isDefined)
     }
   }
+
+  test("mixed supported and unsupported aggregate functions") {
+    val df = spark.sql("SELECT a, collect_set(b), max(b) FROM testData2 group by a")
+    try {
+      checkAnswer(
+        df,
+        Row(1, Array(1, 2), 2) :: Row(2, Array(1, 2), 2) :: Row(3, Array(1, 2), 2) :: Nil)
+    } catch {
+      case _: Exception =>
+        // set is not determined
+        checkAnswer(
+          df,
+          Row(1, Array(2, 1), 2) :: Row(2, Array(2, 1), 2) :: Row(3, Array(2, 1), 2) :: Nil)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fixes the bug that in native validation, when we check the aggregate signatures, we will return true once one of the aggregate functions matches. This pr changes to return ture only if all aggregate functions signatures match.


```sql
select c1, collect_set(c2), max(c2) from t group by c1;
```

```
23/08/24 13:27:45 ERROR TaskSetManager: Task 1 in stage 9.0 failed 1 times; aborting job
org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 9.0 failed 1 times, most recent failure: Lost task 1.0 in stage 9.0 (TID 23) (10.221.106.37 executor driver): java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Aggregate function 'array_distinct' not registered
Retriable: False
Function: intermediateType
File: /Users/cathy/Desktop/code/gluten/ep/build-velox/build/velox_ep/velox/exec/Aggregate.cpp
Line: 248
```

## How was this patch tested?

add test
