### PR TITLE
[VL] Gluten-it: By default use -P spark-3.2

### DIFF
--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -98,6 +98,9 @@
   <profiles>
     <profile>
       <id>spark-3.2</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <spark.version>${spark32.version}</spark.version>
       </properties>
@@ -125,34 +128,6 @@
       <id>spark-3.3</id>
       <properties>
         <spark.version>${spark33.version}</spark.version>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-sql_${scala.binary.version}</artifactId>
-          <version>${spark.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>com.google.protobuf</groupId>
-              <artifactId>protobuf-java</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-sql_${scala.binary.version}</artifactId>
-          <version>${spark.version}</version>
-          <type>test-jar</type>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-3.4</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <spark.version>3.4.0</spark.version>
       </properties>
       <dependencies>
         <dependency>


### PR DESCRIPTION
In #2605 , we by default set -P spark-3.4 for gluten-it to fix the dependent bot alert. However it was more or less a deceit to go around dep bot's code scanning without actually fixing the issue.

Let's use spark-3.2 to avoid mismatching with gluten's main code until we came up with a better fix.