### PR TITLE
[VL] Add config option spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1132,6 +1132,13 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
+  val COLUMNAR_VELOX_ENABLE_SYSTEM_EXCEPTION_STACKTRACE =
+    buildConf("spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace")
+      .internal()
+      .doc("Enable the stacktrace for system type of VeloxException")
+      .booleanConf
+      .createWithDefault(true)
+
   val TEXT_INPUT_ROW_MAX_BLOCK_SIZE =
     buildConf("spark.gluten.sql.text.input.max.block.size")
       .internal()


### PR DESCRIPTION
Related to https://github.com/oap-project/gluten/issues/3048.

We observed some rare crashes in library `libunwind` when Velox is trying to handle exceptions.

After this patch, set both `spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace=false` and `spark.gluten.sql.columnar.backend.velox.enableUserExceptionStacktrace=false` to workaround the crash issue to let the exceptions throw normally.