### PR TITLE
[VL] Show uncompressed data size for ColumnarExchange

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
@@ -254,7 +254,8 @@ class MetricsHandler extends MetricsApi with Logging {
       "numOutputRows" -> SQLMetrics
         .createMetric(sparkContext, "number of output rows"),
       "inputBatches" -> SQLMetrics
-        .createMetric(sparkContext, "number of input batches")
+        .createMetric(sparkContext, "number of input batches"),
+      "uncompressedDataSize" -> SQLMetrics.createMetric(sparkContext, "uncompressed data size")
     )
 
   override def genWindowTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -188,6 +188,7 @@ class ColumnarShuffleWriter[K, V](
     dep.metrics("compressTime").add(splitResult.getTotalCompressTime)
     dep.metrics("bytesSpilled").add(splitResult.getTotalBytesSpilled)
     dep.metrics("splitBufferSize").add(splitResult.getSplitBufferSize)
+    dep.metrics("uncompressedDataSize").add(splitResult.getRawPartitionLengths.sum)
     writeMetrics.incBytesWritten(splitResult.getTotalBytesWritten)
     writeMetrics.incWriteTime(splitResult.getTotalWriteTime + splitResult.getTotalSpillTime)
 


### PR DESCRIPTION
`data size` collects the raw size of input rowvectors.
Add `uncompressed data size` to show the partition buffer data size before compression.