### PR TITLE
[CORE] Use thread local to hold original plan in ColumnarOverrideRules

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -724,7 +724,7 @@ case class VanillaColumnarPlanOverrides(session: SparkSession) extends Rule[Spar
 }
 
 object ColumnarOverrideRules {
-  val GLUTEN_IS_ADAPTIVE_CONTEXT = "glutenIsAdaptiveContext"
+  val GLUTEN_IS_ADAPTIVE_CONTEXT = "gluten.isAdaptiveContext"
 }
 
 case class ColumnarOverrideRules(session: SparkSession)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ColumnarOverrideRules` will be instanced per Spark session rather than per query, so better to use thread local to hold variable to make it thread safe. Including `oringalPlan` and `isAdaptiveContext`.

The local property of SparkContext is a little bit heavy that it would post it to executor side, so we should cleanup it before execution.

## How was this patch tested?

Pass CI
