### PR TITLE
[GLUTEN-2612][VL] Fix updateHdfsTokens double free or corruption

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -367,6 +367,7 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
 
 #ifdef ENABLE_HDFS
 void WholeStageResultIterator::updateHdfsTokens() {
+  std::lock_guard lock{mutex};
   const auto& username = confMap_[kUGIUserName];
   const auto& allTokens = confMap_[kUGITokens];
 

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -25,6 +25,10 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h"
 
+#ifdef ENABLE_HDFS
+#include <mutex>
+#endif
+
 namespace gluten {
 
 class WholeStageResultIterator : public ColumnarBatchIterator {
@@ -71,6 +75,7 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
 
 #ifdef ENABLE_HDFS
   /// Set latest tokens to global HiveConnector
+  inline static std::mutex mutex;
   void updateHdfsTokens();
 #endif
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When multiple Cores execute tasks on an Executor at the same time, the following exception will occur.
```
*** Error in `/usr/jdk64/current/bin/java': double free or corruption (fasttop): 0x000055b1677232d0 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x81329)[0x7f9634f1d329]
/data04/hadoop/yarn/local/usercache/op/appcache/application_1685359810729_0140/gluten-daf0d89c-a915-4270-aaa2-a0dc27e7789f/jni/bb70bf12-76bb-4989-bfb2-5dd76859d4da/gluten-2748809769443381838/libhdfs3.so.1(hdfsSetDefautUserName+0x10d)[0x7f95f62ae99d]
/data04/hadoop/yarn/local/usercache/op/appcache/application_1685359810729_0140/gluten-daf0d89c-a915-4270-aaa2-a0dc27e7789f/jni/bb70bf12-76bb-4989-bfb2-5dd76859d4da/gluten-2748809769443381838/libvelox.so(_ZN6gluten24WholeStageResultIterator16updateHdfsTokensEv+0x65)[0x7f95eecf87c5]
```

(Fixes: \#2612、\#2447、\#2093)

## How was this patch tested?
- centos 7 + gcc 4.8.5
- TPCDS-5T
- --conf spark.executor.cores=4

