### PR TITLE
[CH] Fix core dump when partition key not found

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/CHExecUtil.scala
@@ -177,13 +177,14 @@ object CHExecUtil extends Logging {
       partitoining: HashPartitioning,
       childOutput: Seq[Attribute],
       output: Seq[Attribute]): NativePartitioning = {
-    val hashFields = partitoining.expressions.map {
-      case a: Attribute =>
-        BindReferences
-          .bindReference(a, childOutput)
-          .asInstanceOf[BoundReference]
-          .ordinal
-    }
+    val hashFields =
+      partitoining.expressions.map(ConverterUtils.getAttrFromExpr(_).toAttribute).map {
+        case a: Attribute =>
+          BindReferences
+            .bindReference(a, childOutput)
+            .asInstanceOf[BoundReference]
+            .ordinal
+      }
     val outputFields = if (output != null) {
       output.map {
         a: Attribute =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

There some functions like KnownFloatingPointNormalized need skip in preproject of aggregation. The issue can reproduce by tpch q2

## How was this patch tested?

unit tests

