### PR TITLE
[VL] Set a GHA workflow run to emulate random task kills/retries

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -313,9 +313,9 @@ jobs:
         run: |
           docker exec centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
           mvn clean install -Pspark-3.2 \
-          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
+          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries \
             --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks \
-          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
+          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1 --skip-data-gen --random-kill-tasks' || true
       - name: Exit docker container
         if: ${{ always() }}

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -309,6 +309,14 @@ jobs:
             --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 \
           && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1'
+      - name: (To be fixed) TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2 random kill tasks
+        run: |
+          docker exec velox-centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean install -Pspark-3.2 \
+          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
+            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks \
+          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
+            --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1 --skip-data-gen --random-kill-tasks' || true
       - name: Exit docker container
         if: ${{ always() }}
         run: |

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -312,8 +312,7 @@ jobs:
       - name: (To be fixed) TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2 random kill tasks
         run: |
           docker exec velox-centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean install -Pspark-3.2 \
-          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
+          GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks \
           && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1 --skip-data-gen --random-kill-tasks' || true

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -314,7 +314,7 @@ jobs:
           docker exec centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
           mvn clean install -Pspark-3.2 \
           && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
-            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks\
+            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks \
           && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1 --skip-data-gen --random-kill-tasks' || true
       - name: Exit docker container

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -312,9 +312,9 @@ jobs:
       - name: (To be fixed) TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2 random kill tasks
         run: |
           docker exec velox-centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
+          GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries \
             --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks \
-          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
+          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1 --skip-data-gen --random-kill-tasks' || true
       - name: Exit docker container
         if: ${{ always() }}

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -311,10 +311,11 @@ jobs:
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1'
       - name: (To be fixed) TPC-H SF1.0 && TPC-DS SF30.0 Parquet local spark3.2 random kill tasks
         run: |
-          docker exec velox-centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries \
-            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=20g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks \
-          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries \
+          docker exec centos8-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean install -Pspark-3.2 \
+          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
+            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 --skip-data-gen --random-kill-tasks\
+          && GLUTEN_IT_JVM_ARGS=-Xmx50G sbin/gluten-it.sh queries-compare \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=50g -s=30.0 --threads=32 --iterations=1 --skip-data-gen --random-kill-tasks' || true
       - name: Exit docker container
         if: ${{ always() }}

--- a/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Queries.java
+++ b/tools/gluten-it/common/src/main/java/io/glutenproject/integration/tpc/command/Queries.java
@@ -41,7 +41,7 @@ public class Queries implements Callable<Integer> {
   @CommandLine.Option(names = {"--iterations"}, description = "How many iterations to run", defaultValue = "1")
   private int iterations;
 
-  @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Each task gets 20% chance to be killed and retried after running for seconds", defaultValue = "false")
+  @CommandLine.Option(names = {"--random-kill-tasks"}, description = "Every single task will get killed and retried after running for some time", defaultValue = "false")
   private boolean randomKillTasks;
 
   @Override

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql
 
+import org.apache.spark.SparkContext
 import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorMetricsUpdate, SparkListenerTaskStart}
 
@@ -24,6 +25,7 @@ import org.apache.commons.lang3.RandomUtils
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
 
 object QueryRunner {
   private val availableExecutorMetrics: Set[String] = Set(
@@ -59,42 +61,20 @@ object QueryRunner {
     }
     val sc = spark.sparkContext
     sc.setJobDescription(desc)
+
+    // metrics listener
     val em = new ExecutorMetrics()
-    val metricsListener = new SparkListener {
-      override def onExecutorMetricsUpdate(
-          executorMetricsUpdate: SparkListenerExecutorMetricsUpdate): Unit = {
-        executorMetricsUpdate.executorUpdates.foreach {
-          case (_, peakUpdates) =>
-            em.compareAndUpdatePeakValues(peakUpdates)
-        }
-        super.onExecutorMetricsUpdate(executorMetricsUpdate)
-      }
-    }
+    val metricsListener = new MetricsListener(em)
     sc.addSparkListener(metricsListener)
-    if (randomKillTasks) {
-      sc.addSparkListener(new SparkListener {
-        override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
-          val killer = new Thread {
-            override def run(): Unit = {
-              // TODO make this configurable
-              // After 1s - 10s, kill the task
-              val waitMs = RandomUtils.nextLong(1000L, 10000L)
-              Thread.sleep(waitMs)
-              // We have 20% chance to kill the task. Otherwise let the task run
-              if (RandomUtils.nextFloat(0.0f, 1.0f) < 0.2f) {
-                if (sc.isStopped) {
-                  return
-                }
-                println(s"Killing task attempt after $waitMs ms: ${taskStart.taskInfo.taskId}")
-                sc.killTaskAttempt(taskStart.taskInfo.taskId, interruptThread = true)
-              }
-            }
-          }
-          killer.setDaemon(true)
-          killer.start()
-        }
-      })
+
+    // kill task listener
+    val killTaskListener: Option[KillTaskListener] = if (randomKillTasks) {
+      Some(new KillTaskListener(sc))
+    } else {
+      None
     }
+    killTaskListener.foreach(sc.addSparkListener(_))
+
     println(s"Executing SQL query from resource path $queryPath...")
     try {
       val sql = resourceToString(queryPath)
@@ -109,6 +89,12 @@ object QueryRunner {
       RunResult(rows, millis, collectedMetrics)
     } finally {
       sc.removeSparkListener(metricsListener)
+      killTaskListener.foreach(
+        l => {
+          sc.removeSparkListener(l)
+          println(s"Success kill rate ${"%.2f%%".format(
+              100 * l.successRate())} during execution of app: ${sc.applicationId}")
+        })
       sc.setJobDescription(null)
     }
   }
@@ -135,3 +121,48 @@ object QueryRunner {
 }
 
 case class RunResult(rows: Seq[Row], executionTimeMillis: Long, metrics: Map[String, Long])
+
+class MetricsListener(em: ExecutorMetrics) extends SparkListener {
+  override def onExecutorMetricsUpdate(
+      executorMetricsUpdate: SparkListenerExecutorMetricsUpdate): Unit = {
+    executorMetricsUpdate.executorUpdates.foreach {
+      case (_, peakUpdates) =>
+        em.compareAndUpdatePeakValues(peakUpdates)
+    }
+    super.onExecutorMetricsUpdate(executorMetricsUpdate)
+  }
+}
+
+class KillTaskListener(val sc: SparkContext) extends SparkListener {
+  private val killCount = new AtomicInteger(0)
+  private val successCount = new AtomicInteger(0)
+
+  override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = {
+    val killer = new Thread {
+      override def run(): Unit = {
+        // TODO make this configurable
+        // After 1s - 10s, kill the task
+        val waitMs = RandomUtils.nextLong(1000L, 10000L)
+        Thread.sleep(waitMs)
+        // We have 20% chance to kill the task. Otherwise let the task run
+        if (RandomUtils.nextFloat(0.0f, 1.0f) < 0.2f) {
+          if (sc.isStopped) {
+            return
+          }
+          println(s"Killing task attempt after $waitMs ms: ${taskStart.taskInfo.taskId}")
+          val succeeded = sc.killTaskAttempt(taskStart.taskInfo.taskId, interruptThread = true)
+          if (succeeded) {
+            successCount.getAndIncrement()
+          }
+          killCount.getAndIncrement()
+        }
+      }
+    }
+    killer.setDaemon(true)
+    killer.start()
+  }
+
+  def successRate(): Float = {
+    successCount.get().asInstanceOf[Float] / killCount.get()
+  }
+}

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -174,7 +174,7 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
         val elapsed = wait()
 
         // We have 50% chance to kill the task. FIXME make it configurable?
-        if (RandomUtils.nextFloat(0.0f, 0.5f) < 1.0f) {
+        if (RandomUtils.nextFloat(0.0f, 1.0f) < 0.5f) {
           if (sc.isStopped) {
             return
           }

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -175,7 +175,6 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
         // We have 50% chance to kill the task. FIXME make it configurable?
         if (RandomUtils.nextFloat(0.0f, 0.5f) < 1.0f) {
           if (sc.isStopped) {
-            println("WARN: context was stopped when preparing to kill task")
             return
           }
           println(

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -210,5 +210,5 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
 }
 
 object KillTaskListener {
-  private val INIT_WAIT_TIME_MS: Long = 500L
+  private val INIT_WAIT_TIME_MS: Long = 50L
 }

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -166,7 +166,7 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
                 sync.notifyAll()
                 return elapsed
               }
-              stageKillWaitTimeLookup.wait(remaining)
+              sync.wait(remaining)
             }
           }
           throw new IllegalStateException()

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkContext, TaskKilled}
+import org.apache.spark.{SparkContext, Success, TaskKilled}
 import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorMetricsUpdate, SparkListenerTaskEnd, SparkListenerTaskStart}
 import org.apache.spark.sql.KillTaskListener.INIT_WAIT_TIME_MS
@@ -191,7 +191,7 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
     taskEnd.reason match {
       case TaskKilled(_, _, _, _) =>
         killCount.getAndIncrement()
-      case _ =>
+      case Success =>
         // once one task from the stage ends, kill all the others immediately
         stageKillWaitTimeLookup.synchronized {
           stageKillMaxWaitTimeLookup.put(
@@ -199,6 +199,7 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
             (taskEnd.taskInfo.duration * 0.8d).asInstanceOf[Long])
           stageKillWaitTimeLookup.notifyAll()
         }
+      case _ =>
     }
 
   }

--- a/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/spark/sql/QueryRunner.scala
@@ -190,6 +190,8 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
   override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
     taskEnd.reason match {
       case TaskKilled(_, _, _, _) =>
+        killCount.getAndIncrement()
+      case _ =>
         // once one task from the stage ends, kill all the others immediately
         stageKillWaitTimeLookup.synchronized {
           stageKillMaxWaitTimeLookup.put(
@@ -197,8 +199,6 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
             (taskEnd.taskInfo.duration * 0.8d).asInstanceOf[Long])
           stageKillWaitTimeLookup.notifyAll()
         }
-        killCount.getAndIncrement()
-      case _ =>
     }
 
   }
@@ -209,5 +209,5 @@ class KillTaskListener(val sc: SparkContext) extends SparkListener {
 }
 
 object KillTaskListener {
-  private val INIT_WAIT_TIME_MS: Long = 50L
+  private val INIT_WAIT_TIME_MS: Long = 500L
 }


### PR DESCRIPTION
Using gluten-it `--random-kill-tasks` to emulate random task kills/retries on a complete TPC-H + TPC-DS run.

Within `--random-kill-tasks`, each task gets some chance to be killed after running for several seconds.

Temporarily, failures from this test will be ignored so doesn't block CI. We'll make it blocking after fixing all the relevant crash issues caused by task kill. See also https://github.com/oap-project/gluten/issues/3048.