### PR TITLE
[VL] Refactor MemoryManager#getArrowMemoryPool to return raw pointer

### DIFF
--- a/cpp/core/compute/ExecutionCtx.h
+++ b/cpp/core/compute/ExecutionCtx.h
@@ -126,19 +126,19 @@ class ExecutionCtx : public std::enable_shared_from_this<ExecutionCtx> {
   virtual ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
-      std::shared_ptr<arrow::MemoryPool> pool,
+      arrow::MemoryPool* pool,
       MemoryManager* memoryManager) = 0;
   virtual std::shared_ptr<ShuffleReader> getShuffleReader(ResourceHandle) = 0;
   virtual void releaseShuffleReader(ResourceHandle) = 0;
 
   virtual ResourceHandle createColumnarBatchSerializer(
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) = 0;
   // TODO: separate serializer and deserializer then remove this method.
   virtual std::unique_ptr<ColumnarBatchSerializer> createTempColumnarBatchSerializer(
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) = 0;
   virtual std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(ResourceHandle) = 0;
   virtual void releaseColumnarBatchSerializer(ResourceHandle) = 0;

--- a/cpp/core/memory/MemoryManager.h
+++ b/cpp/core/memory/MemoryManager.h
@@ -28,8 +28,7 @@ class MemoryManager {
 
   virtual ~MemoryManager() = default;
 
-  // TODO: return raw pointer, caller should not care its lifecycle.
-  virtual std::shared_ptr<arrow::MemoryPool> getArrowMemoryPool() = 0;
+  virtual arrow::MemoryPool* getArrowMemoryPool() = 0;
 
   virtual const MemoryUsageStats collectMemoryUsageStats() const = 0;
 

--- a/cpp/core/operators/serializer/ColumnarBatchSerializer.h
+++ b/cpp/core/operators/serializer/ColumnarBatchSerializer.h
@@ -25,8 +25,7 @@ namespace gluten {
 
 class ColumnarBatchSerializer {
  public:
-  ColumnarBatchSerializer(std::shared_ptr<arrow::MemoryPool> arrowPool, struct ArrowSchema* cSchema)
-      : arrowPool_(std::move(arrowPool)) {}
+  ColumnarBatchSerializer(arrow::MemoryPool* arrowPool, struct ArrowSchema* cSchema) : arrowPool_(arrowPool) {}
 
   virtual ~ColumnarBatchSerializer() = default;
 
@@ -36,7 +35,7 @@ class ColumnarBatchSerializer {
   virtual std::shared_ptr<ColumnarBatch> deserialize(uint8_t* data, int32_t size) = 0;
 
  protected:
-  std::shared_ptr<arrow::MemoryPool> arrowPool_;
+  arrow::MemoryPool* arrowPool_;
 };
 
 } // namespace gluten

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -50,7 +50,7 @@ arrow::Status LocalPartitionWriterBase::openDataFile() {
   if (shuffleWriter_->options().buffered_write) {
     // Output stream buffer is neither partition buffer memory nor ipc memory.
     ARROW_ASSIGN_OR_RAISE(
-        dataFileOs_, arrow::io::BufferedOutputStream::Create(16384, shuffleWriter_->options().memory_pool.get(), fout));
+        dataFileOs_, arrow::io::BufferedOutputStream::Create(16384, shuffleWriter_->options().memory_pool, fout));
   } else {
     dataFileOs_ = fout;
   }

--- a/cpp/core/shuffle/ShuffleReader.cc
+++ b/cpp/core/shuffle/ShuffleReader.cc
@@ -78,10 +78,7 @@ ReaderOptions ReaderOptions::defaults() {
   return {};
 }
 
-ShuffleReader::ShuffleReader(
-    std::shared_ptr<arrow::Schema> schema,
-    ReaderOptions options,
-    std::shared_ptr<arrow::MemoryPool> pool)
+ShuffleReader::ShuffleReader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, arrow::MemoryPool* pool)
     : pool_(pool), options_(std::move(options)), schema_(schema) {}
 
 std::shared_ptr<ResultIterator> ShuffleReader::readStream(std::shared_ptr<arrow::io::InputStream> in) {
@@ -93,7 +90,7 @@ arrow::Status ShuffleReader::close() {
   return arrow::Status::OK();
 }
 
-const std::shared_ptr<arrow::MemoryPool>& ShuffleReader::getPool() const {
+arrow::MemoryPool* ShuffleReader::getPool() const {
   return pool_;
 }
 

--- a/cpp/core/shuffle/ShuffleReader.h
+++ b/cpp/core/shuffle/ShuffleReader.h
@@ -38,7 +38,7 @@ struct ReaderOptions {
 
 class ShuffleReader {
  public:
-  ShuffleReader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, std::shared_ptr<arrow::MemoryPool> pool);
+  explicit ShuffleReader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, arrow::MemoryPool* pool);
 
   virtual ~ShuffleReader() = default;
 
@@ -59,11 +59,10 @@ class ShuffleReader {
     return deserializeTime_;
   }
 
-  const std::shared_ptr<arrow::MemoryPool>& getPool() const;
+  arrow::MemoryPool* getPool() const;
 
  protected:
-  std::shared_ptr<arrow::MemoryPool> pool_;
-
+  arrow::MemoryPool* pool_;
   int64_t decompressTime_ = 0;
   int64_t ipcTime_ = 0;
   int64_t deserializeTime_ = 0;

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -54,7 +54,7 @@ struct ShuffleWriterOptions {
   int64_t thread_id = -1;
   int64_t task_attempt_id = -1;
 
-  std::shared_ptr<arrow::MemoryPool> memory_pool;
+  arrow::MemoryPool* memory_pool;
 
   arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
 
@@ -65,10 +65,10 @@ struct ShuffleWriterOptions {
 
 class ShuffleMemoryPool : public arrow::MemoryPool {
  public:
-  ShuffleMemoryPool(std::shared_ptr<arrow::MemoryPool> pool) : pool_(pool) {}
+  ShuffleMemoryPool(arrow::MemoryPool* pool) : pool_(pool) {}
 
   arrow::MemoryPool* delegated() {
-    return pool_.get();
+    return pool_;
   }
 
   arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
@@ -113,7 +113,7 @@ class ShuffleMemoryPool : public arrow::MemoryPool {
   }
 
  private:
-  std::shared_ptr<arrow::MemoryPool> pool_;
+  arrow::MemoryPool* pool_;
   uint64_t bytesAllocated_ = 0;
 };
 

--- a/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
+++ b/cpp/core/shuffle/rss/CelebornPartitionWriter.cc
@@ -60,7 +60,7 @@ arrow::Status CelebornPartitionWriter::writeArrowToOutputStream(int32_t partitio
   ARROW_ASSIGN_OR_RAISE(
       celebornBufferOs_,
       arrow::io::BufferOutputStream::Create(
-          shuffleWriter_->options().buffer_size, shuffleWriter_->options().memory_pool.get()));
+          shuffleWriter_->options().buffer_size, shuffleWriter_->options().memory_pool));
   int32_t metadataLength = 0; // unused
 #ifndef SKIPWRITE
   for (auto& payload : shuffleWriter_->partitionCachedRecordbatch()[partitionId]) {

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -118,7 +118,7 @@ class BenchmarkShuffleSplit {
     options.buffer_size = kPartitionBufferSize;
     options.buffered_write = true;
     options.prefer_evict = FLAGS_prefer_evict;
-    options.memory_pool = pool;
+    options.memory_pool = pool.get();
     options.partitioning_name = "rr";
 
     std::shared_ptr<VeloxShuffleWriter> shuffleWriter;
@@ -258,7 +258,7 @@ class BenchmarkShuffleSplitCacheScanBenchmark : public BenchmarkShuffleSplit {
     if (state.thread_index() == 0)
       std::cout << localSchema->ToString() << std::endl;
 
-    auto* pool = options.memory_pool.get();
+    auto pool = options.memory_pool;
     GLUTEN_ASSIGN_OR_THROW(
         shuffleWriter,
         VeloxShuffleWriter::create(numPartitions, partitionWriterCreator, options, defaultLeafVeloxMemoryPool()));
@@ -329,7 +329,7 @@ class BenchmarkShuffleSplitIterateScanBenchmark : public BenchmarkShuffleSplit {
     std::unique_ptr<::parquet::arrow::FileReader> parquetReader;
     std::shared_ptr<RecordBatchReader> recordBatchReader;
     GLUTEN_THROW_NOT_OK(::parquet::arrow::FileReader::Make(
-        options.memory_pool.get(), ::parquet::ParquetFileReader::Open(file_), properties_, &parquetReader));
+        options.memory_pool, ::parquet::ParquetFileReader::Open(file_), properties_, &parquetReader));
 
     for (auto _ : state) {
       std::vector<std::shared_ptr<arrow::RecordBatch>> batches;

--- a/cpp/velox/compute/VeloxExecutionCtx.cc
+++ b/cpp/velox/compute/VeloxExecutionCtx.cc
@@ -212,7 +212,7 @@ void VeloxExecutionCtx::releaseDatasource(ResourceHandle handle) {
 ResourceHandle VeloxExecutionCtx::createShuffleReader(
     std::shared_ptr<arrow::Schema> schema,
     ReaderOptions options,
-    std::shared_ptr<arrow::MemoryPool> pool,
+    arrow::MemoryPool* pool,
     MemoryManager* memoryManager) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
   return shuffleReaderHolder_.insert(std::make_shared<VeloxShuffleReader>(schema, options, pool, ctxVeloxPool));
@@ -228,7 +228,7 @@ void VeloxExecutionCtx::releaseShuffleReader(ResourceHandle handle) {
 
 std::unique_ptr<ColumnarBatchSerializer> VeloxExecutionCtx::createTempColumnarBatchSerializer(
     MemoryManager* memoryManager,
-    std::shared_ptr<arrow::MemoryPool> arrowPool,
+    arrow::MemoryPool* arrowPool,
     struct ArrowSchema* cSchema) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
   return std::make_unique<VeloxColumnarBatchSerializer>(arrowPool, ctxVeloxPool, cSchema);
@@ -236,7 +236,7 @@ std::unique_ptr<ColumnarBatchSerializer> VeloxExecutionCtx::createTempColumnarBa
 
 ResourceHandle VeloxExecutionCtx::createColumnarBatchSerializer(
     MemoryManager* memoryManager,
-    std::shared_ptr<arrow::MemoryPool> arrowPool,
+    arrow::MemoryPool* arrowPool,
     struct ArrowSchema* cSchema) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
   return columnarBatchSerializerHolder_.insert(

--- a/cpp/velox/compute/VeloxExecutionCtx.h
+++ b/cpp/velox/compute/VeloxExecutionCtx.h
@@ -104,18 +104,18 @@ class VeloxExecutionCtx final : public ExecutionCtx {
   ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
-      std::shared_ptr<arrow::MemoryPool> pool,
+      arrow::MemoryPool* pool,
       MemoryManager* memoryManager) override;
   std::shared_ptr<ShuffleReader> getShuffleReader(ResourceHandle handle) override;
   void releaseShuffleReader(ResourceHandle handle) override;
 
   std::unique_ptr<ColumnarBatchSerializer> createTempColumnarBatchSerializer(
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) override;
   ResourceHandle createColumnarBatchSerializer(
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) override;
   std::shared_ptr<ColumnarBatchSerializer> getColumnarBatchSerializer(ResourceHandle handle) override;
   void releaseColumnarBatchSerializer(ResourceHandle handle) override;

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -17,7 +17,6 @@
 
 #include "VeloxMemoryManager.h"
 
-#include <execinfo.h>
 #include "memory/ArrowMemoryPool.h"
 #include "utils/exception.h"
 
@@ -199,7 +198,7 @@ VeloxMemoryManager::VeloxMemoryManager(
     std::unique_ptr<AllocationListener> listener)
     : MemoryManager(), name_(name), listener_(std::move(listener)) {
   glutenAlloc_ = std::make_unique<ListenableMemoryAllocator>(allocator.get(), listener_.get());
-  arrowPool_ = std::make_shared<ArrowMemoryPool>(glutenAlloc_.get());
+  arrowPool_ = std::make_unique<ArrowMemoryPool>(glutenAlloc_.get());
 
   auto options = getOptions(allocator);
   veloxMemoryManager_ = std::make_unique<velox::memory::MemoryManager>(options);

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -45,8 +45,8 @@ class VeloxMemoryManager final : public MemoryManager {
     return veloxLeafPool_;
   }
 
-  std::shared_ptr<arrow::MemoryPool> getArrowMemoryPool() override {
-    return arrowPool_;
+  arrow::MemoryPool* getArrowMemoryPool() override {
+    return arrowPool_.get();
   }
 
   const MemoryUsageStats collectMemoryUsageStats() const override;
@@ -65,7 +65,7 @@ class VeloxMemoryManager final : public MemoryManager {
   // This is a listenable allocator used for arrow.
   std::unique_ptr<MemoryAllocator> glutenAlloc_;
   std::unique_ptr<AllocationListener> listener_;
-  std::shared_ptr<arrow::MemoryPool> arrowPool_;
+  std::unique_ptr<arrow::MemoryPool> arrowPool_;
 
   std::unique_ptr<facebook::velox::memory::MemoryManager> veloxMemoryManager_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxAggregatePool_;

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -40,7 +40,7 @@ std::unique_ptr<ByteStream> toByteStream(uint8_t* data, int32_t size) {
 } // namespace
 
 VeloxColumnarBatchSerializer::VeloxColumnarBatchSerializer(
-    std::shared_ptr<arrow::MemoryPool> arrowPool,
+    arrow::MemoryPool* arrowPool,
     std::shared_ptr<memory::MemoryPool> veloxPool,
     struct ArrowSchema* cSchema)
     : ColumnarBatchSerializer(arrowPool, cSchema), veloxPool_(std::move(veloxPool)) {
@@ -62,7 +62,7 @@ std::shared_ptr<arrow::Buffer> VeloxColumnarBatchSerializer::serializeColumnarBa
   auto serializer = serde_->createSerializer(rowType, numRows, arena.get(), /* serdeOptions */ nullptr);
   for (auto& batch : batches) {
     auto rowVector = std::dynamic_pointer_cast<VeloxColumnarBatch>(batch)->getRowVector();
-    auto numRows = rowVector->size();
+    numRows = rowVector->size();
     std::vector<IndexRange> rows(numRows);
     for (int i = 0; i < numRows; i++) {
       rows[i] = IndexRange{i, 1};
@@ -71,8 +71,7 @@ std::shared_ptr<arrow::Buffer> VeloxColumnarBatchSerializer::serializeColumnarBa
   }
 
   std::shared_ptr<arrow::Buffer> valueBuffer;
-  GLUTEN_ASSIGN_OR_THROW(
-      valueBuffer, arrow::AllocateResizableBuffer(serializer->maxSerializedSize(), arrowPool_.get()));
+  GLUTEN_ASSIGN_OR_THROW(valueBuffer, arrow::AllocateResizableBuffer(serializer->maxSerializedSize(), arrowPool_));
   auto output = std::make_shared<arrow::io::FixedSizeBufferWriter>(valueBuffer);
   serializer::presto::PrestoOutputStreamListener listener;
   ArrowFixedSizeBufferOutputStream out(output, &listener);

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.h
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.h
@@ -28,7 +28,7 @@ namespace gluten {
 class VeloxColumnarBatchSerializer final : public ColumnarBatchSerializer {
  public:
   VeloxColumnarBatchSerializer(
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool,
       struct ArrowSchema* cSchema);
 

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -363,7 +363,7 @@ RowVectorPtr readRowVector(
 class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
  public:
   VeloxShuffleReaderOutStream(
-      const std::shared_ptr<arrow::MemoryPool>& pool,
+      arrow::MemoryPool* pool,
       const std::shared_ptr<facebook::velox::memory::MemoryPool>& veloxPool,
       const ReaderOptions& options,
       const RowTypePtr& rowType,
@@ -395,7 +395,7 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
         options_.compression_mode,
         decompressTime,
         deserializeTime,
-        pool_.get(),
+        pool_,
         veloxPool_.get());
 
     decompressionTimeAccumulator_(decompressTime);
@@ -404,7 +404,7 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
   }
 
  private:
-  std::shared_ptr<arrow::MemoryPool> pool_;
+  arrow::MemoryPool* pool_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
   ReaderOptions options_;
   facebook::velox::RowTypePtr rowType_;
@@ -454,7 +454,7 @@ std::string getCompressionType(arrow::Compression::type type) {
 VeloxShuffleReader::VeloxShuffleReader(
     std::shared_ptr<arrow::Schema> schema,
     ReaderOptions options,
-    std::shared_ptr<arrow::MemoryPool> pool,
+    arrow::MemoryPool* pool,
     std::shared_ptr<memory::MemoryPool> veloxPool)
     : ShuffleReader(schema, options, pool), veloxPool_(std::move(veloxPool)) {
   rowType_ = asRowType(gluten::fromArrowSchema(schema));

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -28,7 +28,7 @@ class VeloxShuffleReader final : public ShuffleReader {
   VeloxShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
-      std::shared_ptr<arrow::MemoryPool> pool,
+      arrow::MemoryPool* pool,
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool);
 
   std::shared_ptr<ResultIterator> readStream(std::shared_ptr<arrow::io::InputStream> in) override;

--- a/cpp/velox/tests/ExecutionCtxTest.cc
+++ b/cpp/velox/tests/ExecutionCtxTest.cc
@@ -94,7 +94,7 @@ class DummyExecutionCtx final : public ExecutionCtx {
   ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
       ReaderOptions options,
-      std::shared_ptr<arrow::MemoryPool> pool,
+      arrow::MemoryPool* pool,
       MemoryManager* memoryManager) override {
     return kInvalidResourceHandle;
   }
@@ -104,13 +104,13 @@ class DummyExecutionCtx final : public ExecutionCtx {
   void releaseShuffleReader(ResourceHandle handle) override {}
   ResourceHandle createColumnarBatchSerializer(
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) override {
     return kInvalidResourceHandle;
   }
   std::unique_ptr<ColumnarBatchSerializer> createTempColumnarBatchSerializer(
       MemoryManager* memoryManager,
-      std::shared_ptr<arrow::MemoryPool> arrowPool,
+      arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) override {
     return std::unique_ptr<ColumnarBatchSerializer>();
   }

--- a/cpp/velox/tests/VeloxColumnarBatchSerializerTest.cc
+++ b/cpp/velox/tests/VeloxColumnarBatchSerializerTest.cc
@@ -48,12 +48,12 @@ TEST_F(VeloxColumnarBatchSerializerTest, serialize) {
   };
   auto vector = makeRowVector(children);
   auto batch = std::make_shared<VeloxColumnarBatch>(vector);
-  auto serializer = std::make_shared<VeloxColumnarBatchSerializer>(arrowPool_, veloxPool_, nullptr);
+  auto serializer = std::make_shared<VeloxColumnarBatchSerializer>(arrowPool_.get(), veloxPool_, nullptr);
   auto buffer = serializer->serializeColumnarBatches({batch});
 
   ArrowSchema cSchema;
   exportToArrow(vector, cSchema);
-  auto deserializer = std::make_shared<VeloxColumnarBatchSerializer>(arrowPool_, veloxPool_, &cSchema);
+  auto deserializer = std::make_shared<VeloxColumnarBatchSerializer>(arrowPool_.get(), veloxPool_, &cSchema);
   auto deserialized = deserializer->deserialize(const_cast<uint8_t*>(buffer->data()), buffer->size());
   auto deserializedVector = std::dynamic_pointer_cast<VeloxColumnarBatch>(deserialized)->getRowVector();
   test::assertEqualVectors(vector, deserializedVector);

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -72,7 +72,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
 
     shuffleWriterOptions_ = ShuffleWriterOptions::defaults();
     shuffleWriterOptions_.buffer_compress_threshold = 0;
-    shuffleWriterOptions_.memory_pool = arrowPool_;
+    shuffleWriterOptions_.memory_pool = arrowPool_.get();
 
     ShuffleTestParams params = GetParam();
     shuffleWriterOptions_.prefer_evict = params.prefer_evict;
@@ -172,7 +172,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
     ReaderOptions options;
     options.compression_type = shuffleWriterOptions_.compression_type;
     options.compression_mode = shuffleWriterOptions_.compression_mode;
-    auto reader = std::make_shared<VeloxShuffleReader>(schema, options, arrowPool_, pool_);
+    auto reader = std::make_shared<VeloxShuffleReader>(schema, options, arrowPool_.get(), pool_);
     auto iter = reader->readStream(file_);
     while (iter->hasNext()) {
       auto vector = std::dynamic_pointer_cast<VeloxColumnarBatch>(iter->next())->getRowVector();
@@ -572,7 +572,7 @@ TEST_P(VeloxShuffleWriterTest, memoryLeak) {
 
   int32_t numPartitions = 2;
   shuffleWriterOptions_.buffer_size = 4;
-  shuffleWriterOptions_.memory_pool = pool;
+  shuffleWriterOptions_.memory_pool = pool.get();
   shuffleWriterOptions_.partitioning_name = "rr";
 
   ARROW_ASSIGN_OR_THROW(
@@ -594,7 +594,7 @@ TEST_P(VeloxShuffleWriterTest, spillFailWithOutOfMemory) {
 
   int32_t numPartitions = 2;
   shuffleWriterOptions_.buffer_size = 4;
-  shuffleWriterOptions_.memory_pool = pool;
+  shuffleWriterOptions_.memory_pool = pool.get();
   shuffleWriterOptions_.partitioning_name = "rr";
   ARROW_ASSIGN_OR_THROW(
       shuffleWriter_, VeloxShuffleWriter::create(numPartitions, partitionWriterCreator_, shuffleWriterOptions_, pool_));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix exist TODO, caller was not expected to care memory pool's ownership, just get raw pointer for use, like Arrow style.