### PR TITLE
[GLUTEN-2853] [VL] Move native arrow memory pool to MemoryManager

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -769,7 +769,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
 
   MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
-  shuffleWriterOptions.memory_pool = asArrowMemoryPool(memoryManager->getMemoryAllocator());
+  shuffleWriterOptions.memory_pool = memoryManager->getArrowMemoryPool();
   shuffleWriterOptions.ipc_memory_pool = shuffleWriterOptions.memory_pool;
 
   jclass cls = env->FindClass("java/lang/Thread");
@@ -952,7 +952,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
   JNI_METHOD_START
   MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
-  auto pool = asArrowMemoryPool(memoryManager->getMemoryAllocator());
+  auto pool = memoryManager->getArrowMemoryPool();
   ReaderOptions options = ReaderOptions::defaults();
   options.ipc_read_options.memory_pool = pool.get();
   options.ipc_read_options.use_threads = false;
@@ -1191,7 +1191,7 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializ
   env->ReleaseLongArrayElements(handles, batchhandles, JNI_ABORT);
 
   auto backend = createBackend();
-  auto arrowPool = asArrowMemoryPool(memoryManager->getMemoryAllocator());
+  auto arrowPool = memoryManager->getArrowMemoryPool();
   auto serializer = backend->getColumnarBatchSerializer(memoryManager, arrowPool, nullptr);
   auto buffer = serializer->serializeColumnarBatches(batches);
   auto bufferArr = env->NewByteArray(buffer->size());
@@ -1212,7 +1212,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializer
   JNI_METHOD_START
   MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
   GLUTEN_DCHECK(memoryManager != nullptr, "Memory manager does not exist or has been closed");
-  auto arrowPool = asArrowMemoryPool(memoryManager->getMemoryAllocator());
+  auto arrowPool = memoryManager->getArrowMemoryPool();
   auto backend = createBackend();
   auto serializer =
       backend->getColumnarBatchSerializer(memoryManager, arrowPool, reinterpret_cast<struct ArrowSchema*>(cSchema));

--- a/cpp/core/memory/ArrowMemoryPool.cc
+++ b/cpp/core/memory/ArrowMemoryPool.cc
@@ -20,12 +20,8 @@
 
 namespace gluten {
 
-std::shared_ptr<arrow::MemoryPool> asArrowMemoryPool(MemoryAllocator* allocator) {
-  return std::make_shared<ArrowMemoryPool>(allocator);
-}
-
 std::shared_ptr<arrow::MemoryPool> defaultArrowMemoryPool() {
-  static auto staticPool = asArrowMemoryPool(defaultMemoryAllocator().get());
+  static auto staticPool = std::make_shared<ArrowMemoryPool>(defaultMemoryAllocator().get());
   return staticPool;
 }
 

--- a/cpp/core/memory/ArrowMemoryPool.h
+++ b/cpp/core/memory/ArrowMemoryPool.h
@@ -21,9 +21,6 @@
 
 namespace gluten {
 
-/// This pool was tracked by Spark.
-std::shared_ptr<arrow::MemoryPool> asArrowMemoryPool(MemoryAllocator* allocator);
-
 /// This pool was not tracked by Spark, should only used in test.
 std::shared_ptr<arrow::MemoryPool> defaultArrowMemoryPool();
 

--- a/cpp/core/memory/MemoryManager.h
+++ b/cpp/core/memory/MemoryManager.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "MemoryAllocator.h"
+#include "arrow/memory_pool.h"
 #include "memory.pb.h"
 
 namespace gluten {
@@ -28,7 +28,7 @@ class MemoryManager {
 
   virtual ~MemoryManager() = default;
 
-  virtual MemoryAllocator* getMemoryAllocator() const = 0;
+  virtual std::shared_ptr<arrow::MemoryPool> getArrowMemoryPool() = 0;
 
   virtual const MemoryUsageStats collectMemoryUsageStats() const = 0;
 };

--- a/cpp/core/memory/MemoryManager.h
+++ b/cpp/core/memory/MemoryManager.h
@@ -28,6 +28,7 @@ class MemoryManager {
 
   virtual ~MemoryManager() = default;
 
+  // TODO: return raw pointer, caller should not care its lifecycle.
   virtual std::shared_ptr<arrow::MemoryPool> getArrowMemoryPool() = 0;
 
   virtual const MemoryUsageStats collectMemoryUsageStats() const = 0;

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -63,7 +63,7 @@ std::shared_ptr<VeloxShuffleWriter> createShuffleWriter(VeloxMemoryManager* memo
       std::make_shared<LocalPartitionWriterCreator>(false);
 
   auto options = ShuffleWriterOptions::defaults();
-  options.memory_pool = asArrowMemoryPool(memoryManager->getMemoryAllocator());
+  options.memory_pool = memoryManager->getArrowMemoryPool();
   options.ipc_memory_pool = options.memory_pool;
   options.partitioning_name = "rr"; // Round-Robin partitioning
   if (FLAGS_zstd) {

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -17,6 +17,7 @@
 
 #include "VeloxMemoryManager.h"
 
+#include "memory/ArrowMemoryPool.h"
 #include "utils/exception.h"
 
 namespace gluten {

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -164,12 +164,11 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
 };
 
 velox::memory::IMemoryManager::Options VeloxMemoryManager::getOptions(
-    std::shared_ptr<MemoryAllocator> allocator,
-    std::shared_ptr<AllocationListener> listener) const {
+    std::shared_ptr<MemoryAllocator> allocator) const {
   auto veloxAlloc = velox::memory::MemoryAllocator::getInstance();
 
 #ifdef GLUTEN_ENABLE_HBM
-  wrappedAlloc_ = std::move(std::make_unique<VeloxMemoryAllocator>(allocator.get(), veloxAlloc));
+  wrappedAlloc_ = std::make_unique<VeloxMemoryAllocator>(allocator.get(), veloxAlloc);
   veloxAlloc = wrappedAlloc_.get();
 #endif
 
@@ -194,13 +193,14 @@ velox::memory::IMemoryManager::Options VeloxMemoryManager::getOptions(
 }
 
 VeloxMemoryManager::VeloxMemoryManager(
-    const std::string& name,
+    std::string name,
     std::shared_ptr<MemoryAllocator> allocator,
     std::shared_ptr<AllocationListener> listener)
     : MemoryManager(), name_(name), listener_(listener) {
   glutenAlloc_ = std::make_unique<ListenableMemoryAllocator>(allocator.get(), listener_);
+  arrowPool_ = std::make_shared<ArrowMemoryPool>(glutenAlloc_.get());
 
-  auto options = getOptions(allocator, listener_);
+  auto options = getOptions(allocator);
   veloxMemoryManager_ = std::make_unique<velox::memory::MemoryManager>(options);
 
   veloxAggregatePool_ = veloxMemoryManager_->addRootPool(

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -27,7 +27,7 @@ namespace gluten {
 class VeloxMemoryManager final : public MemoryManager {
  public:
   explicit VeloxMemoryManager(
-      const std::string& name,
+      std::string name,
       std::shared_ptr<MemoryAllocator> allocator,
       std::shared_ptr<AllocationListener> listener);
 
@@ -39,8 +39,8 @@ class VeloxMemoryManager final : public MemoryManager {
     return veloxLeafPool_;
   }
 
-  MemoryAllocator* getMemoryAllocator() const override {
-    return glutenAlloc_.get();
+  std::shared_ptr<arrow::MemoryPool> getArrowMemoryPool() override {
+    return arrowPool_;
   }
 
   const MemoryUsageStats collectMemoryUsageStats() const override;
@@ -59,6 +59,8 @@ class VeloxMemoryManager final : public MemoryManager {
   // This is a listenable allocator used for arrow.
   std::unique_ptr<MemoryAllocator> glutenAlloc_;
   std::shared_ptr<AllocationListener> listener_;
+
+  std::shared_ptr<arrow::MemoryPool> arrowPool_;
 
   std::unique_ptr<facebook::velox::memory::MemoryManager> veloxMemoryManager_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxAggregatePool_;

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -46,9 +46,7 @@ class VeloxMemoryManager final : public MemoryManager {
   const MemoryUsageStats collectMemoryUsageStats() const override;
 
  private:
-  facebook::velox::memory::IMemoryManager::Options getOptions(
-      std::shared_ptr<MemoryAllocator> allocator,
-      std::shared_ptr<AllocationListener> listener) const;
+  facebook::velox::memory::IMemoryManager::Options getOptions(std::shared_ptr<MemoryAllocator> allocator) const;
 
   std::string name_;
 
@@ -59,7 +57,6 @@ class VeloxMemoryManager final : public MemoryManager {
   // This is a listenable allocator used for arrow.
   std::unique_ptr<MemoryAllocator> glutenAlloc_;
   std::shared_ptr<AllocationListener> listener_;
-
   std::shared_ptr<arrow::MemoryPool> arrowPool_;
 
   std::unique_ptr<facebook::velox::memory::MemoryManager> veloxMemoryManager_;


### PR DESCRIPTION
## What changes were proposed in this pull request?


Expose shared ptr getter API in MemoryManager for arrow memory pool, partial fix #2853. Will refactor getter API to raw pointer after consider memory_pool and ipc_writer_pool in ShuffleWriterOptions.
