### PR TITLE
[VL] Avoid hold unmanaged velox memory pool for caller

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -81,7 +81,6 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
   }
 
   auto veloxPool = getAggregateVeloxPool(memoryManager);
-  auto ctxPool = veloxPool->addAggregateChild("result_iterator", facebook::velox::memory::MemoryReclaimer::create());
 
   VeloxPlanConverter veloxPlanConverter(inputIters_, getLeafVeloxPool(memoryManager).get(), sessionConf);
   veloxPlan_ = veloxPlanConverter.toVeloxPlan(substraitPlan_);
@@ -97,11 +96,11 @@ std::shared_ptr<ResultIterator> VeloxBackend::getResultIterator(
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter = std::make_unique<WholeStageResultIteratorMiddleStage>(
-        ctxPool, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
+        veloxPool, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
     return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
   } else {
     auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
-        ctxPool, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
+        veloxPool, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
     return std::make_shared<ResultIterator>(std::move(wholestageIter), shared_from_this());
   }
 }

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -92,8 +92,7 @@ class VeloxBackend final : public Backend {
       MemoryManager* memoryManager,
       std::shared_ptr<arrow::Schema> schema) override {
     auto veloxPool = getAggregateVeloxPool(memoryManager);
-    auto ctxVeloxPool = veloxPool->addAggregateChild("velox_parquet_writer");
-    return std::make_shared<VeloxParquetDatasource>(filePath, ctxVeloxPool, schema);
+    return std::make_shared<VeloxParquetDatasource>(filePath, veloxPool, schema);
   }
 
   std::shared_ptr<Reader> getShuffleReader(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox's addXXXPool only hold weak ptr in parent pool, returned shared ptr should be managed by caller.

Before this patch, WholeStageIter hold the shared pool and will release pool when we release iterator, but in some cases, there still some unused/unreleased batches before release iterator, so we may get bad memory usage error from Velox.

Since we implement MemoryManager to hold the shared ptr of memory pool, use getXXXPool of VeloxMemoryManager directly is more safe.

(Fixes: \#ISSUE-ID)
