### PR TITLE
[GLUTEN-2808][VL] All managed Velox memory pools should be shrinkable

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -187,7 +187,7 @@ class JniColumnarBatchIterator : public ColumnarBatchIterator {
     jColumnarBatchItr_ = env->NewGlobalRef(jColumnarBatchItr);
   }
 
-  // singleton, avoid stack instantiation
+  // singleton
   JniColumnarBatchIterator(const JniColumnarBatchIterator&) = delete;
   JniColumnarBatchIterator(JniColumnarBatchIterator&&) = delete;
   JniColumnarBatchIterator& operator=(const JniColumnarBatchIterator&) = delete;

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1160,6 +1160,15 @@ JNIEXPORT jbyteArray JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManage
   return out;
 }
 
+JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_shrink( // NOLINT
+    JNIEnv* env,
+    jclass,
+    jlong memoryManagerId,
+    jlong size) {
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  return memoryManager->shrink(static_cast<int64_t>(size));
+}
+
 JNIEXPORT void JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_release( // NOLINT
     JNIEnv* env,
     jclass,

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -125,12 +125,12 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   LOG(INFO) << logPrefix << "Pool has reserved " << pool_->currentBytes() << "/" << pool_->root()->reservedBytes()
             << "/" << pool_->root()->capacity() << "/" << pool_->root()->maxCapacity() << " bytes.";
   LOG(INFO) << logPrefix << "Shrinking...";
-  int64_t shrunk = pool_->shrinkManaged(pool_.get(), size);
-  LOG(INFO) << logPrefix << shrunk << " bytes released from shrinking.";
+  int64_t shrunken = pool_->shrinkManaged(pool_.get(), size);
+  LOG(INFO) << logPrefix << shrunken << " bytes released from shrinking.";
 
   // todo return the actual spilled size?
   if (spillStrategy_ == "auto") {
-    int64_t remaining = size - shrunk;
+    int64_t remaining = size - shrunken;
     LOG(INFO) << logPrefix << "Trying to request spilling for remaining " << remaining << " bytes...";
     // if we are on one of the driver of the spilled task, suspend it
     velox::exec::Driver* thisDriver = nullptr;
@@ -143,21 +143,21 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
       // not the driver, no need to suspend
       uint64_t spilledOut = pool_->reclaim(remaining);
       LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";
-      uint64_t total = shrunk + spilledOut;
+      uint64_t total = shrunken + spilledOut;
       LOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
-      return shrunk + spilledOut;
+      return shrunken + spilledOut;
     }
     // suspend since we are on driver
     velox::exec::SuspendedSection noCancel(thisDriver);
     uint64_t spilledOut = pool_->reclaim(remaining);
     LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";
-    uint64_t total = shrunk + spilledOut;
+    uint64_t total = shrunken + spilledOut;
     LOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
-    return shrunk + spilledOut;
+    return shrunken + spilledOut;
   }
 
-  LOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunk << " bytes.";
-  return shrunk;
+  LOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";
+  return shrunken;
 }
 
 void WholeStageResultIterator::getOrderedNodeIds(

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -118,20 +118,46 @@ std::shared_ptr<ColumnarBatch> WholeStageResultIterator::next() {
   return std::make_shared<VeloxColumnarBatch>(vector);
 }
 
+namespace {
+class ConditionalSuspendedSection {
+ public:
+  ConditionalSuspendedSection(velox::exec::Driver* driver, bool condition) {
+    if (condition) {
+      section_ = new velox::exec::SuspendedSection(driver);
+    }
+  }
+
+  virtual ~ConditionalSuspendedSection() {
+    if (section_) {
+      delete section_;
+    }
+  }
+
+  // singleton
+  ConditionalSuspendedSection(const ConditionalSuspendedSection&) = delete;
+  ConditionalSuspendedSection(ConditionalSuspendedSection&&) = delete;
+  ConditionalSuspendedSection& operator=(const ConditionalSuspendedSection&) = delete;
+  ConditionalSuspendedSection& operator=(ConditionalSuspendedSection&&) = delete;
+
+ private:
+  velox::exec::SuspendedSection* section_ = nullptr;
+};
+} // namespace
+
 int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   std::string poolName{pool_->root()->name() + "/" + pool_->name()};
   std::string logPrefix{"Spill[" + poolName + "]: "};
-  LOG(INFO) << logPrefix << "Trying to reclaim " << size << " bytes of data...";
-  LOG(INFO) << logPrefix << "Pool has reserved " << pool_->currentBytes() << "/" << pool_->root()->reservedBytes()
-            << "/" << pool_->root()->capacity() << "/" << pool_->root()->maxCapacity() << " bytes.";
-  LOG(INFO) << logPrefix << "Shrinking...";
+  DLOG(INFO) << logPrefix << "Trying to reclaim " << size << " bytes of data...";
+  DLOG(INFO) << logPrefix << "Pool has reserved " << pool_->currentBytes() << "/" << pool_->root()->reservedBytes()
+             << "/" << pool_->root()->capacity() << "/" << pool_->root()->maxCapacity() << " bytes.";
+  DLOG(INFO) << logPrefix << "Shrinking...";
   int64_t shrunken = pool_->shrinkManaged(pool_.get(), size);
-  LOG(INFO) << logPrefix << shrunken << " bytes released from shrinking.";
+  DLOG(INFO) << logPrefix << shrunken << " bytes released from shrinking.";
 
   // todo return the actual spilled size?
   if (spillStrategy_ == "auto") {
     int64_t remaining = size - shrunken;
-    LOG(INFO) << logPrefix << "Trying to request spilling for remaining " << remaining << " bytes...";
+    LOG(INFO) << logPrefix << "Trying to request spilling for " << remaining << " bytes...";
     // if we are on one of the driver of the spilled task, suspend it
     velox::exec::Driver* thisDriver = nullptr;
     task_->testingVisitDrivers([&](velox::exec::Driver* driver) {
@@ -139,24 +165,16 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
         thisDriver = driver;
       }
     });
-    if (thisDriver == nullptr) {
-      // not the driver, no need to suspend
-      uint64_t spilledOut = pool_->reclaim(remaining);
-      LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";
-      uint64_t total = shrunken + spilledOut;
-      LOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
-      return shrunken + spilledOut;
-    }
-    // suspend since we are on driver
-    velox::exec::SuspendedSection noCancel(thisDriver);
+    // suspend the driver when we are on it
+    ConditionalSuspendedSection noCancel(thisDriver, thisDriver != nullptr);
     uint64_t spilledOut = pool_->reclaim(remaining);
     LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";
     uint64_t total = shrunken + spilledOut;
-    LOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
+    DLOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
     return shrunken + spilledOut;
   }
 
-  LOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";
+  DLOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";
   return shrunken;
 }
 

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -116,7 +116,7 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
       //
       // We are likely in destructor, do not throw. INFO log is fine since we have leak checks from Spark's memory
       //   manager
-      LOG(INFO) << "Memory pool " << pool->name() << " not completely shrunk when Memory::dropPool() is called";
+      LOG(INFO) << "Memory pool " << pool->name() << " not completely shrunken when Memory::dropPool() is called";
     }
     return freeBytes;
   }
@@ -240,6 +240,11 @@ const MemoryUsageStats VeloxMemoryManager::collectMemoryUsageStats() const {
   stats.mutable_children()->emplace("velox", std::move(veloxPoolStats));
   stats.mutable_children()->emplace("arrow", std::move(arrowPoolStats));
   return stats;
+}
+
+const int64_t VeloxMemoryManager::shrink(int64_t size) {
+  int64_t shrunken = veloxAggregatePool_->shrinkManaged(veloxAggregatePool_.get(), size);
+  return shrunken;
 }
 
 velox::memory::IMemoryManager* getDefaultVeloxMemoryManager() {

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -45,6 +45,8 @@ class VeloxMemoryManager final : public MemoryManager {
 
   const MemoryUsageStats collectMemoryUsageStats() const override;
 
+  const int64_t shrink(int64_t size) override;
+
  private:
   facebook::velox::memory::IMemoryManager::Options getOptions(std::shared_ptr<MemoryAllocator> allocator) const;
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -53,6 +53,12 @@ public class NativeMemoryManager implements TaskResource {
     return collectMemoryUsage(nativeInstanceId);
   }
 
+  public long shrink(long size) {
+    return shrink(nativeInstanceId, size);
+  }
+
+  private static native long shrink(long nativeInstanceId, long size);
+
   private static native long create(
       String name, long allocatorId, long reservationBlockSize, ReservationListener listener);
 


### PR DESCRIPTION
So far we only adopt Velox reclaim/shrink APIs to plan execution pools.

We should extend the usage to all Velox pools using a common path.

https://github.com/oap-project/gluten/issues/2808