### PR TITLE
[VL] Gluten-it: Add option --random-kill-tasks to emulate the case that tasks are frequently killed and retried

### DIFF
--- a/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Queries.java
@@ -41,10 +41,13 @@ public class Queries implements Callable<Integer> {
   @CommandLine.Option(names = {"--iterations"}, description = "How many iterations to run", defaultValue = "1")
   private int iterations;
 
+  @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Each task get 20% chance to be killed and retried after running for seconds", defaultValue = "false")
+  private boolean randomKillTasks;
+
   @Override
   public Integer call() throws Exception {
     io.glutenproject.integration.tpc.action.Queries queries =
-        new io.glutenproject.integration.tpc.action.Queries(dataGenMixin.getScale(), this.queries, explain, iterations);
+        new io.glutenproject.integration.tpc.action.Queries(dataGenMixin.getScale(), this.queries, explain, iterations, randomKillTasks);
     return mixin.runActions(ArrayUtils.addAll(dataGenMixin.makeActions(), queries));
   }
 }

--- a/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Queries.java
@@ -41,7 +41,7 @@ public class Queries implements Callable<Integer> {
   @CommandLine.Option(names = {"--iterations"}, description = "How many iterations to run", defaultValue = "1")
   private int iterations;
 
-  @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Each task get 20% chance to be killed and retried after running for seconds", defaultValue = "false")
+  @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Each task gets 20% chance to be killed and retried after running for seconds", defaultValue = "false")
   private boolean randomKillTasks;
 
   @Override

--- a/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/TpcRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/io/glutenproject/integration/tpc/TpcRunner.scala
@@ -33,9 +33,10 @@ class TpcRunner(val queryResourceFolder: String, val dataPath: String) {
       desc: String,
       caseId: String,
       explain: Boolean = false,
-      metrics: Array[String] = Array()): RunResult = {
+      metrics: Array[String] = Array(),
+      randomKillTasks: Boolean = false): RunResult = {
     val path = "%s/%s.sql".format(queryResourceFolder, caseId)
-    QueryRunner.runTpcQuery(spark, desc, path, explain, metrics)
+    QueryRunner.runTpcQuery(spark, desc, path, explain, metrics, randomKillTasks)
   }
 }
 


### PR DESCRIPTION
Umbrella: https://github.com/oap-project/gluten/issues/3048

To simulate speculative execution's task killing actions in local test, even using more aggressive kills.