### PR TITLE
[VL] Support offlaod map literal

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxFunctionsValidateSuite.scala
@@ -19,6 +19,7 @@ package io.glutenproject.execution
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, NullPropagation}
+import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.types._
 
 import java.nio.file.Files
@@ -342,5 +343,49 @@ class VeloxFunctionsValidateSuite extends WholeStageTransformerSuite {
           checkOperatorMatch[ProjectExecTransformer]
         }
     }
+  }
+
+  test("map literal - offload") {
+    def validateOffloadResult(sql: String): Unit = {
+      // allow constant folding
+      withSQLConf("spark.sql.optimizer.excludedRules" -> "") {
+        runQueryAndCompare(sql) {
+          df =>
+            val plan = df.queryExecution.executedPlan
+            assert(plan.find(_.isInstanceOf[ProjectExecTransformer]).isDefined, sql)
+            assert(plan.find(_.isInstanceOf[ProjectExec]).isEmpty, sql)
+        }
+      }
+    }
+
+    validateOffloadResult("SELECT map('b', 'a', 'e', 'e')")
+    validateOffloadResult("SELECT map(1, 'a', 2, 'e')")
+    validateOffloadResult("SELECT map(1, map(1,2,3,4))")
+    validateOffloadResult("SELECT array(map(1,2,3,4))")
+    validateOffloadResult("SELECT map(array(1,2,3), array(1))")
+    validateOffloadResult("SELECT array(map(array(1,2), map(1,2,3,4)))")
+    validateOffloadResult("SELECT map(array(1,2), map(1,2))")
+  }
+
+  test("map literal - fallback") {
+    def validateFallbackResult(sql: String): Unit = {
+      withSQLConf("spark.sql.optimizer.excludedRules" -> "") {
+        runQueryAndCompare(sql) {
+          df =>
+            val plan = df.queryExecution.executedPlan
+            assert(plan.find(_.isInstanceOf[ProjectExecTransformer]).isEmpty, sql)
+            assert(plan.find(_.isInstanceOf[ProjectExec]).isDefined, sql)
+        }
+      }
+    }
+
+    validateFallbackResult("SELECT array()")
+    validateFallbackResult("SELECT array(array())")
+    validateFallbackResult("SELECT array(null)")
+    validateFallbackResult("SELECT array(map())")
+    validateFallbackResult("SELECT map()")
+    validateFallbackResult("SELECT map(1, null)")
+    validateFallbackResult("SELECT map(1, array())")
+    validateFallbackResult("SELECT map(1, map())")
   }
 }

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.h
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.h
@@ -87,8 +87,14 @@ class SubstraitVeloxExprConverter {
 
  private:
   /// Convert list literal to ArrayVector.
-  ArrayVectorPtr literalsToArrayVector(const ::substrait::Expression::Literal& listLiteral);
-
+  ArrayVectorPtr literalsToArrayVector(const ::substrait::Expression::Literal& literal);
+  /// Convert map literal to MapVector.
+  MapVectorPtr literalsToMapVector(const ::substrait::Expression::Literal& literal);
+  VectorPtr literalsToVector(
+      ::substrait::Expression_Literal::LiteralTypeCase childTypeCase,
+      vector_size_t childSize,
+      const ::substrait::Expression::Literal& literal,
+      std::function<::substrait::Expression::Literal(vector_size_t /* idx */)> elementAtFunc);
   RowVectorPtr literalsToRowVector(const ::substrait::Expression::Literal& structLiteral);
 
   /// Memory pool.

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -249,9 +249,30 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
 bool SubstraitToVeloxPlanValidator::validateLiteral(
     const ::substrait::Expression_Literal& literal,
     const RowTypePtr& inputType) {
-  if (literal.has_list() && literal.list().values_size() == 0) {
-    logValidateMsg("native validation failed due to: literal is a list but has no value.");
-    return false;
+  if (literal.has_list()) {
+    if (literal.list().values_size() == 0) {
+      logValidateMsg("native validation failed due to: literal is a list but has no value.");
+      return false;
+    } else {
+      for (auto child : literal.list().values()) {
+        if (!validateLiteral(child, inputType)) {
+          // the error msg has been set, so do not need to set it again.
+          return false;
+        }
+      }
+    }
+  } else if (literal.has_map()) {
+    if (literal.map().key_values().empty()) {
+      logValidateMsg("native validation failed due to: literal is a map but has no value.");
+      return false;
+    } else {
+      for (auto child : literal.map().key_values()) {
+        if (!validateLiteral(child.key(), inputType) || !validateLiteral(child.value(), inputType)) {
+          // the error msg has been set, so do not need to set it again.
+          return false;
+        }
+      }
+    }
   }
   return true;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr supports offload map literal to velox backend. Including nested array/map literal. e.g.,
```
select map(1, 2);
select map(1, map(1,2));
select map(1, array(1,2));
```

This pr also fixes the issue that we should fallback the array literal if it has empty nested array. e.g.,
```
select array(array());

Caused by: java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: UNSUPPORTED
Reason: Unsupported type: UNKNOWN
Retriable: False
Function: initialize
File: /Users/cathy/Desktop/code/gluten/ep/build-velox/build/velox_ep/velox/row/UnsafeRowFast.cpp
Line: 137
```

## How was this patch tested?

add test
