### PR TITLE
[VL] Download maven from archive site

### DIFF
--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -18,7 +18,7 @@ install_centos_any_maven() {
         fi
 
         cd /tmp
-        wget https://downloads.apache.org/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz
+        wget https://archive.apache.org/dist/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz
         tar -xvf apache-maven-$maven_version-bin.tar.gz
         rm apache-maven-$maven_version-bin.tar.gz
         mv apache-maven-$maven_version "${maven_install_dir}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Version 3.9.2 is not available from  https://downloads.apache.org/maven/maven-3/ which has been archived.

## How was this patch tested?

manual tests

