### PR TITLE
[VL] Add timing for velox shuffle reader

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
@@ -246,6 +246,8 @@ class MetricsHandler extends MetricsApi with Logging {
       "compressTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime to compress"),
       "prepareTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime to prepare"),
       "decompressTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_decompress"),
+      "ipcTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_ipc"),
+      "deserializeTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_deserialize"),
       "avgReadBatchNumRows" -> SQLMetrics
         .createAverageMetric(sparkContext, "avg read batch num rows"),
       "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
@@ -245,9 +245,9 @@ class MetricsHandler extends MetricsApi with Logging {
       "spillTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime to spill"),
       "compressTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime to compress"),
       "prepareTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime to prepare"),
-      "decompressTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_decompress"),
-      "ipcTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_ipc"),
-      "deserializeTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime_deserialize"),
+      "decompressTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime decompress"),
+      "ipcTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime ipc"),
+      "deserializeTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime deserialize"),
       "avgReadBatchNumRows" -> SQLMetrics
         .createAverageMetric(sparkContext, "avg read batch num rows"),
       "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
@@ -331,8 +331,8 @@ class MetricsHandler extends MetricsApi with Logging {
       "prepareTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to prepare left list"),
       "processTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to process"),
       "joinTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to merge join"),
-      "totaltime_sortmergejoin" -> SQLMetrics
-        .createTimingMetric(sparkContext, "totaltime_sortmergejoin")
+      "totaltimeSortmergejoin" -> SQLMetrics
+        .createTimingMetric(sparkContext, "totaltime sortmergejoin")
     )
 
   override def genSortMergeJoinTransformerMetricsUpdater(

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
@@ -261,7 +261,13 @@ class SparkPlanExecHandler extends SparkPlanExecApi {
         clazz.getConstructor(classOf[StructType], classOf[SQLMetric], classOf[SQLMetric])
       constructor.newInstance(schema, readBatchNumRows, numOutputRows).asInstanceOf[Serializer]
     } else {
-      new ColumnarBatchSerializer(schema, readBatchNumRows, numOutputRows, decompressTime, ipcTime, deserializeTime)
+      new ColumnarBatchSerializer(
+        schema,
+        readBatchNumRows,
+        numOutputRows,
+        decompressTime,
+        ipcTime,
+        deserializeTime)
     }
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
@@ -253,13 +253,15 @@ class SparkPlanExecHandler extends SparkPlanExecApi {
     val readBatchNumRows = metrics("avgReadBatchNumRows")
     val numOutputRows = metrics("numOutputRows")
     val decompressTime = metrics("decompressTime")
+    val ipcTime = metrics("ipcTime")
+    val deserializeTime = metrics("deserializeTime")
     if (GlutenConfig.getConf.isUseCelebornShuffleManager) {
       val clazz = ClassUtils.getClass("org.apache.spark.shuffle.CelebornColumnarBatchSerializer")
       val constructor =
         clazz.getConstructor(classOf[StructType], classOf[SQLMetric], classOf[SQLMetric])
       constructor.newInstance(schema, readBatchNumRows, numOutputRows).asInstanceOf[Serializer]
     } else {
-      new ColumnarBatchSerializer(schema, readBatchNumRows, numOutputRows, decompressTime)
+      new ColumnarBatchSerializer(schema, readBatchNumRows, numOutputRows, decompressTime, ipcTime, deserializeTime)
     }
   }
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -76,6 +76,8 @@ static jmethodID veloxColumnarBatchScannerNext;
 
 static jclass shuffleReaderMetricsClass;
 static jmethodID shuffleReaderMetricsSetDecompressTime;
+static jmethodID shuffleReaderMetricsSetIpcTime;
+static jmethodID shuffleReaderMetricsSetDeserializeTime;
 
 class JavaInputStreamAdaptor final : public arrow::io::InputStream {
  public:
@@ -293,6 +295,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       createGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ShuffleReaderMetrics;");
   shuffleReaderMetricsSetDecompressTime =
       getMethodIdOrError(env, shuffleReaderMetricsClass, "setDecompressTime", "(J)V");
+  shuffleReaderMetricsSetIpcTime = getMethodIdOrError(env, shuffleReaderMetricsClass, "setIpcTime", "(J)V");
+  shuffleReaderMetricsSetDeserializeTime =
+      getMethodIdOrError(env, shuffleReaderMetricsClass, "SetDeserializeTime", "(J)V");
 
   return jniVersion;
 }
@@ -1056,10 +1061,8 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_
 
   auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   env->CallVoidMethod(metrics, shuffleReaderMetricsSetDecompressTime, reader->getDecompressTime());
-
-  // TODO zhaokuo
-  // env->CallVoidMethod(metrics, shuffleReaderMetricsSetIpcTime, reader->getIpcTime());
-  // env->CallVoidMethod(metrics, shuffleReaderMetricsSetDeserializeTime, reader->getDeserializeTime());
+  env->CallVoidMethod(metrics, shuffleReaderMetricsSetIpcTime, reader->getIpcTime());
+  env->CallVoidMethod(metrics, shuffleReaderMetricsSetDeserializeTime, reader->getDeserializeTime());
 
   checkException(env);
   JNI_METHOD_END()

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1056,6 +1056,11 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper_
 
   auto reader = executionCtx->getShuffleReader(shuffleReaderHandle);
   env->CallVoidMethod(metrics, shuffleReaderMetricsSetDecompressTime, reader->getDecompressTime());
+
+  // TODO zhaokuo
+  // env->CallVoidMethod(metrics, shuffleReaderMetricsSetIpcTime, reader->getIpcTime());
+  // env->CallVoidMethod(metrics, shuffleReaderMetricsSetDeserializeTime, reader->getDeserializeTime());
+
   checkException(env);
   JNI_METHOD_END()
 }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -297,7 +297,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       getMethodIdOrError(env, shuffleReaderMetricsClass, "setDecompressTime", "(J)V");
   shuffleReaderMetricsSetIpcTime = getMethodIdOrError(env, shuffleReaderMetricsClass, "setIpcTime", "(J)V");
   shuffleReaderMetricsSetDeserializeTime =
-      getMethodIdOrError(env, shuffleReaderMetricsClass, "SetDeserializeTime", "(J)V");
+      getMethodIdOrError(env, shuffleReaderMetricsClass, "setDeserializeTime", "(J)V");
 
   return jniVersion;
 }

--- a/cpp/core/shuffle/ShuffleReader.cc
+++ b/cpp/core/shuffle/ShuffleReader.cc
@@ -30,10 +30,11 @@ using namespace gluten;
 class ShuffleReaderOutStream : public ColumnarBatchIterator {
  public:
   ShuffleReaderOutStream(
+      const ReaderOptions& options,
       const std::shared_ptr<arrow::Schema>& schema,
       const std::shared_ptr<arrow::io::InputStream>& in,
-      const ReaderOptions& options)
-      : options_(options), in_(in) {
+      const std::function<void(int64_t&)> ipcTimeAccumulator)
+      : options_(options), in_(in), ipcTimeAccumulator_(ipcTimeAccumulator) {
     if (options.compression_type != arrow::Compression::UNCOMPRESSED) {
       writeSchema_ = toCompressWriteSchema(*schema);
     } else {
@@ -44,6 +45,10 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
   std::shared_ptr<ColumnarBatch> next() override {
     std::shared_ptr<arrow::RecordBatch> arrowBatch;
     std::unique_ptr<arrow::ipc::Message> messageToRead;
+
+    int64_t ipcTime = 0;
+    TIME_NANO_START(ipcTime);
+
     GLUTEN_ASSIGN_OR_THROW(messageToRead, arrow::ipc::ReadMessage(in_.get()))
     if (messageToRead == nullptr) {
       return nullptr;
@@ -51,6 +56,10 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
 
     GLUTEN_ASSIGN_OR_THROW(
         arrowBatch, arrow::ipc::ReadRecordBatch(*messageToRead, writeSchema_, nullptr, options_.ipc_read_options))
+
+    TIME_NANO_END(ipcTime);
+    ipcTimeAccumulator_(ipcTime);
+
     std::shared_ptr<ColumnarBatch> glutenBatch = std::make_shared<ArrowColumnarBatch>(arrowBatch);
     return glutenBatch;
   }
@@ -58,6 +67,7 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
  private:
   ReaderOptions options_;
   std::shared_ptr<arrow::io::InputStream> in_;
+  std::function<void(int64_t&)> ipcTimeAccumulator_;
   std::shared_ptr<arrow::Schema> writeSchema_;
 };
 } // namespace
@@ -75,16 +85,14 @@ ShuffleReader::ShuffleReader(
     : pool_(pool), options_(std::move(options)), schema_(schema) {}
 
 std::shared_ptr<ResultIterator> ShuffleReader::readStream(std::shared_ptr<arrow::io::InputStream> in) {
-  return std::make_shared<ResultIterator>(std::make_unique<ShuffleReaderOutStream>(schema_, in, options_));
+  return std::make_shared<ResultIterator>(std::make_unique<ShuffleReaderOutStream>(
+      options_, schema_, in, [this](int64_t ipcTime) { this->ipcTime_ += ipcTime; }));
 }
 
 arrow::Status ShuffleReader::close() {
   return arrow::Status::OK();
 }
 
-int64_t ShuffleReader::getDecompressTime() {
-  return decompressTime_;
-}
 const std::shared_ptr<arrow::MemoryPool>& ShuffleReader::getPool() const {
   return pool_;
 }

--- a/cpp/core/shuffle/ShuffleReader.cc
+++ b/cpp/core/shuffle/ShuffleReader.cc
@@ -33,7 +33,7 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
       const ReaderOptions& options,
       const std::shared_ptr<arrow::Schema>& schema,
       const std::shared_ptr<arrow::io::InputStream>& in,
-      const std::function<void(int64_t&)> ipcTimeAccumulator)
+      const std::function<void(int64_t)> ipcTimeAccumulator)
       : options_(options), in_(in), ipcTimeAccumulator_(ipcTimeAccumulator) {
     if (options.compression_type != arrow::Compression::UNCOMPRESSED) {
       writeSchema_ = toCompressWriteSchema(*schema);
@@ -67,7 +67,7 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
  private:
   ReaderOptions options_;
   std::shared_ptr<arrow::io::InputStream> in_;
-  std::function<void(int64_t&)> ipcTimeAccumulator_;
+  std::function<void(int64_t)> ipcTimeAccumulator_;
   std::shared_ptr<arrow::Schema> writeSchema_;
 };
 } // namespace

--- a/cpp/core/shuffle/ShuffleReader.h
+++ b/cpp/core/shuffle/ShuffleReader.h
@@ -46,12 +46,28 @@ class ShuffleReader {
   virtual std::shared_ptr<ResultIterator> readStream(std::shared_ptr<arrow::io::InputStream> in);
 
   arrow::Status close();
-  int64_t getDecompressTime();
+
+  int64_t getDecompressTime() const {
+    return decompressTime_;
+  }
+
+  int64_t getIpcTime() const {
+    return ipcTime_;
+  }
+
+  int64_t getDeserializeTime() const {
+    return deserializeTime_;
+  }
+
   const std::shared_ptr<arrow::MemoryPool>& getPool() const;
 
  protected:
   std::shared_ptr<arrow::MemoryPool> pool_;
+
   int64_t decompressTime_ = 0;
+  int64_t ipcTime_ = 0;
+  int64_t deserializeTime_ = 0;
+
   ReaderOptions options_;
 
  private:

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -22,6 +22,9 @@
 
 #include "operators/functions/RegistrationAllFunctions.h"
 #include "operators/plannodes/RowVectorStream.h"
+
+#include "shuffle/VeloxShuffleReader.h"
+
 #ifdef GLUTEN_ENABLE_QAT
 #include "utils/qat/QatCodec.h"
 #endif
@@ -96,6 +99,9 @@ const std::string kMaxSpillFileSizeDefault = std::to_string(20L * 1024 * 1024);
 // backtrace allocation
 const std::string kBacktraceAllocation = "spark.gluten.backtrace.allocation";
 
+// VeloxShuffleReader print flag.
+const std::string kVeloxShuffleReaderPrintFlag = "spark.gluten.velox.shuffleReaderPrintFlag";
+
 } // namespace
 
 namespace gluten {
@@ -142,6 +148,14 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
     auto got = conf.find(kBacktraceAllocation);
     if (got != conf.end()) {
       gluten::backtrace_allocation = (got->second == "true");
+    }
+  }
+
+  // Set veloxShuffleReaderPrintFlag
+  {
+    auto got = conf.find(kVeloxShuffleReaderPrintFlag);
+    if (got != conf.end()) {
+      gluten::veloxShuffleReaderPrintFlag = (got->second == "true");
     }
   }
 

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -367,14 +367,15 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
       const std::shared_ptr<facebook::velox::memory::MemoryPool>& veloxPool,
       const ReaderOptions& options,
       const RowTypePtr& rowType,
-      const std::function<void(int64_t&)> decompressionTimeAccumulator,
-      const std::function<void(int64_t&)> deserializeTimeAccumulator,
+      const std::function<void(int64_t)> decompressionTimeAccumulator,
+      const std::function<void(int64_t)> deserializeTimeAccumulator,
       ResultIterator& in)
       : pool_(pool),
         veloxPool_(veloxPool),
         options_(options),
         rowType_(rowType),
         decompressionTimeAccumulator_(decompressionTimeAccumulator),
+        deserializeTimeAccumulator_(deserializeTimeAccumulator),
         in_(std::move(in)) {}
 
   std::shared_ptr<ColumnarBatch> next() override {
@@ -408,8 +409,8 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
   ReaderOptions options_;
   facebook::velox::RowTypePtr rowType_;
 
-  std::function<void(int64_t&)> decompressionTimeAccumulator_;
-  std::function<void(int64_t&)> deserializeTimeAccumulator_;
+  std::function<void(int64_t)> decompressionTimeAccumulator_;
+  std::function<void(int64_t)> deserializeTimeAccumulator_;
 
   ResultIterator in_;
 };

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -35,6 +35,8 @@ using namespace facebook::velox;
 
 namespace gluten {
 
+bool veloxShuffleReaderPrintFlag = true;
+
 namespace {
 
 struct BufferViewReleaser {
@@ -327,6 +329,7 @@ RowVectorPtr readRowVector(
     CodecBackend codecBackend,
     CompressionMode compressionMode,
     int64_t& decompressTime,
+    int64_t& deserializeTime,
     arrow::MemoryPool* arrowPool,
     memory::MemoryPool* pool) {
   auto header = readColumnBuffer(batch, 0);
@@ -349,7 +352,12 @@ RowVectorPtr readRowVector(
     getUncompressedBuffers(batch, arrowPool, codec.get(), compressionMode, buffers);
     TIME_NANO_END(decompressTime);
   }
-  return deserialize(rowType, length, buffers, pool);
+
+  TIME_NANO_START(deserializeTime);
+  auto rv = deserialize(rowType, length, buffers, pool);
+  TIME_NANO_END(deserializeTime);
+
+  return rv;
 }
 
 class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
@@ -360,6 +368,7 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
       const ReaderOptions& options,
       const RowTypePtr& rowType,
       const std::function<void(int64_t&)> decompressionTimeAccumulator,
+      const std::function<void(int64_t&)> deserializeTimeAccumulator,
       ResultIterator& in)
       : pool_(pool),
         veloxPool_(veloxPool),
@@ -374,16 +383,22 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
     }
     auto batch = in_.next();
     auto rb = std::dynamic_pointer_cast<ArrowColumnarBatch>(batch)->getRecordBatch();
+
     int64_t decompressTime = 0LL;
+    int64_t deserializeTime = 0LL;
+
     auto vp = readRowVector(
         *rb,
         rowType_,
         options_.codec_backend,
         options_.compression_mode,
         decompressTime,
+        deserializeTime,
         pool_.get(),
         veloxPool_.get());
+
     decompressionTimeAccumulator_(decompressTime);
+    deserializeTimeAccumulator_(deserializeTime);
     return std::make_shared<VeloxColumnarBatch>(vp);
   }
 
@@ -392,9 +407,46 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
   ReaderOptions options_;
   facebook::velox::RowTypePtr rowType_;
+
   std::function<void(int64_t&)> decompressionTimeAccumulator_;
+  std::function<void(int64_t&)> deserializeTimeAccumulator_;
+
   ResultIterator in_;
 };
+
+std::string getCompressionMode(CompressionMode type) {
+  if (type == CompressionMode::BUFFER) {
+    return "BUFFER";
+  } else if (type == CompressionMode::ROWVECTOR) {
+    return "ROWVECTOR";
+  } else {
+    return "UNKNOWN";
+  }
+}
+
+std::string getCodecBackend(CodecBackend type) {
+  if (type == CodecBackend::QAT) {
+    return "QAT";
+  } else if (type == CodecBackend::IAA) {
+    return "IAA";
+  } else {
+    return "NONE";
+  }
+}
+
+std::string getCompressionType(arrow::Compression::type type) {
+  if (type == arrow::Compression::UNCOMPRESSED) {
+    return "UNCOMPRESSED";
+  } else if (type == arrow::Compression::LZ4_FRAME) {
+    return "LZ4_FRAME";
+  } else if (type == arrow::Compression::ZSTD) {
+    return "ZSTD";
+  } else if (type == arrow::Compression::GZIP) {
+    return "GZIP";
+  } else {
+    return "UNKNOWN";
+  }
+}
 
 } // namespace
 
@@ -405,6 +457,13 @@ VeloxShuffleReader::VeloxShuffleReader(
     std::shared_ptr<memory::MemoryPool> veloxPool)
     : ShuffleReader(schema, options, pool), veloxPool_(std::move(veloxPool)) {
   rowType_ = asRowType(gluten::fromArrowSchema(schema));
+  if (gluten::veloxShuffleReaderPrintFlag) {
+    std::ostringstream oss;
+    oss << "VeloxShuffleReader create, compression_type:" << getCompressionType(options.compression_type);
+    oss << " codec_backend:" << getCodecBackend(options.codec_backend);
+    oss << " compression_mode:" << getCompressionMode(options.compression_mode);
+    LOG(INFO) << oss.str();
+  }
 }
 
 std::shared_ptr<ResultIterator> VeloxShuffleReader::readStream(std::shared_ptr<arrow::io::InputStream> in) {
@@ -415,6 +474,7 @@ std::shared_ptr<ResultIterator> VeloxShuffleReader::readStream(std::shared_ptr<a
       options_,
       rowType_,
       [this](int64_t decompressionTime) { this->decompressTime_ += decompressionTime; },
+      [this](int64_t deserializeTime) { this->deserializeTime_ += deserializeTime; },
       *wrappedIn));
 }
 

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -22,6 +22,7 @@
 #include "velox/vector/ComplexVector.h"
 
 namespace gluten {
+
 class VeloxShuffleReader final : public ShuffleReader {
  public:
   VeloxShuffleReader(
@@ -36,5 +37,7 @@ class VeloxShuffleReader final : public ShuffleReader {
   facebook::velox::RowTypePtr rowType_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
 };
+
+extern bool veloxShuffleReaderPrintFlag;
 
 } // namespace gluten

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderMetrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderMetrics.java
@@ -37,7 +37,7 @@ public class ShuffleReaderMetrics {
     return ipcTime;
   }
 
-  public void SetDeserializeTime(long ipcTime) {
+  public void setDeserializeTime(long ipcTime) {
     this.deserializeTime = deserializeTime;
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderMetrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderMetrics.java
@@ -18,6 +18,8 @@ package io.glutenproject.vectorized;
 
 public class ShuffleReaderMetrics {
   private long decompressTime;
+  private long ipcTime;
+  private long deserializeTime;
 
   public void setDecompressTime(long decompressTime) {
     this.decompressTime = decompressTime;
@@ -25,5 +27,21 @@ public class ShuffleReaderMetrics {
 
   public long getDecompressTime() {
     return decompressTime;
+  }
+
+  public void setIpcTime(long ipcTime) {
+    this.ipcTime = ipcTime;
+  }
+
+  public long getIpcTime() {
+    return ipcTime;
+  }
+
+  public void SetDeserializeTime(long ipcTime) {
+    this.deserializeTime = deserializeTime;
+  }
+
+  public long getDeserializeTime() {
+    return deserializeTime;
   }
 }

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -56,8 +56,13 @@ class ColumnarBatchSerializer(
 
   /** Creates a new [[SerializerInstance]]. */
   override def newInstance(): SerializerInstance = {
-    new ColumnarBatchSerializerInstance(schema, readBatchNumRows, numOutputRows, decompressTime,
-      ipcTime, deserializeTime)
+    new ColumnarBatchSerializerInstance(
+      schema,
+      readBatchNumRows,
+      numOutputRows,
+      decompressTime,
+      ipcTime,
+      deserializeTime)
   }
 
   override def supportsRelocationOfSerializedObjects: Boolean = supportsRelocation

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -45,7 +45,9 @@ class ColumnarBatchSerializer(
     schema: StructType,
     readBatchNumRows: SQLMetric,
     numOutputRows: SQLMetric,
-    decompressTime: SQLMetric)
+    decompressTime: SQLMetric,
+    ipcTime: SQLMetric,
+    deserializeTime: SQLMetric)
   extends Serializer
   with Serializable {
 
@@ -54,7 +56,8 @@ class ColumnarBatchSerializer(
 
   /** Creates a new [[SerializerInstance]]. */
   override def newInstance(): SerializerInstance = {
-    new ColumnarBatchSerializerInstance(schema, readBatchNumRows, numOutputRows, decompressTime)
+    new ColumnarBatchSerializerInstance(schema, readBatchNumRows, numOutputRows, decompressTime,
+      ipcTime, deserializeTime)
   }
 
   override def supportsRelocationOfSerializedObjects: Boolean = supportsRelocation
@@ -64,7 +67,9 @@ private class ColumnarBatchSerializerInstance(
     schema: StructType,
     readBatchNumRows: SQLMetric,
     numOutputRows: SQLMetric,
-    decompressTime: SQLMetric)
+    decompressTime: SQLMetric,
+    ipcTime: SQLMetric,
+    deserializeTime: SQLMetric)
   extends SerializerInstance
   with Logging {
 
@@ -106,6 +111,8 @@ private class ColumnarBatchSerializerInstance(
         shuffleReaderHandle,
         readerMetrics)
       decompressTime += readerMetrics.getDecompressTime
+      ipcTime += readerMetrics.getIpcTime
+      deserializeTime += readerMetrics.getDeserializeTime
 
       cSchema.close()
       ShuffleReaderJniWrapper.INSTANCE.close(executionCtxHandle, shuffleReaderHandle)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some jobs of ours consume most of their time for the operator of `ColumnarExchange`, and the metrics of VeloxShuffleReader don't contain `IO(IPC read)` and `deserialize` steps.

So I proposed this PR to complement these missing metrics. 

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

