### PR TITLE
[GLUTEN-2929][CH] Read s3 file using global ch readsetting

### DIFF
--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -430,7 +430,7 @@ public:
 
         DB::StoredObjects stored_objects{DB::StoredObject{key, object_size}};
         auto s3_impl = std::make_unique<DB::ReadBufferFromRemoteFSGather>(
-            std::move(read_buffer_creator), stored_objects, new_settings, /* cache_log */ nullptr, /* use_external_buffer */ false);
+            std::move(read_buffer_creator), stored_objects, new_settings, /* cache_log */ nullptr, /* use_external_buffer */ true);
 
         auto & pool_reader = context->getThreadPoolReader(DB::FilesystemReaderType::ASYNCHRONOUS_REMOTE_FS_READER);
         auto async_reader


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. S3 ReadSetting 从全局参数中复制来
2. 修改remotebuffer    use_external_buffer=true
    arrow读取parquet footer时,当footsize小于metalength，重新读取metaleng
```
if (footer_read_size >= (metadata_len + kFooterSize)) {
      metadata_buffer = SliceBuffer(
          footer_buffer, footer_read_size - metadata_len - kFooterSize, metadata_len);
    } else {
      PARQUET_ASSIGN_OR_THROW(metadata_buffer,
                              source_->ReadAt(metadata_start, metadata_len));
    }
```
读取时会先将bufer seek到metadata pos
```
  std::lock_guard<std::mutex> lock(interface_impl_->lock_);
  RETURN_NOT_OK(Seek(position));
  return Read(nbytes);
```
当use_external_buffer=false时，cachebufer无法完成seek，但是最后readsize=0

(Fixes: \#2929)





