### PR TITLE
[GLUTEN-3241][CORE] Use vanilla ColumnarToRowExec if scan operator falls back

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -701,7 +701,7 @@ case class VanillaColumnarPlanOverrides(session: SparkSession) extends Rule[Spar
   }
 
   private def isVanillaColumnarReader(plan: SparkPlan): Boolean = plan match {
-    case _: BatchScanExec | _: FileSourceScanExec =>
+    case _: BatchScanExec | _: DataSourceScanExec =>
       !plan.isInstanceOf[GlutenPlan] && plan.supportsColumnar
     case _: InMemoryTableScanExec =>
       if (BackendsApiManager.isVeloxBackend && GlutenConfig.getConf.columnarTableCacheEnabled) {


### PR DESCRIPTION
[GLUTEN-3241][CH] Disable conversion of ColumnarToRowExec to CHColumnarToRowExec when operator of SourceScan fallback vilina spark

## What changes were proposed in this pull request?

Disable conversion of ColumnarToRowExec to CHColumnarToRowExec when operator of SourceScan fallback vilina spark


