### PR TITLE
[GLUTEN-3154][CORE] Override doCanonicalize in scan operators

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -287,6 +287,21 @@ class FileSourceScanExecTransformer(
       case "CSVFileFormat" => ReadFileFormat.TextReadFormat
       case _ => ReadFileFormat.UnknownFormat
     }
+
+  override def doCanonicalize(): FileSourceScanExecTransformer = {
+    val canonicalized = super.doCanonicalize()
+    new FileSourceScanExecTransformer(
+      canonicalized.relation,
+      canonicalized.output,
+      canonicalized.requiredSchema,
+      canonicalized.partitionFilters,
+      canonicalized.optionalBucketSet,
+      canonicalized.optionalNumCoalescedBuckets,
+      canonicalized.dataFilters,
+      canonicalized.tableIdentifier,
+      canonicalized.disableBucketedScan
+    )
+  }
 }
 
 object FileSourceScanExecTransformer {

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -219,6 +219,14 @@ class HiveTableScanExecTransformer(
   }
 
   override def hashCode(): Int = super.hashCode()
+
+  override def doCanonicalize(): HiveTableScanExecTransformer = {
+    val canonicalized = super.doCanonicalize()
+    new HiveTableScanExecTransformer(
+      canonicalized.requestedAttributes,
+      canonicalized.relation,
+      canonicalized.partitionPruningPred)(canonicalized.session)
+  }
 }
 
 object HiveTableScanExecTransformer {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix https://github.com/oap-project/gluten/issues/3154

Spark will try to get reused queryStage based on plan.canonicalized.
https://github.com/apache/spark/blob/822f58f0d26b7d760469151a65eaf9ee863a07a1/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala#L523-L523

## How was this patch tested?

<img width="874" alt="image" src="https://github.com/oap-project/gluten/assets/13622031/211dd966-353b-4f83-a54e-ca1ceb0b1446">
<img width="843" alt="image" src="https://github.com/oap-project/gluten/assets/13622031/d4afea04-f031-4886-9932-34b02c2ab3f4">


