### PR TITLE
[GLUTEN-2978][VL]fix: GlutenConfig.getConf should not be called before SQLConf initialize

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.FileFormatWriter.Empty2Null
 object ExpressionMappings {
 
   /** Mapping Spark scalar expression to Substrait function name */
-  private val SCALAR_SIGS: Seq[Sig] = Seq(
+  private lazy val SCALAR_SIGS: Seq[Sig] = Seq(
     Sig[Add](ADD),
     Sig[Asinh](ASINH),
     Sig[Acosh](ACOSH),


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/oap-project/gluten/issues/2978

## How was this patch tested?

pass the existing test

