### PR TITLE
[VL] Fix Row to Columnar memory leak when cancel task

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -105,7 +105,7 @@ case class RowToVeloxColumnarExec(child: SparkPlan)
               var arrowBuf: ArrowBuf = null
               TaskResources.addRecycler("RowToColumnar_arrowBuf", 100) {
                 // Remind, remove isOpen here
-                if (arrowBuf != null && arrowBuf.refCnt() == 0) {
+                if (arrowBuf != null && arrowBuf.refCnt() != 0) {
                   arrowBuf.close()
                 }
               }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before, when cancel the follow query, it would cause memory leak due to arrow buffer not released.

```
val sql = "select /*+ repartition(10) */ * from (select *, java_method('java.lang.Thread', 'sleep', 1000 * cast(spark_partition_id() as long)) from range(100))"
sc.setJobGroup("g1", sql, true)
spark.sql(sql).collect
```

```
23/09/01 15:26:58 WARN ArrowBufferAllocators$ArrowBufferAllocatorManager: Detected leaked Arrow allocator, size: 2097152, process accumulated leaked size: 6291456...
23/09/01 15:26:58 WARN ArrowBufferAllocators$ArrowBufferAllocatorManager: Leaked allocator stack Allocator(ROOT) 0/2097152/2097152/9223372036854775807 (res/actual/peak/limit)
```

## How was this patch tested?

manually test
