### PR TITLE
[Gluten-3296] Supports configuring the spark.yarn.dist.files configuration to allow yarn to automatically upload and load the libch.so package

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ContextInitializer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ContextInitializer.scala
@@ -101,7 +101,7 @@ class ContextInitializer extends ContextApi {
 
   override def taskResourceFactories(): Seq[() => TaskResource] = Seq.empty
 
-  override def initialize(conf: SparkConf): Unit = {
+  override def initialize(conf: SparkConf, isDriver: Boolean = true): Unit = {
     val workspace = JniWorkspace.getDefault
     val loader = workspace.libLoader
 

--- a/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/GlutenPlugin.scala
@@ -70,7 +70,7 @@ private[glutenproject] class GlutenDriverPlugin extends DriverPlugin with Loggin
     setPredefinedConfigs(sc, conf)
     // Initialize Backends API
     BackendsApiManager.initialize()
-    BackendsApiManager.getContextApiInstance.initialize(conf)
+    BackendsApiManager.getContextApiInstance.initialize(conf, true)
     GlutenDriverEndpoint.glutenDriverEndpointRef = (new GlutenDriverEndpoint).self
     GlutenListenerFactory.addToSparkListenerBus(sc)
     ExpressionMappings.expressionExtensionTransformer =
@@ -227,7 +227,7 @@ private[glutenproject] class GlutenExecutorPlugin extends ExecutorPlugin {
     // Initialize Backends API
     // TODO categorize the APIs by driver's or executor's
     BackendsApiManager.initialize()
-    BackendsApiManager.getContextApiInstance.initialize(conf)
+    BackendsApiManager.getContextApiInstance.initialize(conf, false)
 
     executorEndpoint = new GlutenExecutorEndpoint(ctx.executorID(), conf)
   }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ContextApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ContextApi.scala
@@ -22,7 +22,7 @@ import org.apache.spark.util.TaskResource
 import java.util
 
 trait ContextApi {
-  def initialize(conf: SparkConf): Unit = {}
+  def initialize(conf: SparkConf, isDriver: Boolean = true): Unit = {}
 
   def shutdown(): Unit = {}
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -284,6 +284,7 @@ object GlutenConfig {
   val GLUTEN_ENABLE_KEY = "spark.gluten.enabled"
   val GLUTEN_LIB_NAME = "spark.gluten.sql.columnar.libname"
   val GLUTEN_LIB_PATH = "spark.gluten.sql.columnar.libpath"
+  val GLUTEN_EXECUTOR_LIB_PATH = "spark.gluten.sql.columnar.executor.libpath"
 
   // Hive configurations.
   val SPARK_PREFIX = "spark."


### PR DESCRIPTION


## What changes were proposed in this pull request?

Supports configuring the spark.yarn.dist.files configuration to allow yarn to automatically upload and load the libch.so package
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


Avoid having to manually distribute packages in the hadoop cluster for each deployment

Supports configuring the spark.yarn.dist.files configuration to allow yarn to automatically upload and load the libch.so package.

In this way, you can allow libch.so to be loaded on the executor by configuring xx as follows:

spark.gluten.sql.columnar.libpath=/your/path/to/libch.so
spark.yarn.dist.files=/your/path/to/libch.so
spark.gluten.sql.columnar.executor.libpath=libch.so
spark.executorEnv.LD_PRELOAD=$PWD/libch.so
