### PR TITLE
[VL] Include Arrow memory pool in OOM error message

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -212,21 +212,34 @@ VeloxMemoryManager::VeloxMemoryManager(
 }
 
 namespace {
-MemoryUsageStats collectMemoryUsageStatsInternal(const velox::memory::MemoryPool* pool) {
+MemoryUsageStats collectVeloxMemoryPoolUsageStats(const velox::memory::MemoryPool* pool) {
   MemoryUsageStats stats;
   stats.set_current(pool->currentBytes());
   stats.set_peak(pool->peakBytes());
   // walk down root and all children
   pool->visitChildren([&](velox::memory::MemoryPool* pool) -> bool {
-    stats.mutable_children()->emplace(pool->name(), collectMemoryUsageStatsInternal(pool));
+    stats.mutable_children()->emplace(pool->name(), collectVeloxMemoryPoolUsageStats(pool));
     return true;
   });
+  return stats;
+}
+
+MemoryUsageStats collectArrowMemoryPoolUsageStats(const arrow::MemoryPool* pool) {
+  MemoryUsageStats stats;
+  stats.set_current(pool->bytes_allocated());
   return stats;
 }
 } // namespace
 
 const MemoryUsageStats VeloxMemoryManager::collectMemoryUsageStats() const {
-  return collectMemoryUsageStatsInternal(veloxAggregatePool_.get());
+  const MemoryUsageStats& veloxPoolStats = collectVeloxMemoryPoolUsageStats(veloxAggregatePool_.get());
+  const MemoryUsageStats& arrowPoolStats = collectArrowMemoryPoolUsageStats(arrowPool_.get());
+  MemoryUsageStats stats;
+  stats.set_current(veloxPoolStats.current() + arrowPoolStats.current());
+  stats.set_peak(-1L); // we don't know about peak
+  stats.mutable_children()->emplace("velox", std::move(veloxPoolStats));
+  stats.mutable_children()->emplace("arrow", std::move(arrowPoolStats));
+  return stats;
 }
 
 velox::memory::IMemoryManager* getDefaultVeloxMemoryManager() {


### PR DESCRIPTION
Arrow memory pool will be shown in the OOM error message as a sub leaf node of Gluten's memory consumer.

For example:

```
23/08/31 13:25:53 ERROR ManagedReservationListener: Error reserving memory from target
io.glutenproject.memory.memtarget.ThrowOnOomMemoryTarget$OutOfMemoryException: Not enough spark off-heap execution memory. Acquired: 8388608, granted: 0. Try tweaking config option spark.memory.offHeap.size to get larger space to run this application. 
Current config settings: 
	spark.gluten.memory.offHeap.size.in.bytes=4.0 GiB
	spark.gluten.memory.task.offHeap.size.in.bytes=512.0 MiB
Memory consumer stats:
	GlutenMemoryConsumer/WholeStageIterator@57eaa45b:                Current used bytes:  408.0 MiB, peak bytes:  408.0 MiB
	+- velox:                                                        Current used bytes:  408.0 MiB, peak bytes:  408.0 MiB
	|  +- result_iterator:                                           Current used bytes:  408.0 MiB, peak bytes:  408.0 MiB
	|  |  \- task.Gluten stage-27 task-32:                           Current used bytes:  408.0 MiB, peak bytes:  408.0 MiB
	|  |     +- node.15:                                             Current used bytes:  344.0 MiB, peak bytes:  344.0 MiB
	|  |     |  \- op.15.0.0.PartialAggregation:                     Current used bytes:  339.6 MiB, peak bytes:  339.6 MiB
	|  |     +- node.10:                                             Current used bytes:   33.0 MiB, peak bytes:   33.0 MiB
	|  |     |  +- op.10.3.0.HashBuild:                              Current used bytes:   28.9 MiB, peak bytes:   28.9 MiB
	|  |     |  \- op.10.0.0.HashProbe:                              Current used bytes:  240.9 KiB, peak bytes:  241.0 KiB
	|  |     +- node.3:                                              Current used bytes:   24.0 MiB, peak bytes:   24.0 MiB
	|  |     |  +- op.3.0.0.TableScan:                               Current used bytes:   23.4 MiB, peak bytes:   23.6 MiB
	|  |     |  \- op.3.0.0.TableScan.test-hive:                     Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.4:                                              Current used bytes:    2.0 MiB, peak bytes:    2.0 MiB
	|  |     |  +- op.4.1.0.HashBuild:                               Current used bytes:   68.0 KiB, peak bytes:   68.0 KiB
	|  |     |  \- op.4.0.0.HashProbe:                               Current used bytes:   56.6 KiB, peak bytes:   96.0 KiB
	|  |     +- node.7:                                              Current used bytes:    2.0 MiB, peak bytes:    2.0 MiB
	|  |     |  +- op.7.2.0.HashBuild:                               Current used bytes:  132.0 KiB, peak bytes:  132.0 KiB
	|  |     |  \- op.7.0.0.HashProbe:                               Current used bytes:   96.2 KiB, peak bytes:  104.0 KiB
	|  |     +- node.17:                                             Current used bytes:    2.0 MiB, peak bytes:    2.0 MiB
	|  |     |  \- op.17.0.0.FilterProject:                          Current used bytes: 1111.5 KiB, peak bytes: 1111.5 KiB
	|  |     +- node.14:                                             Current used bytes: 1024.0 KiB, peak bytes: 1024.0 KiB
	|  |     |  \- op.14.0.0.FilterProject:                          Current used bytes:    8.2 KiB, peak bytes:   32.5 KiB
	|  |     +- node.5:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.5.0.0.FilterProject:                           Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.13:                                             Current used bytes:      0.0 B, peak bytes: 1024.0 KiB
	|  |     |  \- op.13.0.0.Expand:                                 Current used bytes:      0.0 B, peak bytes:   1024.0 B
	|  |     +- node.12:                                             Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.12.0.0.FilterProject:                          Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.2:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.2.3.0.ValueStream:                             Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.8:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.8.0.0.FilterProject:                           Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.9:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.9.0.0.FilterProject:                           Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.6:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.6.0.0.FilterProject:                           Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.0:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.0.1.0.ValueStream:                             Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.16:                                             Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.16.0.0.FilterProject:                          Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     +- node.11:                                             Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     |  \- op.11.0.0.FilterProject:                          Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |     \- node.1:                                              Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  |        \- op.1.2.0.ValueStream:                             Current used bytes:      0.0 B, peak bytes:      0.0 B
	|  \- WholeStageIterator_default_leaf:                           Current used bytes:      0.0 B, peak bytes:      0.0 B
	\- arrow:                                                        Current used bytes:      0.0 B, peak bytes:      0.0 B
	GlutenMemoryConsumer/ShuffleWriter@cf042d5:                      Current used bytes:   64.0 MiB, peak bytes:   64.0 MiB
	+- arrow:                                                        Current used bytes:   63.0 MiB, peak bytes:      0.0 B   <- the arrow memory pool
	\- velox:                                                        Current used bytes:      0.0 B, peak bytes: 1024.0 KiB
	   \- ShuffleWriter_default_leaf:                                Current used bytes:      0.0 B, peak bytes:   1408.0 B
	GlutenMemoryConsumer/BuildSideRelation#BatchSerializer@6aa0d12e: Current used bytes:   40.0 MiB, peak bytes:   40.0 MiB
	+- velox:                                                        Current used bytes:      0.0 B, peak bytes:   32.0 MiB
	|  \- BuildSideRelation#BatchSerializer_default_leaf:            Current used bytes:      0.0 B, peak bytes:   31.6 MiB
	\- arrow:                                                        Current used bytes:      0.0 B, peak bytes:      0.0 B
	OverAcquire.DummyTarget@19b0bd8:                                 Current used bytes:      0.0 B, peak bytes:   12.0 MiB
	OverAcquire.DummyTarget@55ec4d58:                                Current used bytes:      0.0 B, peak bytes:   14.4 MiB
	OverAcquire.DummyTarget@60b5c64c:                                Current used bytes:      0.0 B, peak bytes:  108.0 MiB
	GlutenMemoryConsumer/ArrowContextInstance@2629af25:              Current used bytes:      0.0 B, peak bytes:    8.0 MiB
```