### PR TITLE
[GLUTEN-3077][VL] followup: add jniCastOrThrow method and codes clean up

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -308,6 +308,26 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   env->DeleteGlobalRef(shuffleReaderMetricsClass);
 }
 
+JNIEXPORT jlong JNICALL Java_io_glutenproject_init_BackendJniWrapper_createExecutionCtx( // NOLINT
+    JNIEnv* env,
+    jclass) {
+  JNI_METHOD_START
+  auto executionCtx = gluten::createExecutionCtx();
+  return reinterpret_cast<jlong>(executionCtx);
+  JNI_METHOD_END(kInvalidResourceHandle)
+}
+
+JNIEXPORT void JNICALL Java_io_glutenproject_init_BackendJniWrapper_releaseExecutionCtx( // NOLINT
+    JNIEnv* env,
+    jclass,
+    jlong ctxHandle) {
+  JNI_METHOD_START
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+
+  gluten::releaseExecutionCtx(executionCtx);
+  JNI_METHOD_END()
+}
+
 JNIEXPORT jlong JNICALL
 Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithIterator( // NOLINT
     JNIEnv* env,

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -40,6 +40,10 @@
 
 using namespace gluten;
 
+#define GLUTEN_JNI_CAST(name, addr, clazz)    \
+  auto name = reinterpret_cast<clazz*>(addr); \
+  GLUTEN_CHECK(name != nullptr, #clazz " should not be null.");
+
 static jclass serializableObjBuilderClass;
 
 static jclass javaReservationListenerClass;
@@ -319,10 +323,9 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
     jstring spillDir,
     jbyteArray confArr) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   auto spillDirStr = jStringToCString(env, spillDir);
 
@@ -364,8 +367,7 @@ JNIEXPORT jboolean JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIter
     jlong ctxHandle,
     jlong iterHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto iter = executionCtx->getResultIterator(iterHandle);
   if (iter == nullptr) {
@@ -382,8 +384,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterato
     jlong ctxHandle,
     jlong iterHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto iter = executionCtx->getResultIterator(iterHandle);
   if (!iter->hasNext()) {
@@ -404,8 +405,7 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutItera
     jlong ctxHandle,
     jlong iterHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto iter = executionCtx->getResultIterator(iterHandle);
   std::shared_ptr<Metrics> metrics = iter->getMetrics();
@@ -507,8 +507,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterato
     jlong iterHandle,
     jlong size) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto it = executionCtx->getResultIterator(iterHandle);
   return it->spillFixedSize(size);
@@ -521,8 +520,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutIterator
     jlong ctxHandle,
     jlong iterHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   executionCtx->releaseResultIterator(iterHandle);
   JNI_METHOD_END()
@@ -535,10 +533,8 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToR
     jlong ctxHandle,
     jlong memoryManagerHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   // Convert the native batch to Spark unsafe row.
   return executionCtx->createColumnar2RowConverter(memoryManager);
@@ -553,8 +549,7 @@ Java_io_glutenproject_vectorized_NativeColumnarToRowJniWrapper_nativeColumnarToR
     jlong batchHandle,
     jlong c2rHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
   auto columnarToRowConverter = executionCtx->getColumnar2RowConverter(c2rHandle);
   auto cb = executionCtx->getBatch(batchHandle);
   columnarToRowConverter->convert(cb);
@@ -584,8 +579,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_NativeColumnarToRowJniWr
     jlong ctxHandle,
     jlong c2rHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   executionCtx->releaseColumnar2RowConverter(c2rHandle);
   JNI_METHOD_END()
@@ -598,10 +592,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_NativeRowToColumnarJniW
     jlong ctxHandle,
     jlong memoryManagerHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   return executionCtx->createRow2ColumnarConverter(memoryManager, reinterpret_cast<struct ArrowSchema*>(cSchema));
   JNI_METHOD_END(kInvalidResourceHandle)
@@ -616,8 +608,7 @@ Java_io_glutenproject_vectorized_NativeRowToColumnarJniWrapper_nativeConvertRowT
     jlongArray rowLength,
     jlong memoryAddress) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   if (rowLength == nullptr) {
     throw gluten::GlutenException("Native convert row to columnar: buf_addrs can't be null");
@@ -639,8 +630,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_NativeRowToColumnarJniWr
     jlong ctxHandle,
     jlong r2cHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   executionCtx->releaseRow2ColumnarConverter(r2cHandle);
   JNI_METHOD_END()
@@ -652,8 +642,7 @@ JNIEXPORT jstring JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWr
     jlong ctxHandle,
     jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto batch = executionCtx->getBatch(batchHandle);
   return env->NewStringUTF(batch->getType().c_str());
@@ -667,8 +656,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
     jlong batchHandle) { // NOLINT
   JNI_METHOD_START
 
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto batch = executionCtx->getBatch(batchHandle);
   return batch->numBytes();
@@ -681,8 +669,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
     jlong ctxHandle,
     jlong batchHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto batch = executionCtx->getBatch(batchHandle);
   return batch->numColumns();
@@ -695,8 +682,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
     jlong ctxHandle,
     jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto batch = executionCtx->getBatch(batchHandle);
   return batch->numRows();
@@ -709,8 +695,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
     jlong ctxHandle,
     jlongArray handles) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   int handleCount = env->GetArrayLength(handles);
   jlong* handleArray = env->GetLongArrayElements(handles, nullptr);
@@ -735,8 +720,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapp
     jlong cSchema,
     jlong cArray) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto batch = executionCtx->getBatch(batchHandle);
   std::shared_ptr<ArrowSchema> exportedSchema = batch->exportArrowSchema();
@@ -753,8 +737,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
     jlong cSchema,
     jlong cArray) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   std::unique_ptr<ArrowSchema> targetSchema = std::make_unique<ArrowSchema>();
   std::unique_ptr<ArrowArray> targetArray = std::make_unique<ArrowArray>();
@@ -774,8 +757,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapp
     jlong ctxHandle,
     jlong batchHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   executionCtx->releaseBatch(batchHandle);
   JNI_METHOD_END()
@@ -806,10 +788,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jobject partitionPusher,
     jstring partitionWriterTypeJstr) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
   if (partitioningNameJstr == nullptr) {
     throw gluten::GlutenException(std::string("Short partitioning name can't be null"));
     return kInvalidResourceHandle;
@@ -913,8 +893,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jlong size,
     jboolean callBySelf) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto shuffleWriter = executionCtx->getShuffleWriter(shuffleWriterHandle);
   if (!shuffleWriter) {
@@ -936,8 +915,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jint numRows,
     jlong batchHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto shuffleWriter = executionCtx->getShuffleWriter(shuffleWriterHandle);
   if (!shuffleWriter) {
@@ -959,8 +937,7 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapp
     jlong ctxHandle,
     jlong shuffleWriterHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto shuffleWriter = executionCtx->getShuffleWriter(shuffleWriterHandle);
   if (!shuffleWriter) {
@@ -1003,8 +980,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper_
     jlong ctxHandle,
     jlong shuffleWriterHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   executionCtx->releaseShuffleWriter(shuffleWriterHandle);
   JNI_METHOD_END()
@@ -1033,10 +1009,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
     jstring compressionBackend,
     jstring compressionMode) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   auto pool = memoryManager->getArrowMemoryPool();
   ReaderOptions options = ReaderOptions::defaults();
@@ -1061,8 +1035,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
     jlong shuffleReaderHandle,
     jobject jniIn) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   std::shared_ptr<arrow::io::InputStream> in = std::make_shared<JavaInputStreamAdaptor>(env, reader->getPool(), jniIn);
@@ -1078,8 +1051,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_
     jlong shuffleReaderHandle,
     jobject metrics) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   env->CallVoidMethod(metrics, shuffleReaderMetricsSetDecompressTime, reader->getDecompressTime());
@@ -1093,8 +1065,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_
     jlong ctxHandle,
     jlong shuffleReaderHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   GLUTEN_THROW_NOT_OK(reader->close());
@@ -1112,10 +1083,8 @@ Java_io_glutenproject_spark_sql_execution_datasources_velox_DatasourceJniWrapper
     jlong memoryManagerHandle,
     jbyteArray options) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   ResourceHandle handle = kInvalidResourceHandle;
 
@@ -1144,8 +1113,7 @@ Java_io_glutenproject_spark_sql_execution_datasources_velox_DatasourceJniWrapper
     jlong dsHandle,
     jlong cSchema) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto datasource = executionCtx->getDatasource(dsHandle);
   datasource->inspectSchema(reinterpret_cast<struct ArrowSchema*>(cSchema));
@@ -1158,8 +1126,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_vel
     jlong ctxHandle,
     jlong dsHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto datasource = executionCtx->getDatasource(dsHandle);
   datasource->close();
@@ -1174,8 +1141,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_spark_sql_execution_datasources_vel
     jlong dsHandle,
     jobject iter) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto datasource = executionCtx->getDatasource(dsHandle);
 
@@ -1270,7 +1236,8 @@ JNIEXPORT jbyteArray JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManage
     jclass,
     jlong memoryManagerHandle) {
   JNI_METHOD_START
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
+
   const MemoryUsageStats& stats = memoryManager->collectMemoryUsageStats();
   auto size = stats.ByteSizeLong();
   jbyteArray out = env->NewByteArray(size);
@@ -1289,7 +1256,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_shr
     jlong memoryManagerHandle,
     jlong size) {
   JNI_METHOD_START
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
   return memoryManager->shrink(static_cast<int64_t>(size));
   JNI_METHOD_END(kInvalidResourceHandle)
 }
@@ -1299,7 +1266,8 @@ JNIEXPORT void JNICALL Java_io_glutenproject_memory_nmm_NativeMemoryManager_rele
     jclass,
     jlong memoryManagerHandle) {
   JNI_METHOD_START
-  delete reinterpret_cast<MemoryManager*>(memoryManagerHandle);
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
+  delete memoryManager;
   JNI_METHOD_END()
 }
 
@@ -1310,10 +1278,8 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializ
     jlongArray handles,
     jlong memoryManagerHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_CHECK(memoryManager != nullptr, "MemoryManager should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   int32_t numBatches = env->GetArrayLength(handles);
   jlong* batchHandles = env->GetLongArrayElements(handles, nullptr);
@@ -1348,10 +1314,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializer
     jlong ctxHandle,
     jlong memoryManagerHandle) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-  MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerHandle);
-  GLUTEN_DCHECK(memoryManager != nullptr, "Memory manager does not exist or has been closed");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
+  GLUTEN_JNI_CAST(memoryManager, memoryManagerHandle, MemoryManager)
 
   auto arrowPool = memoryManager->getArrowMemoryPool();
   return executionCtx->createColumnarBatchSerializer(
@@ -1366,8 +1330,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializer
     jlong serializerHandle,
     jbyteArray data) {
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   auto serializer = executionCtx->getColumnarBatchSerializer(serializerHandle);
   GLUTEN_DCHECK(serializer != nullptr, "ColumnarBatchSerializer cannot be null");
@@ -1385,8 +1348,7 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializerJ
     jlong ctxHandle,
     jlong serializerHandle) { // NOLINT
   JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
+  GLUTEN_JNI_CAST(executionCtx, ctxHandle, ExecutionCtx)
 
   executionCtx->releaseColumnarBatchSerializer(serializerHandle);
   JNI_METHOD_END()

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -82,27 +82,6 @@ JNIEXPORT void JNICALL Java_io_glutenproject_init_BackendJniWrapper_initializeBa
   JNI_METHOD_END()
 }
 
-JNIEXPORT jlong JNICALL Java_io_glutenproject_init_BackendJniWrapper_createExecutionCtx( // NOLINT
-    JNIEnv* env,
-    jclass) {
-  JNI_METHOD_START
-  auto executionCtx = gluten::createExecutionCtx();
-  return reinterpret_cast<jlong>(executionCtx);
-  JNI_METHOD_END(-1)
-}
-
-JNIEXPORT void JNICALL Java_io_glutenproject_init_BackendJniWrapper_releaseExecutionCtx( // NOLINT
-    JNIEnv* env,
-    jclass,
-    jlong ctxHandle) {
-  JNI_METHOD_START
-  auto executionCtx = reinterpret_cast<gluten::ExecutionCtx*>(ctxHandle);
-  GLUTEN_CHECK(executionCtx != nullptr, "ExecutionCtx should not be null.");
-
-  gluten::releaseExecutionCtx(executionCtx);
-  JNI_METHOD_END()
-}
-
 JNIEXPORT void JNICALL Java_io_glutenproject_udf_UdfJniWrapper_nativeLoadUdfLibraries( // NOLINT
     JNIEnv* env,
     jclass,


### PR DESCRIPTION
Summary:
1. add `jniCastOrThrow` method to wrap reinterpret_cast and reduce duplicate codes.
2. move `create/releaseExecutionCtx` from VeloxJniWrapper.cc to JniWrapper.cc, `initializeBackend` will be refactored in spilt JniWrapper patch.