### PR TITLE
[VL] Refactor parseType for the cpp substrait module

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -21,7 +21,7 @@
 
 namespace gluten {
 
-std::shared_ptr<SubstraitParser::SubstraitType> SubstraitParser::parseType(const ::substrait::Type& substraitType) {
+SubstraitParser::SubstraitType SubstraitParser::parseType(const ::substrait::Type& substraitType) {
   // The used type names should be aligned with those in Velox.
   std::string typeName;
   ::substrait::Type_Nullability nullability;
@@ -83,7 +83,7 @@ std::shared_ptr<SubstraitParser::SubstraitType> SubstraitParser::parseType(const
         if (i > 0) {
           typeName += ',';
         }
-        typeName += parseType(structTypes[i])->type;
+        typeName += parseType(structTypes[i]).type;
         // Struct names could be empty.
         if (nameProvided) {
           typeName += (':' + structNames[i]);
@@ -97,7 +97,7 @@ std::shared_ptr<SubstraitParser::SubstraitType> SubstraitParser::parseType(const
       // The type name of list is in the format of: ARRAY<T>.
       const auto& sList = substraitType.list();
       const auto& sType = sList.type();
-      typeName = "ARRAY<" + parseType(sType)->type + ">";
+      typeName = "ARRAY<" + parseType(sType).type + ">";
       nullability = substraitType.list().nullability();
       break;
     }
@@ -106,7 +106,7 @@ std::shared_ptr<SubstraitParser::SubstraitType> SubstraitParser::parseType(const
       const auto& sMap = substraitType.map();
       const auto& keyType = sMap.key();
       const auto& valueType = sMap.value();
-      typeName = "MAP<" + parseType(keyType)->type + "," + parseType(valueType)->type + ">";
+      typeName = "MAP<" + parseType(keyType).type + "," + parseType(valueType).type + ">";
       nullability = substraitType.map().nullability();
       break;
     }
@@ -158,8 +158,7 @@ std::shared_ptr<SubstraitParser::SubstraitType> SubstraitParser::parseType(const
     default:
       VELOX_NYI("Substrait parsing for nullability {} not supported.", nullability);
   }
-  SubstraitType type = {typeName, nullable};
-  return std::make_shared<SubstraitType>(type);
+  return SubstraitType{typeName, nullable};
 }
 
 std::string SubstraitParser::parseType(const std::string& substraitType) {
@@ -180,7 +179,7 @@ std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> SubstraitParser::pa
   std::vector<std::shared_ptr<SubstraitParser::SubstraitType>> substraitTypeList;
   substraitTypeList.reserve(substraitTypes.size());
   for (const auto& type : substraitTypes) {
-    substraitTypeList.emplace_back(parseType(type));
+    substraitTypeList.emplace_back(std::make_shared<SubstraitParser::SubstraitType>(parseType(type)));
   }
   return substraitTypeList;
 }

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -47,7 +47,7 @@ class SubstraitParser {
   static std::vector<bool> parsePartitionColumns(const ::substrait::NamedStruct& namedStruct);
 
   /// Parse Substrait Type.
-  static std::shared_ptr<SubstraitType> parseType(const ::substrait::Type& substraitType);
+  static SubstraitType parseType(const ::substrait::Type& substraitType);
 
   // Parse substraitType type such as i32.
   static std::string parseType(const std::string& substraitType);

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -355,7 +355,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     for (const auto& arg : aggFunction.arguments()) {
       aggParams.emplace_back(exprConverter_->toVeloxExpr(arg.value(), inputType));
     }
-    auto aggVeloxType = toVeloxType(SubstraitParser::parseType(aggFunction.output_type())->type);
+    auto aggVeloxType = substraitTypeToVeloxType(aggFunction.output_type());
     auto aggExpr = std::make_shared<const core::CallTypedExpr>(aggVeloxType, std::move(aggParams), funcName);
     aggregates.emplace_back(core::AggregationNode::Aggregate{aggExpr, mask, {}, {}});
   }
@@ -555,7 +555,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     for (const auto& arg : windowFunction.arguments()) {
       windowParams.emplace_back(exprConverter_->toVeloxExpr(arg.value(), inputType));
     }
-    auto windowVeloxType = toVeloxType(SubstraitParser::parseType(windowFunction.output_type())->type);
+    auto windowVeloxType = substraitTypeToVeloxType(windowFunction.output_type());
     auto windowCall = std::make_shared<const core::CallTypedExpr>(windowVeloxType, std::move(windowParams), funcName);
     auto upperBound = windowFunction.upper_bound();
     auto lowerBound = windowFunction.lower_bound();

--- a/cpp/velox/substrait/TypeUtils.cc
+++ b/cpp/velox/substrait/TypeUtils.cc
@@ -16,6 +16,7 @@
  */
 
 #include "TypeUtils.h"
+#include "SubstraitParser.h"
 #include "velox/type/Type.h"
 
 namespace gluten {
@@ -153,6 +154,14 @@ TypePtr toVeloxType(const std::string& typeName, bool asLowerCase) {
     default:
       VELOX_NYI("Velox type conversion not supported for type {}.", typeName);
   }
+}
+
+TypePtr substraitTypeToVeloxType(const std::string& substraitType) {
+  return toVeloxType(SubstraitParser::parseType(substraitType));
+}
+
+TypePtr substraitTypeToVeloxType(const ::substrait::Type& substraitType) {
+  return toVeloxType(SubstraitParser::parseType(substraitType).type);
 }
 
 } // namespace gluten

--- a/cpp/velox/substrait/TypeUtils.h
+++ b/cpp/velox/substrait/TypeUtils.h
@@ -29,6 +29,12 @@ namespace gluten {
 /// Return the Velox type according to the typename.
 TypePtr toVeloxType(const std::string& typeName, bool asLowerCase = false);
 
+/// Return the Velox type according to substrait type string.
+TypePtr substraitTypeToVeloxType(const std::string& substraitType);
+
+/// Return the Velox type according to substrait type.
+TypePtr substraitTypeToVeloxType(const ::substrait::Type& substraitType);
+
 #endif /* TOVELOXTYPE_H */
 
 std::string_view getNameBeforeDelimiter(const std::string& compoundName, const std::string& delimiter);

--- a/cpp/velox/substrait/VeloxToSubstraitType.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitType.cc
@@ -30,7 +30,6 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
       auto substraitBool = google::protobuf::Arena::CreateMessage<::substrait::Type_Boolean>(&arena);
       substraitBool->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
       substraitType->set_allocated_bool_(substraitBool);
-
       break;
     }
     case velox::TypeKind::TINYINT: {
@@ -89,25 +88,17 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
     }
     case velox::TypeKind::ARRAY: {
       ::substrait::Type_List* substraitList = google::protobuf::Arena::CreateMessage<::substrait::Type_List>(&arena);
-
       substraitList->mutable_type()->MergeFrom(toSubstraitType(arena, type->asArray().elementType()));
-
       substraitList->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
-
       substraitType->set_allocated_list(substraitList);
-
       break;
     }
     case velox::TypeKind::MAP: {
       ::substrait::Type_Map* substraitMap = google::protobuf::Arena::CreateMessage<::substrait::Type_Map>(&arena);
-
       substraitMap->mutable_key()->MergeFrom(toSubstraitType(arena, type->asMap().keyType()));
       substraitMap->mutable_value()->MergeFrom(toSubstraitType(arena, type->asMap().valueType()));
-
       substraitMap->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
-
       substraitType->set_allocated_map(substraitMap);
-
       break;
     }
     case velox::TypeKind::ROW: {

--- a/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
+++ b/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
@@ -32,7 +32,7 @@ class VeloxToSubstraitTypeTest : public ::testing::Test {
 
     google::protobuf::Arena arena;
     auto substraitType = typeConvertor_->toSubstraitType(arena, type);
-    auto sameType = toVeloxType(SubstraitParser::parseType(substraitType)->type);
+    auto sameType = substraitTypeToVeloxType(substraitType);
     ASSERT_TRUE(sameType->kindEquals(type))
         << "Expected: " << type->toString() << ", but got: " << sameType->toString();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Why I made this change and what's the benefit?
1. Return `SubstraitType` instead of `std::shared_ptr<SubstraitType>`, and this change may avoid unnecessary dynamic `new` because most calling sides don't need a heap allocation object.  Returning a stack object is more effective.
2. Providing a new interface `fromSubstraitTypeToVeloxType` implemented with `toVeloxType(SubstraitParser::parseType(substraitType).type)` will make code simpler and clearer.

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

