### PR TITLE
[VL] Fix generated spilled file already created

### DIFF
--- a/cpp/core/shuffle/utils.h
+++ b/cpp/core/shuffle/utils.h
@@ -25,8 +25,6 @@
 #include <arrow/type.h>
 #include <arrow/util/io_util.h>
 
-#include <bits/fcntl.h>
-#include <boost/thread.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <fcntl.h>
@@ -116,6 +114,8 @@ static inline arrow::Result<std::string> createTempShuffleFile(const std::string
         } else {
           return arrow::Status::IOError("Failed to open local file " + filePath + ", Reason: " + strerror(errno));
         }
+      } else {
+        close(fd);
       }
     }
   }

--- a/cpp/core/shuffle/utils.h
+++ b/cpp/core/shuffle/utils.h
@@ -106,15 +106,13 @@ static inline arrow::Result<std::string> createTempShuffleFile(const std::string
     filePath = arrow::fs::internal::ConcatAbstractPath(dir, "temp_shuffle_" + generateUuid());
     ARROW_ASSIGN_OR_RAISE(auto file_info, fs->GetFileInfo(filePath));
     if (file_info.type() == arrow::fs::FileType::NotFound) {
-      exist = false;
       int fd = open(filePath.c_str(), O_CREAT | O_EXCL | O_RDWR, 0666);
       if (fd < 0) {
-        if (errno == EEXIST) {
-          exist = true;
-        } else {
+        if (errno != EEXIST) {
           return arrow::Status::IOError("Failed to open local file " + filePath + ", Reason: " + strerror(errno));
         }
       } else {
+        exist = false;
         close(fd);
       }
     }


### PR DESCRIPTION
The current judgement of whether a new filename of local shuffle spill has already been created is wrong. Should use "O_EXCL" in the read flag to judge if the file has been created.