### PR TITLE
[WIP][CORE] Optimize shuffle partitioner algorithm to take advantage of  auto-vectorization in GCC

### DIFF
--- a/cpp/core/shuffle/FallbackRangePartitioner.cc
+++ b/cpp/core/shuffle/FallbackRangePartitioner.cc
@@ -22,18 +22,18 @@ namespace gluten {
 arrow::Status gluten::FallbackRangePartitioner::compute(
     const int32_t* pidArr,
     const int64_t numRows,
-    std::vector<uint16_t>& partitionId,
-    std::vector<uint32_t>& partitionIdCnt) {
-  partitionId.resize(numRows);
-  std::fill(std::begin(partitionIdCnt), std::end(partitionIdCnt), 0);
+    std::vector<uint16_t>& row2Partition,
+    std::vector<uint32_t>& partition2RowCount) {
+  row2Partition.resize(numRows);
+  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
   for (auto i = 0; i < numRows; ++i) {
     auto pid = pidArr[i];
     if (pid >= numPartitions_) {
       return arrow::Status::Invalid(
           "Partition id ", std::to_string(pid), " is equal or greater than ", std::to_string(numPartitions_));
     }
-    partitionId[i] = pid;
-    partitionIdCnt[pid]++;
+    row2Partition[i] = pid;
+    partition2RowCount[pid]++;
   }
   return arrow::Status::OK();
 }

--- a/cpp/core/shuffle/FallbackRangePartitioner.h
+++ b/cpp/core/shuffle/FallbackRangePartitioner.h
@@ -27,8 +27,8 @@ class FallbackRangePartitioner final : public ShuffleWriter::Partitioner {
   arrow::Status compute(
       const int32_t* pidArr,
       const int64_t numRows,
-      std::vector<uint16_t>& partitionId,
-      std::vector<uint32_t>& partitionIdCnt) override;
+      std::vector<uint16_t>& row2partition,
+      std::vector<uint32_t>& partition2RowCount) override;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/HashPartitioner.cc
+++ b/cpp/core/shuffle/HashPartitioner.cc
@@ -22,10 +22,10 @@ namespace gluten {
 arrow::Status gluten::HashPartitioner::compute(
     const int32_t* pidArr,
     const int64_t numRows,
-    std::vector<uint16_t>& partitionId,
-    std::vector<uint32_t>& partitionIdCnt) {
-  partitionId.resize(numRows);
-  std::fill(std::begin(partitionIdCnt), std::end(partitionIdCnt), 0);
+    std::vector<uint16_t>& row2partition,
+    std::vector<uint32_t>& partition2RowCount) {
+  row2partition.resize(numRows);
+  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
 
   for (auto i = 0; i < numRows; ++i) {
     auto pid = pidArr[i] % numPartitions_;
@@ -42,9 +42,13 @@ arrow::Status gluten::HashPartitioner::compute(
       pid += numPartitions_;
     }
 #endif
-    partitionId[i] = pid;
-    partitionIdCnt[pid]++;
+    row2partition[i] = pid;
   }
+
+  for (auto& pid : row2partition) {
+    partition2RowCount[pid]++;
+  }
+
   return arrow::Status::OK();
 }
 

--- a/cpp/core/shuffle/HashPartitioner.h
+++ b/cpp/core/shuffle/HashPartitioner.h
@@ -28,8 +28,8 @@ class HashPartitioner final : public ShuffleWriter::Partitioner {
   arrow::Status compute(
       const int32_t* pidArr,
       const int64_t numRows,
-      std::vector<uint16_t>& partitionId,
-      std::vector<uint32_t>& partitionIdCnt) override;
+      std::vector<uint16_t>& row2partition,
+      std::vector<uint32_t>& partition2RowCount) override;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/Partitioner.h
+++ b/cpp/core/shuffle/Partitioner.h
@@ -39,8 +39,8 @@ class ShuffleWriter::Partitioner {
   virtual arrow::Status compute(
       const int32_t* pidArr,
       const int64_t numRows,
-      std::vector<uint16_t>& partitionId,
-      std::vector<uint32_t>& partitionIdCnt) = 0;
+      std::vector<uint16_t>& row2partition,
+      std::vector<uint32_t>& partition2RowCount) = 0;
 
  protected:
   Partitioner(int32_t numPartitions, bool hasPid) : numPartitions_(numPartitions), hasPid_(hasPid) {}

--- a/cpp/core/shuffle/RoundRobinPartitioner.cc
+++ b/cpp/core/shuffle/RoundRobinPartitioner.cc
@@ -22,15 +22,27 @@ namespace gluten {
 arrow::Status gluten::RoundRobinPartitioner::compute(
     const int32_t* pidArr,
     const int64_t numRows,
-    std::vector<uint16_t>& partitionId,
-    std::vector<uint32_t>& partitionIdCnt) {
-  std::fill(std::begin(partitionIdCnt), std::end(partitionIdCnt), 0);
-  partitionId.resize(numRows);
-  for (auto& pid : partitionId) {
-    pid = pidSelection_;
-    partitionIdCnt[pidSelection_]++;
-    pidSelection_ = (pidSelection_ + 1) == numPartitions_ ? 0 : (pidSelection_ + 1);
+    std::vector<uint16_t>& row2Partition,
+    std::vector<uint32_t>& partition2RowCount) {
+  std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
+  row2Partition.resize(numRows);
+
+  int32_t pidSelection = 0;
+  for (int32_t i = 0; i < numRows;) {
+    int32_t low = i;
+    int32_t up = std::min(i + numPartitions_, numRows);
+    for (; low != up; ) {
+      row2Partition[low++] = pidSelection++;
+    }
+
+    pidSelection = 0;
+    i = up;
   }
+
+  for (auto& pid : row2Partition) {
+    partition2RowCount[pid]++;
+  }
+
   return arrow::Status::OK();
 }
 } // namespace gluten

--- a/cpp/core/shuffle/RoundRobinPartitioner.cc
+++ b/cpp/core/shuffle/RoundRobinPartitioner.cc
@@ -30,7 +30,7 @@ arrow::Status gluten::RoundRobinPartitioner::compute(
   int32_t pidSelection = 0;
   for (int32_t i = 0; i < numRows;) {
     int32_t low = i;
-    int32_t up = std::min(i + numPartitions_, numRows);
+    int32_t up = std::min((int64_t)(i + numPartitions_), numRows);
     for (; low != up; ) {
       row2Partition[low++] = pidSelection++;
     }

--- a/cpp/core/shuffle/RoundRobinPartitioner.cc
+++ b/cpp/core/shuffle/RoundRobinPartitioner.cc
@@ -27,16 +27,21 @@ arrow::Status gluten::RoundRobinPartitioner::compute(
   std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
   row2Partition.resize(numRows);
 
-  int32_t pidSelection = 0;
+  int32_t pidSelection = pidSelection_;
   for (int32_t i = 0; i < numRows;) {
     int32_t low = i;
-    int32_t up = std::min((int64_t)(i + numPartitions_), numRows);
-    for (; low != up; ) {
+    int32_t up = std::min((int64_t)(i + (numPartitions_ - pidSelection)), numRows);
+    for (; low != up;) {
       row2Partition[low++] = pidSelection++;
     }
 
+    pidSelection_ = pidSelection;
     pidSelection = 0;
     i = up;
+  }
+
+  if (pidSelection_ >= numPartitions_) {
+    pidSelection_ -= numPartitions_;
   }
 
   for (auto& pid : row2Partition) {

--- a/cpp/core/shuffle/RoundRobinPartitioner.h
+++ b/cpp/core/shuffle/RoundRobinPartitioner.h
@@ -27,8 +27,8 @@ class RoundRobinPartitioner final : public ShuffleWriter::Partitioner {
   arrow::Status compute(
       const int32_t* pidArr,
       const int64_t numRows,
-      std::vector<uint16_t>& partitionId,
-      std::vector<uint32_t>& partitionIdCnt) override;
+      std::vector<uint16_t>& row2Partition,
+      std::vector<uint32_t>& partition2RowCount) override;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/RoundRobinPartitioner.h
+++ b/cpp/core/shuffle/RoundRobinPartitioner.h
@@ -29,9 +29,6 @@ class RoundRobinPartitioner final : public ShuffleWriter::Partitioner {
       const int64_t numRows,
       std::vector<uint16_t>& partitionId,
       std::vector<uint32_t>& partitionIdCnt) override;
-
- private:
-  int32_t pidSelection_ = 0;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/RoundRobinPartitioner.h
+++ b/cpp/core/shuffle/RoundRobinPartitioner.h
@@ -29,6 +29,9 @@ class RoundRobinPartitioner final : public ShuffleWriter::Partitioner {
       const int64_t numRows,
       std::vector<uint16_t>& row2Partition,
       std::vector<uint32_t>& partition2RowCount) override;
+
+ private:
+  int32_t pidSelection_ = 0;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/SinglePartPartitioner.cc
+++ b/cpp/core/shuffle/SinglePartPartitioner.cc
@@ -22,8 +22,8 @@ namespace gluten {
 arrow::Status gluten::SinglePartPartitioner::compute(
     const int32_t* pidArr,
     const int64_t numRows,
-    std::vector<uint16_t>& partitionId,
-    std::vector<uint32_t>& partitionIdCnt) {
+    std::vector<uint16_t>& row2partition,
+    std::vector<uint32_t>& partition2RowCount) {
   // nothing is need do here
   return arrow::Status::OK();
 }

--- a/cpp/core/shuffle/SinglePartPartitioner.h
+++ b/cpp/core/shuffle/SinglePartPartitioner.h
@@ -27,8 +27,8 @@ class SinglePartPartitioner final : public ShuffleWriter::Partitioner {
   arrow::Status compute(
       const int32_t* pidArr,
       const int64_t numRows,
-      std::vector<uint16_t>& partitionId,
-      std::vector<uint32_t>& partitionIdCnt) override;
+      std::vector<uint16_t>& row2partition,
+      std::vector<uint32_t>& partition2RowCount) override;
 };
 
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?
Why we make this change?

We made vs. benchmark in https://quick-bench.com/, And the result shows the speed of the improved Partitioner::computer is 2x faster than the old implementation.

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

