### PR TITLE
[VL] Suppress a compilation warning from CompressionBenchmark.cc

### DIFF
--- a/cpp/core/benchmarks/CompressionBenchmark.cc
+++ b/cpp/core/benchmarks/CompressionBenchmark.cc
@@ -304,6 +304,7 @@ class BenchmarkCompression {
           GLUTEN_ASSIGN_OR_THROW(
               auto len,
               codec->Decompress(buffers[j]->size() - 8, buffers[j]->data() + 8, outputSize, out->mutable_data()));
+          (void)len;
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

very little change, just fix a compilation warning.

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

