### PR TITLE
[GLUTEN-2941] Enable spill support during shuffle splitter stop

### DIFF
--- a/cpp/core/shuffle/ShuffleWriter.cc
+++ b/cpp/core/shuffle/ShuffleWriter.cc
@@ -141,4 +141,9 @@ std::shared_ptr<arrow::Schema> ShuffleWriter::compressWriteSchema() {
   compressWriteSchema_ = toCompressWriteSchema(*schema_);
   return compressWriteSchema_;
 }
+
+void ShuffleWriter::clearCachedPayloads(uint32_t partitionId) {
+  partitionCachedRecordbatch()[partitionId].clear();
+  setPartitionCachedRecordbatchSize(partitionId, 0);
+}
 } // namespace gluten

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -128,6 +128,8 @@ class ShuffleWriter {
     return schema_;
   }
 
+  void clearCachedPayloads(uint32_t partitionId);
+
   int32_t numPartitions() const {
     return numPartitions_;
   }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1505,7 +1505,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
       } else {
         RETURN_NOT_OK(evictPartition(-1));
 #ifdef GLUTEN_PRINT_DEBUG
-        std::cout << "Evicted all partition. " << std::to_string(totalCachedSize) << " bytes released" << std::endl;
+        std::cout << "Evicted all partitions. " << std::to_string(totalCachedSize) << " bytes released" << std::endl;
 #endif
         *size = totalCachedSize;
       }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -95,6 +95,8 @@ namespace gluten {
 
 #endif // end of VELOX_SHUFFLE_WRITER_PRINT
 
+enum SplitState { INIT, SPLIT, STOP };
+
 class VeloxShuffleWriter final : public ShuffleWriter {
   enum { kValidityBufferIndex = 0, kOffsetBufferIndex = 1, kValueBufferIndex = 2 };
 
@@ -191,6 +193,11 @@ class VeloxShuffleWriter final : public ShuffleWriter {
     VS_PRINT_CONTAINER(input_has_null_);
   }
 
+  // For test only.
+  void setSplitState(SplitState state) {
+    splitState_ = state;
+  }
+
  protected:
   VeloxShuffleWriter(
       uint32_t numPartitions,
@@ -280,9 +287,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   arrow::Result<int64_t> shrinkPartitionBuffers();
 
  protected:
-  enum SplitState { kInit, kSplit, kStop };
-
-  SplitState splitState_{kInit};
+  SplitState splitState_{INIT};
 
   bool supportAvx512_ = false;
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -275,8 +275,14 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   std::shared_ptr<arrow::Buffer> generateComplexTypeBuffers(facebook::velox::RowVectorPtr vector);
 
- protected:
   arrow::Status resetValidityBuffers(uint32_t partitionId);
+
+  arrow::Result<int64_t> shrinkPartitionBuffers();
+
+ protected:
+  enum SplitState { kInit, kSplit, kStop };
+
+  SplitState splitState_{kInit};
 
   bool supportAvx512_ = false;
 


### PR DESCRIPTION
The stop function performs several tasks:
1. Opens the final data file.
2. Iterates over each partition ID (pid) to:
   a. Record the offset for each partition in the final file.
   b. Merge data from spilled files and write to the final file.
   c. Write cached payloads to the final file.
   d. Create the last payload from split buffer, and write to the final file.
   e. Optionally, write End of Stream (EOS) if any payload has been written.
3. Closes and deletes all the spilled files.
4. Records various metrics such as total write time, bytes evicted, and bytes written.
5. Clears any buffered resources and closes the final file.

Spill handling:
Spill is allowed during stop(). If OOM happens during stop(), it will first shrink the split buffers and then perform spill if necessary.
Among above steps, 1. and 2.d requires memory allocation and may trigger spill.
If spill is triggered by 1., cached payloads of all partitions will be spilled.
If spill is triggered by 2.d, cached payloads of the remaining unmerged partitions will be spilled.