### PR TITLE
[GLUTEN-3062][VL] Check Java exception immediately when a call from C++ to Java ended

### DIFF
--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -140,6 +140,9 @@ static inline void checkException(JNIEnv* env) {
         env->GetStaticMethodID(describerClass, "describe", "(Ljava/lang/Throwable;)Ljava/lang/String;");
     std::string description =
         jStringToCString(env, (jstring)env->CallStaticObjectMethod(describerClass, describeMethod, t));
+    if (env->ExceptionCheck()) {
+      std::cerr << "Fatal: Uncaught Java exception during calling the Java exception describer method! " << std::endl;
+    }
     throw gluten::GlutenException("Error during calling Java code from native code: " + description);
   }
 }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -147,7 +147,9 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
   arrow::Result<int64_t> Tell() const override {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm_, &env);
-    return env->CallLongMethod(jniIn_, jniByteInputStreamTell);
+    jlong told = env->CallLongMethod(jniIn_, jniByteInputStreamTell);
+    checkException(env);
+    return told;
   }
 
   bool closed() const override {
@@ -157,7 +159,9 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
   arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm_, &env);
-    return env->CallLongMethod(jniIn_, jniByteInputStreamRead, reinterpret_cast<jlong>(out), nbytes);
+    jlong read = env->CallLongMethod(jniIn_, jniByteInputStreamRead, reinterpret_cast<jlong>(out), nbytes);
+    checkException(env);
+    return read;
   }
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
@@ -775,11 +779,13 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   jclass cls = env->FindClass("java/lang/Thread");
   jmethodID mid = env->GetStaticMethodID(cls, "currentThread", "()Ljava/lang/Thread;");
   jobject thread = env->CallStaticObjectMethod(cls, mid);
+  checkException(env);
   if (thread == NULL) {
     std::cerr << "Thread.currentThread() return NULL" << std::endl;
   } else {
     jmethodID midGetid = getMethodIdOrError(env, cls, "getId", "()J");
     jlong sid = env->CallLongMethod(thread, midGetid);
+    checkException(env);
     shuffleWriterOptions.thread_id = (int64_t)sid;
   }
 
@@ -1068,13 +1074,15 @@ JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_vel
   auto datasource = glutenDatasourceHolder.lookup(instanceId);
 
   while (env->CallBooleanMethod(iter, veloxColumnarbatchScannerHasNext)) {
+    checkException(env);
     jlong handler = env->CallLongMethod(iter, veloxColumnarbatchScannerNext);
+    checkException(env);
     auto batch = columnarBatchHolder.lookup(handler);
     datasource->write(batch);
     // fixme this skips the general Java side batch-closing routine
     columnarBatchHolder.erase(handler);
   }
-
+  checkException(env);
   JNI_METHOD_END()
 }
 

--- a/cpp/velox/jni/JniFileSystem.cc
+++ b/cpp/velox/jni/JniFileSystem.cc
@@ -292,8 +292,8 @@ class JniFileSystem : public facebook::velox::filesystems::FileSystem {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm, &env);
     jobject obj = env->CallObjectMethod(obj_, jniFileSystemOpenFileForRead, createJString(env, path));
-    auto out = std::make_unique<JniReadFile>(obj);
     checkException(env);
+    auto out = std::make_unique<JniReadFile>(obj);
     return out;
   }
 
@@ -306,8 +306,8 @@ class JniFileSystem : public facebook::velox::filesystems::FileSystem {
     JNIEnv* env;
     attachCurrentThreadAsDaemonOrThrow(vm, &env);
     jobject obj = env->CallObjectMethod(obj_, jniFileSystemOpenFileForWrite, createJString(env, path));
-    auto out = std::make_unique<JniWriteFile>(obj);
     checkException(env);
+    auto out = std::make_unique<JniWriteFile>(obj);
     return out;
   }
 
@@ -338,13 +338,13 @@ class JniFileSystem : public facebook::velox::filesystems::FileSystem {
     attachCurrentThreadAsDaemonOrThrow(vm, &env);
     std::vector<std::string> out;
     jobjectArray jarray = (jobjectArray)env->CallObjectMethod(obj_, jniFileSystemList, createJString(env, path));
+    checkException(env);
     jsize length = env->GetArrayLength(jarray);
     for (jsize i = 0; i < length; ++i) {
       jstring element = (jstring)env->GetObjectArrayElement(jarray, i);
       std::string cElement = jStringToCString(env, element);
       out.push_back(cElement);
     }
-    checkException(env);
     return out;
   }
 
@@ -380,9 +380,9 @@ class JniFileSystem : public facebook::velox::filesystems::FileSystem {
       JNIEnv* env;
       attachCurrentThreadAsDaemonOrThrow(vm, &env);
       jobject obj = env->CallStaticObjectMethod(jniFileSystemClass, jniGetFileSystem);
+      checkException(env);
       // remove "jni:" or "jol:" prefix.
       std::shared_ptr<FileSystem> lfs = FileSystemWrapper::wrap(std::make_shared<JniFileSystem>(obj, properties));
-      checkException(env);
       return lfs;
     };
   }

--- a/cpp/velox/jni/JniUdf.cc
+++ b/cpp/velox/jni/JniUdf.cc
@@ -61,5 +61,6 @@ void gluten::jniLoadUdf(JNIEnv* env, const std::string& libPaths) {
     jobject instance = env->GetStaticObjectField(
         udfResolverClass, env->GetStaticFieldID(udfResolverClass, "MODULE$", kUdfResolverClassPath.c_str()));
     env->CallVoidMethod(instance, registerUDFMethod, name, returnType);
+    checkException(env);
   }
 }


### PR DESCRIPTION
May fix https://github.com/oap-project/gluten/issues/3062, still in testing

After the patch, we should abide by the rule that any C++ to Java invocations should be followed by a `checkException()` guard.

`checkException()` prevents its guarding code from running into undefined state and throw immediately if an Java exception was thrown.

For Java to C++, we have JNI_METHOD_START and JNI_METHOD_END to do the similar guarding job.

In future we may want to use macros to ease the manual `checkException` calls.

