### PR TITLE
[VL] Remove preferSpill=true for VeloxShuffleWriter

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -245,7 +245,10 @@ jobs:
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2 with Celeborn
         run: |
           docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c \
-          'bash /opt/apache-celeborn-0.3.0-incubating-bin/sbin/start-master.sh && bash /opt/apache-celeborn-0.3.0-incubating-bin/sbin/start-worker.sh && \
+          'mv /opt/apache-celeborn-0.3.0-incubating-bin/conf/celeborn-env.sh.template /opt/apache-celeborn-0.3.0-incubating-bin/conf/celeborn-env.sh && \
+          echo -e "CELEBORN_MASTER_MEMORY=4g\nCELEBORN_WORKER_MEMORY=4g\nCELEBORN_WORKER_OFFHEAP_MEMORY=8g" > /opt/apache-celeborn-0.3.0-incubating-bin/conf/celeborn-env.sh && \
+          echo -e "celeborn.worker.commitFiles.threads 128\nceleborn.worker.sortPartition.threads 64" > /opt/apache-celeborn-0.3.0-incubating-bin/conf/celeborn-defaults.conf \
+          && bash /opt/apache-celeborn-0.3.0-incubating-bin/sbin/start-master.sh && bash /opt/apache-celeborn-0.3.0-incubating-bin/sbin/start-worker.sh && \
           cd /opt/gluten/tools/gluten-it && mvn clean install -Pspark-3.2,rss \
           && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox-with-celeborn --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 \

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -52,7 +52,7 @@ class CHColumnarShuffleWriter[K, V](
   private val splitSize = GlutenConfig.getConf.maxBatchSize
   private val customizedCompressCodec =
     GlutenShuffleUtils.getCompressionCodec(conf).toUpperCase(Locale.ROOT)
-  private val preferSpill = GlutenConfig.getConf.columnarShufflePreferSpill
+  private val preferSpill = GlutenConfig.getConf.chColumnarShufflePreferSpill
   private val spillThreshold = GlutenConfig.getConf.chColumnarShuffleSpillThreshold
   private val jniWrapper = new CHShuffleSplitterJniWrapper
   // Are we in the process of stopping? Because map tasks can call stop() with success = true

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHousePreferSpillColumnarShuffleAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHousePreferSpillColumnarShuffleAQESuite.scala
@@ -37,7 +37,7 @@ class GlutenClickHousePreferSpillColumnarShuffleAQESuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
       .set("spark.sql.adaptive.enabled", "true")
-      .set("spark.gluten.sql.columnar.shuffle.preferSpill", "true")
+      .set("spark.gluten.sql.columnar.backend.ch.shuffle.preferSpill", "true")
   }
 
   test("TPCH Q1") {

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -113,8 +113,6 @@ find_package(Threads REQUIRED)
 
 find_package(JNI REQUIRED)
 
-find_package(glog REQUIRED)
-
 if(BUILD_TESTS)
   set(GLUTEN_GTEST_MIN_VERSION "1.13.0")
   find_package(GTest ${GLUTEN_GTEST_MIN_VERSION} CONFIG)
@@ -123,6 +121,7 @@ if(BUILD_TESTS)
   endif()
   include(GoogleTest)
   enable_testing()
+  find_package(glog REQUIRED)
 endif()
 
 function(ADD_TEST_CASE TEST_NAME)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -113,6 +113,8 @@ find_package(Threads REQUIRED)
 
 find_package(JNI REQUIRED)
 
+find_package(glog REQUIRED)
+
 if(BUILD_TESTS)
   set(GLUTEN_GTEST_MIN_VERSION "1.13.0")
   find_package(GTest ${GLUTEN_GTEST_MIN_VERSION} CONFIG)
@@ -121,7 +123,6 @@ if(BUILD_TESTS)
   endif()
   include(GoogleTest)
   enable_testing()
-  find_package(glog REQUIRED)
 endif()
 
 function(ADD_TEST_CASE TEST_NAME)

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -205,6 +205,7 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
         shuffle/LocalPartitionWriter.cc
         shuffle/rss/RemotePartitionWriter.cc
         shuffle/rss/CelebornPartitionWriter.cc
+        shuffle/Utils.cc
         utils/Compression.cc
         utils/DebugOut.cc
         utils/StringUtil.cc
@@ -321,7 +322,7 @@ else()
 endif()
 
 target_link_libraries(gluten
-    PUBLIC Arrow::arrow Arrow::parquet)
+    PUBLIC Arrow::arrow Arrow::parquet glog::glog)
 
 install(TARGETS gluten
         DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -322,7 +322,7 @@ else()
 endif()
 
 target_link_libraries(gluten
-    PUBLIC Arrow::arrow Arrow::parquet glog::glog)
+    PUBLIC Arrow::arrow Arrow::parquet)
 
 install(TARGETS gluten
         DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -26,6 +26,7 @@
 #include "compute/ProtobufUtils.h"
 #include "config/GlutenConfig.h"
 #include "memory/AllocationListener.h"
+#include "shuffle/rss/RssClient.h"
 #include "utils/DebugOut.h"
 #include "utils/compression.h"
 #include "utils/exception.h"
@@ -314,11 +315,6 @@ class BacktraceAllocationListener final : public gluten::AllocationListener {
   std::atomic_int64_t backtraceBytes_{1L << 30};
 };
 
-class RssClient {
- public:
-  virtual ~RssClient() = default;
-};
-
 class CelebornClient : public RssClient {
  public:
   CelebornClient(JavaVM* vm, jobject javaCelebornShuffleWriter, jmethodID javaCelebornPushPartitionDataMethod)
@@ -346,7 +342,7 @@ class CelebornClient : public RssClient {
     env->DeleteGlobalRef(array_);
   }
 
-  int32_t pushPartitonData(int32_t partitionId, char* bytes, int64_t size) {
+  int32_t pushPartitionData(int32_t partitionId, char* bytes, int64_t size) {
     JNIEnv* env;
     if (vm_->GetEnv(reinterpret_cast<void**>(&env), jniVersion) != JNI_OK) {
       throw gluten::GlutenException("JNIEnv was not attached to current thread");
@@ -365,6 +361,8 @@ class CelebornClient : public RssClient {
     checkException(env);
     return static_cast<int32_t>(celebornBytesSize);
   }
+
+  void stop() {}
 
   JavaVM* vm_;
   jobject javaCelebornShuffleWriter_;

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -811,7 +811,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator;
 
   if (partitionWriterType == "local") {
-    shuffleWriterOptions.partition_writer_type = "local";
+    shuffleWriterOptions.partition_writer_type = kLocal;
     if (dataFileJstr == NULL) {
       throw gluten::GlutenException(std::string("Shuffle DataFile can't be null"));
     }
@@ -820,7 +820,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     }
 
     shuffleWriterOptions.write_eos = writeEOS;
-    shuffleWriterOptions.prefer_evict = preferEvict;
     shuffleWriterOptions.buffer_realloc_threshold = reallocThreshold;
 
     if (numSubDirs > 0) {
@@ -836,7 +835,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     env->ReleaseStringUTFChars(localDirsJstr, localDirs);
     partitionWriterCreator = std::make_shared<LocalPartitionWriterCreator>();
   } else if (partitionWriterType == "celeborn") {
-    shuffleWriterOptions.partition_writer_type = "celeborn";
+    shuffleWriterOptions.partition_writer_type = PartitionWriterType::kCeleborn;
     jclass celebornPartitionPusherClass =
         createGlobalClassReferenceOrError(env, "Lorg/apache/spark/shuffle/CelebornPartitionPusher;");
     jmethodID celebornPushPartitionDataMethod =

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -34,8 +34,8 @@
 #include "shuffle/PartitionWriterCreator.h"
 #include "shuffle/ShuffleReader.h"
 #include "shuffle/ShuffleWriter.h"
+#include "shuffle/Utils.h"
 #include "shuffle/rss/CelebornPartitionWriter.h"
-#include "shuffle/utils.h"
 #include "utils/ArrowStatus.h"
 
 using namespace gluten;
@@ -834,7 +834,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     auto localDirs = env->GetStringUTFChars(localDirsJstr, JNI_FALSE);
     setenv(gluten::kGlutenSparkLocalDirs.c_str(), localDirs, 1);
     env->ReleaseStringUTFChars(localDirsJstr, localDirs);
-    partitionWriterCreator = std::make_shared<LocalPartitionWriterCreator>(preferEvict);
+    partitionWriterCreator = std::make_shared<LocalPartitionWriterCreator>();
   } else if (partitionWriterType == "celeborn") {
     shuffleWriterOptions.partition_writer_type = "celeborn";
     jclass celebornPartitionPusherClass =

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -754,7 +754,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jstring dataFileJstr,
     jint numSubDirs,
     jstring localDirsJstr,
-    jboolean preferEvict,
     jlong memoryManagerHandle,
     jboolean writeEOS,
     jdouble reallocThreshold,

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -19,6 +19,7 @@
 #include <thread>
 #include "shuffle/Utils.h"
 #include "utils/DebugOut.h"
+#include "utils/Timer.h"
 
 namespace gluten {
 
@@ -101,13 +102,13 @@ arrow::Status PreferCachePartitionWriter::spill() {
 }
 
 arrow::Status PreferCachePartitionWriter::stop() {
-  int64_t totalWriteTime = 0;
   int64_t totalBytesEvicted = 0;
   int64_t totalBytesWritten = 0;
-  int64_t lastPayloadCompressTime = 0;
   auto numPartitions = shuffleWriter_->numPartitions();
 
-  TIME_NANO_START(totalWriteTime)
+  auto writeTimer = Timer();
+  writeTimer.start();
+
   // Open final file.
   // If options_.buffered_write is set, it will acquire 16KB memory that might trigger spill.
   RETURN_NOT_OK(openDataFile());
@@ -145,9 +146,9 @@ arrow::Status PreferCachePartitionWriter::stop() {
       RETURN_NOT_OK(flushCachedPayloads(pid, dataFileOs_.get()));
     }
     // Write the last payload.
-    TIME_NANO_START(lastPayloadCompressTime)
+    writeTimer.stop();
     ARROW_ASSIGN_OR_RAISE(auto lastPayload, shuffleWriter_->createPayloadFromBuffer(pid, false));
-    TIME_NANO_END(lastPayloadCompressTime)
+    writeTimer.start();
     if (lastPayload) {
       firstWrite = false;
       int32_t metadataLength = 0; // unused
@@ -175,9 +176,9 @@ arrow::Status PreferCachePartitionWriter::stop() {
 
   ARROW_ASSIGN_OR_RAISE(totalBytesWritten, dataFileOs_->Tell());
 
-  TIME_NANO_END(totalWriteTime)
+  writeTimer.stop();
 
-  shuffleWriter_->setTotalWriteTime(totalWriteTime - lastPayloadCompressTime);
+  shuffleWriter_->setTotalWriteTime(writeTimer.realTimeUsed());
   shuffleWriter_->setTotalBytesEvicted(totalBytesEvicted);
   shuffleWriter_->setTotalBytesWritten(totalBytesWritten);
 

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -85,7 +85,7 @@ arrow::Status PreferCachePartitionWriter::spill() {
       RETURN_NOT_OK(flushCachedPayloads(pid, spilledFileOs.get()));
       ARROW_ASSIGN_OR_RAISE(auto end, spilledFileOs->Tell());
       spillInfo.partitionSpillInfos.push_back({pid, end - start});
-      DEBUG_OUT << "Spilled partition " << pid << " file start: " << start << ", file end: " << end;
+      DEBUG_OUT << "Spilled partition " << pid << " file start: " << start << ", file end: " << end << std::endl;
     }
   }
   RETURN_NOT_OK(spilledFileOs->Close());

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -86,7 +86,6 @@ arrow::Status PreferCachePartitionWriter::spill() {
       ARROW_ASSIGN_OR_RAISE(auto end, spilledFileOs->Tell());
       spillInfo.partitionSpillInfos.push_back({pid, end - start});
       DEBUG_OUT << "Spilled partition " << pid << " file start: " << start << ", file end: " << end;
-                << ", cachedPayloadSize: " << cachedPayloadSize << std::endl;
     }
   }
   RETURN_NOT_OK(spilledFileOs->Close());

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -17,6 +17,7 @@
 
 #include "shuffle/LocalPartitionWriter.h"
 #include <thread>
+#include "shuffle/Utils.h"
 #include "utils/DebugOut.h"
 
 namespace gluten {
@@ -59,187 +60,16 @@ arrow::Status LocalPartitionWriterBase::openDataFile() {
 
 arrow::Status LocalPartitionWriterBase::clearResource() {
   RETURN_NOT_OK(dataFileOs_->Close());
-  schemaPayload_.reset();
-  shuffleWriter_->partitionBuffer().clear();
-  return arrow::Status::OK();
-}
-
-class PreferEvictPartitionWriter::LocalPartitionWriterInstance {
- public:
-  LocalPartitionWriterInstance(
-      PreferEvictPartitionWriter* partitionWriter,
-      ShuffleWriter* shuffleWriter,
-      uint32_t partitionId)
-      : partitionWriter_(partitionWriter), shuffleWriter_(shuffleWriter), partitionId_(partitionId) {}
-
-  arrow::Status spill() {
-#ifndef SKIPWRITE
-    RETURN_NOT_OK(ensureOpened());
-#endif
-    RETURN_NOT_OK(writeRecordBatchPayload(spilledFileOs_.get()));
-    shuffleWriter_->clearCachedPayloads(partitionId_);
-    return arrow::Status::OK();
-  }
-
-  arrow::Status writeCachedRecordBatchAndClose() {
-    const auto& dataFileOs = partitionWriter_->dataFileOs_;
-    ARROW_ASSIGN_OR_RAISE(auto before_write, dataFileOs->Tell());
-
-    if (spilledFileOpened_) {
-      RETURN_NOT_OK(spilledFileOs_->Close());
-      RETURN_NOT_OK(mergeSpilled());
-    } else {
-      if (shuffleWriter_->partitionCachedRecordbatchSize()[partitionId_] == 0) {
-        return arrow::Status::Invalid("Partition writer got empty partition");
-      }
-    }
-
-    RETURN_NOT_OK(writeRecordBatchPayload(dataFileOs.get()));
-    if (shuffleWriter_->options().write_eos) {
-      RETURN_NOT_OK(writeEos(dataFileOs.get()));
-    }
-    shuffleWriter_->clearCachedPayloads(partitionId_);
-
-    ARROW_ASSIGN_OR_RAISE(auto after_write, dataFileOs->Tell());
-    partition_length = after_write - before_write;
-
-    return arrow::Status::OK();
-  }
-
-  // metrics
-  int64_t bytes_spilled = 0;
-  int64_t partition_length = 0;
-  int64_t compress_time = 0;
-
- private:
-  arrow::Status ensureOpened() {
-    if (!spilledFileOpened_) {
-      ARROW_ASSIGN_OR_RAISE(spilledFile_, createTempShuffleFile(partitionWriter_->nextSpilledFileDir()));
-      ARROW_ASSIGN_OR_RAISE(spilledFileOs_, arrow::io::FileOutputStream::Open(spilledFile_, true));
-      spilledFileOpened_ = true;
-    }
-    return arrow::Status::OK();
-  }
-
-  arrow::Status mergeSpilled() {
-    ARROW_ASSIGN_OR_RAISE(
-        auto spilled_file_is_, arrow::io::MemoryMappedFile::Open(spilledFile_, arrow::io::FileMode::READ));
-    // copy spilled data blocks
-    ARROW_ASSIGN_OR_RAISE(auto nbytes, spilled_file_is_->GetSize());
-    ARROW_ASSIGN_OR_RAISE(auto buffer, spilled_file_is_->Read(nbytes));
-    RETURN_NOT_OK(partitionWriter_->dataFileOs_->Write(buffer));
-
-    // close spilled file streams and delete the file
-    RETURN_NOT_OK(spilled_file_is_->Close());
-    auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
-    RETURN_NOT_OK(fs->DeleteFile(spilledFile_));
-    bytes_spilled += nbytes;
-    return arrow::Status::OK();
-  }
-
-  arrow::Status writeRecordBatchPayload(arrow::io::OutputStream* os) {
-    int32_t metadataLength = 0; // unused
-#ifndef SKIPWRITE
-    for (auto& payload : shuffleWriter_->partitionCachedRecordbatch()[partitionId_]) {
-      RETURN_NOT_OK(
-          arrow::ipc::WriteIpcPayload(*payload, shuffleWriter_->options().ipc_write_options, os, &metadataLength));
-      payload = nullptr;
-    }
-#endif
-    return arrow::Status::OK();
-  }
-
-  arrow::Status writeEos(arrow::io::OutputStream* os) {
-    // This 0xFFFFFFFF value is the first 4 bytes of a valid IPC message
-    constexpr int32_t kIpcContinuationToken = -1;
-    constexpr int32_t kZeroLength = 0;
-    RETURN_NOT_OK(os->Write(&kIpcContinuationToken, sizeof(int32_t)));
-    RETURN_NOT_OK(os->Write(&kZeroLength, sizeof(int32_t)));
-    return arrow::Status::OK();
-  }
-
-  PreferEvictPartitionWriter* partitionWriter_;
-  ShuffleWriter* shuffleWriter_;
-  uint32_t partitionId_;
-  std::string spilledFile_;
-  std::shared_ptr<arrow::io::FileOutputStream> spilledFileOs_;
-
-  bool spilledFileOpened_ = false;
-};
-
-arrow::Status PreferEvictPartitionWriter::init() {
-  partitionWriterInstances_.resize(shuffleWriter_->numPartitions());
-  RETURN_NOT_OK(setLocalDirs());
-  return arrow::Status::OK();
-}
-
-arrow::Result<std::shared_ptr<arrow::ipc::IpcPayload>> LocalPartitionWriterBase::getSchemaPayload(
-    std::shared_ptr<arrow::Schema> schema) {
-  if (schemaPayload_ != nullptr) {
-    return schemaPayload_;
-  }
-  schemaPayload_ = std::make_shared<arrow::ipc::IpcPayload>();
-  arrow::ipc::DictionaryFieldMapper dictFileMapper; // unused
-  RETURN_NOT_OK(arrow::ipc::GetSchemaPayload(
-      *schema, shuffleWriter_->options().ipc_write_options, dictFileMapper, schemaPayload_.get()));
-  return schemaPayload_;
-}
-
-arrow::Status PreferEvictPartitionWriter::evictPartition(int32_t partitionId) {
-  if (partitionWriterInstances_[partitionId] == nullptr) {
-    partitionWriterInstances_[partitionId] =
-        std::make_shared<LocalPartitionWriterInstance>(this, shuffleWriter_, partitionId);
-  }
-  int64_t tempTotalEvictTime = 0;
-  TIME_NANO_OR_RAISE(tempTotalEvictTime, partitionWriterInstances_[partitionId]->spill());
-  shuffleWriter_->setTotalEvictTime(shuffleWriter_->totalEvictTime() + tempTotalEvictTime);
-
-  return arrow::Status::OK();
-}
-
-arrow::Status PreferEvictPartitionWriter::stop() {
-  RETURN_NOT_OK(openDataFile());
-  // stop PartitionWriter and collect metrics
-  for (auto pid = 0; pid < shuffleWriter_->numPartitions(); ++pid) {
-    RETURN_NOT_OK(shuffleWriter_->createRecordBatchFromBuffer(pid, true));
-    if (shuffleWriter_->partitionCachedRecordbatchSize()[pid] > 0) {
-      if (partitionWriterInstances_[pid] == nullptr) {
-        partitionWriterInstances_[pid] = std::make_shared<LocalPartitionWriterInstance>(this, shuffleWriter_, pid);
-      }
-    }
-    if (partitionWriterInstances_[pid] != nullptr) {
-      const auto& writer = partitionWriterInstances_[pid];
-      int64_t tempTotalWriteTime = 0;
-      TIME_NANO_OR_RAISE(tempTotalWriteTime, writer->writeCachedRecordBatchAndClose());
-      shuffleWriter_->setTotalWriteTime(shuffleWriter_->totalWriteTime() + tempTotalWriteTime);
-      shuffleWriter_->setPartitionLengths(pid, writer->partition_length);
-      shuffleWriter_->setTotalBytesWritten(shuffleWriter_->totalBytesWritten() + writer->partition_length);
-      shuffleWriter_->setTotalBytesEvicted(shuffleWriter_->totalBytesEvicted() + writer->bytes_spilled);
-    } else {
-      shuffleWriter_->setPartitionLengths(pid, 0);
-    }
-  }
-  RETURN_NOT_OK(clearResource());
-  return arrow::Status::OK();
-}
-
-arrow::Status PreferEvictPartitionWriter::clearResource() {
-  RETURN_NOT_OK(LocalPartitionWriterBase::clearResource());
-  partitionWriterInstances_.clear();
   return arrow::Status::OK();
 }
 
 arrow::Status PreferCachePartitionWriter::init() {
+  partitionCachedPayload_.resize(shuffleWriter_->numPartitions());
   RETURN_NOT_OK(setLocalDirs());
   return arrow::Status::OK();
 }
 
-arrow::Status PreferCachePartitionWriter::evictPartition(int32_t partitionId /* not used */) {
-  // TODO: Remove this check.
-  if (partitionId != -1) {
-    return arrow::Status::Invalid("Cannot spill single partition. Invalid code path.");
-  }
-
+arrow::Status PreferCachePartitionWriter::spill() {
   int64_t evictTime = 0;
   TIME_NANO_START(evictTime)
 
@@ -249,15 +79,13 @@ arrow::Status PreferCachePartitionWriter::evictPartition(int32_t partitionId /* 
   // Spill all cached batches into one file, record their start and length.
   ARROW_ASSIGN_OR_RAISE(auto spilledFileOs, arrow::io::FileOutputStream::Open(spilledFile, true));
   for (auto pid = 0; pid < shuffleWriter_->numPartitions(); ++pid) {
-    auto cachedPayloadSize = shuffleWriter_->partitionCachedRecordbatchSize()[pid];
-    if (cachedPayloadSize > 0) {
+    if (partitionCachedPayload_[pid].size() > 0) {
       ARROW_ASSIGN_OR_RAISE(auto start, spilledFileOs->Tell());
-      RETURN_NOT_OK(flushCachedPayloads(spilledFileOs.get(), shuffleWriter_->partitionCachedRecordbatch()[pid]));
+      RETURN_NOT_OK(flushCachedPayloads(pid, spilledFileOs.get()));
       ARROW_ASSIGN_OR_RAISE(auto end, spilledFileOs->Tell());
       spillInfo.partitionSpillInfos.push_back({pid, end - start});
-      DEBUG_OUT << "Spilled partition " << pid << " file start: " << start << ", file end: " << end
+      DEBUG_OUT << "Spilled partition " << pid << " file start: " << start << ", file end: " << end;
                 << ", cachedPayloadSize: " << cachedPayloadSize << std::endl;
-      shuffleWriter_->clearCachedPayloads(pid);
     }
   }
   RETURN_NOT_OK(spilledFileOs->Close());
@@ -312,28 +140,18 @@ arrow::Status PreferCachePartitionWriter::stop() {
       }
     }
     // Write cached batches.
-    auto cachedPayloadSize = shuffleWriter_->partitionCachedRecordbatchSize()[pid];
-    if (cachedPayloadSize > 0) {
+    if (!partitionCachedPayload_[pid].empty()) {
       firstWrite = false;
-      auto partitionCachedRecordBatch = std::move(shuffleWriter_->partitionCachedRecordbatch()[pid]);
-      // Clear cached batches before creating the payloads, to avoid spilling this partition.
-      shuffleWriter_->clearCachedPayloads(pid);
-      RETURN_NOT_OK(flushCachedPayloads(dataFileOs_.get(), partitionCachedRecordBatch));
+      RETURN_NOT_OK(flushCachedPayloads(pid, dataFileOs_.get()));
     }
     // Write the last payload.
-    ARROW_ASSIGN_OR_RAISE(auto rb, shuffleWriter_->createArrowRecordBatchFromBuffer(pid, true));
-    if (rb) {
+    TIME_NANO_START(lastPayloadCompressTime)
+    ARROW_ASSIGN_OR_RAISE(auto lastPayload, shuffleWriter_->createPayloadFromBuffer(pid, false));
+    TIME_NANO_END(lastPayloadCompressTime)
+    if (lastPayload) {
       firstWrite = false;
-      TIME_NANO_START(lastPayloadCompressTime)
-      // Record rawPartitionLength and flush the last payload.
-      // Payload compression requires extra allocation and may trigger spill.
-      ARROW_ASSIGN_OR_RAISE(auto lastPayload, shuffleWriter_->createArrowIpcPayload(*rb, false));
-      TIME_NANO_END(lastPayloadCompressTime)
-
-      shuffleWriter_->setRawPartitionLength(
-          pid, shuffleWriter_->rawPartitionLengths()[pid] + lastPayload->raw_body_length);
       int32_t metadataLength = 0; // unused
-      RETURN_NOT_OK(flushCachedPayload(dataFileOs_.get(), lastPayload, &metadataLength));
+      RETURN_NOT_OK(flushCachedPayload(dataFileOs_.get(), std::move(lastPayload), &metadataLength));
     }
     // Write EOS if any payload written.
     if (shuffleWriter_->options().write_eos && !firstWrite) {
@@ -374,19 +192,19 @@ arrow::Status PreferCachePartitionWriter::clearResource() {
   spills_.clear();
   return arrow::Status::OK();
 }
+arrow::Status PreferCachePartitionWriter::processPayload(
+    uint32_t partitionId,
+    std::unique_ptr<arrow::ipc::IpcPayload> payload) {
+  partitionCachedPayload_[partitionId].push_back(std::move(payload));
+  return arrow::Status::OK();
+}
 
-LocalPartitionWriterCreator::LocalPartitionWriterCreator(bool preferEvict)
-    : PartitionWriterCreator(), preferEvict_(preferEvict) {}
+LocalPartitionWriterCreator::LocalPartitionWriterCreator() : PartitionWriterCreator() {}
 
 arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> LocalPartitionWriterCreator::make(
     ShuffleWriter* shuffleWriter) {
-  std::shared_ptr<ShuffleWriter::PartitionWriter> res;
-  if (preferEvict_) {
-    res = std::make_shared<PreferEvictPartitionWriter>(shuffleWriter);
-  } else {
-    res = std::make_shared<PreferCachePartitionWriter>(shuffleWriter);
-  }
-  RETURN_NOT_OK(res->init());
-  return res;
+  auto partitionWriter = std::make_shared<PreferCachePartitionWriter>(shuffleWriter);
+  RETURN_NOT_OK(partitionWriter->init());
+  return partitionWriter;
 }
 } // namespace gluten

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -105,12 +105,12 @@ arrow::Status PreferCachePartitionWriter::stop() {
   int64_t totalBytesWritten = 0;
   auto numPartitions = shuffleWriter_->numPartitions();
 
-  auto writeTimer = Timer();
-  writeTimer.start();
-
   // Open final file.
   // If options_.buffered_write is set, it will acquire 16KB memory that might trigger spill.
   RETURN_NOT_OK(openDataFile());
+
+  auto writeTimer = Timer();
+  writeTimer.start();
 
   // Iterator over pid.
   for (auto pid = 0; pid < numPartitions; ++pid) {

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <arrow/filesystem/localfs.h>
 #include <arrow/io/api.h>
 
 #include "shuffle/PartitionWriter.h"
@@ -118,8 +119,8 @@ class PreferCachePartitionWriter : public LocalPartitionWriterBase {
   };
 
   std::vector<SpillInfo> spills_;
-
   std::vector<std::vector<std::unique_ptr<arrow::ipc::IpcPayload>>> partitionCachedPayload_;
+  std::shared_ptr<arrow::fs::LocalFileSystem> fs_{};
 };
 
 class LocalPartitionWriterCreator : public ShuffleWriter::PartitionWriterCreator {

--- a/cpp/core/shuffle/ShuffleWriter.cc
+++ b/cpp/core/shuffle/ShuffleWriter.cc
@@ -53,9 +53,4 @@ std::shared_ptr<arrow::Schema> ShuffleWriter::compressWriteSchema() {
   return compressWriteSchema_;
 }
 
-void ShuffleWriter::clearCachedPayloads(uint32_t partitionId) {
-  partitionCachedRecordbatch()[partitionId].clear();
-  setPartitionCachedRecordbatchSize(partitionId, 0);
-}
-
 } // namespace gluten

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -257,8 +257,6 @@ class ShuffleWriter {
   // col partid
   std::vector<std::vector<std::vector<std::shared_ptr<arrow::Buffer>>>> partitionBuffers_;
 
-  std::shared_ptr<PartitionWriter> partitionWriter_;
-
   std::shared_ptr<Partitioner> partitioner_;
 };
 

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -132,7 +132,7 @@ class ShuffleWriter {
       uint32_t partitionId,
       bool reuseBuffers) = 0;
 
-  virtual arrow::Status transferPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) = 0;
+  virtual arrow::Status evictPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) = 0;
 
   virtual arrow::Status stop() = 0;
 

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -255,7 +255,7 @@ class ShuffleWriter {
   std::shared_ptr<arrow::Schema> compressWriteSchema_;
 
   // col partid
-  std::vector<std::vector<std::vector<std::shared_ptr<arrow::Buffer>>>> partitionBuffers_;
+  std::vector<std::vector<std::vector<std::shared_ptr<arrow::ResizableBuffer>>>> partitionBuffers_;
 
   std::shared_ptr<Partitioner> partitioner_;
 };

--- a/cpp/core/shuffle/Utils.h
+++ b/cpp/core/shuffle/Utils.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <arrow/array.h>
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/filesystem/path_util.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/type.h>
+#include <arrow/util/io_util.h>
+#include <chrono>
+
+namespace gluten {
+
+const std::string kGlutenSparkLocalDirs = "GLUTEN_SPARK_LOCAL_DIRS";
+
+#define EVAL_START(name, thread_id) \
+  //  auto eval_start = std::chrono::duration_cast<std::chrono::nanoseconds>(    \
+                        std::chrono::system_clock::now().time_since_epoch()) \
+                        .count();
+
+#define EVAL_END(name, thread_id, task_attempt_id) \
+  //  std::cout << "xgbtck " << name << " " << eval_start << " "            \
+            << std::chrono::duration_cast<std::chrono::nanoseconds>(    \
+                   std::chrono::system_clock::now().time_since_epoch()) \
+                       .count() -                                       \
+                   eval_start                                           \
+            << " " << thread_id << " " << task_attempt_id << std::endl;
+
+std::string generateUuid();
+
+std::string getSpilledShuffleFileDir(const std::string& configuredDir, int32_t subDirId);
+
+arrow::Result<std::vector<std::string>> getConfiguredLocalDirs();
+
+arrow::Result<std::string> createTempShuffleFile(const std::string& dir);
+
+arrow::Result<std::vector<std::shared_ptr<arrow::DataType>>> toShuffleWriterTypeId(
+    const std::vector<std::shared_ptr<arrow::Field>>& fields);
+
+int64_t getBufferSizes(const std::shared_ptr<arrow::Array>& array);
+
+arrow::Status writeEos(arrow::io::OutputStream* os);
+
+} // namespace gluten

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
@@ -23,20 +23,11 @@ arrow::Status CelebornPartitionWriter::init() {
   return arrow::Status::OK();
 }
 
-arrow::Status CelebornPartitionWriter::evictPartition(int32_t partitionId) {
-  int64_t tempTotalTime = 0;
-  TIME_NANO_OR_RAISE(tempTotalTime, writeArrowToOutputStream(partitionId));
-  shuffleWriter_->setTotalWriteTime(shuffleWriter_->totalWriteTime() + tempTotalTime);
-  TIME_NANO_OR_RAISE(tempTotalTime, pushPartition(partitionId));
-  shuffleWriter_->setTotalEvictTime(shuffleWriter_->totalEvictTime() + tempTotalTime);
-  return arrow::Status::OK();
-}
-
 arrow::Status CelebornPartitionWriter::pushPartition(int32_t partitionId) {
   auto buffer = celebornBufferOs_->Finish();
   int32_t size = buffer->get()->size();
   char* dst = reinterpret_cast<char*>(buffer->get()->mutable_data());
-  int32_t celebornBytesSize = celebornClient_->pushPartitonData(partitionId, dst, size);
+  int32_t celebornBytesSize = celebornClient_->pushPartitionData(partitionId, dst, size);
   shuffleWriter_->partitionCachedRecordbatch()[partitionId].clear();
   shuffleWriter_->setPartitionCachedRecordbatchSize(partitionId, 0);
   shuffleWriter_->setPartitionLengths(partitionId, shuffleWriter_->partitionLengths()[partitionId] + celebornBytesSize);
@@ -46,33 +37,48 @@ arrow::Status CelebornPartitionWriter::pushPartition(int32_t partitionId) {
 arrow::Status CelebornPartitionWriter::stop() {
   // push data and collect metrics
   for (auto pid = 0; pid < shuffleWriter_->numPartitions(); ++pid) {
-    RETURN_NOT_OK(shuffleWriter_->createRecordBatchFromBuffer(pid, true));
-    if (shuffleWriter_->partitionCachedRecordbatchSize()[pid] > 0) {
-      RETURN_NOT_OK(evictPartition(pid));
+    ARROW_ASSIGN_OR_RAISE(auto payload, shuffleWriter_->createPayloadFromBuffer(pid, false));
+    if (payload) {
+      RETURN_NOT_OK(processPayload(pid, std::move(payload)));
     }
     shuffleWriter_->setTotalBytesWritten(shuffleWriter_->totalBytesWritten() + shuffleWriter_->partitionLengths()[pid]);
   }
-  shuffleWriter_->partitionBuffer().clear();
+  celebornClient_->stop();
   return arrow::Status::OK();
 }
 
-arrow::Status CelebornPartitionWriter::writeArrowToOutputStream(int32_t partitionId) {
+arrow::Status CelebornPartitionWriter::processPayload(
+    uint32_t partitionId,
+    std::unique_ptr<arrow::ipc::IpcPayload> payload) {
+  // Copy payload to arrow buffered os.
+  int64_t writeTime = 0;
+  TIME_NANO_START(writeTime)
   ARROW_ASSIGN_OR_RAISE(
       celebornBufferOs_,
       arrow::io::BufferOutputStream::Create(
           shuffleWriter_->options().buffer_size, shuffleWriter_->options().memory_pool.get()));
   int32_t metadataLength = 0; // unused
 #ifndef SKIPWRITE
-  for (auto& payload : shuffleWriter_->partitionCachedRecordbatch()[partitionId]) {
-    RETURN_NOT_OK(arrow::ipc::WriteIpcPayload(
-        *payload, shuffleWriter_->options().ipc_write_options, celebornBufferOs_.get(), &metadataLength));
-    payload = nullptr;
-  }
+  RETURN_NOT_OK(arrow::ipc::WriteIpcPayload(
+      *payload, shuffleWriter_->options().ipc_write_options, celebornBufferOs_.get(), &metadataLength));
 #endif
+  payload = nullptr; // Invalidate payload immediately.
+  TIME_NANO_END(writeTime)
+  shuffleWriter_->setTotalWriteTime(shuffleWriter_->totalWriteTime() + writeTime);
+
+  // Push.
+  int64_t evictTime = 0;
+  TIME_NANO_OR_RAISE(evictTime, pushPartition(partitionId));
+  shuffleWriter_->setTotalEvictTime(shuffleWriter_->totalEvictTime() + evictTime);
   return arrow::Status::OK();
 }
 
-CelebornPartitionWriterCreator::CelebornPartitionWriterCreator(std::shared_ptr<CelebornClient> client)
+arrow::Status CelebornPartitionWriter::spill() {
+  // No-op because there's no cached data to spill.
+  return arrow::Status::OK();
+}
+
+CelebornPartitionWriterCreator::CelebornPartitionWriterCreator(std::shared_ptr<RssClient> client)
     : PartitionWriterCreator(), client_(client) {}
 
 arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> CelebornPartitionWriterCreator::make(

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.h
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.h
@@ -23,41 +23,40 @@
 
 #include "jni/JniCommon.h"
 #include "shuffle/PartitionWriterCreator.h"
-#include "shuffle/utils.h"
 #include "utils/macros.h"
 
 namespace gluten {
 
 class CelebornPartitionWriter : public RemotePartitionWriter {
  public:
-  CelebornPartitionWriter(ShuffleWriter* shuffleWriter, std::shared_ptr<CelebornClient> celebornClient)
+  CelebornPartitionWriter(ShuffleWriter* shuffleWriter, std::shared_ptr<RssClient> celebornClient)
       : RemotePartitionWriter(shuffleWriter) {
     celebornClient_ = celebornClient;
   }
 
   arrow::Status init() override;
 
-  arrow::Status evictPartition(int32_t partitionId) override;
+  arrow::Status processPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) override;
+
+  arrow::Status spill() override;
 
   arrow::Status stop() override;
 
   arrow::Status pushPartition(int32_t partitionId);
 
-  arrow::Status writeArrowToOutputStream(int32_t partitionId);
-
   std::shared_ptr<arrow::io::BufferOutputStream> celebornBufferOs_;
 
-  std::shared_ptr<CelebornClient> celebornClient_;
+  std::shared_ptr<RssClient> celebornClient_;
 };
 
 class CelebornPartitionWriterCreator : public ShuffleWriter::PartitionWriterCreator {
  public:
-  explicit CelebornPartitionWriterCreator(std::shared_ptr<CelebornClient> client);
+  explicit CelebornPartitionWriterCreator(std::shared_ptr<RssClient> client);
 
   arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> make(ShuffleWriter* shuffleWriter) override;
 
  private:
-  std::shared_ptr<CelebornClient> client_;
+  std::shared_ptr<RssClient> client_;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.h
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.h
@@ -42,9 +42,7 @@ class CelebornPartitionWriter : public RemotePartitionWriter {
 
   arrow::Status stop() override;
 
-  arrow::Status pushPartition(int32_t partitionId);
-
-  std::shared_ptr<arrow::io::BufferOutputStream> celebornBufferOs_;
+  arrow::Status pushPartition(int32_t partitionId, char* data, int64_t size);
 
   std::shared_ptr<RssClient> celebornClient_;
 };

--- a/cpp/core/shuffle/rss/RssClient.h
+++ b/cpp/core/shuffle/rss/RssClient.h
@@ -17,24 +17,11 @@
 
 #pragma once
 
-#include "shuffle/ShuffleWriter.h"
-
-namespace gluten {
-
-class ShuffleWriter::PartitionWriter {
+class RssClient {
  public:
-  PartitionWriter(ShuffleWriter* shuffleWriter) : shuffleWriter_(shuffleWriter) {}
-  virtual ~PartitionWriter() = default;
+  virtual ~RssClient() = default;
 
-  virtual arrow::Status init() = 0;
+  virtual int32_t pushPartitionData(int32_t partitionId, char* bytes, int64_t size) = 0;
 
-  virtual arrow::Status processPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) = 0;
-
-  virtual arrow::Status spill() = 0;
-
-  virtual arrow::Status stop() = 0;
-
-  ShuffleWriter* shuffleWriter_;
+  virtual void stop() = 0;
 };
-
-} // namespace gluten

--- a/cpp/core/utils/DebugOut.h
+++ b/cpp/core/utils/DebugOut.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <ostream>
+#include <iostream>
 
 #ifdef GLUTEN_PRINT_DEBUG
 

--- a/cpp/core/utils/Timer.h
+++ b/cpp/core/utils/Timer.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+
+using namespace std::chrono;
+using TimePoint = time_point<steady_clock, nanoseconds>;
+
+namespace gluten {
+class Timer {
+ public:
+  explicit Timer() = default;
+
+  void start() {
+    running_ = true;
+    startTime_ = std::chrono::steady_clock::now();
+  }
+
+  void stop() {
+    if (!running_) {
+      return;
+    }
+    running_ = false;
+    realTimeUsed_ += duration_cast<nanoseconds>(std::chrono::steady_clock::now() - startTime_).count();
+  }
+
+  bool running() const {
+    return running_;
+  }
+
+  // REQUIRES: timer is not running
+  uint64_t realTimeUsed() const {
+    return realTimeUsed_;
+  }
+
+ private:
+  bool running_ = false; // Is the timer running
+  TimePoint startTime_{}; // If running_
+
+  // Accumulated time so far (does not contain current slice if running_)
+  uint64_t realTimeUsed_ = 0;
+};
+} // namespace gluten

--- a/cpp/core/utils/Timer.h
+++ b/cpp/core/utils/Timer.h
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <chrono>
 
-using namespace std::chrono;
-using TimePoint = time_point<steady_clock, nanoseconds>;
+using TimePoint = std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds>;
 
 namespace gluten {
 class Timer {
@@ -35,7 +36,8 @@ class Timer {
       return;
     }
     running_ = false;
-    realTimeUsed_ += duration_cast<nanoseconds>(std::chrono::steady_clock::now() - startTime_).count();
+    realTimeUsed_ +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - startTime_).count();
   }
 
   bool running() const {

--- a/cpp/core/utils/Timer.h
+++ b/cpp/core/utils/Timer.h
@@ -45,7 +45,7 @@ class Timer {
   }
 
   // REQUIRES: timer is not running
-  uint64_t realTimeUsed() const {
+  int64_t realTimeUsed() const {
     return realTimeUsed_;
   }
 
@@ -54,6 +54,21 @@ class Timer {
   TimePoint startTime_{}; // If running_
 
   // Accumulated time so far (does not contain current slice if running_)
-  uint64_t realTimeUsed_ = 0;
+  int64_t realTimeUsed_ = 0;
+};
+
+class ScopedTimer : public Timer {
+ public:
+  explicit ScopedTimer(int64_t& toAdd) : Timer(), toAdd_(toAdd) {
+    Timer::start();
+  }
+
+  ~ScopedTimer() {
+    Timer::stop();
+    toAdd_ += realTimeUsed();
+  }
+
+ private:
+  int64_t& toAdd_;
 };
 } // namespace gluten

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -60,7 +60,7 @@ struct WriterMetrics {
 
 std::shared_ptr<VeloxShuffleWriter> createShuffleWriter(VeloxMemoryManager* memoryManager) {
   std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator =
-      std::make_shared<LocalPartitionWriterCreator>(false);
+      std::make_shared<LocalPartitionWriterCreator>();
 
   auto options = ShuffleWriterOptions::defaults();
   options.memory_pool = memoryManager->getArrowMemoryPool();

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -112,7 +112,7 @@ class BenchmarkShuffleSplit {
     std::shared_ptr<arrow::MemoryPool> pool = defaultArrowMemoryPool();
 
     std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator =
-        std::make_shared<LocalPartitionWriterCreator>(FLAGS_prefer_evict);
+        std::make_shared<LocalPartitionWriterCreator>();
 
     auto options = ShuffleWriterOptions::defaults();
     options.buffer_size = kPartitionBufferSize;

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -56,7 +56,6 @@ using gluten::GlutenException;
 using gluten::ShuffleWriterOptions;
 using gluten::VeloxShuffleWriter;
 
-DEFINE_bool(prefer_evict, true, "SplitOptions prefer_evict=true");
 DEFINE_int32(partitions, -1, "Shuffle partitions");
 DEFINE_string(file, "", "Input file to split");
 
@@ -117,7 +116,6 @@ class BenchmarkShuffleSplit {
     auto options = ShuffleWriterOptions::defaults();
     options.buffer_size = kPartitionBufferSize;
     options.buffered_write = true;
-    options.prefer_evict = FLAGS_prefer_evict;
     options.memory_pool = pool;
     options.partitioning_name = "rr";
 
@@ -365,9 +363,6 @@ int main(int argc, char** argv) {
   gluten::BenchmarkShuffleSplitIterateScanBenchmark iterateScanBenchmark(FLAGS_file);
 
   auto bm = benchmark::RegisterBenchmark("BenchmarkShuffleSplit::IterateScan", iterateScanBenchmark)
-                ->Args({
-                    FLAGS_prefer_evict,
-                })
                 ->ReportAggregatesOnly(false)
                 ->MeasureProcessCPUTime()
                 ->Unit(benchmark::kSecond);

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -671,6 +671,7 @@ arrow::Status VeloxShuffleWriter::updateInputHasNull(const velox::RowVector& rv)
 }
 
 arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv, int64_t memLimit) {
+  setSplitState(SplitState::kPreAlloc);
   auto rowNum = rv.size();
   RETURN_NOT_OK(buildPartition2Row(rowNum));
   RETURN_NOT_OK(updateInputHasNull(rv));
@@ -1535,8 +1536,8 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
   arrow::Status VeloxShuffleWriter::evictPartitionsOnDemand(int64_t * size) {
     SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingEvictPartition]);
     // Evict all cached partitions
-    int64_t beforeEvict = cachedPayloadSize();
-    if (beforeEvict <= 0) {
+    auto beforeEvict = cachedPayloadSize();
+    if (beforeEvict == 0) {
       *size = 0;
     } else {
       RETURN_NOT_OK(partitionWriter_->spill());

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1720,7 +1720,8 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
     return payloadPool_->bytes_allocated();
   }
 
-  arrow::Status VeloxShuffleWriter::transferDataFromPartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers) {
+  arrow::Status VeloxShuffleWriter::transferDataFromPartitionBuffer(
+      uint32_t partitionId, uint32_t newSize, bool reuseBuffers) {
     ARROW_ASSIGN_OR_RAISE(auto payload, createPayloadFromBuffer(partitionId, reuseBuffers));
     if (payload) {
       RETURN_NOT_OK(evictPayload(partitionId, std::move(payload)));

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -131,7 +131,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
       uint32_t partitionId,
       bool reuseBuffers) override;
 
-  arrow::Status evictPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) override;
+  arrow::Status transferPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) override;
 
   const uint64_t cachedPayloadSize() const override;
 
@@ -256,8 +256,6 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   arrow::Result<std::unique_ptr<arrow::ipc::IpcPayload>> createArrowIpcPayload(
       const arrow::RecordBatch& rb,
       bool reuseBuffers);
-
-  arrow::Status cacheRecordBatch(uint32_t partitionId, const arrow::RecordBatch& rb, bool reuseBuffers);
 
   template <typename T>
   arrow::Status splitFixedType(const uint8_t* srcAddr, const std::vector<uint8_t*>& dstAddrs) {

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -235,7 +235,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   arrow::Result<std::shared_ptr<arrow::ResizableBuffer>>
   allocateValidityBuffer(uint32_t col, uint32_t partitionId, uint32_t newSize);
 
-  arrow::Status allocatePartitionBuffers(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
+  arrow::Status allocatePartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
 
   arrow::Status allocatePartitionBuffersWithRetry(uint32_t partitionId, uint32_t newSize);
 
@@ -251,7 +251,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Status splitComplexType(const facebook::velox::RowVector& rv);
 
-  arrow::Status preparePartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
+  arrow::Status transferDataFromPartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
 
   arrow::Result<std::shared_ptr<arrow::RecordBatch>> createArrowRecordBatchFromBuffer(
       uint32_t partitionId,

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -237,10 +237,6 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Status allocatePartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
 
-  arrow::Status allocatePartitionBuffersWithRetry(uint32_t partitionId, uint32_t newSize);
-
-  arrow::Status allocatePartitionBuffersWithRetry(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
-
   arrow::Status splitFixedWidthValueBuffer(const facebook::velox::RowVector& rv);
 
   arrow::Status splitBoolType(const uint8_t* srcAddr, const std::vector<uint8_t*>& dstAddrs);

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -311,6 +311,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   bool shrinkAfterSpill() const;
 
+  arrow::Result<uint32_t> sizeAfterShrink(uint32_t partitionId) const;
+
  protected:
   // Memory Pool used to track memory allocation of Arrow IPC payloads.
   // The actual allocation is delegated to options_.memory_pool.

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -131,7 +131,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
       uint32_t partitionId,
       bool reuseBuffers) override;
 
-  arrow::Status transferPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) override;
+  arrow::Status evictPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) override;
 
   const uint64_t cachedPayloadSize() const override;
 
@@ -191,9 +191,14 @@ class VeloxShuffleWriter final : public ShuffleWriter {
     VS_PRINT_CONTAINER(input_has_null_);
   }
 
-  // For test only.
+  // Public for test only.
   void setSplitState(SplitState state) {
     splitState_ = state;
+  }
+
+  // For test only.
+  SplitState getSplitState() {
+    return splitState_;
   }
 
  protected:
@@ -230,6 +235,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   uint32_t calculatePartitionBufferSize(const facebook::velox::RowVector& rv, int64_t memLimit);
 
+  arrow::Status preAllocPartitionBuffers(uint32_t preAllocBufferSize);
+
   arrow::Status updateValidityBuffers(uint32_t partitionId, uint32_t newSize);
 
   arrow::Result<std::shared_ptr<arrow::ResizableBuffer>>
@@ -247,7 +254,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Status splitComplexType(const facebook::velox::RowVector& rv);
 
-  arrow::Status transferDataFromPartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
+  arrow::Status evictPartitionBuffer(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
 
   arrow::Result<std::shared_ptr<arrow::RecordBatch>> createArrowRecordBatchFromBuffer(
       uint32_t partitionId,
@@ -291,7 +298,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   std::shared_ptr<arrow::Buffer> generateComplexTypeBuffers(facebook::velox::RowVectorPtr vector);
 
-  arrow::Status resetValidityBuffers(uint32_t partitionId);
+  arrow::Status resetValidityBuffer(uint32_t partitionId);
 
   arrow::Result<int64_t> shrinkPartitionBuffers();
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -307,6 +307,10 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   void stat() const;
 
+  bool shrinkBeforeSpill() const;
+
+  bool shrinkAfterSpill() const;
+
  protected:
   // Memory Pool used to track memory allocation of Arrow IPC payloads.
   // The actual allocation is delegated to options_.memory_pool.

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -312,6 +312,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   // The actual allocation is delegated to options_.memory_pool.
   std::shared_ptr<ShuffleMemoryPool> payloadPool_;
 
+  std::shared_ptr<PartitionWriter> partitionWriter_;
+
   SplitState splitState_{kInit};
 
   bool supportAvx512_ = false;

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -695,7 +695,7 @@ We have two modes of columnar shuffle
 1. prefer cache
 2. prefer spill
 
-Switch through the configuration `spark.gluten.sql.columnar.shuffle.preferSpill`, the default is `false`, enable prefer cache shuffle.
+Switch through the configuration `spark.gluten.sql.columnar.backend.ch.shuffle.preferSpill`, the default is `false`, enable prefer cache shuffle.
 
 In the prefer cache mode, as much memory as possible will be used to cache the shuffle data. When the memory is insufficient,
 spark will actively trigger the memory spill. You can also specify the threshold size through `spark.gluten.sql.columnar.backend.ch.spillThreshold` to Limit memory usage. The default value is `0MB`, which means no limit on memory usage.

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -49,7 +49,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
    * @param dataFile acquired from spark IndexShuffleBlockResolver
    * @param subDirsPerLocalDir SparkConf spark.diskStore.subDirectories
    * @param localDirs configured local directories where Spark can write files
-   * @param preferEvict if true, write the partition buffer to disk once it is full
    * @return native shuffle writer instance handle if created successfully.
    */
   public long make(
@@ -62,7 +61,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
       String dataFile,
       int subDirsPerLocalDir,
       String localDirs,
-      boolean preferEvict,
       long memoryManagerHandle,
       boolean writeEOS,
       double reallocThreshold,
@@ -79,7 +77,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
         dataFile,
         subDirsPerLocalDir,
         localDirs,
-        preferEvict,
         memoryManagerHandle,
         writeEOS,
         reallocThreshold,
@@ -122,7 +119,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
         null,
         0,
         null,
-        true,
         memoryManagerHandle,
         true,
         reallocThreshold,
@@ -144,7 +140,6 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
       String dataFile,
       int subDirsPerLocalDir,
       String localDirs,
-      boolean preferEvict,
       long memoryManagerHandle,
       boolean writeEOS,
       double reallocThreshold,

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -74,8 +74,6 @@ class ColumnarShuffleWriter[K, V](
   private val bufferCompressThreshold =
     GlutenConfig.getConf.columnarShuffleBufferCompressThreshold
 
-  private val preferSpill = GlutenConfig.getConf.columnarShufflePreferSpill
-
   private val writeEOS = GlutenConfig.getConf.columnarShuffleWriteEOS
 
   private val reallocThreshold = GlutenConfig.getConf.columnarShuffleReallocThreshold
@@ -132,7 +130,6 @@ class ColumnarShuffleWriter[K, V](
             dataTmp.getAbsolutePath,
             blockManager.subDirsPerLocalDir,
             localDirs,
-            preferSpill,
             NativeMemoryManagers
               .create(
                 "ShuffleWriter",

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -121,8 +121,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   @deprecated def broadcastCacheTimeout: Int = conf.getConf(COLUMNAR_BROADCAST_CACHE_TIMEOUT)
 
-  def columnarShufflePreferSpill: Boolean = conf.getConf(COLUMNAR_SHUFFLE_PREFER_SPILL_ENABLED)
-
   def columnarShuffleWriteEOS: Boolean = conf.getConf(COLUMNAR_SHUFFLE_WRITE_EOS_ENABLED)
 
   def columnarShuffleReallocThreshold: Double = conf.getConf(COLUMNAR_SHUFFLE_REALLOC_THRESHOLD)
@@ -229,6 +227,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def veloxMaxSpillFileSize: Long = conf.getConf(COLUMNAR_VELOX_MAX_SPILL_FILE_SIZE)
 
   def veloxSpillFileSystem: String = conf.getConf(COLUMNAR_VELOX_SPILL_FILE_SYSTEM)
+
+  def chColumnarShufflePreferSpill: Boolean = conf.getConf(COLUMNAR_CH_SHUFFLE_PREFER_SPILL_ENABLED)
 
   def chColumnarShuffleSpillThreshold: Long = conf.getConf(COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD)
 
@@ -769,16 +769,6 @@ object GlutenConfig {
       .intConf
       .createWithDefault(-1)
 
-  val COLUMNAR_SHUFFLE_PREFER_SPILL_ENABLED =
-    buildConf("spark.gluten.sql.columnar.shuffle.preferSpill")
-      .internal()
-      .doc(
-        "Whether to spill the partition buffers when buffers are full. " +
-          "If false, the partition buffers will be cached in memory first, " +
-          "and the cached buffers will be spilled when reach maximum memory.")
-      .booleanConf
-      .createWithDefault(false)
-
   val COLUMNAR_SHUFFLE_WRITE_EOS_ENABLED =
     buildConf("spark.gluten.sql.columnar.shuffle.writeEOS")
       .internal()
@@ -1067,6 +1057,16 @@ object GlutenConfig {
       .stringConf
       .checkValues(Set("local", "heap-over-local"))
       .createWithDefaultString("local")
+
+  val COLUMNAR_CH_SHUFFLE_PREFER_SPILL_ENABLED =
+    buildConf("spark.gluten.sql.columnar.backend.ch.shuffle.preferSpill")
+      .internal()
+      .doc(
+        "Whether to spill the partition buffers when buffers are full. " +
+          "If false, the partition buffers will be cached in memory first, " +
+          "and the cached buffers will be spilled when reach maximum memory.")
+      .booleanConf
+      .createWithDefault(false)
 
   val COLUMNAR_CH_SHUFFLE_SPILL_THRESHOLD =
     buildConf("spark.gluten.sql.columnar.backend.ch.spillThreshold")


### PR DESCRIPTION
PreferSpill=true strategy can cause small file issue. After preferSpill=false has been implemented in Velox backend, the codepath of preferSpill=true is deprecated and no longer being tested and used for a long time.

This PR removes the preferSpill=true for LocalPartitionWriter in Velox backend. But keep the option for CH backend, and partially refactored CelebornPartitionWriter to keep the "evict immediately" behavior for Velox backend.

renamed `spark.gluten.sql.columnar.shuffle.preferSpill` -> `spark.gluten.sql.columnar.backend.ch.shuffle.preferSpill`

#### Details
After this change, the spill will rely on the memory management and only be triggered by the Gluten Spiller. To make the allocated partition buffers reclaimable, it maintains a `SplitState` to help decide whether/when to shrink and the size after shrinking. 

For `SingleParititioner`, input data will be directly converted to IPC payload and evict, therefore shrink is not supported as there are no partition buffers.

For other Partitioners (`HashPartitioner`, `RoundRobinPartitioner`, `FallbackRangePartitioner`), the state transition and the memory reclaim order are described as follows:

- `kInit`: Initial state, and state after one split. ***Reclaim order:*** Spill cached data -> shrink partition buffers to the **already filled size** (TODO: Only shrink the requested size #3265) -> (TODO: compress and spill partition buffers #3265)

- `kPreAlloc`: Before one split, may evict current partition buffer and allocate new buffers, or resize the buffer. ***Reclaim order:*** Spill cached data. Cannot shrink or spill partition buffers during allocation.

- `kSplit`: During one split. ***Reclaim order:*** Spill cached data -> shrink partition buffers to the **already filled + to be filled size**.

- `kStop`: Stage finish. No more input. ***Reclaim order:*** Shrink **all** partition buffers to the **already filled size** -> spill cached data.

![image](https://github.com/oap-project/gluten/assets/52736607/8a3119cb-d2d7-486e-8e1a-b833fa5b785d)

