### PR TITLE
[GLUTEN-3077][VL] Use ResourceMap to replace ConcurrentMap in VeloxExecutionCtx

### DIFF
--- a/cpp/core/compute/ExecutionCtx.h
+++ b/cpp/core/compute/ExecutionCtx.h
@@ -29,9 +29,11 @@
 #include "shuffle/ShuffleReader.h"
 #include "shuffle/ShuffleWriter.h"
 #include "substrait/plan.pb.h"
-#include "utils/ConcurrentMap.h"
 
 namespace gluten {
+
+using ResourceHandle = int64_t;
+constexpr static ResourceHandle kInvalidResourceHandle = -1;
 
 class ResultIterator;
 

--- a/cpp/core/tests/CMakeLists.txt
+++ b/cpp/core/tests/CMakeLists.txt
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_test_case(execution_ctx_test SOURCES ExecutionCtxTest.cc)
 
 if(ENABLE_HBM)
   add_test_case(hbw_allocator_test SOURCES HbwAllocatorTest.cc)

--- a/cpp/velox/compute/VeloxExecutionCtx.cc
+++ b/cpp/velox/compute/VeloxExecutionCtx.cc
@@ -100,17 +100,17 @@ ResourceHandle VeloxExecutionCtx::createResultIterator(
     auto wholestageIter = std::make_unique<WholeStageResultIteratorMiddleStage>(
         veloxPool, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
     auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
-    return resultIteratorHolder_.insert(resultIter);
+    return resultIteratorHolder_.insert(std::move(resultIter));
   } else {
     auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
         veloxPool, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
     auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
-    return resultIteratorHolder_.insert(resultIter);
+    return resultIteratorHolder_.insert(std::move(resultIter));
   }
 }
 
 ResourceHandle VeloxExecutionCtx::addResultIterator(std::shared_ptr<ResultIterator> iterator) {
-  return resultIteratorHolder_.insert(iterator);
+  return resultIteratorHolder_.insert(std::move(iterator));
 }
 
 std::shared_ptr<ResultIterator> VeloxExecutionCtx::getResultIterator(ResourceHandle iterHandle) {
@@ -128,8 +128,7 @@ void VeloxExecutionCtx::releaseResultIterator(ResourceHandle iterHandle) {
 
 ResourceHandle VeloxExecutionCtx::createColumnar2RowConverter(MemoryManager* memoryManager) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
-  auto converter = std::make_shared<VeloxColumnarToRowConverter>(ctxVeloxPool);
-  return columnarToRowConverterHolder_.insert(converter);
+  return columnarToRowConverterHolder_.insert(std::make_shared<VeloxColumnarToRowConverter>(ctxVeloxPool));
 }
 
 std::shared_ptr<ColumnarToRowConverter> VeloxExecutionCtx::getColumnar2RowConverter(ResourceHandle handle) {
@@ -141,7 +140,7 @@ void VeloxExecutionCtx::releaseColumnar2RowConverter(ResourceHandle handle) {
 }
 
 ResourceHandle VeloxExecutionCtx::addBatch(std::shared_ptr<ColumnarBatch> batch) {
-  return columnarBatchHolder_.insert(batch);
+  return columnarBatchHolder_.insert(std::move(batch));
 }
 
 std::shared_ptr<ColumnarBatch> VeloxExecutionCtx::getBatch(ResourceHandle handle) {
@@ -156,8 +155,7 @@ ResourceHandle VeloxExecutionCtx::createRow2ColumnarConverter(
     MemoryManager* memoryManager,
     struct ArrowSchema* cSchema) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
-  auto converter = std::make_shared<VeloxRowToColumnarConverter>(cSchema, ctxVeloxPool);
-  return rowToColumnarConverterHolder_.insert(converter);
+  return rowToColumnarConverterHolder_.insert(std::make_shared<VeloxRowToColumnarConverter>(cSchema, ctxVeloxPool));
 }
 
 std::shared_ptr<RowToColumnarConverter> VeloxExecutionCtx::getRow2ColumnarConverter(ResourceHandle handle) {
@@ -177,7 +175,7 @@ ResourceHandle VeloxExecutionCtx::createShuffleWriter(
   GLUTEN_ASSIGN_OR_THROW(
       auto shuffle_writer,
       VeloxShuffleWriter::create(numPartitions, std::move(partitionWriterCreator), std::move(options), ctxPool));
-  return shuffleWriterHolder_.insert(shuffle_writer);
+  return shuffleWriterHolder_.insert(std::move(shuffle_writer));
 }
 
 std::shared_ptr<ShuffleWriter> VeloxExecutionCtx::getShuffleWriter(ResourceHandle handle) {
@@ -193,8 +191,7 @@ ResourceHandle VeloxExecutionCtx::createDatasource(
     MemoryManager* memoryManager,
     std::shared_ptr<arrow::Schema> schema) {
   auto veloxPool = getAggregateVeloxPool(memoryManager);
-  auto datasource = std::make_shared<VeloxParquetDatasource>(filePath, veloxPool, schema);
-  return datasourceHolder_.insert(datasource);
+  return datasourceHolder_.insert(std::make_shared<VeloxParquetDatasource>(filePath, veloxPool, schema));
 }
 
 std::shared_ptr<Datasource> VeloxExecutionCtx::getDatasource(ResourceHandle handle) {
@@ -211,8 +208,7 @@ ResourceHandle VeloxExecutionCtx::createShuffleReader(
     std::shared_ptr<arrow::MemoryPool> pool,
     MemoryManager* memoryManager) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
-  auto shuffleReader = std::make_shared<VeloxShuffleReader>(schema, options, pool, ctxVeloxPool);
-  return shuffleReaderHolder_.insert(shuffleReader);
+  return shuffleReaderHolder_.insert(std::make_shared<VeloxShuffleReader>(schema, options, pool, ctxVeloxPool));
 }
 
 std::shared_ptr<ShuffleReader> VeloxExecutionCtx::getShuffleReader(ResourceHandle handle) {
@@ -236,8 +232,8 @@ ResourceHandle VeloxExecutionCtx::createColumnarBatchSerializer(
     std::shared_ptr<arrow::MemoryPool> arrowPool,
     struct ArrowSchema* cSchema) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
-  auto serializer = std::make_shared<VeloxColumnarBatchSerializer>(arrowPool, ctxVeloxPool, cSchema);
-  return columnarBatchSerializerHolder_.insert(serializer);
+  return columnarBatchSerializerHolder_.insert(
+      std::make_shared<VeloxColumnarBatchSerializer>(arrowPool, ctxVeloxPool, cSchema));
 }
 
 std::shared_ptr<ColumnarBatchSerializer> VeloxExecutionCtx::getColumnarBatchSerializer(ResourceHandle handle) {

--- a/cpp/velox/compute/VeloxExecutionCtx.h
+++ b/cpp/velox/compute/VeloxExecutionCtx.h
@@ -26,6 +26,7 @@
 #include "shuffle/ShuffleReader.h"
 #include "shuffle/ShuffleWriter.h"
 #include "shuffle/VeloxShuffleReader.h"
+#include "utils/ResourceMap.h"
 
 namespace gluten {
 
@@ -129,14 +130,14 @@ class VeloxExecutionCtx final : public ExecutionCtx {
       std::vector<facebook::velox::core::PlanNodeId>& streamIds);
 
  private:
-  ConcurrentMap<std::shared_ptr<ColumnarBatch>> columnarBatchHolder_;
-  ConcurrentMap<std::shared_ptr<Datasource>> datasourceHolder_;
-  ConcurrentMap<std::shared_ptr<ColumnarToRowConverter>> columnarToRowConverterHolder_;
-  ConcurrentMap<std::shared_ptr<ShuffleReader>> shuffleReaderHolder_;
-  ConcurrentMap<std::shared_ptr<ShuffleWriter>> shuffleWriterHolder_;
-  ConcurrentMap<std::shared_ptr<ColumnarBatchSerializer>> columnarBatchSerializerHolder_;
-  ConcurrentMap<std::shared_ptr<RowToColumnarConverter>> rowToColumnarConverterHolder_;
-  ConcurrentMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
+  ResourceMap<std::shared_ptr<ColumnarBatch>> columnarBatchHolder_;
+  ResourceMap<std::shared_ptr<Datasource>> datasourceHolder_;
+  ResourceMap<std::shared_ptr<ColumnarToRowConverter>> columnarToRowConverterHolder_;
+  ResourceMap<std::shared_ptr<ShuffleReader>> shuffleReaderHolder_;
+  ResourceMap<std::shared_ptr<ShuffleWriter>> shuffleWriterHolder_;
+  ResourceMap<std::shared_ptr<ColumnarBatchSerializer>> columnarBatchSerializerHolder_;
+  ResourceMap<std::shared_ptr<RowToColumnarConverter>> rowToColumnarConverterHolder_;
+  ResourceMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
 
   std::vector<std::shared_ptr<ResultIterator>> inputIters_;
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -54,3 +54,4 @@ add_velox_test(
   JsonToProtoConverter.cc
   FilePathGenerator.cc)
 add_velox_test(spark_functions_test SOURCES SparkFunctionTest.cc)
+add_velox_test(execution_ctx_test SOURCES ExecutionCtxTest.cc)

--- a/cpp/velox/tests/ExecutionCtxTest.cc
+++ b/cpp/velox/tests/ExecutionCtxTest.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "compute/ExecutionCtx.h"
+#include "compute/VeloxExecutionCtx.h"
 
 #include <gtest/gtest.h>
 
@@ -119,7 +119,7 @@ class DummyExecutionCtx final : public ExecutionCtx {
   void releaseColumnarBatchSerializer(ResourceHandle handle) override {}
 
  private:
-  ConcurrentMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
+  ResourceMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
 
   class DummyResultIterator : public ColumnarBatchIterator {
    public:

--- a/cpp/velox/utils/ResourceMap.h
+++ b/cpp/velox/utils/ResourceMap.h
@@ -17,39 +17,31 @@
 
 #pragma once
 
-#include <memory>
-#include <mutex>
-#include <unordered_map>
-#include <utility>
+#include "folly/container/F14Map.h"
 
 namespace gluten {
 
-using ResourceHandle = int64_t;
-constexpr static ResourceHandle kInvalidResourceHandle = -1;
-
 /**
- * An utility class that map module id to module pointers.
- * @tparam Holder class of the object to hold.
+ * An utility class that map resource handle to its shared pointers.
+ * Not thread-safe.
+ * @tparam TResource class of the object to hold.
  */
-template <typename Holder>
-class ConcurrentMap {
+template <typename TResource>
+class ResourceMap {
  public:
-  ConcurrentMap() : moduleId_(kInitModuleId) {}
+  ResourceMap() : resourceId_(kInitResourceId) {}
 
-  ResourceHandle insert(Holder holder) {
-    std::lock_guard<std::mutex> lock(mtx_);
-    ResourceHandle result = moduleId_++;
-    map_.insert(std::pair<ResourceHandle, Holder>(result, holder));
+  ResourceHandle insert(TResource holder) {
+    ResourceHandle result = resourceId_++;
+    map_.insert(std::pair<ResourceHandle, TResource>(result, holder));
     return result;
   }
 
   void erase(ResourceHandle moduleId) {
-    std::lock_guard<std::mutex> lock(mtx_);
     map_.erase(moduleId);
   }
 
-  Holder lookup(ResourceHandle moduleId) {
-    std::lock_guard<std::mutex> lock(mtx_);
+  TResource lookup(ResourceHandle moduleId) {
     auto it = map_.find(moduleId);
     if (it != map_.end()) {
       return it->second;
@@ -58,25 +50,22 @@ class ConcurrentMap {
   }
 
   void clear() {
-    std::lock_guard<std::mutex> lock(mtx_);
     map_.clear();
   }
 
   size_t size() {
-    std::lock_guard<std::mutex> lock(mtx_);
     return map_.size();
   }
 
  private:
-  // Initialize the module id starting value to a number greater than zero
+  // Initialize the resource id starting value to a number greater than zero
   // to allow for easier debugging of uninitialized java variables.
-  static constexpr int kInitModuleId = 4;
+  static constexpr int kInitResourceId = 4;
 
-  ResourceHandle moduleId_;
-  std::mutex mtx_;
+  ResourceHandle resourceId_;
 
-  // map from module ids returned to Java and module pointers
-  std::unordered_map<ResourceHandle, Holder> map_;
+  // map from resource ids returned to Java and resource pointers
+  folly::F14FastMap<ResourceHandle, TResource> map_;
 };
 
 } // namespace gluten


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since ExecutionCtx does not expected to use in concurrent context, we can remove Concurrent which has mutex for each methods.

Added ResourceMap is backed by folly::F14FastMap.