### PR TITLE
[VL] Support columnar table cache with count(1)

### DIFF
--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -323,7 +323,7 @@ public class ColumnarBatches {
     int numColumns = Math.toIntExact(iv.getNumColumns());
     int numRows = Math.toIntExact(iv.getNumRows());
     if (numColumns == 0) {
-      return new ColumnarBatch(new ColumnVector[0], numRows);
+      return new ColumnarBatch(new ColumnVector[] {iv}, numRows);
     }
     final ColumnVector[] columnVectors = new ColumnVector[numColumns];
     columnVectors[0] = iv;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Supports columnar `df.cache.count`. It is a special case that the selected schema is empty.

## How was this patch tested?

add test