### PR TITLE
[VL] Change preferEvict to preferSpill

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -758,7 +758,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jstring dataFileJstr,
     jint numSubDirs,
     jstring localDirsJstr,
-    jboolean preferEvict,
+    jboolean preferSpill,
     jlong memoryManagerHandle,
     jboolean writeEOS,
     jdouble reallocThreshold,
@@ -824,7 +824,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     }
 
     shuffleWriterOptions.write_eos = writeEOS;
-    shuffleWriterOptions.prefer_evict = preferEvict;
+    shuffleWriterOptions.prefer_spill = preferSpill;
     shuffleWriterOptions.buffer_realloc_threshold = reallocThreshold;
 
     if (numSubDirs > 0) {
@@ -838,7 +838,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     auto localDirs = env->GetStringUTFChars(localDirsJstr, JNI_FALSE);
     setenv(gluten::kGlutenSparkLocalDirs.c_str(), localDirs, 1);
     env->ReleaseStringUTFChars(localDirsJstr, localDirs);
-    partitionWriterCreator = std::make_shared<LocalPartitionWriterCreator>(preferEvict);
+    partitionWriterCreator = std::make_shared<LocalPartitionWriterCreator>(preferSpill);
   } else if (partitionWriterType == "celeborn") {
     shuffleWriterOptions.partition_writer_type = "celeborn";
     jclass celebornPartitionPusherClass =

--- a/cpp/core/shuffle/LocalPartitionWriter.h
+++ b/cpp/core/shuffle/LocalPartitionWriter.h
@@ -52,9 +52,9 @@ class LocalPartitionWriterBase : public ShuffleWriter::PartitionWriter {
   std::shared_ptr<arrow::io::OutputStream> dataFileOs_;
 };
 
-class PreferEvictPartitionWriter : public LocalPartitionWriterBase {
+class PreferSpillPartitionWriter : public LocalPartitionWriterBase {
  public:
-  explicit PreferEvictPartitionWriter(ShuffleWriter* shuffleWriter) : LocalPartitionWriterBase(shuffleWriter) {}
+  explicit PreferSpillPartitionWriter(ShuffleWriter* shuffleWriter) : LocalPartitionWriterBase(shuffleWriter) {}
 
   arrow::Status init() override;
 
@@ -152,11 +152,11 @@ class PreferCachePartitionWriter : public LocalPartitionWriterBase {
 
 class LocalPartitionWriterCreator : public ShuffleWriter::PartitionWriterCreator {
  public:
-  LocalPartitionWriterCreator(bool preferEvict);
+  LocalPartitionWriterCreator(bool preferSpill);
 
   arrow::Result<std::shared_ptr<ShuffleWriter::PartitionWriter>> make(ShuffleWriter* shuffleWriter) override;
 
  private:
-  bool preferEvict_;
+  bool preferSpill;
 };
 } // namespace gluten

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -44,7 +44,7 @@ struct ShuffleWriterOptions {
   arrow::Compression::type compression_type = arrow::Compression::LZ4_FRAME;
   CodecBackend codec_backend = CodecBackend::NONE;
   CompressionMode compression_mode = CompressionMode::BUFFER;
-  bool prefer_evict = false;
+  bool prefer_spill = false;
   bool buffered_write = false;
   bool write_eos = true;
 

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -56,7 +56,7 @@ using gluten::GlutenException;
 using gluten::ShuffleWriterOptions;
 using gluten::VeloxShuffleWriter;
 
-DEFINE_bool(prefer_evict, true, "SplitOptions prefer_evict=true");
+DEFINE_bool(prefer_spill, true, "SplitOptions prefer_spill=true");
 DEFINE_int32(partitions, -1, "Shuffle partitions");
 DEFINE_string(file, "", "Input file to split");
 
@@ -112,12 +112,12 @@ class BenchmarkShuffleSplit {
     std::shared_ptr<arrow::MemoryPool> pool = defaultArrowMemoryPool();
 
     std::shared_ptr<ShuffleWriter::PartitionWriterCreator> partitionWriterCreator =
-        std::make_shared<LocalPartitionWriterCreator>(FLAGS_prefer_evict);
+        std::make_shared<LocalPartitionWriterCreator>(FLAGS_prefer_spill);
 
     auto options = ShuffleWriterOptions::defaults();
     options.buffer_size = kPartitionBufferSize;
     options.buffered_write = true;
-    options.prefer_evict = FLAGS_prefer_evict;
+    options.prefer_spill = FLAGS_prefer_spill;
     options.memory_pool = pool;
     options.partitioning_name = "rr";
 
@@ -366,7 +366,7 @@ int main(int argc, char** argv) {
 
   auto bm = benchmark::RegisterBenchmark("BenchmarkShuffleSplit::IterateScan", iterateScanBenchmark)
                 ->Args({
-                    FLAGS_prefer_evict,
+                    FLAGS_prefer_spill,
                 })
                 ->ReportAggregatesOnly(false)
                 ->MeasureProcessCPUTime()

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -366,7 +366,7 @@ arrow::Result<std::shared_ptr<VeloxShuffleWriter>> VeloxShuffleWriter::create(
   oss << " compression_type:" << (int)options.compression_type;
   oss << " codec_backend:" << (int)options.codec_backend;
   oss << " compression_mode:" << (int)options.compression_mode;
-  oss << " prefer_evict:" << options.prefer_evict;
+  oss << " prefer_spill:" << options.prefer_spill;
   oss << " buffered_write:" << options.buffered_write;
   oss << " write_eos:" << options.write_eos;
   oss << " partition_writer_type:" << options.partition_writer_type;
@@ -695,8 +695,8 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv, int64_t me
           if (rb) {
             RETURN_NOT_OK(cacheRecordBatch(pid, *rb, reuseBuffers));
           }
-          if (options_.prefer_evict) {
-            // if prefer_evict is set, evict current RowVector
+          if (options_.prefer_spill) {
+            // if prefer_spill is set, evict current RowVector
             RETURN_NOT_OK(evictPartition(pid));
             RETURN_NOT_OK(resetValidityBuffers(pid));
           }
@@ -717,8 +717,8 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv, int64_t me
             if (rb) {
               RETURN_NOT_OK(cacheRecordBatch(pid, *rb, reuseBuffers));
             }
-            if (options_.prefer_evict) {
-              // if prefer_evict is set, evict current RowVector
+            if (options_.prefer_spill) {
+              // if prefer_spill is set, evict current RowVector
               RETURN_NOT_OK(evictPartition(pid));
               RETURN_NOT_OK(resetValidityBuffers(pid));
             }
@@ -738,8 +738,8 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv, int64_t me
               RETURN_NOT_OK(cacheRecordBatch(pid, *rb, reuseBuffers));
             }
           } // rb destructed
-          if (options_.prefer_evict) {
-            // if prefer_evict is set, evict current RowVector
+          if (options_.prefer_spill) {
+            // if prefer_spill is set, evict current RowVector
             RETURN_NOT_OK(evictPartition(pid));
             RETURN_NOT_OK(resetValidityBuffers(pid));
           }
@@ -754,8 +754,8 @@ arrow::Status VeloxShuffleWriter::doSplit(const velox::RowVector& rv, int64_t me
               RETURN_NOT_OK(cacheRecordBatch(pid, *rb, reuseBuffers));
             }
           } // rb destructed
-          if (options_.prefer_evict) {
-            // if prefer_evict is set, evict current RowVector
+          if (options_.prefer_spill) {
+            // if prefer_spill is set, evict current RowVector
             RETURN_NOT_OK(evictPartition(pid));
           }
           // Reset validity buffer for reuse.
@@ -1611,7 +1611,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
 
   arrow::Status VeloxShuffleWriter::evictPartitionsOnDemand(int64_t * size) {
     SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingEvictPartition]);
-    if (options_.prefer_evict) {
+    if (options_.prefer_spill) {
       return arrow::Status::OK();
     }
     // Evict all cached partitions

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -49,7 +49,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
    * @param dataFile acquired from spark IndexShuffleBlockResolver
    * @param subDirsPerLocalDir SparkConf spark.diskStore.subDirectories
    * @param localDirs configured local directories where Spark can write files
-   * @param preferEvict if true, write the partition buffer to disk once it is full
+   * @param preferSpill if true, write the partition buffer to disk once it is full
    * @return native shuffle writer instance handle if created successfully.
    */
   public long make(
@@ -62,7 +62,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
       String dataFile,
       int subDirsPerLocalDir,
       String localDirs,
-      boolean preferEvict,
+      boolean preferSpill,
       long memoryManagerHandle,
       boolean writeEOS,
       double reallocThreshold,
@@ -79,7 +79,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
         dataFile,
         subDirsPerLocalDir,
         localDirs,
-        preferEvict,
+        preferSpill,
         memoryManagerHandle,
         writeEOS,
         reallocThreshold,
@@ -144,7 +144,7 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
       String dataFile,
       int subDirsPerLocalDir,
       String localDirs,
-      boolean preferEvict,
+      boolean preferSpill,
       long memoryManagerHandle,
       boolean writeEOS,
       double reallocThreshold,


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's misleading to use `preferEvict` and `preferSpill` interleaved, I prefer `preferSpill` to `preferEvict`.

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

