### PR TITLE
[VL] Avoid repetitively calculating fixed-size columns' bytes in calculatePartitionBufferSize

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -300,6 +300,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   uint64_t calculateValueBufferSizeForBinaryArray(uint32_t binaryIdx, int64_t newSize);
 
+  void calculateSimpleColumnBytes();
+
   void stat() const;
 
  protected:
@@ -355,6 +357,9 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   uint64_t totalInputNumRows_ = 0;
   std::vector<uint64_t> binaryArrayTotalSizeBytes_;
+
+  // used for calculating bufferSize, calculate once.
+  uint32_t simpleColumnBytes_ = 0;
 
   std::vector<std::vector<BinaryBuf>> partitionBinaryAddrs_;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

calculating once on init step to avoid repetitive calculating

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

