### PR TITLE
[DNM][VL] Enable casting timestamp to date type to support to_date function

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -312,7 +312,7 @@ bool SubstraitToVeloxPlanValidator::validateCast(
       }
       break;
     }
-    case TypeKind::TIMESTAMP: {
+    case TypeKind::TIMESTAMP:
     default: {
     }
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -313,10 +313,6 @@ bool SubstraitToVeloxPlanValidator::validateCast(
       break;
     }
     case TypeKind::TIMESTAMP: {
-      logValidateMsg(
-          "native validation failed due to: Casting from TIMESTAMP is not supported or has incorrect result.");
-      return false;
-    }
     default: {
     }
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -312,7 +312,13 @@ bool SubstraitToVeloxPlanValidator::validateCast(
       }
       break;
     }
-    case TypeKind::TIMESTAMP:
+    case TypeKind::TIMESTAMP: {
+      if (toType->kind() != TypeKind::DATE) {
+        logValidateMsg(fmt::format(
+            "native validation failed due to: Casting from TIMESTAMP to {} is not supported.", toType->toString()));
+        return false;
+      }
+    }
     default: {
     }
   }

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=main
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=get-timestamp
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
## What changes were proposed in this pull request?

To support to_date function, we need enable casting timestamp type to other type, like date.
This PR depends on velox PR: https://github.com/oap-project/velox/pull/411.

## How was this patch tested?

Spark UTs.

