### PR TITLE
[GLUTEN-3189] Fix shuffle spill failure and wrong result

### DIFF
--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -172,6 +172,8 @@ class ShuffleWriter {
       const arrow::RecordBatch& rb,
       bool reuseBuffers) = 0;
 
+  virtual arrow::Status cacheRecordBatch(uint32_t partitionId, const arrow::RecordBatch& rb, bool reuseBuffers) = 0;
+
   virtual arrow::Status stop() = 0;
 
   virtual std::shared_ptr<arrow::Schema> writeSchema();

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1098,7 +1098,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
           binaryBuf.valueCapacity = capacity;
           dstValuePtr = binaryBuf.valuePtr + valueOffset - stringLen;
 
-          std::cout << "Split value buffer resized colIdx" << binaryIdx << std::endl;
+          DLOG(INFO) << "Split value buffer resized. Column index: " << binaryColumnIndices_[binaryIdx] << std::endl;
           VsPrintSplit(" dst_start", dstOffsetBase[x]);
           VsPrintSplit(" dst_end", dstOffsetBase[x + 1]);
           VsPrintSplit(" old size", oldCapacity);
@@ -1776,7 +1776,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
       RETURN_NOT_OK(shrinkPartitionBuffer(pid));
     }
     auto shrunken = beforeShrink - pool_->bytes_allocated();
-    LOG(INFO) << shrunken << " bytes released from shrinking.";
+    DLOG(INFO) << shrunken << " bytes released from shrinking.";
     return shrunken;
   }
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -730,6 +730,7 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv) {
           if (options_.prefer_evict) {
             // if prefer_evict is set, evict current RowVector
             RETURN_NOT_OK(evictPartition(pid));
+            RETURN_NOT_OK(resetValidityBuffers(pid));
           }
           RETURN_NOT_OK(allocatePartitionBuffersWithRetry(pid, newSize, reuseBuffers)); // resize
         } else {
@@ -751,6 +752,7 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv) {
             if (options_.prefer_evict) {
               // if prefer_evict is set, evict current RowVector
               RETURN_NOT_OK(evictPartition(pid));
+              RETURN_NOT_OK(resetValidityBuffers(pid));
             }
             RETURN_NOT_OK(allocatePartitionBuffersWithRetry(pid, newSize, reuseBuffers));
           }
@@ -771,6 +773,7 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv) {
           if (options_.prefer_evict) {
             // if prefer_evict is set, evict current RowVector
             RETURN_NOT_OK(evictPartition(pid));
+            RETURN_NOT_OK(resetValidityBuffers(pid));
           }
           RETURN_NOT_OK(allocatePartitionBuffersWithRetry(pid, newSize));
         } else {
@@ -786,9 +789,9 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv) {
           if (options_.prefer_evict) {
             // if prefer_evict is set, evict current RowVector
             RETURN_NOT_OK(evictPartition(pid));
-          } else {
-            RETURN_NOT_OK(resetValidityBuffers(pid));
           }
+          // Reset validity buffer for reuse.
+          RETURN_NOT_OK(resetValidityBuffers(pid));
         }
       }
     }
@@ -1684,10 +1687,6 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
   // TODO: Move into PartitionWriter
   arrow::Status VeloxShuffleWriter::evictPartition(int32_t partitionId) {
     RETURN_NOT_OK(partitionWriter_->evictPartition(partitionId));
-    // reset validity buffer after evict
-    if (partitionId != -1) {
-      RETURN_NOT_OK(resetValidityBuffers(partitionId));
-    }
     return arrow::Status::OK();
   }
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -138,6 +138,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
       const arrow::RecordBatch& rb,
       bool reuseBuffers) override;
 
+  arrow::Status cacheRecordBatch(uint32_t partitionId, const arrow::RecordBatch& rb, bool reuseBuffers) override;
+
   int64_t rawPartitionBytes() const {
     return std::accumulate(rawPartitionLengths_.begin(), rawPartitionLengths_.end(), 0LL);
   }
@@ -241,8 +243,6 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   arrow::Status allocatePartitionBuffersWithRetry(uint32_t partitionId, uint32_t newSize);
 
   arrow::Status allocatePartitionBuffersWithRetry(uint32_t partitionId, uint32_t newSize, bool reuseBuffers);
-
-  arrow::Status cacheRecordBatch(uint32_t partitionId, const arrow::RecordBatch& rb, bool reuseBuffers);
 
   arrow::Status splitFixedWidthValueBuffer(const facebook::velox::RowVector& rv);
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -294,9 +294,11 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Result<int64_t> shrinkPartitionBuffers();
 
+  arrow::Status resetPartitionBuffer(uint32_t partitionId);
+
   arrow::Status shrinkPartitionBuffer(uint32_t partitionId);
 
-  arrow::Status resizePartitionBuffer(uint32_t pid, int64_t newSize);
+  arrow::Status resizePartitionBuffer(uint32_t partitionId, int64_t newSize);
 
   uint64_t calculateValueBufferSizeForBinaryArray(uint32_t binaryIdx, int64_t newSize);
 

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -771,6 +771,8 @@ TEST_P(VeloxShuffleWriterTest, TestShrinkZeroSizeBuffer) {
   ASSERT_EQ(evicted, payloadSize + bufferSize);
   // All buffers should be released.
   ASSERT_EQ(shuffleWriter_->pool()->bytes_allocated(), 0);
+
+  ASSERT_NOT_OK(shuffleWriter_->stop());
 }
 
 TEST_P(VeloxShuffleWriterTest, SmallBufferSizeNoShrink) {
@@ -787,6 +789,8 @@ TEST_P(VeloxShuffleWriterTest, SmallBufferSizeNoShrink) {
   auto payloadSize = shuffleWriter_->totalCachedPayloadSize();
   ASSERT_NOT_OK(shuffleWriter_->evictFixedSize(payloadSize + bufferSize, &evicted));
   ASSERT_EQ(evicted, 0);
+
+  ASSERT_NOT_OK(shuffleWriter_->stop());
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -228,10 +228,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
         if (i != 0) {
           ASSERT_NOT_OK(file_->Advance(lengths[i - 1]));
         }
-        if (expectedVectors[i].size() != deserializedVectors.size()) {
-          std::cout << i << " " << expectedVectors[i].size() << " " << deserializedVectors.size() << std::endl;
-        }
-        //      ASSERT_EQ(expectedVectors[i].size(), deserializedVectors.size());
+        ASSERT_EQ(expectedVectors[i].size(), deserializedVectors.size());
         for (int32_t j = 0; j < expectedVectors[i].size(); j++) {
           velox::test::assertEqualVectors(expectedVectors[i][j], deserializedVectors[j]);
         }


### PR DESCRIPTION
This patch fixes several cases:
1. If the buffer size after shrink is 0, do not shrink but reset the buffers.
2. If the buffer size before shrink is 0 or no space to shrink, skip shrink.
3. Fix split after spill wrong result.

Added several C++ UT to cover above cases.
