### PR TITLE
[CORE] Switch default Maven dependency scope of Spark to provided (by default) in gluten-it

### DIFF
--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -46,16 +46,19 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-repl_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>org.apache.arrow</groupId>
@@ -67,17 +70,20 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-hive_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
         <type>test-jar</type>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

FIXES https://github.com/oap-project/gluten/security/dependabot/37

## How was this patch tested?

Verify via local maven build.

