### PR TITLE
[VL] Update get_velox.sh for macos

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -241,7 +241,7 @@ function setup_macos {
     exit 1
   fi
 
-  sed -i '' $'/^  run_and_time install_fmt/a\\\n  run_and_time install_folly\\\n' scripts/setup-macos.sh
+  sed -i '' $'/^  run_and_time install_double_conversion/a\\\n  run_and_time install_folly\\\n' scripts/setup-macos.sh
 }
 
 if [ $OS == 'Linux' ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix velox_ep/scripts/setup-macos.sh

folly needs to be installed after install_double_conversion

https://github.com/oap-project/velox/blob/1910a1722dcb5e7dde83e84defdc33f21327be84/scripts/setup-macos.sh#L116-L124

## How was this patch tested?

manual tests