### PR TITLE
[GLUTEN-3058][VL] Fix shuffle reader on speculation run

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/zhouyuan/velox.git
+VELOX_BRANCH=wip_timsort
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/zhouyuan/velox.git
-VELOX_BRANCH=wip_timsort
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentJniByteInputStream.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/LowCopyFileSegmentJniByteInputStream.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.FileChannel;
 
 /**
@@ -106,6 +107,9 @@ public class LowCopyFileSegmentJniByteInputStream implements JniByteInputStream 
       bytesRead += bytes;
       left -= bytes;
       return bytes;
+    } catch (ClosedByInterruptException ce) {
+      System.out.printf("Failed to create input stream from local block, " + ce.getMessage());
+      return 0;
     } catch (IOException e) {
       throw new GlutenException(e);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

this patch improved the exception handling on shuffle reading. If it's `ClosedByInterruptException` Gluten will print log only

https://github.com/apache/spark/pull/25674/files

(Fixes: #3058)

## How was this patch tested?

manually test, with speculation on 
