### PR TITLE
[GLUTEN-2943][VL] implement `GenerateExec`

### DIFF
--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -50,6 +50,14 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::ExpandRel& sexpand)
   }
 }
 
+void VeloxPlanConverter::setInputPlanNode(const ::substrait::GenerateRel& sGenerate) {
+  if (sGenerate.has_input()) {
+    setInputPlanNode(sGenerate.input());
+  } else {
+    throw std::runtime_error("Child expected");
+  }
+}
+
 void VeloxPlanConverter::setInputPlanNode(const ::substrait::SortRel& ssort) {
   if (ssort.has_input()) {
     setInputPlanNode(ssort.input());
@@ -160,6 +168,8 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::Rel& srel) {
     setInputPlanNode(srel.fetch());
   } else if (srel.has_window()) {
     setInputPlanNode(srel.window());
+  } else if (srel.has_generate()) {
+    setInputPlanNode(srel.generate());
   } else {
     throw std::runtime_error("Rel is not supported: " + srel.DebugString());
   }

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -44,6 +44,8 @@ class VeloxPlanConverter {
 
   void setInputPlanNode(const ::substrait::ExpandRel& sExpand);
 
+  void setInputPlanNode(const ::substrait::GenerateRel& sGenerate);
+
   void setInputPlanNode(const ::substrait::SortRel& sSort);
 
   void setInputPlanNode(const ::substrait::WindowRel& s);

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -507,7 +507,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
   auto projNode = std::dynamic_pointer_cast<const core::ProjectNode>(childNode);
 
-  if (projNode->names().size() > 1) {
+  if (projNode != nullptr && projNode->names().size() > 1) {
     // generator is a scalarfunction node -> explode(array(col, 'all'))
     // use the last one, this is ensure by scala code
     auto innerName = projNode->names().back();
@@ -520,8 +520,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   } else {
     // generator should be a array column -> explode(col)
     auto explodeFunc = generator.scalar_function();
-    auto innerfunc = explodeFunc.arguments(0).value().scalar_function();
-    auto unnestExpr = exprConverter_->toVeloxExpr(innerfunc.arguments(0).value(), inputType);
+    auto unnestExpr = exprConverter_->toVeloxExpr(explodeFunc.arguments(0).value(), inputType);
     auto unnestFieldExpr = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(unnestExpr);
     VELOX_CHECK_NOT_NULL(unnestFieldExpr, " the key in unnest Operator only support field");
     unnest.emplace_back(unnestFieldExpr);

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -59,6 +59,9 @@ class SubstraitToVeloxPlanConverter {
   /// Used to convert Substrait ExpandRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& expandRel);
 
+  /// Used to convert Substrait GenerateRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::GenerateRel& generateRel);
+
   /// Used to convert Substrait SortRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::WindowRel& windowRel);
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -354,6 +354,11 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
   return true;
 }
 
+bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& generateRel) {
+  // TODO(yuan): add check
+  return true;
+}
+
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expandRel) {
   if (expandRel.has_input() && !validate(expandRel.input())) {
     logValidateMsg("native validation failed due to: input validation fails in ExpandRel.");

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1170,6 +1170,8 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::Rel& rel) {
     return validate(rel.sort());
   } else if (rel.has_expand()) {
     return validate(rel.expand());
+  } else if (rel.has_generate()) {
+    return validate(rel.generate());
   } else if (rel.has_fetch()) {
     return validate(rel.fetch());
   } else if (rel.has_window()) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -34,7 +34,7 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Expand is supported.
   bool validate(const ::substrait::ExpandRel& expandRel);
 
-  /// Used to validate whether the computing of this Expand is supported.
+  /// Used to validate whether the computing of this Generate is supported.
   bool validate(const ::substrait::GenerateRel& generateRel);
 
   /// Used to validate whether the computing of this Sort is supported.

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -34,6 +34,9 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Expand is supported.
   bool validate(const ::substrait::ExpandRel& expandRel);
 
+  /// Used to validate whether the computing of this Expand is supported.
+  bool validate(const ::substrait::GenerateRel& generateRel);
+
   /// Used to validate whether the computing of this Sort is supported.
   bool validate(const ::substrait::SortRel& sortRel);
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/zhouyuan/velox.git
+VELOX_BRANCH=wip_generate
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/zhouyuan/velox.git
-VELOX_BRANCH=wip_generate
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=main
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.exception.GlutenException
 import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.expression.ExpressionConverter
@@ -88,10 +87,6 @@ case class GenerateExecTransformer(
   override def supportsColumnar: Boolean = true
 
   override protected def doValidateInternal(): ValidationResult = {
-    if (BackendsApiManager.isVeloxBackend) {
-      return ValidationResult.notOk(s"Velox backend does not support this operator: $nodeName")
-    }
-
     val context = new SubstraitContext
     val args = context.registeredFunction
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -93,6 +93,9 @@ case class GenerateExecTransformer(
   override protected def doValidateInternal(): ValidationResult = {
     // TODO(yuan): support posexplode and remove this check
     if (BackendsApiManager.isVeloxBackend) {
+      if (generator.isInstanceOf[JsonTuple]) {
+        return ValidationResult.notOk(s"Velox backend does not support this json_tuple")
+      }
       if (generator.isInstanceOf[PosExplode]) {
         return ValidationResult.notOk(s"Velox backend does not support this posexplode")
       }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.UnaryExecNode
+import org.apache.spark.sql.types.MapType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import com.google.protobuf.Any
@@ -97,7 +98,14 @@ case class GenerateExecTransformer(
       }
       if (generator.isInstanceOf[Explode]) {
         if (generator.asInstanceOf[Explode].child.isInstanceOf[CreateMap]) {
-          return ValidationResult.notOk(s"Velox backend does not support this posexplode")
+          return ValidationResult.notOk(s"Velox backend does not support MAP datatype")
+        }
+        generator.asInstanceOf[Explode].child.dataType match {
+          case _: MapType =>
+            return ValidationResult.notOk(s"Velox backend does not support MAP datatype")
+        }
+        if (outer) {
+          return ValidationResult.notOk(s"Velox backend does not support outer")
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch implements `GenerateExec` for Velox backend. 

it does not support below cases:
- explode with outer option
- posexplode
- MapType as the input

(Partially Fixes: #2943 )

## How was this patch tested?

existing UT

