### PR TITLE
[VL] IllegalStateException: TaskResourceRegistry is not initialized when closing deserialized broadcast

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -19,6 +19,7 @@ package org.apache.spark.util
 import org.apache.spark.{TaskContext, TaskFailedReason, TaskKilledException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
+
 import _root_.io.glutenproject.backendsapi.BackendsApiManager
 import _root_.io.glutenproject.memory.SimpleMemoryUsageRecorder
 import _root_.io.glutenproject.utils.TaskListener


### PR DESCRIPTION
Error log
```
2023-09-26T02:59:31.1223487Z 23/09/26 10:59:31 WARN TaskResourceRegistry: Failed to call release() on task resource BuildSideRelation_deserialized_4
2023-09-26T02:59:31.1224120Z java.lang.IllegalStateException: TaskResourceRegistry is not initialized, please ensure TaskResources is added to GlutenExecutorPlugin's task listener list
2023-09-26T02:59:31.1224385Z   at org.apache.spark.util.TaskResources$.getTaskResourceRegistry(TaskResources.scala:63)
2023-09-26T02:59:31.1224655Z   at org.apache.spark.util.TaskResources$.addResourceIfNotRegistered(TaskResources.scala:85)
2023-09-26T02:59:31.1224875Z   at io.glutenproject.exec.ExecutionCtxs$.contextInstance(ExecutionCtxs.scala:30)
2023-09-26T02:59:31.1225138Z   at io.glutenproject.exec.ExecutionCtxs.contextInstance(ExecutionCtxs.scala)
2023-09-26T02:59:31.1225549Z   at io.glutenproject.vectorized.ColumnarBatchSerializerJniWrapper.create(ColumnarBatchSerializerJniWrapper.java:32)
2023-09-26T02:59:31.1225903Z   at org.apache.spark.sql.execution.ColumnarBuildSideRelation$$anon$1.$anonfun$new$1(ColumnarBuildSideRelation.scala:71)
2023-09-26T02:59:31.1226133Z   at org.apache.spark.util.TaskResources$$anon$1.release(TaskResources.scala:72)
2023-09-26T02:59:31.1226420Z   at org.apache.spark.util.TaskResourceRegistry.releaseAll(TaskResources.scala:195)
2023-09-26T02:59:31.1226712Z   at org.apache.spark.util.TaskResources$$anon$3.onTaskCompletion(TaskResources.scala:136)
2023-09-26T02:59:31.1227007Z   at org.apache.spark.TaskContextImpl.$anonfun$invokeTaskCompletionListeners$1(TaskContextImpl.scala:142)
2023-09-26T02:59:31.1227287Z   at org.apache.spark.TaskContextImpl.$anonfun$invokeTaskCompletionListeners$1$adapted(TaskContextImpl.scala:142)
2023-09-26T02:59:31.1227550Z   at org.apache.spark.TaskContextImpl.invokeListeners(TaskContextImpl.scala:197)
2023-09-26T02:59:31.1227867Z   at org.apache.spark.TaskContextImpl.invokeTaskCompletionListeners(TaskContextImpl.scala:142)
2023-09-26T02:59:31.1228139Z   at org.apache.spark.TaskContextImpl.markTaskCompleted(TaskContextImpl.scala:135)
2023-09-26T02:59:31.1228332Z   at org.apache.spark.scheduler.Task.run(Task.scala:147)
2023-09-26T02:59:31.1228569Z   at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
2023-09-26T02:59:31.1228783Z   at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
2023-09-26T02:59:31.1229011Z   at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
2023-09-26T02:59:31.1229288Z   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2023-09-26T02:59:31.1229513Z   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2023-09-26T02:59:31.1229661Z   at java.lang.Thread.run(Thread.java:750)
```