### PR TITLE
[VL] Fix UT: CheckOverflow

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -201,6 +201,9 @@ class VeloxTestSettings extends BackendTestSettings {
     // Unsupported format: yyyy-MM-dd HH:mm:ss.SSS
     .exclude("SPARK-33498: GetTimestamp,UnixTimestamp,ToUnixTimestamp with parseError")
   enableSuite[GlutenDecimalExpressionSuite]
+    // CheckOverflow is removed to avoid precision loss caused by rescaling.
+    // Replaced by "change decimal precision by cast"
+    .exclude("CheckOverflow")
   enableSuite[GlutenStringFunctionsSuite]
   enableSuite[GlutenRegexpExpressionsSuite]
   enableSuite[GlutenNullExpressionsSuite]

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDecimalExpressionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDecimalExpressionSuite.scala
@@ -17,5 +17,25 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.GlutenTestsTrait
+import org.apache.spark.sql.types.{Decimal, DecimalType}
 
-class GlutenDecimalExpressionSuite extends DecimalExpressionSuite with GlutenTestsTrait {}
+class GlutenDecimalExpressionSuite extends DecimalExpressionSuite with GlutenTestsTrait {
+  // Replace CheckOverflow with Cast to test the decimal precision change.
+  // nullOnOverflow is true because ANSI mode is not supported in expressions.
+  test("change decimal precision by cast") {
+    val d1 = Decimal("10.1")
+    checkEvaluation(Cast(Literal(d1), DecimalType(4, 0)), Decimal("10"))
+    checkEvaluation(Cast(Literal(d1), DecimalType(4, 1)), d1)
+    checkEvaluation(Cast(Literal(d1), DecimalType(4, 2)), d1)
+    checkEvaluation(Cast(Literal(d1), DecimalType(4, 3)), null)
+
+    val d2 = Decimal(101, 3, 1)
+    checkEvaluation(Cast(Literal(d2), DecimalType(4, 0)), Decimal("10"))
+    checkEvaluation(Cast(Literal(d2), DecimalType(4, 1)), d2)
+    checkEvaluation(Cast(Literal(d2), DecimalType(4, 2)), d2)
+    checkEvaluation(Cast(Literal(d2), DecimalType(4, 3)), null)
+
+    checkEvaluation(Cast(Literal.create(null, DecimalType(2, 1)), DecimalType(3, 2)), null)
+    checkEvaluation(Cast(Literal.create(null, DecimalType(2, 1)), DecimalType(3, 2)), null)
+  }
+}


### PR DESCRIPTION
On Gluten's main branch, `CheckOverflowExpression` is transformed into `CheckOverflowExpressionTransformer`, and is used to change the precision of a decimal value. But after rebase, the `CheckOverflowExpressionTransformer` is removed and the native computation will directly use the original scale/precision to avoid precision loss. Therefore after rebase, the UT failed because the `CheckOverflow` is nolonger used to change the precision of a decimal, and it should use `Cast` instead.

Reference:

Gluten main: https://github.com/oap-project/gluten/blob/0891942447560b26ad4374ad533b05b53bbb65c2/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala#L159-L183

Gluten rebase: https://github.com/oap-project/gluten/blob/647bdb611eb1d81ac1269658d42f201911972723/gluten-core/src/main/scala/io/glutenproject/expression/UnaryExpressionTransformer.scala#L159-L168