### PR TITLE
[VL] Refine CompositeColumnarBatch

### DIFF
--- a/cpp/core/memory/ColumnarBatch.h
+++ b/cpp/core/memory/ColumnarBatch.h
@@ -115,7 +115,10 @@ class CompositeColumnarBatch final : public ColumnarBatch {
   const std::vector<std::shared_ptr<ColumnarBatch>>& getBatches() const;
 
  private:
-  CompositeColumnarBatch(long numColumns, long numRows, std::vector<std::shared_ptr<ColumnarBatch>> batches);
+  explicit CompositeColumnarBatch(
+      int32_t numColumns,
+      int32_t numRows,
+      std::vector<std::shared_ptr<ColumnarBatch>> batches);
 
   // We use ArrowColumnarBatch as the way to compose columnar batches
   void ensureUnderlyingBatchCreated();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr refines the `CompositeColumnarBatch`, inlcuding:
- use  std::move to pass vector batch to avoid data copy
- use int32_t to replace long to avoid implicat conversion
- use underlying batch to get numBytes if exists

## How was this patch tested?

PASS CI
