### PR TITLE
[VL] Get avaliable off-heap memory for split buffer calculation everytime split() is called

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -792,7 +792,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jobject,
     jstring partitioningNameJstr,
     jint numPartitions,
-    jlong offheapPerTask,
     jint bufferSize,
     jstring codecJstr,
     jstring codecBackendJstr,
@@ -827,7 +826,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   if (bufferSize > 0) {
     shuffleWriterOptions.buffer_size = bufferSize;
   }
-  shuffleWriterOptions.offheap_per_task = offheapPerTask;
 
   if (codecJstr != NULL) {
     shuffleWriterOptions.compression_type = getCompressionType(env, codecJstr);
@@ -938,7 +936,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jlong ctxHandle,
     jlong shuffleWriterHandle,
     jint numRows,
-    jlong batchHandle) {
+    jlong batchHandle,
+    jlong memLimit) {
   JNI_METHOD_START
   auto executionCtx = jniCastOrThrow<ExecutionCtx>(ctxHandle);
 
@@ -951,7 +950,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   // The column batch maybe VeloxColumnBatch or ArrowCStructColumnarBatch(FallbackRangeShuffleWriter)
   auto batch = executionCtx->getBatch(batchHandle);
   auto numBytes = batch->numBytes();
-  gluten::arrowAssertOkOrThrow(shuffleWriter->split(batch), "Native split: shuffle writer split failed");
+  gluten::arrowAssertOkOrThrow(shuffleWriter->split(batch, memLimit), "Native split: shuffle writer split failed");
   return numBytes;
   JNI_METHOD_END(kInvalidResourceHandle)
 }

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -36,7 +36,6 @@ static constexpr double kDefaultBufferReallocThreshold = 0.25;
 } // namespace
 
 struct ShuffleWriterOptions {
-  int64_t offheap_per_task = 0;
   int32_t buffer_size = kDefaultShuffleWriterBufferSize;
   int32_t push_buffer_max_size = kDefaultShuffleWriterBufferSize;
   int32_t num_sub_dirs = kDefaultNumSubDirs;
@@ -153,7 +152,7 @@ class ShuffleWriter {
    */
   virtual arrow::Status evictFixedSize(int64_t size, int64_t* actual) = 0;
 
-  virtual arrow::Status split(std::shared_ptr<ColumnarBatch> cb) = 0;
+  virtual arrow::Status split(std::shared_ptr<ColumnarBatch> cb, int64_t memLimit) = 0;
 
   // Cache the partition buffer/builder as compressed record batch. If reset
   // buffers, the partition buffer/builder will be set to nullptr. Two cases for

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -147,6 +147,7 @@ class ShuffleBufferPool {
 
 class ShuffleWriter {
  public:
+  static constexpr int64_t kMinMemLimit = 128LL * 1024 * 1024;
   /**
    * Evict fixed size of partition data from memory
    */

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -157,7 +157,7 @@ auto BM_Generic = [](::benchmark::State& state,
       TIME_NANO_START(shuffleWriteTime);
       const auto& shuffleWriter = createShuffleWriter(memoryManager.get());
       while (resultIter->hasNext()) {
-        GLUTEN_THROW_NOT_OK(shuffleWriter->split(resultIter->next(), 128 * 1024 * 1024));
+        GLUTEN_THROW_NOT_OK(shuffleWriter->split(resultIter->next(), ShuffleWriter::kMinMemLimit));
       }
       GLUTEN_THROW_NOT_OK(shuffleWriter->stop());
       TIME_NANO_END(shuffleWriteTime);

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -157,7 +157,7 @@ auto BM_Generic = [](::benchmark::State& state,
       TIME_NANO_START(shuffleWriteTime);
       const auto& shuffleWriter = createShuffleWriter(memoryManager.get());
       while (resultIter->hasNext()) {
-        GLUTEN_THROW_NOT_OK(shuffleWriter->split(resultIter->next()));
+        GLUTEN_THROW_NOT_OK(shuffleWriter->split(resultIter->next(), 128 * 1024 * 1024));
       }
       GLUTEN_THROW_NOT_OK(shuffleWriter->stop());
       TIME_NANO_END(shuffleWriteTime);

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -343,7 +343,7 @@ class BenchmarkShuffleSplitIterateScanBenchmark : public BenchmarkShuffleSplit {
         numRows += recordBatch->num_rows();
         std::shared_ptr<ColumnarBatch> cb;
         ARROW_ASSIGN_OR_THROW(cb, recordBatch2VeloxColumnarBatch(*recordBatch));
-        TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb));
+        TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb, 128 * 1024 * 1024));
         TIME_NANO_OR_THROW(elapseRead, recordBatchReader->ReadNext(&recordBatch));
       }
     }

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -117,7 +117,6 @@ class BenchmarkShuffleSplit {
     auto options = ShuffleWriterOptions::defaults();
     options.buffer_size = kSplitBufferSize;
     options.buffered_write = true;
-    options.offheap_per_task = 128 * 1024 * 1024 * 1024L;
     options.prefer_evict = FLAGS_prefer_evict;
     options.memory_pool = pool;
     options.partitioning_name = "rr";
@@ -292,7 +291,7 @@ class BenchmarkShuffleSplitCacheScanBenchmark : public BenchmarkShuffleSplit {
           [&shuffleWriter, &splitTime](const std::shared_ptr<arrow::RecordBatch>& recordBatch) {
             std::shared_ptr<ColumnarBatch> cb;
             ARROW_ASSIGN_OR_THROW(cb, recordBatch2VeloxColumnarBatch(*recordBatch));
-            TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb));
+            TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb, 128 * 1024 * 1024 * 1024LL));
           });
       // std::cout << " split done memory allocated = " <<
       // options.memory_pool->bytes_allocated() << std::endl;

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -291,7 +291,7 @@ class BenchmarkShuffleSplitCacheScanBenchmark : public BenchmarkShuffleSplit {
           [&shuffleWriter, &splitTime](const std::shared_ptr<arrow::RecordBatch>& recordBatch) {
             std::shared_ptr<ColumnarBatch> cb;
             ARROW_ASSIGN_OR_THROW(cb, recordBatch2VeloxColumnarBatch(*recordBatch));
-            TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb, 128 * 1024 * 1024 * 1024LL));
+            TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb, ShuffleWriter::kMinMemLimit));
           });
       // std::cout << " split done memory allocated = " <<
       // options.memory_pool->bytes_allocated() << std::endl;
@@ -343,7 +343,7 @@ class BenchmarkShuffleSplitIterateScanBenchmark : public BenchmarkShuffleSplit {
         numRows += recordBatch->num_rows();
         std::shared_ptr<ColumnarBatch> cb;
         ARROW_ASSIGN_OR_THROW(cb, recordBatch2VeloxColumnarBatch(*recordBatch));
-        TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb, 128 * 1024 * 1024));
+        TIME_NANO_OR_THROW(splitTime, shuffleWriter->split(cb, ShuffleWriter::kMinMemLimit));
         TIME_NANO_OR_THROW(elapseRead, recordBatchReader->ReadNext(&recordBatch));
       }
     }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1275,6 +1275,8 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
     VS_PRINTLF(bytesPerRow);
 
     // remove the cache memory size since it can be spilled.
+    // The logic here is to keep the split buffer as large as possible, to get max batch size for reducer
+    // The risk is the cached buffer must be spilled once we evict a batch from split buffer
     // we can't use pool_->bytes_allocated() here because it's arrow::default_pool(). we should define a
     // pool for spill buffer, just like the pool for split buffer
     // memLimit+=pool_->bytes_allocated();

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1218,17 +1218,17 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
 
     VS_PRINTLF(bytesPerRow);
 
-    //remove the cache memory size since it can be spilled.
-    //we can't use pool_->bytes_allocated() here because it's arrow::default_pool(). we should define a
+    // remove the cache memory size since it can be spilled.
+    // we can't use pool_->bytes_allocated() here because it's arrow::default_pool(). we should define a
     // pool for spill buffer, just like the pool for split buffer
     // memLimit+=pool_->bytes_allocated();
     memLimit += totalCachedPayloadSize();
-    //make sure split buffer uses 128M memory at least, let's hardcode it here for now
-    if (memLimit<128*1024*1024) memLimit=128*1024*1024;
+    // make sure split buffer uses 128M memory at least, let's hardcode it here for now
+    if (memLimit < 128 * 1024 * 1024)
+      memLimit = 128 * 1024 * 1024;
 
-    uint64_t preAllocRowCnt = memLimit > 0 && bytesPerRow > 0
-        ? memLimit / bytesPerRow / numPartitions_ >> 2
-        : options_.buffer_size;
+    uint64_t preAllocRowCnt =
+        memLimit > 0 && bytesPerRow > 0 ? memLimit / bytesPerRow / numPartitions_ >> 2 : options_.buffer_size;
     preAllocRowCnt = std::min(preAllocRowCnt, (uint64_t)options_.buffer_size);
 
     VS_PRINTLF(preAllocRowCnt);

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1218,6 +1218,14 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
 
     VS_PRINTLF(bytesPerRow);
 
+    //remove the cache memory size since it can be spilled.
+    //we can't use pool_->bytes_allocated() here because it's arrow::default_pool(). we should define a
+    // pool for spill buffer, just like the pool for split buffer
+    // memLimit+=pool_->bytes_allocated();
+    memLimit += totalCachedPayloadSize();
+    //make sure split buffer uses 128M memory at least, let's hardcode it here for now
+    if (memLimit<128*1024*1024) memLimit=128*1024*1024;
+
     uint64_t preAllocRowCnt = memLimit > 0 && bytesPerRow > 0
         ? memLimit / bytesPerRow / numPartitions_ >> 2
         : options_.buffer_size;

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1280,8 +1280,8 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
     // memLimit+=pool_->bytes_allocated();
     memLimit += totalCachedPayloadSize();
     // make sure split buffer uses 128M memory at least, let's hardcode it here for now
-    if (memLimit < 128 * 1024 * 1024)
-      memLimit = 128 * 1024 * 1024;
+    if (memLimit < kMinMemLimit)
+      memLimit = kMinMemLimit;
 
     uint64_t preAllocRowCnt =
         memLimit > 0 && bytesPerRow > 0 ? memLimit / bytesPerRow / numPartitions_ >> 2 : options_.buffer_size;

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -121,7 +121,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
       ShuffleWriterOptions options,
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool);
 
-  arrow::Status split(std::shared_ptr<ColumnarBatch> cb) override;
+  arrow::Status split(std::shared_ptr<ColumnarBatch> cb, int64_t memLimit) override;
 
   arrow::Status stop() override;
 
@@ -224,11 +224,11 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Status updateInputHasNull(const facebook::velox::RowVector& rv);
 
-  arrow::Status doSplit(const facebook::velox::RowVector& rv);
+  arrow::Status doSplit(const facebook::velox::RowVector& rv, int64_t memLimit);
 
   bool beyondThreshold(uint32_t partitionId, uint64_t newSize);
 
-  uint32_t calculatePartitionBufferSize(const facebook::velox::RowVector& rv);
+  uint32_t calculatePartitionBufferSize(const facebook::velox::RowVector& rv, int64_t memLimit);
 
   arrow::Status updateValidityBuffers(uint32_t partitionId, uint32_t newSize);
 

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -139,7 +139,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
 
   void splitRowVector(VeloxShuffleWriter& shuffleWriter, velox::RowVectorPtr vector) {
     std::shared_ptr<ColumnarBatch> cb = std::make_shared<VeloxColumnarBatch>(vector);
-    GLUTEN_THROW_NOT_OK(shuffleWriter.split(cb));
+    GLUTEN_THROW_NOT_OK(shuffleWriter.split(cb, 128 * 1024 * 1024));
   }
 
   RowVectorPtr takeRows(const RowVectorPtr& source, const std::vector<int32_t>& idxs) const {
@@ -231,7 +231,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
       TypePtr dataType,
       std::vector<std::vector<velox::RowVectorPtr>> expectedVectors) { /* blockId = pid, rowVector in block */
     for (auto& batch : batches) {
-      GLUTEN_THROW_NOT_OK(shuffleWriter.split(batch));
+      GLUTEN_THROW_NOT_OK(shuffleWriter.split(batch, 128 * 1024 * 1024));
     }
     shuffleWriteReadMultiBlocks(shuffleWriter, expectPartitionLength, dataType, expectedVectors);
   }
@@ -268,7 +268,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
 
 arrow::Status splitRowVectorStatus(VeloxShuffleWriter& shuffleWriter, velox::RowVectorPtr vector) {
   std::shared_ptr<ColumnarBatch> cb = std::make_shared<VeloxColumnarBatch>(vector);
-  return shuffleWriter.split(cb);
+  return shuffleWriter.split(cb, 128 * 1024 * 1024);
 }
 
 TEST_P(VeloxShuffleWriterTest, singlePart1Vector) {

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
@@ -152,7 +152,12 @@ class CelebornHashBasedVeloxColumnarShuffleWriter[K, V](
         }
         val startTime = System.nanoTime()
         val bytes =
-          jniWrapper.split(executionCtxHandle, nativeShuffleWriter, cb.numRows, handle, availableOffHeapPerTask())
+          jniWrapper.split(
+            executionCtxHandle,
+            nativeShuffleWriter,
+            cb.numRows,
+            handle,
+            availableOffHeapPerTask())
         dep.metrics("dataSize").add(bytes)
         dep.metrics("splitTime").add(System.nanoTime() - startTime)
         dep.metrics("numInputRows").add(cb.numRows)

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
@@ -115,7 +115,6 @@ class CelebornHashBasedVeloxColumnarShuffleWriter[K, V](
         if (nativeShuffleWriter == -1L) {
           nativeShuffleWriter = jniWrapper.makeForRSS(
             dep.nativePartitioning,
-            availableOffHeapPerTask(),
             nativeBufferSize,
             customizedCompressionCodec,
             bufferCompressThreshold,
@@ -152,7 +151,8 @@ class CelebornHashBasedVeloxColumnarShuffleWriter[K, V](
           )
         }
         val startTime = System.nanoTime()
-        val bytes = jniWrapper.split(executionCtxHandle, nativeShuffleWriter, cb.numRows, handle)
+        val bytes =
+          jniWrapper.split(executionCtxHandle, nativeShuffleWriter, cb.numRows, handle, availableOffHeapPerTask())
         dep.metrics("dataSize").add(bytes)
         dep.metrics("splitTime").add(System.nanoTime() - startTime)
         dep.metrics("numInputRows").add(cb.numRows)

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -39,7 +39,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
    */
   public long make(
       NativePartitioning part,
-      long offheapPerTask,
       int bufferSize,
       String codec,
       String codecBackend,
@@ -58,7 +57,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
     return nativeMake(
         part.getShortName(),
         part.getNumPartitions(),
-        offheapPerTask,
         bufferSize,
         codec,
         codecBackend,
@@ -89,7 +87,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
    */
   public long makeForRSS(
       NativePartitioning part,
-      long offheapPerTask,
       int bufferSize,
       String codec,
       int bufferCompressThreshold,
@@ -105,7 +102,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
     return nativeMake(
         part.getShortName(),
         part.getNumPartitions(),
-        offheapPerTask,
         bufferSize,
         codec,
         null,
@@ -129,7 +125,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
   public native long nativeMake(
       String shortName,
       int numPartitions,
-      long offheapPerTask,
       int bufferSize,
       String codec,
       String codecBackend,
@@ -169,11 +164,12 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
    * @param shuffleWriterHandle shuffle writer instance handle
    * @param numRows Rows per batch
    * @param handler handler of Velox Vector
+   * @param memLimit memory usage limit for the split operation FIXME setting a cap to pool /
+   *     allocator instead
    * @return batch bytes.
    */
   public native long split(
-      long executionCtxHandle, long shuffleWriterHandle, int numRows, long handler)
-      throws IOException;
+      long executionCtxHandle, long shuffleWriterHandle, int numRows, long handler, long memLimit);
 
   /**
    * Write the data remained in the buffers hold by native shuffle writer to each partition's

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -127,7 +127,6 @@ class ColumnarShuffleWriter[K, V](
         if (nativeShuffleWriter == -1L) {
           nativeShuffleWriter = jniWrapper.make(
             dep.nativePartitioning,
-            availableOffHeapPerTask(),
             nativeBufferSize,
             compressionCodec,
             compressionCodecBackend,
@@ -166,7 +165,7 @@ class ColumnarShuffleWriter[K, V](
           )
         }
         val startTime = System.nanoTime()
-        val bytes = jniWrapper.split(executionCtxHandle, nativeShuffleWriter, rows, handle)
+        val bytes = jniWrapper.split(executionCtxHandle, nativeShuffleWriter, rows, handle, availableOffHeapPerTask())
         dep.metrics("dataSize").add(bytes)
         dep.metrics("splitTime").add(System.nanoTime() - startTime)
         dep.metrics("numInputRows").add(rows)

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -165,7 +165,12 @@ class ColumnarShuffleWriter[K, V](
           )
         }
         val startTime = System.nanoTime()
-        val bytes = jniWrapper.split(executionCtxHandle, nativeShuffleWriter, rows, handle, availableOffHeapPerTask())
+        val bytes = jniWrapper.split(
+          executionCtxHandle,
+          nativeShuffleWriter,
+          rows,
+          handle,
+          availableOffHeapPerTask())
         dep.metrics("dataSize").add(bytes)
         dep.metrics("splitTime").add(System.nanoTime() - startTime)
         dep.metrics("numInputRows").add(rows)


### PR DESCRIPTION
Rely on https://github.com/oap-project/gluten/pull/2982

Without the PR, we pass available off-heap memory size to shuffle writer when it's created. The problem is sometimes the shuffle writer is created before operators allocating large block memory like hash agg. Then the split buffer is preallocated according to whole off-heap memory instead of available memory when shuffle writer really works.

The PR pass the available memory to shuffle write with each batches, so we can recalculate the buffer size on each batch.