### PR TITLE
[VL] Decouple Spark's memory manager from Gluten's memory target API

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/memory/alloc/CHNativeMemoryAllocators.java
@@ -18,7 +18,7 @@ package io.glutenproject.memory.alloc;
 
 import io.glutenproject.memory.SimpleMemoryUsageRecorder;
 import io.glutenproject.memory.memtarget.MemoryTargets;
-import io.glutenproject.memory.memtarget.spark.Spiller;
+import io.glutenproject.memory.memtarget.Spiller;
 
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.util.TaskResources;

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/CHColumnarShuffleWriter.scala
@@ -18,7 +18,7 @@ package org.apache.spark.shuffle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.memory.alloc.CHNativeMemoryAllocators
-import io.glutenproject.memory.memtarget.spark.Spiller
+import io.glutenproject.memory.memtarget.{MemoryTarget, Spiller}
 import io.glutenproject.vectorized._
 
 import org.apache.spark.SparkEnv
@@ -105,7 +105,7 @@ class CHColumnarShuffleWriter[K, V](
       CHNativeMemoryAllocators.createSpillable(
         "ShuffleWriter",
         new Spiller() {
-          override def spill(size: Long): Long = {
+          override def spill(self: MemoryTarget, size: Long): Long = {
             if (nativeSplitter == 0) {
               throw new IllegalStateException(
                 "Fatal: spill() called before a shuffle writer " +

--- a/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
+++ b/backends-clickhouse/src/test/java/org/apache/spark/memory/TestTaskMemoryManagerSuite.java
@@ -21,7 +21,7 @@ import io.glutenproject.memory.alloc.CHManagedCHReservationListener;
 import io.glutenproject.memory.alloc.CHNativeMemoryAllocator;
 import io.glutenproject.memory.alloc.CHNativeMemoryAllocatorManagerImpl;
 import io.glutenproject.memory.memtarget.MemoryTargets;
-import io.glutenproject.memory.memtarget.spark.Spiller;
+import io.glutenproject.memory.memtarget.Spiller;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.internal.config.package$;

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedCHColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedCHColumnarShuffleWriter.scala
@@ -18,7 +18,7 @@ package org.apache.spark.shuffle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.memory.alloc.CHNativeMemoryAllocators
-import io.glutenproject.memory.memtarget.spark.Spiller
+import io.glutenproject.memory.memtarget.MemoryTarget
 import io.glutenproject.vectorized._
 
 import org.apache.spark._
@@ -72,7 +72,7 @@ class CelebornHashBasedCHColumnarShuffleWriter[K, V](
       CHNativeMemoryAllocators.createSpillable(
         "CelebornShuffleWriter",
         new Spiller() {
-          override def spill(size: Long): Long = {
+          override def spill(self: MemoryTarget, size: Long): Long = {
             if (nativeShuffleWriter == -1L) {
               throw new IllegalStateException(
                 "Fatal: spill() called before a celeborn shuffle writer " +

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedCHColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedCHColumnarShuffleWriter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.shuffle
 import io.glutenproject.GlutenConfig
 import io.glutenproject.memory.alloc.CHNativeMemoryAllocators
 import io.glutenproject.memory.memtarget.MemoryTarget
+import io.glutenproject.memory.memtarget.Spiller
 import io.glutenproject.vectorized._
 
 import org.apache.spark._

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
@@ -18,7 +18,8 @@ package org.apache.spark.shuffle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.columnarbatch.ColumnarBatches
-import io.glutenproject.memory.memtarget.spark.Spiller
+import io.glutenproject.memory.memtarget.MemoryTarget
+import io.glutenproject.memory.memtarget.Spiller
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.vectorized._
 
@@ -83,7 +84,7 @@ class CelebornHashBasedVeloxColumnarShuffleWriter[K, V](
               .create(
                 "CelebornShuffleWriter",
                 new Spiller() {
-                  override def spill(size: Long): Long = {
+                  override def spill(self: MemoryTarget, size: Long): Long = {
                     if (nativeShuffleWriter == -1L) {
                       throw new IllegalStateException(
                         "Fatal: spill() called before a celeborn shuffle writer " +

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/KnownNameAndStats.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/KnownNameAndStats.java
@@ -14,25 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.memory.memtarget.spark;
+package io.glutenproject.memory.memtarget;
 
-import io.glutenproject.memory.MemoryUsageStatsBuilder;
+import io.glutenproject.proto.MemoryUsageStats;
 
-import java.util.Map;
+/**
+ * The implementation provides a String name and {@link MemoryUsageStats}.
+ *
+ * <p>The API is used to format the dumped message when utility method {@link
+ * org.apache.spark.memory.SparkMemoryUtil#dumpMemoryTargetStats} is called.
+ */
+public interface KnownNameAndStats {
+  String name();
 
-/** An abstract for both {@link TreeMemoryConsumer} and it's non-consumer children nodes. */
-public interface TreeMemoryConsumerNode extends TaskMemoryTarget {
-  long CAPACITY_UNLIMITED = Long.MAX_VALUE;
-
-  TreeMemoryConsumerNode newChild(
-      String name,
-      long capacity,
-      Spiller spiller,
-      Map<String, MemoryUsageStatsBuilder> virtualChildren);
-
-  Map<String, TreeMemoryConsumerNode> children();
-
-  TreeMemoryConsumerNode parent();
-
-  Spiller getNodeSpiller();
+  MemoryUsageStats stats();
 }

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/MemoryTargetVisitor.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/MemoryTargetVisitor.java
@@ -14,16 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.memory.memtarget.spark;
+package io.glutenproject.memory.memtarget;
 
-public interface Spiller {
-  Spiller NO_OP =
-      new Spiller() {
-        @Override
-        public long spill(long size) {
-          return 0L;
-        }
-      };
+import io.glutenproject.memory.memtarget.spark.RegularMemoryConsumer;
+import io.glutenproject.memory.memtarget.spark.TreeMemoryConsumer;
 
-  long spill(long size);
+public interface MemoryTargetVisitor<T> {
+  T visit(OverAcquire overAcquire);
+
+  T visit(RegularMemoryConsumer regularMemoryConsumer);
+
+  T visit(ThrowOnOomMemoryTarget throwOnOomMemoryTarget);
+
+  T visit(TreeMemoryConsumer treeMemoryConsumer);
+
+  T visit(TreeMemoryTargets.Node node);
 }

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/MemoryTargets.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/MemoryTargets.java
@@ -20,8 +20,6 @@ import io.glutenproject.GlutenConfig;
 import io.glutenproject.memory.MemoryUsageStatsBuilder;
 import io.glutenproject.memory.memtarget.spark.IsolatedMemoryConsumers;
 import io.glutenproject.memory.memtarget.spark.RegularMemoryConsumer;
-import io.glutenproject.memory.memtarget.spark.Spiller;
-import io.glutenproject.memory.memtarget.spark.TaskMemoryTarget;
 
 import org.apache.spark.memory.TaskMemoryManager;
 
@@ -33,18 +31,19 @@ public final class MemoryTargets {
     // enclose factory ctor
   }
 
-  public static MemoryTarget throwOnOom(TaskMemoryTarget target) {
+  public static MemoryTarget throwOnOom(MemoryTarget target) {
     return new ThrowOnOomMemoryTarget(target);
   }
 
-  public static TaskMemoryTarget overAcquire(TaskMemoryTarget target, double overAcquiredRatio) {
+  public static MemoryTarget overAcquire(
+      MemoryTarget target, MemoryTarget overTarget, double overAcquiredRatio) {
     if (overAcquiredRatio == 0.0D) {
       return target;
     }
-    return new OverAcquire(target, overAcquiredRatio);
+    return new OverAcquire(target, overTarget, overAcquiredRatio);
   }
 
-  public static TaskMemoryTarget newConsumer(
+  public static MemoryTarget newConsumer(
       TaskMemoryManager tmm,
       String name,
       Spiller spiller,

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/Spiller.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/Spiller.java
@@ -16,16 +16,14 @@
  */
 package io.glutenproject.memory.memtarget;
 
-// The naming convention "borrow" and "repay" are for preventing collisions with
-//   other APIs.
-//
-// Implementations are not necessary to be thread-safe
-public interface MemoryTarget {
-  long borrow(long size);
+public interface Spiller {
+  Spiller NO_OP =
+      new Spiller() {
+        @Override
+        public long spill(MemoryTarget self, long size) {
+          return 0L;
+        }
+      };
 
-  long repay(long size);
-
-  long usedBytes();
-
-  <T> T accept(MemoryTargetVisitor<T> visitor);
+  long spill(MemoryTarget self, long size);
 }

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/Spillers.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/Spillers.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.memory.memtarget.spark;
+package io.glutenproject.memory.memtarget;
 
 public final class Spillers {
   private Spillers() {
@@ -23,11 +23,11 @@ public final class Spillers {
 
   // calls the spillers one by one within the order
   public static Spiller withOrder(Spiller... spillers) {
-    return (size) -> {
+    return (self, size) -> {
       long remaining = size;
       for (int i = 0; i < spillers.length && remaining > 0; i++) {
         Spiller spiller = spillers[i];
-        remaining -= spiller.spill(remaining);
+        remaining -= spiller.spill(self, remaining);
       }
       return size - remaining;
     };
@@ -50,8 +50,8 @@ public final class Spillers {
     }
 
     @Override
-    public long spill(long size) {
-      return delegated.spill(Math.max(size, minSize));
+    public long spill(MemoryTarget self, long size) {
+      return delegated.spill(self, Math.max(size, minSize));
     }
   }
 }

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/TreeMemoryTarget.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/TreeMemoryTarget.java
@@ -14,19 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.memory.memtarget.spark;
+package io.glutenproject.memory.memtarget;
 
-import io.glutenproject.memory.memtarget.MemoryTarget;
-import io.glutenproject.proto.MemoryUsageStats;
+import io.glutenproject.memory.MemoryUsageStatsBuilder;
+import io.glutenproject.memory.memtarget.spark.TreeMemoryConsumer;
 
-import org.apache.spark.memory.TaskMemoryManager;
+import java.util.Map;
 
-// Memory target that is bound to Spark TMM (task memory manager). This is typically a Spark
-// consumer.
-public interface TaskMemoryTarget extends MemoryTarget {
-  TaskMemoryManager getTaskMemoryManager();
+/** An abstract for both {@link TreeMemoryConsumer} and it's non-consumer children nodes. */
+public interface TreeMemoryTarget extends MemoryTarget, KnownNameAndStats {
+  long CAPACITY_UNLIMITED = Long.MAX_VALUE;
 
-  String name();
+  TreeMemoryTarget newChild(
+      String name,
+      long capacity,
+      Spiller spiller,
+      Map<String, MemoryUsageStatsBuilder> virtualChildren);
 
-  MemoryUsageStats stats();
+  Map<String, TreeMemoryTarget> children();
+
+  TreeMemoryTarget parent();
+
+  Spiller getNodeSpiller();
 }

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/TreeMemoryTargets.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/TreeMemoryTargets.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.memory.memtarget;
+
+import io.glutenproject.memory.MemoryUsageStatsBuilder;
+import io.glutenproject.memory.SimpleMemoryUsageRecorder;
+import io.glutenproject.proto.MemoryUsageStats;
+
+import com.google.common.base.Preconditions;
+import org.apache.spark.util.Utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+public class TreeMemoryTargets {
+  private TreeMemoryTargets() {
+    // enclose factory ctor
+  }
+
+  public static TreeMemoryTarget newChild(
+      TreeMemoryTarget parent,
+      String name,
+      long capacity,
+      Spiller spiller,
+      Map<String, MemoryUsageStatsBuilder> virtualChildren) {
+    return new Node(parent, name, capacity, spiller, virtualChildren);
+  }
+
+  public static long spillTree(TreeMemoryTarget node, final long bytes) {
+    // sort children by used bytes, descending
+    Queue<TreeMemoryTarget> q =
+        new PriorityQueue<>(
+            (o1, o2) -> {
+              long diff = o1.usedBytes() - o2.usedBytes();
+              return -(diff > 0 ? 1 : diff < 0 ? -1 : 0); // descending
+            });
+    q.addAll(node.children().values());
+
+    long remainingBytes = bytes;
+    while (q.peek() != null && remainingBytes > 0) {
+      TreeMemoryTarget head = q.remove();
+      long spilled = spillTree(head, remainingBytes);
+      remainingBytes -= spilled;
+    }
+
+    if (remainingBytes > 0) {
+      // if still doesn't fit, spill self
+      final long spilled = node.getNodeSpiller().spill(node, remainingBytes);
+      remainingBytes -= spilled;
+    }
+
+    return bytes - remainingBytes;
+  }
+
+  // non-root nodes are not Spark memory consumer
+  public static class Node implements TreeMemoryTarget, KnownNameAndStats {
+    private final Map<String, Node> children = new HashMap<>();
+    private final TreeMemoryTarget parent;
+    private final String name;
+    private final long capacity;
+    private final Spiller spiller;
+    private final Map<String, MemoryUsageStatsBuilder> virtualChildren;
+    private final SimpleMemoryUsageRecorder selfRecorder = new SimpleMemoryUsageRecorder();
+
+    private Node(
+        TreeMemoryTarget parent,
+        String name,
+        long capacity,
+        Spiller spiller,
+        Map<String, MemoryUsageStatsBuilder> virtualChildren) {
+      this.parent = parent;
+      this.capacity = capacity;
+      final String uniqueName = MemoryTargetUtil.toUniqueName(name);
+      if (capacity == CAPACITY_UNLIMITED) {
+        this.name = uniqueName;
+      } else {
+        this.name = String.format("%s, %s", uniqueName, Utils.bytesToString(capacity));
+      }
+      this.spiller = spiller;
+      this.virtualChildren = virtualChildren;
+    }
+
+    @Override
+    public long borrow(long size) {
+      ensureFreeCapacity(size);
+      return borrow0(Math.min(freeBytes(), size));
+    }
+
+    private long freeBytes() {
+      return capacity - usedBytes();
+    }
+
+    private long borrow0(long size) {
+      long granted = parent.borrow(size);
+      selfRecorder.inc(granted);
+      return granted;
+    }
+
+    public Spiller getNodeSpiller() {
+      return spiller;
+    }
+
+    private boolean ensureFreeCapacity(long bytesNeeded) {
+      while (true) { // FIXME should we add retry limit?
+        long freeBytes = freeBytes();
+        Preconditions.checkState(freeBytes >= 0);
+        if (freeBytes >= bytesNeeded) {
+          // free bytes fit requirement
+          return true;
+        }
+        // spill
+        long bytesToSpill = bytesNeeded - freeBytes;
+        long spilledBytes = TreeMemoryTargets.spillTree(this, bytesToSpill);
+        Preconditions.checkState(spilledBytes >= 0);
+        if (spilledBytes == 0) {
+          // OOM
+          return false;
+        }
+      }
+    }
+
+    @Override
+    public long repay(long size) {
+      long toFree = Math.min(usedBytes(), size);
+      long freed = parent.repay(toFree);
+      selfRecorder.inc(-freed);
+      return freed;
+    }
+
+    @Override
+    public long usedBytes() {
+      return selfRecorder.current();
+    }
+
+    @Override
+    public <T> T accept(MemoryTargetVisitor<T> visitor) {
+      return visitor.visit(this);
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public MemoryUsageStats stats() {
+      final Map<String, MemoryUsageStats> childrenStats =
+          new HashMap<>(
+              children.entrySet().stream()
+                  .collect(Collectors.toMap(e -> e.getValue().name(), e -> e.getValue().stats())));
+
+      Preconditions.checkState(childrenStats.size() == children.size());
+
+      // add virtual children
+      for (Map.Entry<String, MemoryUsageStatsBuilder> entry : virtualChildren.entrySet()) {
+        if (childrenStats.containsKey(entry.getKey())) {
+          throw new IllegalArgumentException("Child stats already exists: " + entry.getKey());
+        }
+        childrenStats.put(entry.getKey(), entry.getValue().toStats());
+      }
+      return selfRecorder.toStats(childrenStats);
+    }
+
+    @Override
+    public TreeMemoryTarget newChild(
+        String name,
+        long capacity,
+        Spiller spiller,
+        Map<String, MemoryUsageStatsBuilder> virtualChildren) {
+      final Node child = new Node(this, name, capacity, spiller, virtualChildren);
+      if (children.containsKey(child.name())) {
+        throw new IllegalArgumentException("Child already registered: " + child.name());
+      }
+      children.put(child.name(), child);
+      return child;
+    }
+
+    @Override
+    public Map<String, TreeMemoryTarget> children() {
+      return Collections.unmodifiableMap(children);
+    }
+
+    @Override
+    public TreeMemoryTarget parent() {
+      return parent;
+    }
+  }
+}

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -79,7 +79,7 @@ public class NativePlanEvaluator {
     final long memoryManagerHandle =
         NativeMemoryManagers.create(
                 "WholeStageIterator",
-                (size) -> {
+                (self, size) -> {
                   ColumnarBatchOutIterator instance =
                       Optional.of(outIterator.get())
                           .orElseThrow(

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -18,7 +18,8 @@ package org.apache.spark.shuffle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.columnarbatch.ColumnarBatches
-import io.glutenproject.memory.memtarget.spark.Spiller
+import io.glutenproject.memory.memtarget.MemoryTarget
+import io.glutenproject.memory.memtarget.Spiller
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.vectorized._
 
@@ -137,7 +138,7 @@ class ColumnarShuffleWriter[K, V](
               .create(
                 "ShuffleWriter",
                 new Spiller() {
-                  override def spill(size: Long): Long = {
+                  override def spill(self: MemoryTarget, size: Long): Long = {
                     if (nativeShuffleWriter == -1L) {
                       throw new IllegalStateException(
                         "Fatal: spill() called before a shuffle writer " +


### PR DESCRIPTION
Within this patch, interface `TaskMemoryTarget` will be removed, then the memory target API, including the common decorator implementations will no longer directly rely on any of Spark's API.

By doing this we could have opportunity to replace Spark's memory manager with our own implementation within minimum effort. So far the patch is just code refactor in advance of the further actions.

