### PR TITLE
[GLUTEN-3077][VL] part-2: Use ExecutionCtx to manage resources' lifecycle

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
@@ -30,16 +30,26 @@ public class DatasourceJniWrapper extends JniInitialized {
   public DatasourceJniWrapper() throws IOException {}
 
   public long nativeInitDatasource(
-      String filePath, long cSchema, long memoryManagerId, Map<String, String> options) {
-    return nativeInitDatasource(filePath, cSchema, memoryManagerId, JniUtils.toNativeConf(options));
+      String filePath,
+      long cSchema,
+      long executionCtxHandle,
+      long memoryManagerHandle,
+      Map<String, String> options) {
+    return nativeInitDatasource(
+        filePath, cSchema, executionCtxHandle, memoryManagerHandle, JniUtils.toNativeConf(options));
   }
 
   public native long nativeInitDatasource(
-      String filePath, long cSchema, long memoryManagerId, byte[] options);
+      String filePath,
+      long cSchema,
+      long executionCtxHandle,
+      long memoryManagerHandle,
+      byte[] options);
 
-  public native void inspectSchema(long instanceId, long cSchemaAddress);
+  public native void inspectSchema(long executionCtxHandle, long dsHandle, long cSchemaAddress);
 
-  public native void close(long instanceId);
+  public native void close(long executionCtxHandle, long dsHandle);
 
-  public native void write(long instanceId, VeloxColumnarBatchIterator iterator);
+  public native void write(
+      long executionCtxHandle, long dsHandle, VeloxColumnarBatchIterator iterator);
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi.velox
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.SparkPlanExecApi
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.execution._
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
@@ -288,10 +289,11 @@ class SparkPlanExecHandler extends SparkPlanExecApi {
           } else {
             val handleArray = input.map(ColumnarBatches.getNativeHandle).toArray
             val serializeResult = ColumnarBatchSerializerJniWrapper.INSTANCE.serialize(
+              ExecutionCtxs.contextInstance().getHandle,
               handleArray,
               NativeMemoryManagers
                 .contextInstance("BroadcastRelation")
-                .getNativeInstanceId)
+                .getNativeInstanceHandle)
             input.foreach(ColumnarBatches.release)
             Iterator((serializeResult.getNumRows, serializeResult.getSerialized))
           }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/VeloxWriteQueue.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/VeloxWriteQueue.scala
@@ -29,7 +29,8 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.regex.Pattern
 
 class VeloxWriteQueue(
-    instanceId: Long,
+    executionCtxHandle: Long,
+    dsHandle: Long,
     schema: Schema,
     allocator: BufferAllocator,
     datasourceJniWrapper: DatasourceJniWrapper,
@@ -41,7 +42,7 @@ class VeloxWriteQueue(
   private val writeThread = new Thread(
     () => {
       try {
-        datasourceJniWrapper.write(instanceId, scanner)
+        datasourceJniWrapper.write(executionCtxHandle, dsHandle, scanner)
       } catch {
         case e: Throwable =>
           writeException.set(e)

--- a/cpp/core/benchmarks/CompressionBenchmark.cc
+++ b/cpp/core/benchmarks/CompressionBenchmark.cc
@@ -23,13 +23,11 @@
 #include <arrow/record_batch.h>
 #include <arrow/type.h>
 #include <arrow/type_fwd.h>
-#include <arrow/util/io_util.h>
 #include <benchmark/benchmark.h>
 #include <execinfo.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/file_reader.h>
 #include <sched.h>
-#include <sys/mman.h>
 
 #include <chrono>
 #include <iostream>

--- a/cpp/core/compute/ExecutionCtx.cc
+++ b/cpp/core/compute/ExecutionCtx.cc
@@ -40,8 +40,12 @@ void setExecutionCtxFactory(ExecutionCtxFactory factory) {
 #endif
 }
 
-std::shared_ptr<ExecutionCtx> createExecutionCtx() {
+ExecutionCtx* createExecutionCtx() {
   return getExecutionCtxFactoryContext()->create();
+}
+
+void releaseExecutionCtx(ExecutionCtx* executionCtx) {
+  delete executionCtx;
 }
 
 } // namespace gluten

--- a/cpp/core/compute/ResultIterator.h
+++ b/cpp/core/compute/ResultIterator.h
@@ -29,10 +29,8 @@ class ExecutionCtx;
 //  other places.
 class ResultIterator {
  public:
-  explicit ResultIterator(
-      std::unique_ptr<ColumnarBatchIterator> iter,
-      std::shared_ptr<ExecutionCtx> executionCtx = nullptr)
-      : iter_(std::move(iter)), next_(nullptr), executionCtx_(std::move(executionCtx)) {}
+  explicit ResultIterator(std::unique_ptr<ColumnarBatchIterator> iter, ExecutionCtx* executionCtx = nullptr)
+      : iter_(std::move(iter)), next_(nullptr), executionCtx_(executionCtx) {}
 
   // copy constructor and copy assignment (deleted)
   ResultIterator(const ResultIterator& in) = delete;
@@ -88,7 +86,7 @@ class ResultIterator {
 
   std::unique_ptr<ColumnarBatchIterator> iter_;
   std::shared_ptr<ColumnarBatch> next_;
-  std::shared_ptr<ExecutionCtx> executionCtx_;
+  ExecutionCtx* executionCtx_;
   int64_t exportNanos_;
 };
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -22,7 +22,6 @@
 #include "compute/ExecutionCtx.h"
 #include "compute/ProtobufUtils.h"
 #include "config/GlutenConfig.h"
-#include "jni/ConcurrentMap.h"
 #include "jni/JniCommon.h"
 #include "jni/JniErrors.h"
 
@@ -71,37 +70,12 @@ static jmethodID serializedColumnarBatchIteratorNext;
 static jclass nativeColumnarToRowInfoClass;
 static jmethodID nativeColumnarToRowInfoConstructor;
 
-static jclass veloxColumnarbatchScannerClass;
-static jmethodID veloxColumnarbatchScannerHasNext;
-static jmethodID veloxColumnarbatchScannerNext;
+static jclass veloxColumnarBatchScannerClass;
+static jmethodID veloxColumnarBatchScannerHasNext;
+static jmethodID veloxColumnarBatchScannerNext;
 
 static jclass shuffleReaderMetricsClass;
 static jmethodID shuffleReaderMetricsSetDecompressTime;
-
-static ConcurrentMap<std::shared_ptr<ColumnarToRowConverter>> columnarToRowConverterHolder;
-
-static ConcurrentMap<std::shared_ptr<RowToColumnarConverter>> rowToColumnarConverterHolder;
-
-static ConcurrentMap<std::shared_ptr<ResultIterator>> resultIteratorHolder;
-
-static ConcurrentMap<std::shared_ptr<ShuffleWriter>> shuffleWriterHolder;
-
-static ConcurrentMap<std::shared_ptr<ShuffleReader>> shuffleReaderHolder;
-
-static ConcurrentMap<std::shared_ptr<ColumnarBatch>> columnarBatchHolder;
-
-static ConcurrentMap<std::shared_ptr<Datasource>> glutenDatasourceHolder;
-
-static ConcurrentMap<std::shared_ptr<ColumnarBatchSerializer>> columnarBatchSerializerHolder;
-
-std::shared_ptr<ResultIterator> getArrayIterator(JNIEnv*, jlong id) {
-  auto handler = resultIteratorHolder.lookup(id);
-  if (!handler) {
-    std::string errorMessage = "invalid handler id " + std::to_string(id);
-    throw gluten::GlutenException(errorMessage);
-  }
-  return handler;
-}
 
 class JavaInputStreamAdaptor final : public arrow::io::InputStream {
  public:
@@ -182,8 +156,12 @@ class JavaInputStreamAdaptor final : public arrow::io::InputStream {
 
 class JniColumnarBatchIterator : public ColumnarBatchIterator {
  public:
-  explicit JniColumnarBatchIterator(JNIEnv* env, jobject jColumnarBatchItr, std::shared_ptr<ArrowWriter> writer)
-      : writer_(writer) {
+  explicit JniColumnarBatchIterator(
+      JNIEnv* env,
+      jobject jColumnarBatchItr,
+      ExecutionCtx* executionCtx,
+      std::shared_ptr<ArrowWriter> writer)
+      : executionCtx_(executionCtx), writer_(writer) {
     // IMPORTANT: DO NOT USE LOCAL REF IN DIFFERENT THREAD
     if (env->GetJavaVM(&vm_) != JNI_OK) {
       std::string errorMessage = "Unable to get JavaVM instance";
@@ -216,7 +194,7 @@ class JniColumnarBatchIterator : public ColumnarBatchIterator {
     checkException(env);
     jlong handle = env->CallLongMethod(jColumnarBatchItr_, serializedColumnarBatchIteratorNext);
     checkException(env);
-    auto batch = columnarBatchHolder.lookup(handle);
+    auto batch = executionCtx_->getBatch(handle);
     if (writer_ != nullptr) {
       // save snapshot of the batch to file
       std::shared_ptr<ArrowSchema> schema = batch->exportArrowSchema();
@@ -231,12 +209,16 @@ class JniColumnarBatchIterator : public ColumnarBatchIterator {
  private:
   JavaVM* vm_;
   jobject jColumnarBatchItr_;
+  ExecutionCtx* executionCtx_;
   std::shared_ptr<ArrowWriter> writer_;
 };
 
-std::unique_ptr<JniColumnarBatchIterator>
-makeJniColumnarBatchIterator(JNIEnv* env, jobject jColumnarBatchItr, std::shared_ptr<ArrowWriter> writer) {
-  return std::make_unique<JniColumnarBatchIterator>(env, jColumnarBatchItr, writer);
+std::unique_ptr<JniColumnarBatchIterator> makeJniColumnarBatchIterator(
+    JNIEnv* env,
+    jobject jColumnarBatchItr,
+    ExecutionCtx* executionCtx,
+    std::shared_ptr<ArrowWriter> writer) {
+  return std::make_unique<JniColumnarBatchIterator>(env, jColumnarBatchItr, executionCtx, writer);
 }
 
 #ifdef __cplusplus
@@ -293,12 +275,12 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", "(J)J");
   unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", "(J)J");
 
-  veloxColumnarbatchScannerClass =
+  veloxColumnarBatchScannerClass =
       createGlobalClassReference(env, "Lorg/apache/spark/sql/execution/datasources/VeloxColumnarBatchIterator;");
 
-  veloxColumnarbatchScannerHasNext = getMethodId(env, veloxColumnarbatchScannerClass, "hasNext", "()Z");
+  veloxColumnarBatchScannerHasNext = getMethodId(env, veloxColumnarBatchScannerClass, "hasNext", "()Z");
 
-  veloxColumnarbatchScannerNext = getMethodId(env, veloxColumnarbatchScannerClass, "next", "()J");
+  veloxColumnarBatchScannerNext = getMethodId(env, veloxColumnarBatchScannerClass, "next", "()J");
 
   shuffleReaderMetricsClass =
       createGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ShuffleReaderMetrics;");
@@ -309,12 +291,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 }
 
 void JNI_OnUnload(JavaVM* vm, void* reserved) {
-  resultIteratorHolder.clear();
-  columnarToRowConverterHolder.clear();
-  shuffleWriterHolder.clear();
-  shuffleReaderHolder.clear();
-  glutenDatasourceHolder.clear();
-
   JNIEnv* env;
   vm->GetEnv(reinterpret_cast<void**>(&env), jniVersion);
   env->DeleteGlobalRef(serializableObjBuilderClass);
@@ -324,15 +300,16 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   env->DeleteGlobalRef(serializedColumnarBatchIteratorClass);
   env->DeleteGlobalRef(nativeColumnarToRowInfoClass);
   env->DeleteGlobalRef(byteArrayClass);
-  env->DeleteGlobalRef(veloxColumnarbatchScannerClass);
+  env->DeleteGlobalRef(veloxColumnarBatchScannerClass);
   env->DeleteGlobalRef(shuffleReaderMetricsClass);
 }
 
 JNIEXPORT jlong JNICALL
 Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithIterator( // NOLINT
     JNIEnv* env,
-    jobject obj,
-    jlong memoryManagerId,
+    jobject,
+    jlong ctxHandle,
+    jlong memoryManagerHandle,
     jbyteArray planArr,
     jobjectArray iterArr,
     jint stageId,
@@ -342,14 +319,16 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
     jstring spillDir,
     jbyteArray confArr) {
   JNI_METHOD_START
-  arrow::Status msg;
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
+  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
 
   auto spillDirStr = jStringToCString(env, spillDir);
 
   auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArr, nullptr));
   auto planSize = env->GetArrayLength(planArr);
 
-  auto executionCtx = gluten::createExecutionCtx();
   executionCtx->parsePlan(planData, planSize, {stageId, partitionId, taskId});
 
   auto confs = getConfMap(env, confArr);
@@ -370,22 +349,25 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
       writer = std::make_shared<ArrowWriter>(file);
     }
     jobject iter = env->GetObjectArrayElement(iterArr, idx);
-    auto arrayIter = makeJniColumnarBatchIterator(env, iter, writer);
+    auto arrayIter = makeJniColumnarBatchIterator(env, iter, executionCtx, writer);
     auto resultIter = std::make_shared<ResultIterator>(std::move(arrayIter));
     inputIters.push_back(std::move(resultIter));
   }
 
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
-  auto resIter = executionCtx->getResultIterator(memoryManager, spillDirStr, inputIters, confs);
-  return resultIteratorHolder.insert(std::move(resIter));
-  JNI_METHOD_END(-1)
+  return executionCtx->createResultIterator(memoryManager, spillDirStr, inputIters, confs);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeHasNext(JNIEnv* env, jobject obj, jlong id) { // NOLINT
+JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeHasNext(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong iterHandle) { // NOLINT
   JNI_METHOD_START
-  auto iter = getArrayIterator(env, id);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto iter = executionCtx->getResultIterator(iterHandle);
   if (iter == nullptr) {
     std::string errorMessage = "faked to get batch iterator";
     throw gluten::GlutenException(errorMessage);
@@ -394,28 +376,38 @@ Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeHasNext(JNIEnv* 
   JNI_METHOD_END(false)
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeNext(JNIEnv* env, jobject obj, jlong id) { // NOLINT
+JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeNext(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong iterHandle) { // NOLINT
   JNI_METHOD_START
-  auto iter = getArrayIterator(env, id);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto iter = executionCtx->getResultIterator(iterHandle);
   if (!iter->hasNext()) {
-    return -1L;
+    return kInvalidResourceHandle;
   }
 
   std::shared_ptr<ColumnarBatch> batch = iter->next();
-  jlong batchHandle = columnarBatchHolder.insert(batch);
+  auto batchHandle = executionCtx->addBatch(batch);
 
   iter->setExportNanos(batch->getExportNanos());
   return batchHandle;
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeFetchMetrics( // NOLINT
     JNIEnv* env,
-    jobject obj,
-    jlong id) {
+    jobject,
+    jlong ctxHandle,
+    jlong iterHandle) {
   JNI_METHOD_START
-  auto iter = getArrayIterator(env, id);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto iter = executionCtx->getResultIterator(iterHandle);
   std::shared_ptr<Metrics> metrics = iter->getMetrics();
 
   int numMetrics = 0;
@@ -510,27 +502,29 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutItera
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeSpill( // NOLINT
     JNIEnv* env,
-    jobject thisObj,
-    jlong id,
+    jobject,
+    jlong ctxHandle,
+    jlong iterHandle,
     jlong size) {
   JNI_METHOD_START
-  auto it = resultIteratorHolder.lookup(id);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto it = executionCtx->getResultIterator(iterHandle);
   return it->spillFixedSize(size);
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeClose( // NOLINT
     JNIEnv* env,
-    jobject thisObj,
-    jlong id) {
+    jobject,
+    jlong ctxHandle,
+    jlong iterHandle) {
   JNI_METHOD_START
-#ifdef GLUTEN_PRINT_DEBUG
-  auto it = resultIteratorHolder.lookup(id);
-  if (it.use_count() > 2) {
-    std::cout << "ArrowArrayResultIterator Id " << id << " use count is " << it.use_count() << std::endl;
-  }
-#endif
-  resultIteratorHolder.erase(id);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  executionCtx->releaseResultIterator(iterHandle);
   JNI_METHOD_END()
 }
 
@@ -538,27 +532,31 @@ JNIEXPORT jlong JNICALL
 Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToRowInit( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong memoryManagerId) {
+    jlong ctxHandle,
+    jlong memoryManagerHandle) {
   JNI_METHOD_START
-  // Convert the native batch to Spark unsafe row.
-  auto executionCtx = gluten::createExecutionCtx();
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
-  auto columnarToRowConverter = executionCtx->getColumnar2RowConverter(memoryManager);
-  int64_t instanceID = columnarToRowConverterHolder.insert(columnarToRowConverter);
-  return instanceID;
-  JNI_METHOD_END(-1)
+
+  // Convert the native batch to Spark unsafe row.
+  return executionCtx->createColumnar2RowConverter(memoryManager);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jobject JNICALL
 Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToRowConvert( // NOLINT
     JNIEnv* env,
     jobject,
+    jlong ctxHandle,
     jlong batchHandle,
-    jlong instanceId) {
+    jlong c2rHandle) {
   JNI_METHOD_START
-  auto columnarToRowConverter = columnarToRowConverterHolder.lookup(instanceId);
-  std::shared_ptr<ColumnarBatch> cb = columnarBatchHolder.lookup(batchHandle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  auto columnarToRowConverter = executionCtx->getColumnar2RowConverter(c2rHandle);
+  auto cb = executionCtx->getBatch(batchHandle);
   columnarToRowConverter->convert(cb);
 
   const auto& offsets = columnarToRowConverter->getOffsets();
@@ -583,9 +581,13 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToR
 JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeClose( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong instanceId) {
+    jlong ctxHandle,
+    jlong c2rHandle) {
   JNI_METHOD_START
-  columnarToRowConverterHolder.erase(instanceId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  executionCtx->releaseColumnar2RowConverter(c2rHandle);
   JNI_METHOD_END()
 }
 
@@ -593,25 +595,30 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_NativeRowToColumnarJniW
     JNIEnv* env,
     jobject,
     jlong cSchema,
-    jlong memoryManagerId) {
+    jlong ctxHandle,
+    jlong memoryManagerHandle) {
   JNI_METHOD_START
-  auto executionCtx = gluten::createExecutionCtx();
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
-  auto converter =
-      executionCtx->getRowToColumnarConverter(memoryManager, reinterpret_cast<struct ArrowSchema*>(cSchema));
-  return rowToColumnarConverterHolder.insert(converter);
-  JNI_METHOD_END(-1)
+
+  return executionCtx->createRow2ColumnarConverter(memoryManager, reinterpret_cast<struct ArrowSchema*>(cSchema));
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL
 Java_io_glutenproject_vectorized_NativeRowToColumnarJniWrapper_nativeConvertRowToColumnar( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong r2cId,
+    jlong ctxHandle,
+    jlong r2cHandle,
     jlongArray rowLength,
     jlong memoryAddress) {
   JNI_METHOD_START
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
   if (rowLength == nullptr) {
     throw gluten::GlutenException("Native convert row to columnar: buf_addrs can't be null");
   }
@@ -619,82 +626,119 @@ Java_io_glutenproject_vectorized_NativeRowToColumnarJniWrapper_nativeConvertRowT
   jlong* inRowLength = env->GetLongArrayElements(rowLength, nullptr);
   uint8_t* address = reinterpret_cast<uint8_t*>(memoryAddress);
 
-  auto converter = rowToColumnarConverterHolder.lookup(r2cId);
+  auto converter = executionCtx->getRow2ColumnarConverter(r2cHandle);
   auto cb = converter->convert(numRows, reinterpret_cast<int64_t*>(inRowLength), address);
   env->ReleaseLongArrayElements(rowLength, inRowLength, JNI_ABORT);
-  return columnarBatchHolder.insert(cb);
-  JNI_METHOD_END(-1)
+  return executionCtx->addBatch(cb);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_NativeRowToColumnarJniWrapper_close(JNIEnv* env, jobject, jlong r2cId) { // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_NativeRowToColumnarJniWrapper_close(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong r2cHandle) { // NOLINT
   JNI_METHOD_START
-  rowToColumnarConverterHolder.erase(r2cId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  executionCtx->releaseRow2ColumnarConverter(r2cHandle);
   JNI_METHOD_END()
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_getType(JNIEnv* env, jobject, jlong handle) { // NOLINT
+JNIEXPORT jstring JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_getType(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto batch = executionCtx->getBatch(batchHandle);
   return env->NewStringUTF(batch->getType().c_str());
   JNI_METHOD_END(nullptr)
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_numBytes(JNIEnv* env, jobject, jlong handle) { // NOLINT
+JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_numBytes(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto batch = executionCtx->getBatch(batchHandle);
   return batch->numBytes();
-  JNI_METHOD_END(-1)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_numColumns( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong handle) {
+    jlong ctxHandle,
+    jlong batchHandle) {
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto batch = executionCtx->getBatch(batchHandle);
   return batch->numColumns();
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT jlong JNICALL
-Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_numRows(JNIEnv* env, jobject, jlong handle) { // NOLINT
+JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_numRows(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto batch = executionCtx->getBatch(batchHandle);
   return batch->numRows();
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_compose( // NOLINT
     JNIEnv* env,
     jobject,
+    jlong ctxHandle,
     jlongArray handles) {
   JNI_METHOD_START
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
   int handleCount = env->GetArrayLength(handles);
   jlong* handleArray = env->GetLongArrayElements(handles, nullptr);
 
   std::vector<std::shared_ptr<ColumnarBatch>> batches;
   for (int i = 0; i < handleCount; ++i) {
     jlong handle = handleArray[i];
-    std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+    auto batch = executionCtx->getBatch(handle);
     batches.push_back(batch);
   }
   auto newBatch = CompositeColumnarBatch::create(std::move(batches));
   env->ReleaseLongArrayElements(handles, handleArray, JNI_ABORT);
-  return columnarBatchHolder.insert(newBatch);
-  JNI_METHOD_END(-1L)
+  return executionCtx->addBatch(newBatch);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_exportToArrow( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong handle,
+    jlong ctxHandle,
+    jlong batchHandle,
     jlong cSchema,
     jlong cArray) {
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto batch = executionCtx->getBatch(batchHandle);
   std::shared_ptr<ArrowSchema> exportedSchema = batch->exportArrowSchema();
   std::shared_ptr<ArrowArray> exportedArray = batch->exportArrowArray();
   ArrowSchemaMove(exportedSchema.get(), reinterpret_cast<struct ArrowSchema*>(cSchema));
@@ -705,9 +749,13 @@ JNIEXPORT void JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapp
 JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_createWithArrowArray( // NOLINT
     JNIEnv* env,
     jobject,
+    jlong ctxHandle,
     jlong cSchema,
     jlong cArray) {
   JNI_METHOD_START
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
   std::unique_ptr<ArrowSchema> targetSchema = std::make_unique<ArrowSchema>();
   std::unique_ptr<ArrowArray> targetArray = std::make_unique<ArrowArray>();
   auto* arrowSchema = reinterpret_cast<ArrowSchema*>(cSchema);
@@ -716,15 +764,20 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
   ArrowSchemaMove(arrowSchema, targetSchema.get());
   std::shared_ptr<ColumnarBatch> batch =
       std::make_shared<ArrowCStructColumnarBatch>(std::move(targetSchema), std::move(targetArray));
-  return columnarBatchHolder.insert(batch);
-  JNI_METHOD_END(-1L)
+  return executionCtx->addBatch(batch);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_close(JNIEnv* env, jobject, jlong handle) { // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_close(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
-  columnarBatchHolder.erase(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  executionCtx->releaseBatch(batchHandle);
   JNI_METHOD_END()
 }
 
@@ -744,7 +797,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jint numSubDirs,
     jstring localDirsJstr,
     jboolean preferEvict,
-    jlong memoryManagerId,
+    jlong ctxHandle,
+    jlong memoryManagerHandle,
     jboolean writeEOS,
     jlong firstBatchHandle,
     jlong taskAttemptId,
@@ -752,9 +806,13 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jobject partitionPusher,
     jstring partitionWriterTypeJstr) {
   JNI_METHOD_START
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
+  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
   if (partitioningNameJstr == nullptr) {
     throw gluten::GlutenException(std::string("Short partitioning name can't be null"));
-    return 0;
+    return kInvalidResourceHandle;
   }
 
   auto partitioningName = jStringToCString(env, partitioningNameJstr);
@@ -773,8 +831,6 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     shuffleWriterOptions.compression_mode = getCompressionMode(env, compressionModeJstr);
   }
 
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
   shuffleWriterOptions.memory_pool = memoryManager->getArrowMemoryPool();
   shuffleWriterOptions.ipc_memory_pool = shuffleWriterOptions.memory_pool;
 
@@ -844,59 +900,71 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     throw gluten::GlutenException("Unrecognizable partition writer type: " + partitionWriterType);
   }
 
-  auto executionCtx = gluten::createExecutionCtx();
-  auto shuffleWriter = executionCtx->createShuffleWriter(
+  return executionCtx->createShuffleWriter(
       numPartitions, std::move(partitionWriterCreator), std::move(shuffleWriterOptions), memoryManager);
-  return shuffleWriterHolder.insert(shuffleWriter);
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_nativeEvict( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong shuffleWriterId,
+    jlong ctxHandle,
+    jlong shuffleWriterHandle,
     jlong size,
     jboolean callBySelf) {
   JNI_METHOD_START
-  auto shuffleWriter = shuffleWriterHolder.lookup(shuffleWriterId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto shuffleWriter = executionCtx->getShuffleWriter(shuffleWriterHandle);
   if (!shuffleWriter) {
-    std::string errorMessage = "Invalid shuffle writer id " + std::to_string(shuffleWriterId);
+    std::string errorMessage = "Invalid shuffle writer handle " + std::to_string(shuffleWriterHandle);
     throw gluten::GlutenException(errorMessage);
   }
   int64_t evictedSize;
   gluten::arrowAssertOkOrThrow(
       shuffleWriter->evictFixedSize(size, &evictedSize), "(shuffle) nativeEvict: evict failed");
   return (jlong)evictedSize;
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_split( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong shuffleWriterId,
+    jlong ctxHandle,
+    jlong shuffleWriterHandle,
     jint numRows,
-    jlong handle) {
+    jlong batchHandle) {
   JNI_METHOD_START
-  auto shuffleWriter = shuffleWriterHolder.lookup(shuffleWriterId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto shuffleWriter = executionCtx->getShuffleWriter(shuffleWriterHandle);
   if (!shuffleWriter) {
-    std::string errorMessage = "Invalid shuffle writer id " + std::to_string(shuffleWriterId);
+    std::string errorMessage = "Invalid shuffle writer handle " + std::to_string(shuffleWriterHandle);
     throw gluten::GlutenException(errorMessage);
   }
 
   // The column batch maybe VeloxColumnBatch or ArrowCStructColumnarBatch(FallbackRangeShuffleWriter)
-  std::shared_ptr<ColumnarBatch> batch = columnarBatchHolder.lookup(handle);
+  auto batch = executionCtx->getBatch(batchHandle);
   auto numBytes = batch->numBytes();
   gluten::arrowAssertOkOrThrow(shuffleWriter->split(batch), "Native split: shuffle writer split failed");
   return numBytes;
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT jobject JNICALL
-Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_stop(JNIEnv* env, jobject, jlong shuffleWriterId) { // NOLINT
+JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_stop(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong shuffleWriterHandle) { // NOLINT
   JNI_METHOD_START
-  auto shuffleWriter = shuffleWriterHolder.lookup(shuffleWriterId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto shuffleWriter = executionCtx->getShuffleWriter(shuffleWriterHandle);
   if (!shuffleWriter) {
-    std::string errorMessage = "Invalid shuffle writer id " + std::to_string(shuffleWriterId);
+    std::string errorMessage = "Invalid shuffle writer handle " + std::to_string(shuffleWriterHandle);
     throw gluten::GlutenException(errorMessage);
   }
 
@@ -929,10 +997,16 @@ Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_stop(JNIEnv* env, jobje
   JNI_METHOD_END(nullptr)
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_close(JNIEnv* env, jobject, jlong shuffleWriterId) { // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_close(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong shuffleWriterHandle) { // NOLINT
   JNI_METHOD_START
-  shuffleWriterHolder.erase(shuffleWriterId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  executionCtx->releaseShuffleWriter(shuffleWriterHandle);
   JNI_METHOD_END()
 }
 
@@ -953,13 +1027,17 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
     JNIEnv* env,
     jobject,
     jlong cSchema,
-    jlong memoryManagerId,
+    jlong ctxHandle,
+    jlong memoryManagerHandle,
     jstring compressionType,
     jstring compressionBackend,
     jstring compressionMode) {
   JNI_METHOD_START
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+
   auto pool = memoryManager->getArrowMemoryPool();
   ReaderOptions options = ReaderOptions::defaults();
   options.ipc_read_options.memory_pool = pool.get();
@@ -972,32 +1050,38 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
   std::shared_ptr<arrow::Schema> schema =
       gluten::arrowGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(cSchema)));
 
-  auto executionCtx = gluten::createExecutionCtx();
-  auto reader = executionCtx->createShuffleReader(schema, options, pool, memoryManager);
-  return shuffleReaderHolder.insert(reader);
-  JNI_METHOD_END(-1L)
+  return executionCtx->createShuffleReader(schema, options, pool, memoryManager);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_readStream( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong handle,
+    jlong ctxHandle,
+    jlong shuffleReaderHandle,
     jobject jniIn) {
   JNI_METHOD_START
-  auto reader = shuffleReaderHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   std::shared_ptr<arrow::io::InputStream> in = std::make_shared<JavaInputStreamAdaptor>(env, reader->getPool(), jniIn);
   auto outItr = reader->readStream(in);
-  return resultIteratorHolder.insert(outItr);
-  JNI_METHOD_END(-1L)
+  return executionCtx->addResultIterator(outItr);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_populateMetrics( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong handle,
+    jlong ctxHandle,
+    jlong shuffleReaderHandle,
     jobject metrics) {
   JNI_METHOD_START
-  auto reader = shuffleReaderHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   env->CallVoidMethod(metrics, shuffleReaderMetricsSetDecompressTime, reader->getDecompressTime());
   checkException(env);
   JNI_METHOD_END()
@@ -1006,83 +1090,103 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_
 JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_close( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong handle) {
+    jlong ctxHandle,
+    jlong shuffleReaderHandle) {
   JNI_METHOD_START
-  auto reader = shuffleReaderHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   GLUTEN_THROW_NOT_OK(reader->close());
-  shuffleReaderHolder.erase(handle);
+  executionCtx->releaseShuffleReader(shuffleReaderHandle);
   JNI_METHOD_END()
 }
 
 JNIEXPORT jlong JNICALL
 Java_io_glutenproject_spark_sql_execution_datasources_velox_DatasourceJniWrapper_nativeInitDatasource( // NOLINT
     JNIEnv* env,
-    jobject obj,
+    jobject,
     jstring filePath,
     jlong cSchema,
-    jlong memoryManagerId,
+    jlong ctxHandle,
+    jlong memoryManagerHandle,
     jbyteArray options) {
-  auto executionCtx = gluten::createExecutionCtx();
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  JNI_METHOD_START
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
 
-  std::shared_ptr<Datasource> datasource = nullptr;
+  ResourceHandle handle = kInvalidResourceHandle;
 
   if (cSchema == -1) {
     // Only inspect the schema and not write
-    datasource = executionCtx->getDatasource(jStringToCString(env, filePath), memoryManager, nullptr);
+    handle = executionCtx->createDatasource(jStringToCString(env, filePath), memoryManager, nullptr);
   } else {
     auto sparkOptions = gluten::getConfMap(env, options);
     auto sparkConf = executionCtx->getConfMap();
     sparkOptions.insert(sparkConf.begin(), sparkConf.end());
     auto schema = gluten::arrowGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(cSchema)));
-    datasource = executionCtx->getDatasource(jStringToCString(env, filePath), memoryManager, schema);
+    handle = executionCtx->createDatasource(jStringToCString(env, filePath), memoryManager, schema);
+    auto datasource = executionCtx->getDatasource(handle);
     datasource->init(sparkOptions);
   }
 
-  int64_t instanceID = glutenDatasourceHolder.insert(datasource);
-  return instanceID;
+  return handle;
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT void JNICALL
 Java_io_glutenproject_spark_sql_execution_datasources_velox_DatasourceJniWrapper_inspectSchema( // NOLINT
     JNIEnv* env,
-    jobject obj,
-    jlong instanceId,
+    jobject,
+    jlong ctxHandle,
+    jlong dsHandle,
     jlong cSchema) {
   JNI_METHOD_START
-  auto datasource = glutenDatasourceHolder.lookup(instanceId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto datasource = executionCtx->getDatasource(dsHandle);
   datasource->inspectSchema(reinterpret_cast<struct ArrowSchema*>(cSchema));
   JNI_METHOD_END()
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_velox_DatasourceJniWrapper_close( // NOLINT
     JNIEnv* env,
-    jobject obj,
-    jlong instanceId) {
+    jobject,
+    jlong ctxHandle,
+    jlong dsHandle) {
   JNI_METHOD_START
-  auto datasource = glutenDatasourceHolder.lookup(instanceId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto datasource = executionCtx->getDatasource(dsHandle);
   datasource->close();
-  glutenDatasourceHolder.erase(instanceId);
+  executionCtx->releaseDatasource(dsHandle);
   JNI_METHOD_END()
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_velox_DatasourceJniWrapper_write( // NOLINT
     JNIEnv* env,
-    jobject obj,
-    jlong instanceId,
+    jobject,
+    jlong ctxHandle,
+    jlong dsHandle,
     jobject iter) {
   JNI_METHOD_START
-  auto datasource = glutenDatasourceHolder.lookup(instanceId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
 
-  while (env->CallBooleanMethod(iter, veloxColumnarbatchScannerHasNext)) {
+  auto datasource = executionCtx->getDatasource(dsHandle);
+
+  while (env->CallBooleanMethod(iter, veloxColumnarBatchScannerHasNext)) {
     checkException(env);
-    jlong handler = env->CallLongMethod(iter, veloxColumnarbatchScannerNext);
+    jlong batchHandle = env->CallLongMethod(iter, veloxColumnarBatchScannerNext);
     checkException(env);
-    auto batch = columnarBatchHolder.lookup(handler);
+    auto batch = executionCtx->getBatch(batchHandle);
     datasource->write(batch);
     // fixme this skips the general Java side batch-closing routine
-    columnarBatchHolder.erase(handler);
+    executionCtx->releaseBatch(batchHandle);
   }
   checkException(env);
   JNI_METHOD_END()
@@ -1103,7 +1207,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_alloc_NativeMemoryAllocator
     throw GlutenException("Unexpected allocator type name: " + typeName);
   }
   return reinterpret_cast<jlong>(allocator);
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_memory_alloc_NativeMemoryAllocator_releaseAllocator( // NOLINT
@@ -1125,7 +1229,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_alloc_NativeMemoryAllocator
     throw gluten::GlutenException("Memory allocator instance not found. It may not exist nor has been closed");
   }
   return (*alloc)->getBytes();
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_create( // NOLINT
@@ -1149,21 +1253,24 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_cre
       vm, jlistener, reserveMemoryMethod, unreserveMemoryMethod, reservationBlockSize);
 
   if (gluten::backtrace_allocation) {
-    listener = std::move(std::make_unique<BacktraceAllocationListener>(std::move(listener)));
+    listener = std::make_unique<BacktraceAllocationListener>(std::move(listener));
   }
 
   auto name = jStringToCString(env, jname);
+  // TODO: move memory manager into ExecutionCtx then we can use more general ExecutionCtx.
   auto executionCtx = gluten::createExecutionCtx();
   auto manager = executionCtx->createMemoryManager(name, *allocator, std::move(listener));
+  gluten::releaseExecutionCtx(executionCtx);
   return reinterpret_cast<jlong>(manager);
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jbyteArray JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_collectMemoryUsage( // NOLINT
     JNIEnv* env,
     jclass,
-    jlong memoryManagerId) {
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+    jlong memoryManagerHandle) {
+  JNI_METHOD_START
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   const MemoryUsageStats& stats = memoryManager->collectMemoryUsageStats();
   auto size = stats.ByteSizeLong();
   jbyteArray out = env->NewByteArray(size);
@@ -1173,50 +1280,56 @@ JNIEXPORT jbyteArray JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManage
       "Serialization failed when collecting memory usage stats");
   env->SetByteArrayRegion(out, 0, size, reinterpret_cast<jbyte*>(buffer));
   return out;
+  JNI_METHOD_END(nullptr)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_shrink( // NOLINT
     JNIEnv* env,
     jclass,
-    jlong memoryManagerId,
+    jlong memoryManagerHandle,
     jlong size) {
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  JNI_METHOD_START
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   return memoryManager->shrink(static_cast<int64_t>(size));
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT void JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_release( // NOLINT
     JNIEnv* env,
     jclass,
-    jlong memoryManagerId) {
+    jlong memoryManagerHandle) {
   JNI_METHOD_START
-  delete reinterpret_cast<MemoryManager*>(memoryManagerId);
+  delete reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   JNI_METHOD_END()
 }
 
 JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializerJniWrapper_serialize( // NOLINT
     JNIEnv* env,
     jobject,
+    jlong ctxHandle,
     jlongArray handles,
-    jlong memoryManagerId) {
+    jlong memoryManagerHandle) {
   JNI_METHOD_START
-  int32_t numBatches = env->GetArrayLength(handles);
-  jlong* batchhandles = env->GetLongArrayElements(handles, nullptr);
-
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+
+  int32_t numBatches = env->GetArrayLength(handles);
+  jlong* batchHandles = env->GetLongArrayElements(handles, nullptr);
+
   std::vector<std::shared_ptr<ColumnarBatch>> batches;
   int64_t numRows = 0L;
   for (int32_t i = 0; i < numBatches; i++) {
-    auto batch = columnarBatchHolder.lookup(batchhandles[i]);
-    GLUTEN_DCHECK(batch != nullptr, "Cannot find the ColumnarBatch with handle " + std::to_string(batchhandles[i]));
+    auto batch = executionCtx->getBatch(batchHandles[i]);
+    GLUTEN_DCHECK(batch != nullptr, "Cannot find the ColumnarBatch with handle " + std::to_string(batchHandles[i]));
     numRows += batch->numRows();
     batches.emplace_back(batch);
   }
-  env->ReleaseLongArrayElements(handles, batchhandles, JNI_ABORT);
+  env->ReleaseLongArrayElements(handles, batchHandles, JNI_ABORT);
 
-  auto executionCtx = gluten::createExecutionCtx();
   auto arrowPool = memoryManager->getArrowMemoryPool();
-  auto serializer = executionCtx->getColumnarBatchSerializer(memoryManager, arrowPool, nullptr);
+  auto serializer = executionCtx->createTempColumnarBatchSerializer(memoryManager, arrowPool, nullptr);
   auto buffer = serializer->serializeColumnarBatches(batches);
   auto bufferArr = env->NewByteArray(buffer->size());
   env->SetByteArrayRegion(bufferArr, 0, buffer->size(), reinterpret_cast<const jbyte*>(buffer->data()));
@@ -1232,38 +1345,50 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializer
     JNIEnv* env,
     jobject,
     jlong cSchema,
-    jlong memoryManagerId) {
+    jlong ctxHandle,
+    jlong memoryManagerHandle) {
   JNI_METHOD_START
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
   GLUTEN_DCHECK(memoryManager != nullptr, "Memory manager does not exist or has been closed");
+
   auto arrowPool = memoryManager->getArrowMemoryPool();
-  auto executionCtx = gluten::createExecutionCtx();
-  auto serializer = executionCtx->getColumnarBatchSerializer(
+  return executionCtx->createColumnarBatchSerializer(
       memoryManager, arrowPool, reinterpret_cast<struct ArrowSchema*>(cSchema));
-  return columnarBatchSerializerHolder.insert(serializer);
-  JNI_METHOD_END(-1L)
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
 JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializerJniWrapper_deserialize( // NOLINT
     JNIEnv* env,
     jobject,
-    jlong handle,
+    jlong ctxHandle,
+    jlong serializerHandle,
     jbyteArray data) {
   JNI_METHOD_START
-  std::shared_ptr<ColumnarBatchSerializer> serializer = columnarBatchSerializerHolder.lookup(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  auto serializer = executionCtx->getColumnarBatchSerializer(serializerHandle);
   GLUTEN_DCHECK(serializer != nullptr, "ColumnarBatchSerializer cannot be null");
   int32_t size = env->GetArrayLength(data);
   jbyte* serialized = env->GetByteArrayElements(data, nullptr);
   auto batch = serializer->deserialize(reinterpret_cast<uint8_t*>(serialized), size);
   env->ReleaseByteArrayElements(data, serialized, JNI_ABORT);
-  return columnarBatchHolder.insert(batch);
-  JNI_METHOD_END(-1L)
+  return executionCtx->addBatch(batch);
+  JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT void JNICALL
-Java_io_glutenproject_vectorized_ColumnarBatchSerializerJniWrapper_close(JNIEnv* env, jobject, jlong handle) { // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializerJniWrapper_close(
+    JNIEnv* env,
+    jobject,
+    jlong ctxHandle,
+    jlong serializerHandle) { // NOLINT
   JNI_METHOD_START
-  columnarBatchSerializerHolder.erase(handle);
+  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
+  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+
+  executionCtx->releaseColumnarBatchSerializer(serializerHandle);
   JNI_METHOD_END()
 }
 

--- a/cpp/velox/benchmarks/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/BenchmarkUtils.cc
@@ -35,9 +35,8 @@ namespace {
 
 std::unordered_map<std::string, std::string> bmConfMap = {{gluten::kSparkBatchSize, FLAGS_batch_size}};
 
-std::shared_ptr<gluten::ExecutionCtx> veloxExecutionCtxFactory(
-    const std::unordered_map<std::string, std::string>& sparkConfs) {
-  return std::make_shared<gluten::VeloxExecutionCtx>(sparkConfs);
+gluten::ExecutionCtx* veloxExecutionCtxFactory(const std::unordered_map<std::string, std::string>& sparkConfs) {
+  return new gluten::VeloxExecutionCtx(sparkConfs);
 }
 
 } // anonymous namespace

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -126,6 +126,7 @@ auto BM_Generic = [](::benchmark::State& state,
     setCpu(state.thread_index());
   }
   auto memoryManager = getDefaultMemoryManager();
+  auto executionCtx = gluten::createExecutionCtx();
   const auto& filePath = getExampleFilePath(substraitJsonFile);
   auto plan = getPlanFromFile(filePath);
   auto startTime = std::chrono::steady_clock::now();
@@ -133,7 +134,6 @@ auto BM_Generic = [](::benchmark::State& state,
   WriterMetrics writerMetrics{};
 
   for (auto _ : state) {
-    auto executionCtx = gluten::createExecutionCtx();
     std::vector<std::shared_ptr<gluten::ResultIterator>> inputIters;
     std::vector<BatchIterator*> inputItersRaw;
     if (!inputFiles.empty()) {
@@ -148,9 +148,10 @@ auto BM_Generic = [](::benchmark::State& state,
     }
 
     executionCtx->parsePlan(reinterpret_cast<uint8_t*>(plan.data()), plan.size());
-    auto resultIter =
-        executionCtx->getResultIterator(memoryManager.get(), "/tmp/test-spill", std::move(inputIters), conf);
-    auto veloxPlan = std::dynamic_pointer_cast<gluten::VeloxExecutionCtx>(executionCtx)->getVeloxPlan();
+    auto iterHandle =
+        executionCtx->createResultIterator(memoryManager.get(), "/tmp/test-spill", std::move(inputIters), conf);
+    auto resultIter = executionCtx->getResultIterator(iterHandle);
+    auto veloxPlan = dynamic_cast<gluten::VeloxExecutionCtx*>(executionCtx)->getVeloxPlan();
     if (FLAGS_with_shuffle) {
       int64_t shuffleWriteTime;
       TIME_NANO_START(shuffleWriteTime);
@@ -206,6 +207,7 @@ auto BM_Generic = [](::benchmark::State& state,
     auto statsStr = facebook::velox::exec::printPlanWithStats(*planNode, task->taskStats(), true);
     std::cout << statsStr << std::endl;
   }
+  gluten::releaseExecutionCtx(executionCtx);
 
   auto endTime = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();

--- a/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
+++ b/cpp/velox/benchmarks/ParquetWriteBenchmark.cc
@@ -163,8 +163,6 @@ class GoogleBenchmarkArrowParquetWriteCacheScanBenchmark : public GoogleBenchmar
     // reuse the ParquetWriteConverter for batches caused system % increase a lot
     auto fileName = "arrow_parquet_write.parquet";
 
-    auto executionCtx = std::dynamic_pointer_cast<gluten::VeloxExecutionCtx>(gluten::createExecutionCtx());
-
     for (auto _ : state) {
       // Choose compression
       std::shared_ptr<::parquet::WriterProperties> props =
@@ -258,7 +256,7 @@ class GoogleBenchmarkVeloxParquetWriteCacheScanBenchmark : public GoogleBenchmar
     // reuse the ParquetWriteConverter for batches caused system % increase a lot
     auto fileName = "velox_parquet_write.parquet";
 
-    auto executionCtx = std::dynamic_pointer_cast<gluten::VeloxExecutionCtx>(gluten::createExecutionCtx());
+    auto executionCtx = gluten::createExecutionCtx();
     auto memoryManager = getDefaultMemoryManager();
     auto veloxPool = memoryManager->getAggregateMemoryPool();
 
@@ -294,6 +292,7 @@ class GoogleBenchmarkVeloxParquetWriteCacheScanBenchmark : public GoogleBenchmar
         benchmark::Counter(initTime, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
     state.counters["write_time"] =
         benchmark::Counter(writeTime, benchmark::Counter::kAvgThreads, benchmark::Counter::OneK::kIs1000);
+    gluten::releaseExecutionCtx(executionCtx);
   }
 };
 

--- a/cpp/velox/compute/VeloxExecutionCtx.h
+++ b/cpp/velox/compute/VeloxExecutionCtx.h
@@ -17,12 +17,6 @@
 
 #pragma once
 
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <folly/executors/IOThreadPoolExecutor.h>
-
 #include "WholeStageResultIterator.h"
 #include "compute/ExecutionCtx.h"
 #include "memory/VeloxMemoryManager.h"
@@ -63,50 +57,65 @@ class VeloxExecutionCtx final : public ExecutionCtx {
   }
 
   // FIXME This is not thread-safe?
-  std::shared_ptr<ResultIterator> getResultIterator(
+  ResourceHandle createResultIterator(
       MemoryManager* memoryManager,
       const std::string& spillDir,
       const std::vector<std::shared_ptr<ResultIterator>>& inputs = {},
       const std::unordered_map<std::string, std::string>& sessionConf = {}) override;
+  ResourceHandle addResultIterator(std::shared_ptr<ResultIterator> ptr) override;
+  std::shared_ptr<ResultIterator> getResultIterator(ResourceHandle handle) override;
+  void releaseResultIterator(ResourceHandle handle) override;
 
-  std::shared_ptr<ColumnarToRowConverter> getColumnar2RowConverter(MemoryManager* memoryManager) override;
+  ResourceHandle createColumnar2RowConverter(MemoryManager* memoryManager) override;
+  std::shared_ptr<ColumnarToRowConverter> getColumnar2RowConverter(ResourceHandle handle) override;
+  void releaseColumnar2RowConverter(ResourceHandle handle) override;
 
-  std::shared_ptr<RowToColumnarConverter> getRowToColumnarConverter(
-      MemoryManager* memoryManager,
-      struct ArrowSchema* cSchema) override;
+  ResourceHandle addBatch(std::shared_ptr<ColumnarBatch> ptr) override;
+  std::shared_ptr<ColumnarBatch> getBatch(ResourceHandle handle) override;
+  void releaseBatch(ResourceHandle handle) override;
 
-  std::shared_ptr<ShuffleWriter> createShuffleWriter(
+  ResourceHandle createRow2ColumnarConverter(MemoryManager* memoryManager, struct ArrowSchema* cSchema) override;
+  std::shared_ptr<RowToColumnarConverter> getRow2ColumnarConverter(ResourceHandle handle) override;
+  void releaseRow2ColumnarConverter(ResourceHandle handle) override;
+
+  ResourceHandle createShuffleWriter(
       int numPartitions,
       std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator,
       const ShuffleWriterOptions& options,
       MemoryManager* memoryManager) override;
+  std::shared_ptr<ShuffleWriter> getShuffleWriter(ResourceHandle handle) override;
+  void releaseShuffleWriter(ResourceHandle handle) override;
 
   std::shared_ptr<Metrics> getMetrics(ColumnarBatchIterator* rawIter, int64_t exportNanos) override {
     auto iter = static_cast<WholeStageResultIterator*>(rawIter);
     return iter->getMetrics(exportNanos);
   }
 
-  std::shared_ptr<Datasource> getDatasource(
+  ResourceHandle createDatasource(
       const std::string& filePath,
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::Schema> schema) override {
-    auto veloxPool = getAggregateVeloxPool(memoryManager);
-    return std::make_shared<VeloxParquetDatasource>(filePath, veloxPool, schema);
-  }
+      std::shared_ptr<arrow::Schema> schema) override;
+  std::shared_ptr<Datasource> getDatasource(ResourceHandle handle) override;
+  void releaseDatasource(ResourceHandle handle) override;
 
-  std::shared_ptr<ShuffleReader> createShuffleReader(
+  ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
       std::shared_ptr<arrow::MemoryPool> pool,
-      MemoryManager* memoryManager) override {
-    auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
-    return std::make_shared<VeloxShuffleReader>(schema, options, pool, ctxVeloxPool);
-  }
+      MemoryManager* memoryManager) override;
+  std::shared_ptr<ShuffleReader> getShuffleReader(ResourceHandle handle) override;
+  void releaseShuffleReader(ResourceHandle handle) override;
 
-  std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(
+  std::unique_ptr<ColumnarBatchSerializer> createTempColumnarBatchSerializer(
       MemoryManager* memoryManager,
       std::shared_ptr<arrow::MemoryPool> arrowPool,
       struct ArrowSchema* cSchema) override;
+  ResourceHandle createColumnarBatchSerializer(
+      MemoryManager* memoryManager,
+      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      struct ArrowSchema* cSchema) override;
+  std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(ResourceHandle handle) override;
+  void releaseColumnarBatchSerializer(ResourceHandle handle) override;
 
   std::shared_ptr<const facebook::velox::core::PlanNode> getVeloxPlan() {
     return veloxPlan_;
@@ -120,6 +129,15 @@ class VeloxExecutionCtx final : public ExecutionCtx {
       std::vector<facebook::velox::core::PlanNodeId>& streamIds);
 
  private:
+  ConcurrentMap<std::shared_ptr<ColumnarBatch>> columnarBatchHolder_;
+  ConcurrentMap<std::shared_ptr<Datasource>> datasourceHolder_;
+  ConcurrentMap<std::shared_ptr<ColumnarToRowConverter>> columnarToRowConverterHolder_;
+  ConcurrentMap<std::shared_ptr<ShuffleReader>> shuffleReaderHolder_;
+  ConcurrentMap<std::shared_ptr<ShuffleWriter>> shuffleWriterHolder_;
+  ConcurrentMap<std::shared_ptr<ColumnarBatchSerializer>> columnarBatchSerializerHolder_;
+  ConcurrentMap<std::shared_ptr<RowToColumnarConverter>> rowToColumnarConverterHolder_;
+  ConcurrentMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
+
   std::vector<std::shared_ptr<ResultIterator>> inputIters_;
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;
 };

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -17,13 +17,11 @@
 
 #include "VeloxParquetDatasource.h"
 
-#include <arrow/array/array_base.h>
 #include <arrow/buffer.h>
 #include <cstring>
 #include <string>
 
 #include "arrow/c/bridge.h"
-#include "compute/ExecutionCtx.h"
 #include "compute/VeloxExecutionCtx.h"
 #include "config/GlutenConfig.h"
 
@@ -38,8 +36,6 @@ using namespace facebook::velox::dwio::common;
 namespace gluten {
 
 void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::string>& sparkConfs) {
-  auto executionCtx = std::dynamic_pointer_cast<gluten::VeloxExecutionCtx>(gluten::createExecutionCtx());
-
   if (strncmp(filePath_.c_str(), "file:", 5) == 0) {
     sink_ = std::make_unique<velox::dwio::common::LocalFileSink>(filePath_.substr(5));
   } else if (strncmp(filePath_.c_str(), "hdfs:", 5) == 0) {

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
@@ -23,19 +23,20 @@ public class ColumnarBatchJniWrapper extends JniInitialized {
 
   private ColumnarBatchJniWrapper() {}
 
-  public native String getType(long handle);
+  public native String getType(long executionCtxHandle, long batchHandle);
 
-  public native long numColumns(long handle);
+  public native long numColumns(long executionCtxHandle, long batchHandle);
 
-  public native long numRows(long handle);
+  public native long numRows(long executionCtxHandle, long batchHandle);
 
-  public native long numBytes(long handle);
+  public native long numBytes(long executionCtxHandle, long batchHandle);
 
-  public native long compose(long[] handles);
+  public native long compose(long executionCtxHandle, long[] batchHandles);
 
-  public native long createWithArrowArray(long cSchema, long cArray);
+  public native long createWithArrowArray(long executionCtxHandle, long cSchema, long cArray);
 
-  public native void exportToArrow(long handle, long cSchema, long cArray);
+  public native void exportToArrow(
+      long executionCtxHandle, long batchHandle, long cSchema, long cArray);
 
-  public native void close(long handle);
+  public native void close(long executionCtxHandle, long batchHandle);
 }

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -17,12 +17,14 @@
 package io.glutenproject.columnarbatch;
 
 import io.glutenproject.exception.GlutenException;
+import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators;
 import io.glutenproject.utils.ArrowAbiUtil;
 import io.glutenproject.utils.ArrowUtil;
 import io.glutenproject.utils.ImplicitClass;
 import io.glutenproject.vectorized.ArrowWritableColumnVector;
 
+import com.google.common.base.Preconditions;
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.CDataDictionaryProvider;
@@ -147,7 +149,10 @@ public class ColumnarBatches {
         ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
         CDataDictionaryProvider provider = new CDataDictionaryProvider()) {
       ColumnarBatchJniWrapper.INSTANCE.exportToArrow(
-          handle, cSchema.memoryAddress(), cArray.memoryAddress());
+          ExecutionCtxs.contextInstance().getHandle(),
+          handle,
+          cSchema.memoryAddress(),
+          cArray.memoryAddress());
 
       Data.exportSchema(
           allocator, ArrowUtil.toArrowSchema(cSchema, allocator, provider), provider, arrowSchema);
@@ -179,14 +184,15 @@ public class ColumnarBatches {
     if (!isHeavyBatch(input)) {
       throw new IllegalArgumentException("batch is not Arrow columnar batch");
     }
+    final long executionCtxHandle = ExecutionCtxs.contextInstance().getHandle();
     try (ArrowArray cArray = ArrowArray.allocateNew(allocator);
         ArrowSchema cSchema = ArrowSchema.allocateNew(allocator)) {
       ArrowAbiUtil.exportFromSparkColumnarBatch(
           ArrowBufferAllocators.contextInstance(), input, cSchema, cArray);
       long handle =
           ColumnarBatchJniWrapper.INSTANCE.createWithArrowArray(
-              cSchema.memoryAddress(), cArray.memoryAddress());
-      ColumnarBatch output = ColumnarBatches.create(handle);
+              executionCtxHandle, cSchema.memoryAddress(), cArray.memoryAddress());
+      ColumnarBatch output = ColumnarBatches.create(executionCtxHandle, handle);
 
       // Follow input's reference count. This might be optimized using
       // automatic clean-up or once the extensibility of ColumnarBatch is enriched
@@ -243,11 +249,12 @@ public class ColumnarBatches {
   }
 
   public static void close(ColumnarBatch input) {
-    ColumnarBatchJniWrapper.INSTANCE.close(ColumnarBatches.getNativeHandle(input));
+    ColumnarBatchJniWrapper.INSTANCE.close(
+        ColumnarBatches.getExecutionCtxHandle(input), ColumnarBatches.getNativeHandle(input));
   }
 
-  public static void close(long handle) {
-    ColumnarBatchJniWrapper.INSTANCE.close(handle);
+  public static void close(long executionCtxHandle, long handle) {
+    ColumnarBatchJniWrapper.INSTANCE.close(executionCtxHandle, handle);
   }
 
   /**
@@ -256,19 +263,30 @@ public class ColumnarBatches {
    */
   public static long compose(ColumnarBatch... batches) {
     long[] handles = Arrays.stream(batches).mapToLong(ColumnarBatches::getNativeHandle).toArray();
-    return ColumnarBatchJniWrapper.INSTANCE.compose(handles);
+    // we assume all input batches should be managed by same ExecutionCtx.
+    long[] executionCtxHandles =
+        Arrays.stream(batches)
+            .mapToLong(ColumnarBatches::getExecutionCtxHandle)
+            .distinct()
+            .toArray();
+    Preconditions.checkState(
+        executionCtxHandles.length == 1,
+        "All input batches should be managed by same ExecutionCtx.");
+    return ColumnarBatchJniWrapper.INSTANCE.compose(executionCtxHandles[0], handles);
   }
 
   public static long numBytes(ColumnarBatch input) {
-    return ColumnarBatchJniWrapper.INSTANCE.numBytes(ColumnarBatches.getNativeHandle(input));
+    return ColumnarBatchJniWrapper.INSTANCE.numBytes(
+        ColumnarBatches.getExecutionCtxHandle(input), ColumnarBatches.getNativeHandle(input));
   }
 
   public static String getType(ColumnarBatch input) {
-    return ColumnarBatchJniWrapper.INSTANCE.getType(ColumnarBatches.getNativeHandle(input));
+    return ColumnarBatchJniWrapper.INSTANCE.getType(
+        ColumnarBatches.getExecutionCtxHandle(input), ColumnarBatches.getNativeHandle(input));
   }
 
-  public static ColumnarBatch create(long nativeHandle) {
-    final IndicatorVector iv = new IndicatorVector(nativeHandle);
+  public static ColumnarBatch create(long executionCtxHandle, long nativeHandle) {
+    final IndicatorVector iv = new IndicatorVector(executionCtxHandle, nativeHandle);
     int numColumns = Math.toIntExact(iv.getNumColumns());
     int numRows = Math.toIntExact(iv.getNumRows());
     if (numColumns == 0) {
@@ -312,5 +330,15 @@ public class ColumnarBatches {
     }
     IndicatorVector iv = (IndicatorVector) batch.column(0);
     return iv.getNativeHandle();
+  }
+
+  public static long getExecutionCtxHandle(ColumnarBatch batch) {
+    if (!isLightBatch(batch)) {
+      throw new UnsupportedOperationException(
+          "Cannot get native batch handle due to "
+              + "input batch is not intermediate Gluten batch");
+    }
+    IndicatorVector iv = (IndicatorVector) batch.column(0);
+    return iv.getExecutionCtxHandle();
   }
 }

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/IndicatorVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/IndicatorVector.java
@@ -26,28 +26,34 @@ import org.apache.spark.unsafe.types.UTF8String;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class IndicatorVector extends ColumnVector {
-  private final long nativeHandle;
+  private final long executionCtxHandle;
+  private final long batchHandle;
   private final AtomicLong refCnt = new AtomicLong(1L);
 
-  protected IndicatorVector(long nativeHandle) {
+  protected IndicatorVector(long executionCtxHandle, long batchHandle) {
     super(DataTypes.NullType);
-    this.nativeHandle = nativeHandle;
+    this.executionCtxHandle = executionCtxHandle;
+    this.batchHandle = batchHandle;
   }
 
   public long getNativeHandle() {
-    return nativeHandle;
+    return batchHandle;
+  }
+
+  public long getExecutionCtxHandle() {
+    return executionCtxHandle;
   }
 
   public String getType() {
-    return ColumnarBatchJniWrapper.INSTANCE.getType(nativeHandle);
+    return ColumnarBatchJniWrapper.INSTANCE.getType(executionCtxHandle, batchHandle);
   }
 
   public long getNumColumns() {
-    return ColumnarBatchJniWrapper.INSTANCE.numColumns(nativeHandle);
+    return ColumnarBatchJniWrapper.INSTANCE.numColumns(executionCtxHandle, batchHandle);
   }
 
   public long getNumRows() {
-    return ColumnarBatchJniWrapper.INSTANCE.numRows(nativeHandle);
+    return ColumnarBatchJniWrapper.INSTANCE.numRows(executionCtxHandle, batchHandle);
   }
 
   public long refCnt() {
@@ -65,7 +71,7 @@ public class IndicatorVector extends ColumnVector {
       return;
     }
     if (refCnt.decrementAndGet() == 0) {
-      ColumnarBatchJniWrapper.INSTANCE.close(nativeHandle);
+      ColumnarBatchJniWrapper.INSTANCE.close(executionCtxHandle, batchHandle);
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -28,13 +28,14 @@ public class NativeMemoryManager implements TaskResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NativeMemoryManager.class);
 
-  private final long nativeInstanceId;
+  private final long nativeInstanceHandle;
   private final String name;
   private final ReservationListener listener;
 
-  private NativeMemoryManager(String name, long nativeInstanceId, ReservationListener listener) {
+  private NativeMemoryManager(
+      String name, long nativeInstanceHandle, ReservationListener listener) {
     this.name = name;
-    this.nativeInstanceId = nativeInstanceId;
+    this.nativeInstanceHandle = nativeInstanceHandle;
     this.listener = listener;
   }
 
@@ -45,19 +46,19 @@ public class NativeMemoryManager implements TaskResource {
         name, create(name, allocatorId, reservationBlockSize, listener), listener);
   }
 
-  public long getNativeInstanceId() {
-    return this.nativeInstanceId;
+  public long getNativeInstanceHandle() {
+    return this.nativeInstanceHandle;
   }
 
   public byte[] collectMemoryUsage() {
-    return collectMemoryUsage(nativeInstanceId);
+    return collectMemoryUsage(nativeInstanceHandle);
   }
 
   public long shrink(long size) {
-    return shrink(nativeInstanceId, size);
+    return shrink(nativeInstanceHandle, size);
   }
 
-  private static native long shrink(long nativeInstanceId, long size);
+  private static native long shrink(long nativeInstanceHandle, long size);
 
   private static native long create(
       String name, long allocatorId, long reservationBlockSize, ReservationListener listener);
@@ -68,7 +69,7 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
-    release(nativeInstanceId);
+    release(nativeInstanceHandle);
     if (listener.getUsedBytes() != 0) {
       LOGGER.warn(
           name

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializerJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializerJniWrapper.java
@@ -25,12 +25,13 @@ public class ColumnarBatchSerializerJniWrapper extends JniInitialized {
 
   private ColumnarBatchSerializerJniWrapper() {}
 
-  public native ColumnarBatchSerializeResult serialize(long[] handles, long memoryManagerId);
+  public native ColumnarBatchSerializeResult serialize(
+      long executionCtxHandle, long[] handles, long memoryManagerHandle);
 
   // Return the native ColumnarBatchSerializer handle
-  public native long init(long cSchema, long memoryManagerId);
+  public native long init(long cSchema, long executionCtxHandle, long memoryManagerHandle);
 
-  public native long deserialize(long handle, byte[] data);
+  public native long deserialize(long executionCtxHandle, long serializerHandle, byte[] data);
 
-  public native void close(long handle);
+  public native void close(long executionCtxHandle, long serializerHandle);
 }

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
@@ -24,10 +24,11 @@ public class NativeColumnarToRowJniWrapper extends JniInitialized {
 
   public NativeColumnarToRowJniWrapper() throws IOException {}
 
-  public native long nativeColumnarToRowInit(long memoryManagerId) throws RuntimeException;
+  public native long nativeColumnarToRowInit(long executionCtxHandle, long memoryManagerHandle)
+      throws RuntimeException;
 
   public native NativeColumnarToRowInfo nativeColumnarToRowConvert(
-      long batchHandle, long instanceId) throws RuntimeException;
+      long executionCtxHandle, long batchHandle, long c2rHandle) throws RuntimeException;
 
-  public native void nativeClose(long instanceID);
+  public native void nativeClose(long executionCtxHandle, long c2rHandle);
 }

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -18,6 +18,7 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.GlutenConfig;
 import io.glutenproject.backendsapi.BackendsApiManager;
+import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.memory.nmm.NativeMemoryManagers;
 import io.glutenproject.substrait.expression.ExpressionBuilder;
 import io.glutenproject.substrait.expression.StringMapNode;
@@ -64,8 +65,9 @@ public class NativePlanEvaluator {
   // return a columnar result iterator.
   public GeneralOutIterator createKernelWithBatchIterator(
       Plan wsPlan, List<GeneralInIterator> iterList) throws RuntimeException, IOException {
+    final long executionCtxHandle = ExecutionCtxs.contextInstance().getHandle();
     final AtomicReference<ColumnarBatchOutIterator> outIterator = new AtomicReference<>();
-    final long memoryManagerId =
+    final long memoryManagerHandle =
         NativeMemoryManagers.create(
                 "WholeStageIterator",
                 (size) -> {
@@ -80,16 +82,17 @@ public class NativePlanEvaluator {
                                           + "hasNext()/next()"));
                   return instance.spill(size);
                 })
-            .getNativeInstanceId();
+            .getNativeInstanceHandle();
 
     final String spillDirPath =
         SparkDirectoryUtil.namespace("gluten-spill")
             .mkChildDirRoundRobin(UUID.randomUUID().toString())
             .getAbsolutePath();
 
-    long handle =
+    long iterHandle =
         jniWrapper.nativeCreateKernelWithIterator(
-            memoryManagerId,
+            executionCtxHandle,
+            memoryManagerHandle,
             getPlanBytesBuf(wsPlan),
             iterList.toArray(new GeneralInIterator[0]),
             TaskContext.get().stageId(),
@@ -103,12 +106,13 @@ public class NativePlanEvaluator {
                         SQLConf.get().getAllConfs()))
                 .toProtobuf()
                 .toByteArray());
-    outIterator.set(createOutIterator(handle));
+    outIterator.set(createOutIterator(executionCtxHandle, iterHandle));
     return outIterator.get();
   }
 
-  private ColumnarBatchOutIterator createOutIterator(long nativeHandle) throws IOException {
-    return new ColumnarBatchOutIterator(nativeHandle);
+  private ColumnarBatchOutIterator createOutIterator(long executionCtxHandle, long iterHandle)
+      throws IOException {
+    return new ColumnarBatchOutIterator(executionCtxHandle, iterHandle);
   }
 
   private byte[] getPlanBytesBuf(Plan planNode) {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeRowToColumnarJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeRowToColumnarJniWrapper.java
@@ -21,9 +21,10 @@ import io.glutenproject.init.JniInitialized;
 public class NativeRowToColumnarJniWrapper extends JniInitialized {
   public NativeRowToColumnarJniWrapper() {}
 
-  public native long init(long cSchema, long memoryManagerId);
+  public native long init(long cSchema, long executionCtxHandle, long memoryManagerHandle);
 
-  public native long nativeConvertRowToColumnar(long r2CId, long[] rowLength, long bufferAddress);
+  public native long nativeConvertRowToColumnar(
+      long executionCtxHandle, long r2cHandle, long[] rowLength, long bufferAddress);
 
-  public native void close(long r2cId);
+  public native void close(long executionCtxHandle, long r2cHandle);
 }

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
@@ -40,11 +40,12 @@ public class PlanEvaluatorJniWrapper extends JniInitialized {
   /**
    * Create a native compute kernel and return a columnar result iterator.
    *
-   * @param memoryManagerId NativeMemoryManager instance id
+   * @param memoryManagerHandle NativeMemoryManager instance handle
    * @return iterator instance id
    */
   public native long nativeCreateKernelWithIterator(
-      long memoryManagerId,
+      long ctxHandle,
+      long memoryManagerHandle,
       byte[] wsPlan,
       GeneralInIterator[] batchItr,
       int stageId,

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
@@ -25,14 +25,17 @@ public class ShuffleReaderJniWrapper extends JniInitialized {
 
   public native long make(
       long cSchema,
-      long memoryManagerId,
+      long executionCtxHandle,
+      long memoryManagerHandle,
       String compressionType,
       String compressionCodecBackend,
       String compressionMode);
 
-  public native long readStream(long handle, JniByteInputStream jniIn);
+  public native long readStream(
+      long executionCtxHandle, long shuffleReaderHandle, JniByteInputStream jniIn);
 
-  public native void populateMetrics(long handle, ShuffleReaderMetrics metrics);
+  public native void populateMetrics(
+      long executionCtxHandle, long shuffleReaderHandle, ShuffleReaderMetrics metrics);
 
-  public native void close(long handle);
+  public native void close(long executionCtxHandle, long shuffleReaderHandle);
 }

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -35,8 +35,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
    * @param subDirsPerLocalDir SparkConf spark.diskStore.subDirectories
    * @param localDirs configured local directories where Spark can write files
    * @param preferEvict if true, write the partition buffer to disk once it is full
-   * @param memoryPoolId
-   * @return native shuffle writer instance id if created successfully.
+   * @return native shuffle writer instance handle if created successfully.
    */
   public long make(
       NativePartitioning part,
@@ -50,7 +49,8 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
       int subDirsPerLocalDir,
       String localDirs,
       boolean preferEvict,
-      long memoryManagerId,
+      long executionCtxHandle,
+      long memoryManagerHandle,
       boolean writeEOS,
       long handle,
       long taskAttemptId) {
@@ -67,7 +67,8 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
         subDirsPerLocalDir,
         localDirs,
         preferEvict,
-        memoryManagerId,
+        executionCtxHandle,
+        memoryManagerHandle,
         writeEOS,
         handle,
         taskAttemptId,
@@ -82,8 +83,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
    * @param part contains the partitioning parameter needed by native shuffle writer
    * @param bufferSize size of native buffers hold by partition writer
    * @param codec compression codec
-   * @param memoryPoolId
-   * @return native shuffle writer instance id if created successfully.
+   * @return native shuffle writer instance handle if created successfully.
    */
   public long makeForRSS(
       NativePartitioning part,
@@ -94,7 +94,8 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
       String compressionMode,
       int pushBufferMaxSize,
       Object pusher,
-      long memoryManagerId,
+      long executionCtxHandle,
+      long memoryManagerHandle,
       long handle,
       long taskAttemptId,
       String partitionWriterType) {
@@ -111,7 +112,8 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
         0,
         null,
         true,
-        memoryManagerId,
+        executionCtxHandle,
+        memoryManagerHandle,
         true,
         handle,
         taskAttemptId,
@@ -133,7 +135,8 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
       int subDirsPerLocalDir,
       String localDirs,
       boolean preferEvict,
-      long memoryManagerId,
+      long executionCtxHandle,
+      long memoryManagerHandle,
       boolean writeEOS,
       long handle,
       long taskAttemptId,
@@ -144,39 +147,43 @@ public class ShuffleWriterJniWrapper extends JniInitialized {
   /**
    * Evict partition data.
    *
-   * @param shuffleWriterId shuffle writer instance id
+   * @param shuffleWriterHandle shuffle writer instance handle
    * @param size expected size to Evict (in bytes)
    * @param callBySelf whether the caller is the shuffle writer itself, true when running out of
    *     off-heap memory due to allocations from the evaluator itself
    * @return actual spilled size
    */
-  public native long nativeEvict(long shuffleWriterId, long size, boolean callBySelf)
+  public native long nativeEvict(
+      long executionCtxHandle, long shuffleWriterHandle, long size, boolean callBySelf)
       throws RuntimeException;
 
   /**
    * Split one record batch represented by bufAddrs and bufSizes into several batches. The batch is
    * split according to the first column as partition id.
    *
-   * @param shuffleWriterId shuffle writer instance id
+   * @param shuffleWriterHandle shuffle writer instance handle
    * @param numRows Rows per batch
    * @param handler handler of Velox Vector
    * @return batch bytes.
    */
-  public native long split(long shuffleWriterId, int numRows, long handler) throws IOException;
+  public native long split(
+      long executionCtxHandle, long shuffleWriterHandle, int numRows, long handler)
+      throws IOException;
 
   /**
    * Write the data remained in the buffers hold by native shuffle writer to each partition's
    * temporary file. And stop processing splitting
    *
-   * @param shuffleWriterId shuffle writer instance id
+   * @param shuffleWriterHandle shuffle writer instance handle
    * @return GlutenSplitResult
    */
-  public native GlutenSplitResult stop(long shuffleWriterId) throws IOException;
+  public native GlutenSplitResult stop(long executionCtxHandle, long shuffleWriterHandle)
+      throws IOException;
 
   /**
    * Release resources associated with designated shuffle writer instance.
    *
-   * @param shuffleWriterId shuffle writer instance id
+   * @param shuffleWriterHandle shuffle writer instance handle
    */
-  public native void close(long shuffleWriterId);
+  public native void close(long executionCtxHandle, long shuffleWriterHandle);
 }

--- a/gluten-data/src/main/scala/io/glutenproject/exec/ExecutionCtx.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/exec/ExecutionCtx.scala
@@ -14,15 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.init;
+package io.glutenproject.exec
 
-public class BackendJniWrapper {
+import io.glutenproject.init.BackendJniWrapper
 
-  private BackendJniWrapper() {}
+import org.apache.spark.util.TaskResource
 
-  public static native void initializeBackend(byte[] configPlan);
+class ExecutionCtx extends TaskResource {
+  private val handle = BackendJniWrapper.createExecutionCtx()
 
-  public static native long createExecutionCtx();
+  def getHandle: Long = handle
 
-  public static native void releaseExecutionCtx(long handle);
+  override def release(): Unit = BackendJniWrapper.releaseExecutionCtx(handle)
+
+  override def priority(): Int = 10
+
+  override def resourceName(): String = s"ExecutionCtx_" + handle
 }

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.vectorized
 
 import io.glutenproject.GlutenConfig
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.ArrowAbiUtil
@@ -67,7 +68,8 @@ private class ColumnarBatchSerializerInstance(
   extends SerializerInstance
   with Logging {
 
-  private lazy val shuffleReaderHandle = {
+  private lazy val (executionCtxHandle, shuffleReaderHandle) = {
+    val executionCtxHandle = ExecutionCtxs.contextInstance().getHandle
     val allocator: BufferAllocator = ArrowBufferAllocators
       .contextInstance()
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)
@@ -84,9 +86,10 @@ private class ColumnarBatchSerializerInstance(
       }
     val compressionCodecBackend =
       GlutenConfig.getConf.columnarShuffleCodecBackend.orNull
-    val handle = ShuffleReaderJniWrapper.INSTANCE.make(
+    val shuffleReaderHandle = ShuffleReaderJniWrapper.INSTANCE.make(
       cSchema.memoryAddress(),
-      NativeMemoryManagers.contextInstance("ShuffleReader").getNativeInstanceId,
+      executionCtxHandle,
+      NativeMemoryManagers.contextInstance("ShuffleReader").getNativeInstanceHandle,
       compressionCodec,
       compressionCodecBackend,
       GlutenConfig.getConf.columnarShuffleCompressionMode
@@ -95,24 +98,29 @@ private class ColumnarBatchSerializerInstance(
     // since the native reader could hold a reference to memory pool that
     // was used to create all buffers read from shuffle reader. The pool
     // should keep alive before all buffers finish consuming.
-    TaskResources.addRecycler(s"ShuffleReaderHandle_$handle", 50) {
+    TaskResources.addRecycler(s"ShuffleReaderHandle_$shuffleReaderHandle", 50) {
       // Collect Metrics
       val readerMetrics = new ShuffleReaderMetrics()
-      ShuffleReaderJniWrapper.INSTANCE.populateMetrics(handle, readerMetrics)
+      ShuffleReaderJniWrapper.INSTANCE.populateMetrics(
+        executionCtxHandle,
+        shuffleReaderHandle,
+        readerMetrics)
       decompressTime += readerMetrics.getDecompressTime
 
       cSchema.close()
-      ShuffleReaderJniWrapper.INSTANCE.close(handle)
+      ShuffleReaderJniWrapper.INSTANCE.close(executionCtxHandle, shuffleReaderHandle)
       allocator.close()
     }
-    handle
+    (executionCtxHandle, shuffleReaderHandle)
   }
 
   override def deserializeStream(in: InputStream): DeserializationStream = {
     new DeserializationStream {
       private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
       private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
-        ShuffleReaderJniWrapper.INSTANCE.readStream(shuffleReaderHandle, byteIn))
+        executionCtxHandle,
+        ShuffleReaderJniWrapper.INSTANCE
+          .readStream(executionCtxHandle, shuffleReaderHandle, byteIn))
 
       private var cb: ColumnarBatch = _
 


### PR DESCRIPTION
This is second patch of issue 3077, change list:
1. [cpp] refactor ExecutionCtx.h with three main APIs: `createXXX`, `getXXX`, `releaseXXX`, each resource's lifecycle will be managed by ExecutionCtx by these APIs.
2. [cpp] move old resources concurrent map into VeloxExecutionCtx.h, will try to replace with normal map in the following patch, and use ResourceHandle for readability.
3. [java] add ExecutionCtx class which implement TaskResource interface to align with native class, provide two methods to create it for different usage.
4. [java] bind all kinds of resources with ExecutionCtx.

note: MemoryManager has not been managed by ExecutionCtx for now.
