### PR TITLE
[VL] Refactor split buffer allocation

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -279,7 +279,7 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> generateComplexTypeBuffers(facebook::velox::RowVectorPtr vector);
 
-  arrow::Status resetValidityBuffer(uint32_t buffers);
+  arrow::Status resetValidityBuffer(uint32_t partitionId);
 
   arrow::Result<int64_t> shrinkPartitionBuffersMinSize(int64_t size);
 


### PR DESCRIPTION
Extract the duplicated logic in both `resizePartitionBuffer` and `allocatePartitionBuffer`.
In prealloc partition buffer, use `resizePartitionBuffer` instead of `allocatePartitionBuffer` if need to preserve buffer data for the next split, and remove the resize branch in `allocate PartitionBuffer`.