### PR TITLE
[VL] Add backtrace for memory allocation tracking

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1136,10 +1136,15 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_cre
     throw gluten::GlutenException("Allocator does not exist or has been closed");
   }
 
+  std::unique_ptr<AllocationListener> listener = std::make_unique<SparkAllocationListener>(
+      vm, jlistener, reserveMemoryMethod, unreserveMemoryMethod, reservationBlockSize);
+
+  if (gluten::backtrace_allocation) {
+    listener = std::move(std::make_unique<BacktraceAllocationListener>(std::move(listener)));
+  }
+
   auto name = jStringToCString(env, jname);
   auto backend = createBackend();
-  auto listener = std::make_unique<SparkAllocationListener>(
-      vm, jlistener, reserveMemoryMethod, unreserveMemoryMethod, reservationBlockSize);
   auto manager = backend->createMemoryManager(name, *allocator, std::move(listener));
   return reinterpret_cast<jlong>(manager);
   JNI_METHOD_END(-1L)

--- a/cpp/core/memory/AllocationListener.cc
+++ b/cpp/core/memory/AllocationListener.cc
@@ -19,6 +19,8 @@
 
 namespace gluten {
 
+bool backtrace_allocation = false;
+
 class NoopAllocationListener : public gluten::AllocationListener {
  public:
   void allocationChanged(int64_t diff) override {

--- a/cpp/core/memory/AllocationListener.h
+++ b/cpp/core/memory/AllocationListener.h
@@ -21,6 +21,8 @@
 
 namespace gluten {
 
+extern bool backtrace_allocation;
+
 class AllocationListener {
  public:
   static std::unique_ptr<AllocationListener> noop();

--- a/cpp/velox/compute/VeloxInitializer.cc
+++ b/cpp/velox/compute/VeloxInitializer.cc
@@ -89,6 +89,9 @@ const std::string kVeloxUdfLibraryPaths = "spark.gluten.sql.columnar.backend.vel
 const std::string kMaxSpillFileSize = "spark.gluten.sql.columnar.backend.velox.maxSpillFileSize";
 const std::string kMaxSpillFileSizeDefault = std::to_string(20L * 1024 * 1024);
 
+// backtrace allocation
+const std::string kBacktraceAllocation = "spark.gluten.backtrace.allocation";
+
 } // namespace
 
 namespace gluten {
@@ -115,6 +118,14 @@ void VeloxInitializer::init(const std::unordered_map<std::string, std::string>& 
       enableUserExceptionStacktrace = got->second;
     }
     FLAGS_velox_exception_user_stacktrace_enabled = (enableUserExceptionStacktrace == "true");
+  }
+
+  // Set backtrace_allocation
+  {
+    auto got = conf.find(kBacktraceAllocation);
+    if (got != conf.end()) {
+      gluten::backtrace_allocation = (got->second == "true");
+    }
   }
 
   // Setup and register.

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -156,7 +156,11 @@ Here will explain how to run TPC-H on Velox backend with the Parquet file format
 wait to add
 
 # How to track the memory exhaust problem
+When your gluten spark jobs failed because of OOM, you can track the memory allocation's call stack by configuring `spark.gluten.backtrace.allocation = true`.
+The above configuration will use `BacktraceAllocationListener` wrapping from `SparkAllocationListener` to create `VeloxMemoryManager`.
 
-You can track the memory allocation's call stack by configuring `spark.gluten.backtrace.allocation = true`.
+`BacktraceAllocationListener` will check every allocation, if a single allocation bytes exceeds a fixed value or the accumulative allocation bytes exceeds 1/2/3...G,
+the call stack of memory allocation will be outputted to standard output, you can check the backtrace and get some valuable information about tracking the memory exhaust issues.
 
-the call stack of memory allocation will be printed if this allocation bytes exceeds 256M or the total bytes statified condition.
+You can also adjust the policy to decide when to backtrace, such as the fixed value.
+

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -154,3 +154,9 @@ Here will explain how to run TPC-H on Velox backend with the Parquet file format
 
 # How to run TPC-DS
 wait to add
+
+# How to track the memory exhaust problem
+
+You can track the memory allocation's call stack by configuring `spark.gluten.backtrace.allocation = true`.
+
+the call stack of memory allocation will be printed if this allocation bytes exceeds 256M or the total bytes statified condition.


### PR DESCRIPTION
## What changes were proposed in this pull request?

We designed a new class `BacktraceAllocationListener` derived from `gluten::AllocationListener`, It may be useful when we encounter a memory issue.

We use `SparkAllocationListener` by default, but we can use a wrapper class `BacktraceAllocationListener` to dump the allocation call stack by config `spark.gluten.backtrace.allocation = true`.


(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

