### PR TITLE
[GLUTEN-3143][CH] Transform arrayJoin function to array join step to apply max_block_size

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -1285,10 +1285,10 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
 
   test("test posexplode issue: https://github.com/oap-project/gluten/issues/2454") {
     val sqls = Seq(
-      "select explode(array(id, id+1)) from range(10)",
-      "select explode(map(id, id+1, id+2, id+3)) from range(10)",
-      "select posexplode(array(id, id+1)) from range(10)",
-      "select posexplode(map(id, id+1, id+2, id+3)) from range(10)"
+      "select id, explode(array(id, id+1)) from range(10)",
+      "select id, explode(map(id, id+1, id+2, id+3)) from range(10)",
+      "select id, posexplode(array(id, id+1)) from range(10)",
+      "select id, posexplode(map(id, id+1, id+2, id+3)) from range(10)"
     )
 
     for (sql <- sqls) {

--- a/cpp-ch/local-engine/Parser/ProjectRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/ProjectRelParser.cpp
@@ -15,9 +15,13 @@
  * limitations under the License.
  */
 #include "ProjectRelParser.h"
+#include <Interpreters/ArrayJoinAction.h>
 #include <Operator/EmptyProjectStep.h>
+#include <Processors/QueryPlan/ArrayJoinStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Rewriter/ExpressionRewriter.h>
+#include <Common/CHUtil.h>
+
 namespace local_engine
 {
 ProjectRelParser::ProjectRelParser(SerializedPlanParser * plan_paser_) : RelParser(plan_paser_)
@@ -30,7 +34,13 @@ ProjectRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel,
     {
         return parseProject(std::move(query_plan), rel, rel_stack_);
     }
-    return parseGenerate(std::move(query_plan), rel, rel_stack_);
+
+    if (rel.has_generate())
+    {
+        return parseGenerate(std::move(query_plan), rel, rel_stack_);
+    }
+
+    throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "ProjectRelParser can't parse rel:{}", rel.ShortDebugString());
 }
 
 DB::QueryPlanPtr
@@ -65,6 +75,41 @@ ProjectRelParser::parseProject(DB::QueryPlanPtr query_plan, const substrait::Rel
     }
 }
 
+const DB::ActionsDAG::Node * ProjectRelParser::findArrayJoinNode(ActionsDAGPtr actions_dag)
+{
+    const ActionsDAG::Node * array_join_node = nullptr;
+    const auto & nodes = actions_dag->getNodes();
+    for (const auto & node : nodes)
+    {
+        if (node.type == ActionsDAG::ActionType::ARRAY_JOIN)
+        {
+            if (array_join_node)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Expect single ARRAY JOIN node in generate rel");
+            array_join_node = &node;
+        }
+    }
+    return array_join_node;
+}
+
+ProjectRelParser::SplittedActionsDAGs ProjectRelParser::splitActionsDAGInGenerate(ActionsDAGPtr actions_dag)
+{
+    SplittedActionsDAGs res;
+
+    auto array_join_node = findArrayJoinNode(actions_dag);
+    std::unordered_set<const ActionsDAG::Node *> first_split_nodes(array_join_node->children.begin(), array_join_node->children.end());
+    auto first_split_result = actions_dag->split(first_split_nodes);
+    res.before_array_join = first_split_result.first;
+    res.before_array_join->projectInput(true);
+
+    array_join_node = findArrayJoinNode(first_split_result.second);
+    std::unordered_set<const ActionsDAG::Node *> second_split_nodes = {array_join_node};
+    auto second_split_result = first_split_result.second->split(second_split_nodes);
+    res.array_join = second_split_result.first;
+    second_split_result.second->removeUnusedActions();
+    res.after_array_join = second_split_result.second;
+    return res;
+}
+
 DB::QueryPlanPtr
 ProjectRelParser::parseGenerate(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & /*rel_stack_*/)
 {
@@ -77,10 +122,70 @@ ProjectRelParser::parseGenerate(DB::QueryPlanPtr query_plan, const substrait::Re
     expressions.emplace_back(generate_rel.generator());
     auto header = query_plan->getCurrentDataStream().header;
     auto actions_dag = expressionsToActionsDAG(expressions, header);
-    auto expression_step = std::make_unique<ExpressionStep>(query_plan->getCurrentDataStream(), actions_dag);
-    expression_step->setStepDescription("Generate");
-    steps.emplace_back(expression_step.get());
-    query_plan->addStep(std::move(expression_step));
+
+    if (!findArrayJoinNode(actions_dag))
+    {
+        /// If generator in generate rel is not explode/posexplode, e.g. json_tuple
+        auto expression_step = std::make_unique<ExpressionStep>(query_plan->getCurrentDataStream(), actions_dag);
+        expression_step->setStepDescription("Generate");
+        steps.emplace_back(expression_step.get());
+        query_plan->addStep(std::move(expression_step));
+    }
+    else
+    {
+        /// If generator in generate rel is explode/posexplode, transform arrayJoin function to ARRAY JOIN STEP to apply max_block_size
+        /// which avoids OOM when several lateral view explode/posexplode is used in spark sqls
+        LOG_DEBUG(logger, "original actions_dag:{}", actions_dag->dumpDAG());
+        auto splitted_actions_dags = splitActionsDAGInGenerate(actions_dag);
+        LOG_DEBUG(logger, "actions_dag before arrayJoin:{}", splitted_actions_dags.before_array_join->dumpDAG());
+        LOG_DEBUG(logger, "actions_dag during arrayJoin:{}", splitted_actions_dags.array_join->dumpDAG());
+        LOG_DEBUG(logger, "actions_dag after arrayJoin:{}", splitted_actions_dags.after_array_join->dumpDAG());
+
+        auto ignore_actions_dag = [](ActionsDAGPtr actions_dag_) -> bool
+        {
+            /*
+            We should ignore actions_dag like:
+            0 : INPUT () (no column) String a
+            1 : INPUT () (no column) String b
+            Output nodes: 0, 1
+             */
+            return actions_dag_->getOutputs().size() == actions_dag_->getNodes().size()
+                && actions_dag_->getInputs().size() == actions_dag_->getNodes().size();
+        };
+
+        /// Pre-projection before array join
+        const auto & before_array_join = splitted_actions_dags.before_array_join;
+        if (!ignore_actions_dag(before_array_join))
+        {
+            auto step_before_array_join
+                = std::make_unique<ExpressionStep>(query_plan->getCurrentDataStream(), splitted_actions_dags.before_array_join);
+            step_before_array_join->setStepDescription("Pre-projection In Generate");
+            steps.emplace_back(step_before_array_join.get());
+            query_plan->addStep(std::move(step_before_array_join));
+            // LOG_DEBUG(logger, "plan1:{}", PlanUtil::explainPlan(*query_plan));
+        }
+
+        /// ARRAY JOIN
+        NameSet array_joined_columns = {findArrayJoinNode(splitted_actions_dags.array_join)->result_name};
+        auto array_join_action = std::make_shared<ArrayJoinAction>(array_joined_columns, false, getContext());
+        auto array_join_step = std::make_unique<ArrayJoinStep>(query_plan->getCurrentDataStream(), array_join_action);
+        array_join_step->setStepDescription("ARRAY JOIN In Generate");
+        steps.emplace_back(array_join_step.get());
+        query_plan->addStep(std::move(array_join_step));
+        // LOG_DEBUG(logger, "plan2:{}", PlanUtil::explainPlan(*query_plan));
+
+        /// Post-projection after array join(Optional)
+        const auto & after_array_join = splitted_actions_dags.after_array_join;
+        if (!ignore_actions_dag(after_array_join))
+        {
+            auto step_after_array_join = std::make_unique<ExpressionStep>(query_plan->getCurrentDataStream(), after_array_join);
+            step_after_array_join->setStepDescription("Post-projection In Generate");
+            steps.emplace_back(step_after_array_join.get());
+            query_plan->addStep(std::move(step_after_array_join));
+            // LOG_DEBUG(logger, "plan3:{}", PlanUtil::explainPlan(*query_plan));
+        }
+    }
+
     return query_plan;
 }
 

--- a/cpp-ch/local-engine/Parser/ProjectRelParser.h
+++ b/cpp-ch/local-engine/Parser/ProjectRelParser.h
@@ -26,6 +26,13 @@ namespace local_engine
 class ProjectRelParser : public RelParser
 {
 public:
+    struct SplittedActionsDAGs
+    {
+        ActionsDAGPtr before_array_join; /// Optional
+        ActionsDAGPtr array_join;
+        ActionsDAGPtr after_array_join;  /// Optional
+    };
+
     explicit ProjectRelParser(SerializedPlanParser * plan_paser_);
     ~ProjectRelParser() override = default;
 
@@ -37,6 +44,13 @@ private:
 
     DB::QueryPlanPtr parseProject(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_);
     DB::QueryPlanPtr parseGenerate(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_);
+
+    static const DB::ActionsDAG::Node * findArrayJoinNode(ActionsDAGPtr actions_dag);
+
+    /// Split actions_dag of generate rel into 3 parts: before array join + during array join + after array join
+    static SplittedActionsDAGs splitActionsDAGInGenerate(ActionsDAGPtr actions_dag);
+
+
     const substrait::Rel & getSingleInput(const substrait::Rel & rel) override
     {
         if (rel.has_generate())


### PR DESCRIPTION
## What changes were proposed in this pull request?

Notice that arrayJoin function and array join step are executing in different places. The former is in `ExpressionActions::execute`,  and latter is in `ArrayJoinAction::execute`. `max_block_size` is currently only valid in array join step, so we must transform arrayJoin function to array join step to apply max_block_size.  

Notice: This pr relies on https://github.com/ClickHouse/ClickHouse/pull/54664, but it can be merge firstly. 

(Fixes: \#3143)

