### PR TITLE
[VL] Fix config key naming format in  GlutenConfig.scala

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -346,7 +346,7 @@ object GlutenConfig {
   val GLUTEN_MAX_BATCH_SIZE_KEY = "spark.gluten.sql.columnar.maxBatchSize"
 
   // Shuffle Writer buffer size.
-  val GLUTEN_SHUFFLE_WRITER_BUFFER_SIZE = "spark.gluten.shufflewriter.bufferSize"
+  val GLUTEN_SHUFFLE_WRITER_BUFFER_SIZE = "spark.gluten.shuffleWriter.bufferSize"
 
   // Controls whether to load DLL from jars. User can get dependent native libs packed into a jar
   // by executing dev/package.sh. Then, with that jar configured, Gluten can load the native libs


### PR DESCRIPTION
## What changes were proposed in this pull request?

Quick fix naming format typo introduced from https://github.com/oap-project/gluten/pull/2950

