### PR TITLE
[GLUTEN-2970][CH] respect clickhouse settings: query_plan_enable_optimizations

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHTransformerApi.scala
@@ -164,6 +164,13 @@ class CHTransformerApi extends TransformerApi with Logging {
     injectConfig(
       "spark.hadoop.dfs.client.log.severity",
       hdfsConfigPrefix + "dfs_client_log_severity")
+
+    // TODO: set default to true when metrics could be collected
+    // while ch query plan optimization is enabled.
+    val planOptKey = settingPrefix + "query_plan_enable_optimizations"
+    if (!nativeConfMap.containsKey(planOptKey)) {
+      nativeConfMap.put(planOptKey, "false")
+    }
   }
 
   override def getSupportExpressionClassName: util.Set[String] = {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1302,12 +1302,10 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
       noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit = {
     val confName = "spark.gluten.sql.columnar.backend.ch." +
       "runtime_settings.query_plan_enable_optimizations"
-
-    withSQLConf((confName, "false")) {
+    withSQLConf((confName, "true")) {
       compareTPCHQueryAgainstVanillaSpark(queryNum, tpchQueries, customCheck, noFallBack)
     }
-
-    withSQLConf((confName, "true")) {
+    withSQLConf((confName, "false")) {
       compareTPCHQueryAgainstVanillaSpark(queryNum, tpchQueries, customCheck, noFallBack)
     }
   }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1300,7 +1300,16 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
       queriesResults: String = queriesResults,
       compareResult: Boolean = true,
       noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit = {
-    compareTPCHQueryAgainstVanillaSpark(queryNum, tpchQueries, customCheck, noFallBack)
+    val confName = "spark.gluten.sql.columnar.backend.ch." +
+      "runtime_settings.query_plan_enable_optimizations"
+
+    withSQLConf((confName, "false")) {
+      compareTPCHQueryAgainstVanillaSpark(queryNum, tpchQueries, customCheck, noFallBack)
+    }
+
+    withSQLConf((confName, "true")) {
+      compareTPCHQueryAgainstVanillaSpark(queryNum, tpchQueries, customCheck, noFallBack)
+    }
   }
 
   test("test 'ColumnarToRowExec should not be used'") {

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -593,8 +593,10 @@ void BackendInitializerUtil::initSettings(std::map<std::string, std::string> & b
     settings.set("output_format_parquet_fixed_string_as_fixed_byte_array", false);
     settings.set("function_json_value_return_type_allow_complex", true);
     settings.set("function_json_value_return_type_allow_nullable", true);
+
     /// TODO: set default to true when metrics could be collected while ch query plan optimization is enabled.
-    settings.set("query_plan_enable_optimizations", false);
+    if (!settings.has("query_plan_enable_optimizations"))
+        settings.set("query_plan_enable_optimizations", false);
 }
 
 void BackendInitializerUtil::initContexts(DB::Context::ConfigurationPtr config)

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -594,9 +594,7 @@ void BackendInitializerUtil::initSettings(std::map<std::string, std::string> & b
     settings.set("function_json_value_return_type_allow_complex", true);
     settings.set("function_json_value_return_type_allow_nullable", true);
 
-    /// TODO: set default to true when metrics could be collected while ch query plan optimization is enabled.
-    if (!settings.has("query_plan_enable_optimizations"))
-        settings.set("query_plan_enable_optimizations", false);
+
 }
 
 void BackendInitializerUtil::initContexts(DB::Context::ConfigurationPtr config)

--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -593,6 +593,8 @@ void BackendInitializerUtil::initSettings(std::map<std::string, std::string> & b
     settings.set("output_format_parquet_fixed_string_as_fixed_byte_array", false);
     settings.set("function_json_value_return_type_allow_complex", true);
     settings.set("function_json_value_return_type_allow_nullable", true);
+    /// TODO: set default to true when metrics could be collected while ch query plan optimization is enabled.
+    settings.set("query_plan_enable_optimizations", false);
 }
 
 void BackendInitializerUtil::initContexts(DB::Context::ConfigurationPtr config)

--- a/cpp-ch/local-engine/Parser/RelMetric.cpp
+++ b/cpp-ch/local-engine/Parser/RelMetric.cpp
@@ -22,27 +22,33 @@ using namespace rapidjson;
 
 namespace local_engine
 {
+
 RelMetric::RelMetric(size_t id_, const String & name_, std::vector<DB::IQueryPlanStep *> & steps_) : id(id_), name(name_), steps(steps_)
 {
 }
+
 RelMetric::RelMetric(const String & name_, const std::vector<RelMetricPtr> & inputs_, std::vector<DB::IQueryPlanStep *> & steps_)
     : name(name_), steps(steps_), inputs(inputs_)
 {
     auto rel = std::max_element(inputs.begin(), inputs.end(), [](RelMetricPtr a, RelMetricPtr b) { return a->id < b->id; });
     id = rel->get()->id + 1;
 }
+
 size_t RelMetric::getId() const
 {
     return id;
 }
+
 const std::vector<DB::IQueryPlanStep *> & RelMetric::getSteps() const
 {
     return steps;
 }
+
 const std::vector<RelMetricPtr> & RelMetric::getInputs() const
 {
     return inputs;
 }
+
 RelMetricTimes RelMetric::getTotalTime() const
 {
     RelMetricTimes timeMetrics{0, 0, 0};
@@ -115,6 +121,7 @@ void RelMetric::serialize(Writer<StringBuffer> & writer, bool) const
     }
     writer.EndObject();
 }
+
 const String & RelMetric::getName() const
 {
     return name;
@@ -143,4 +150,5 @@ std::string RelMetricSerializer::serializeRelMetric(RelMetricPtr rel_metric, boo
     }
     return result.GetString();
 }
+
 }

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -290,7 +290,7 @@ public:
     void parseExtensions(const ::google::protobuf::RepeatedPtrField<substrait::extensions::SimpleExtensionDeclaration> & extensions);
     std::shared_ptr<DB::ActionsDAG> expressionsToActionsDAG(
         const std::vector<substrait::Expression> & expressions, const DB::Block & header, const DB::Block & read_schema);
-    RelMetricPtr getMetric() { return metrics.at(0); }
+    RelMetricPtr getMetric() { return metrics.empty() ? nullptr : metrics.at(0); }
 
     static std::string getFunctionName(const std::string & function_sig, const substrait::Expression_ScalarFunction & function);
 
@@ -389,8 +389,10 @@ public:
     ~LocalExecutor();
 
     Block & getHeader();
-    const RelMetricPtr getMetric() const { return metric; }
+
+    RelMetricPtr getMetric() const { return metric; }
     void setMetric(RelMetricPtr metric_) { metric = metric_; }
+
     void setExtraPlanHolder(std::vector<QueryPlanPtr> & extra_plan_holder_) { extra_plan_holder = std::move(extra_plan_holder_); }
 
 private:

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -329,15 +329,10 @@ JNIEXPORT void Java_io_glutenproject_vectorized_BatchIterator_nativeClose(JNIEnv
 JNIEXPORT jobject Java_io_glutenproject_vectorized_BatchIterator_nativeFetchMetrics(JNIEnv * env, jobject /*obj*/, jlong executor_address)
 {
     LOCAL_ENGINE_JNI_METHOD_START
-    String metrics_json;
-    const auto & settings = local_engine::SerializedPlanParser::global_context->getSettingsRef();
     /// Collect metrics only if optimizations are disabled, otherwise coredump would happen.
-    if (!settings.query_plan_enable_optimizations)
-    {
-        local_engine::LocalExecutor * executor = reinterpret_cast<local_engine::LocalExecutor *>(executor_address);
-        metrics_json = local_engine::RelMetricSerializer::serializeRelMetric(executor->getMetric());
-    }
-
+    local_engine::LocalExecutor * executor = reinterpret_cast<local_engine::LocalExecutor *>(executor_address);
+    auto metric = executor->getMetric();
+    String metrics_json = metric ? local_engine::RelMetricSerializer::serializeRelMetric(metric) : "";
     LOG_DEBUG(&Poco::Logger::get("jni"), "{}", metrics_json);
     jobject native_metrics = env->NewObject(native_metrics_class, native_metrics_constructor, stringTojstring(env, metrics_json.c_str()));
     return native_metrics;

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -331,13 +331,12 @@ JNIEXPORT jobject Java_io_glutenproject_vectorized_BatchIterator_nativeFetchMetr
     LOCAL_ENGINE_JNI_METHOD_START
     String metrics_json;
     const auto & settings = local_engine::SerializedPlanParser::global_context->getSettingsRef();
+    /// Collect metrics only if optimizations are disabled, otherwise coredump would happen.
     if (!settings.query_plan_enable_optimizations)
     {
         local_engine::LocalExecutor * executor = reinterpret_cast<local_engine::LocalExecutor *>(executor_address);
         metrics_json = local_engine::RelMetricSerializer::serializeRelMetric(executor->getMetric());
     }
-    else
-        metrics_json = "{}";
 
     LOG_DEBUG(&Poco::Logger::get("jni"), "{}", metrics_json);
     jobject native_metrics = env->NewObject(native_metrics_class, native_metrics_constructor, stringTojstring(env, metrics_json.c_str()));
@@ -727,7 +726,6 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHShuffleSplitterJniWrapper_evi
     LOCAL_ENGINE_JNI_METHOD_START
     local_engine::SplitterHolder * splitter = reinterpret_cast<local_engine::SplitterHolder *>(splitterId);
     auto size = splitter->splitter->evictPartitions();
-    std::cerr << "spill data: " << size << std::endl;
     return size;
     LOCAL_ENGINE_JNI_METHOD_END(env, 0)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#2970)

How to enable ch query plan optimization? 
By default ch query plan optimization is disabled, you can use `--conf spark.gluten.sql.columnar.backend.ch.runtime_settings.query_plan_enable_optimizations=true` to enable it. 