### PR TITLE
[VL] Fix the incorrect result type when decimal arithmetic expressions are nested

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -414,15 +414,22 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         val (left, right) = DecimalArithmeticUtil.rescaleCastForDecimal(
           DecimalArithmeticUtil.removeCastForDecimal(rescaleBinary.left),
           DecimalArithmeticUtil.removeCastForDecimal(rescaleBinary.right))
+        val leftChild = replaceWithExpressionTransformer(left, attributeSeq)
+        val rightChild = replaceWithExpressionTransformer(right, attributeSeq)
+
         val resultType = DecimalArithmeticUtil.getResultTypeForOperation(
           DecimalArithmeticUtil.getOperationType(b),
-          left.dataType.asInstanceOf[DecimalType],
-          right.dataType.asInstanceOf[DecimalType]
+          DecimalArithmeticUtil
+            .getResultType(leftChild)
+            .getOrElse(left.dataType.asInstanceOf[DecimalType]),
+          DecimalArithmeticUtil
+            .getResultType(rightChild)
+            .getOrElse(right.dataType.asInstanceOf[DecimalType])
         )
-        new DecimalArithmeticExpressionTransformer(
+        DecimalArithmeticExpressionTransformer(
           substraitExprName,
-          replaceWithExpressionTransformer(left, attributeSeq),
-          replaceWithExpressionTransformer(right, attributeSeq),
+          leftChild,
+          rightChild,
           resultType,
           b)
       case e: Transformable =>

--- a/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
@@ -100,7 +100,7 @@ case class LikeTransformer(
   }
 }
 
-class DecimalArithmeticExpressionTransformer(
+case class DecimalArithmeticExpressionTransformer(
     substraitExprName: String,
     left: ExpressionTransformer,
     right: ExpressionTransformer,


### PR DESCRIPTION
Fix the incorrect result type when decimal arithmetic expressions are nested. For example, in below case the input type got from divide is decimal(35, 20), which is not correct because cast was intentionally removed. Since the input types of divide are decimal(17, 2), the correct result type should be calculated from them.
> promote_precision(CheckOverflow((promote_precision(cast(promotions#850 as decimal(15,4))) / promote_precision(cast(total#851 as decimal(15,4)))), DecimalType(35,20))) * 100.00000000000000000000