### PR TITLE
[VL]Avoid unnecessary filter binding for subfield

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1615,9 +1615,8 @@ void SubstraitToVeloxPlanConverter::setFilterInfo(
       }
       break;
     case TypeKind::ARRAY:
-      // Doing nothing here can let filter IsNotNull still work.
-      break;
     case TypeKind::MAP:
+    case TypeKind::ROW:
       // Doing nothing here can let filter IsNotNull still work.
       break;
     default:

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1936,6 +1936,11 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::mapToFilters(
   for (uint32_t colIdx = 0; colIdx < inputNameList.size(); colIdx++) {
     if (columnToFilterInfo[colIdx].isInitialized()) {
       auto inputType = inputTypeList[colIdx];
+      if (inputType->isDate()) {
+        constructSubfieldFilters<TypeKind::INTEGER, common::BigintRange>(
+            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+        continue;
+      }
       switch (inputType->kind()) {
         case TypeKind::TINYINT:
           constructSubfieldFilters<TypeKind::TINYINT, common::BigintRange>(
@@ -1967,10 +1972,6 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::mapToFilters(
           break;
         case TypeKind::VARCHAR:
           constructSubfieldFilters<TypeKind::VARCHAR, common::Filter>(
-              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-          break;
-        case TypeKind::DATE:
-          constructSubfieldFilters<TypeKind::DATE, common::BigintRange>(
               colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
           break;
         case TypeKind::HUGEINT:

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1935,59 +1935,60 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::mapToFilters(
   // Construct the subfield filters based on the filter info map.
   connector::hive::SubfieldFilters filters;
   for (uint32_t colIdx = 0; colIdx < inputNameList.size(); colIdx++) {
-    auto inputType = inputTypeList[colIdx];
-    if (inputType->isDate()) {
-      constructSubfieldFilters<TypeKind::INTEGER, common::BigintRange>(
-          colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-      continue;
-    }
-    switch (inputType->kind()) {
-      case TypeKind::TINYINT:
-        constructSubfieldFilters<TypeKind::TINYINT, common::BigintRange>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::SMALLINT:
-        constructSubfieldFilters<TypeKind::SMALLINT, common::BigintRange>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::INTEGER:
-        constructSubfieldFilters<TypeKind::INTEGER, common::BigintRange>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::BIGINT:
-        constructSubfieldFilters<TypeKind::BIGINT, common::BigintRange>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::REAL:
-        constructSubfieldFilters<TypeKind::REAL, common::Filter>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::DOUBLE:
-        constructSubfieldFilters<TypeKind::DOUBLE, common::Filter>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::BOOLEAN:
-        constructSubfieldFilters<TypeKind::BOOLEAN, common::BigintRange>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::VARCHAR:
-        constructSubfieldFilters<TypeKind::VARCHAR, common::Filter>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::HUGEINT:
-        constructSubfieldFilters<TypeKind::HUGEINT, common::HugeintRange>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::ARRAY:
-        constructSubfieldFilters<TypeKind::ARRAY, common::Filter>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      case TypeKind::MAP:
-        constructSubfieldFilters<TypeKind::MAP, common::Filter>(
-            colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
-        break;
-      default:
-        VELOX_NYI("Subfield filters creation not supported for input type '{}' in mapToFilters", inputType);
+    if (columnToFilterInfo[colIdx].isInitialized()) {
+      auto inputType = inputTypeList[colIdx];
+      switch (inputType->kind()) {
+        case TypeKind::TINYINT:
+          constructSubfieldFilters<TypeKind::TINYINT, common::BigintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::SMALLINT:
+          constructSubfieldFilters<TypeKind::SMALLINT, common::BigintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::INTEGER:
+          constructSubfieldFilters<TypeKind::INTEGER, common::BigintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::BIGINT:
+          constructSubfieldFilters<TypeKind::BIGINT, common::BigintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::REAL:
+          constructSubfieldFilters<TypeKind::REAL, common::Filter>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::DOUBLE:
+          constructSubfieldFilters<TypeKind::DOUBLE, common::Filter>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::BOOLEAN:
+          constructSubfieldFilters<TypeKind::BOOLEAN, common::BigintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::VARCHAR:
+          constructSubfieldFilters<TypeKind::VARCHAR, common::Filter>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::DATE:
+          constructSubfieldFilters<TypeKind::DATE, common::BigintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::HUGEINT:
+          constructSubfieldFilters<TypeKind::HUGEINT, common::HugeintRange>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::ARRAY:
+          constructSubfieldFilters<TypeKind::ARRAY, common::Filter>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        case TypeKind::MAP:
+          constructSubfieldFilters<TypeKind::MAP, common::Filter>(
+              colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
+          break;
+        default:
+          VELOX_NYI("Subfield filters creation not supported for input type '{}' in mapToFilters", inputType);
+      }
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -40,6 +40,7 @@ import org.apache.spark.util.Utils
 
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
 import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
 import org.apache.hadoop.mapred.TextInputFormat
 
 import java.net.URI
@@ -113,6 +114,9 @@ class HiveTableScanExecTransformer(
       case Some(inputFormat)
           if ORC_INPUT_FORMAT_CLASS.isAssignableFrom(Utils.classForName(inputFormat)) =>
         ReadFileFormat.OrcReadFormat
+      case Some(inputFormat)
+          if PARQUET_INPUT_FORMAT_CLASS.isAssignableFrom(Utils.classForName(inputFormat)) =>
+        ReadFileFormat.ParquetReadFormat
       case _ => ReadFileFormat.UnknownFormat
     }
   }
@@ -203,7 +207,8 @@ object HiveTableScanExecTransformer {
     Utils.classForName("org.apache.hadoop.mapred.TextInputFormat")
   val ORC_INPUT_FORMAT_CLASS: Class[OrcInputFormat] =
     Utils.classForName("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat")
-
+  val PARQUET_INPUT_FORMAT_CLASS: Class[MapredParquetInputFormat] =
+    Utils.classForName("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat")
   def isHiveTableScan(plan: SparkPlan): Boolean = {
     plan.isInstanceOf[HiveTableScanExec]
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -39,8 +39,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-import org.apache.hadoop.hive.ql.plan.TableDesc
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+import org.apache.hadoop.hive.ql.plan.TableDesc
 import org.apache.hadoop.mapred.TextInputFormat
 
 import java.net.URI

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -806,6 +806,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")
+    // Rewrite for supported INT96 - timestamp
+    .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Ignore Spark's filter pushdown check.
     .exclude("Filters should be pushed down for vectorized Parquet reader at row group level")

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -797,7 +797,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .disableByReason("Blocked by ORC Velox upstream not ready")
   enableSuite[GlutenParquetColumnIndexSuite]
-    // Rewrite
+    // Rewrite by just removing test timestamp.
     .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetEncodingSuite]
@@ -808,7 +808,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")
-    // Rewrite for supported INT96 - timestamp
+    // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Ignore Spark's filter pushdown check.
@@ -824,7 +824,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")
-    // Rewrite for supported INT96 - timestamp
+    // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Ignore Spark's filter pushdown check.

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -797,6 +797,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .disableByReason("Blocked by ORC Velox upstream not ready")
   enableSuite[GlutenParquetColumnIndexSuite]
+    // Rewrite
+    .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetEncodingSuite]
   enableSuite[GlutenParquetFileFormatV1Suite]

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -824,6 +824,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")
+    // Rewrite for supported INT96 - timestamp
+    .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Ignore Spark's filter pushdown check.
     .exclude("Filters should be pushed down for vectorized Parquet reader at row group level")

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -18,4 +18,28 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
-class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {}
+class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
+  private val actions: Seq[DataFrame => DataFrame] = Seq(
+    "_1 = 500",
+    "_1 = 500 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
+    "_1 >= 500 and _1 < 1000",
+    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
+  ).map(f => (df: DataFrame) => df.filter(f))
+
+  test("Gluten: test reading unaligned pages - test all types except timestamp") {
+    val df = spark
+      .range(0, 2000)
+      .selectExpr(
+        "id as _1",
+        "cast(id as short) as _3",
+        "cast(id as int) as _4",
+        "cast(id as float) as _5",
+        "cast(id as double) as _6",
+        "cast(id as decimal(20,0)) as _7",
+        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9"
+      )
+    checkUnalignedPages(df)(actions: _*)
+  }
+}

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
 
 class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
   private val actions: Seq[DataFrame => DataFrame] = Seq(

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.CORRECTED
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
+import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.Utils
@@ -41,7 +42,7 @@ import org.apache.parquet.filter2.predicate.Operators.{Column => _, _}
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat, ParquetOutputFormat}
 import org.apache.parquet.hadoop.util.HadoopInputFile
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
 import java.time.LocalDate
 
 import scala.reflect.ClassTag
@@ -68,31 +69,40 @@ abstract class GltuenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
   }
 
   test(GlutenTestConstants.GLUTEN_TEST + "filter pushdown - timestamp") {
-    Seq(true, false).foreach { java8Api =>
-      Seq(CORRECTED, LEGACY).foreach { rebaseMode =>
-        val millisData = Seq(
-          "1000-06-14 08:28:53.123",
-          "1582-06-15 08:28:53.001",
-          "1900-06-16 08:28:53.0",
-          "2018-06-17 08:28:53.999")
-        // INT96 doesn't support pushdown
-        withSQLConf(
-          SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
-          SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
-          SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString) {
-          import testImplicits._
-          withTempPath { file =>
-            millisData.map(i => Tuple1(Timestamp.valueOf(i))).toDF
-              .write.format(dataSourceName).save(file.getCanonicalPath)
-            readParquetFile(file.getCanonicalPath) { df =>
-              val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
-              assertResult(None) {
-                createParquetFilters(schema).createFilter(sources.IsNull("_1"))
+    Seq(true, false).foreach {
+      java8Api =>
+        Seq(CORRECTED, LEGACY).foreach {
+          rebaseMode =>
+            val millisData = Seq(
+              "1000-06-14 08:28:53.123",
+              "1582-06-15 08:28:53.001",
+              "1900-06-16 08:28:53.0",
+              "2018-06-17 08:28:53.999")
+            // INT96 doesn't support pushdown
+            withSQLConf(
+              SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
+              SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
+              SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString
+            ) {
+              import testImplicits._
+              withTempPath {
+                file =>
+                  millisData
+                    .map(i => Tuple1(Timestamp.valueOf(i)))
+                    .toDF
+                    .write
+                    .format(dataSourceName)
+                    .save(file.getCanonicalPath)
+                  readParquetFile(file.getCanonicalPath) {
+                    df =>
+                      val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
+                      assertResult(None) {
+                        createParquetFilters(schema).createFilter(sources.IsNull("_1"))
+                      }
+                  }
               }
             }
-          }
         }
-      }
     }
   }
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -166,4 +166,21 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
       ignoreIfNotExists = true,
       purge = false)
   }
+
+  test("avoid unnecessary filter binding for subfield during scan") {
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      sql("DROP TABLE IF EXISTS test_subfield")
+      sql(
+        "CREATE TABLE test_subfield (name STRING, favorite_color STRING, label STRUCT<label_1:STRING, label_2:STRING>)" +
+          " USING hive OPTIONS(fileFormat 'parquet')")
+      sql("INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a', 'label_2', 'label-b'))");
+      val df = spark.sql("select * from test_subfield where name='test_1'")
+      checkAnswer(df, Seq(Row("test_1", "red", Row("label-a", "label-b"))))
+      checkOperatorMatch[HiveTableScanExecTransformer](df)
+    }
+    spark.sessionState.catalog.dropTable(
+      TableIdentifier("test_subfield"),
+      ignoreIfNotExists = true,
+      purge = false)
+  }
 }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -168,7 +168,7 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
   }
 
   test("avoid unnecessary filter binding for subfield during scan") {
-    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")
       sql(
         "CREATE TABLE test_subfield (name STRING, favorite_color STRING, " +

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -171,9 +171,11 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
     withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")
       sql(
-        "CREATE TABLE test_subfield (name STRING, favorite_color STRING, label STRUCT<label_1:STRING, label_2:STRING>)" +
-          " USING hive OPTIONS(fileFormat 'parquet')")
-      sql("INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a', 'label_2', 'label-b'))");
+        "CREATE TABLE test_subfield (name STRING, favorite_color STRING, " +
+          " label STRUCT<label_1:STRING, label_2:STRING>) USING hive OPTIONS(fileFormat 'parquet')")
+      sql(
+        "INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a'," +
+          " 'label_2', 'label-b'))");
       val df = spark.sql("select * from test_subfield where name='test_1'")
       checkAnswer(df, Seq(Row("test_1", "red", Row("label-a", "label-b"))))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -665,6 +665,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
+    // Rewrite for supported INT96 - timestamp
+    .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Exception bebaviour.
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -625,6 +625,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .disableByReason("Blocked by ORC Velox upstream not ready")
   enableSuite[GlutenParquetColumnIndexSuite]
+    // Rewrite
+    .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -625,7 +625,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .disableByReason("Blocked by ORC Velox upstream not ready")
   enableSuite[GlutenParquetColumnIndexSuite]
-    // Rewrite
+    // Rewrite by just removing test timestamp.
     .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
@@ -647,7 +647,7 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
-    // Rewrite for supported INT96 - timestamp
+    // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Exception bebaviour.
@@ -665,7 +665,7 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
-    // Rewrite for supported INT96 - timestamp
+    // Rewrite for supported INT96 - timestamp.
     .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Exception bebaviour.

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -645,6 +645,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
+    // Rewrite for supported INT96 - timestamp
+    .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Exception bebaviour.
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -16,6 +16,30 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
 
-class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {}
+class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
+  private val actions: Seq[DataFrame => DataFrame] = Seq(
+    "_1 = 500",
+    "_1 = 500 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
+    "_1 >= 500 and _1 < 1000",
+    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
+  ).map(f => (df: DataFrame) => df.filter(f))
+
+  test("Gluten: test reading unaligned pages - test all types") {
+    val df = spark
+      .range(0, 2000)
+      .selectExpr(
+        "id as _1",
+        "cast(id as short) as _3",
+        "cast(id as int) as _4",
+        "cast(id as float) as _5",
+        "cast(id as double) as _6",
+        "cast(id as decimal(20,0)) as _7",
+        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9"
+      )
+    checkUnalignedPages(df)(actions: _*)
+  }
+}

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -29,9 +29,11 @@ import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
+import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.Utils
+
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate}
 import org.apache.parquet.filter2.predicate.FilterApi._
@@ -39,10 +41,10 @@ import org.apache.parquet.filter2.predicate.Operators
 import org.apache.parquet.filter2.predicate.Operators.{Column => _, _}
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat, ParquetOutputFormat}
 import org.apache.parquet.hadoop.util.HadoopInputFile
-import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
 
 import java.sql.{Date, Timestamp}
 import java.time.LocalDate
+
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
@@ -67,31 +69,40 @@ abstract class GltuenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
   }
 
   test(GlutenTestConstants.GLUTEN_TEST + "filter pushdown - timestamp") {
-    Seq(true, false).foreach { java8Api =>
-      Seq(CORRECTED, LEGACY).foreach { rebaseMode =>
-        val millisData = Seq(
-          "1000-06-14 08:28:53.123",
-          "1582-06-15 08:28:53.001",
-          "1900-06-16 08:28:53.0",
-          "2018-06-17 08:28:53.999")
-        // INT96 doesn't support pushdown
-        withSQLConf(
-          SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
-          SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
-          SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString) {
-          import testImplicits._
-          withTempPath { file =>
-            millisData.map(i => Tuple1(Timestamp.valueOf(i))).toDF
-              .write.format(dataSourceName).save(file.getCanonicalPath)
-            readParquetFile(file.getCanonicalPath) { df =>
-              val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
-              assertResult(None) {
-                createParquetFilters(schema).createFilter(sources.IsNull("_1"))
+    Seq(true, false).foreach {
+      java8Api =>
+        Seq(CORRECTED, LEGACY).foreach {
+          rebaseMode =>
+            val millisData = Seq(
+              "1000-06-14 08:28:53.123",
+              "1582-06-15 08:28:53.001",
+              "1900-06-16 08:28:53.0",
+              "2018-06-17 08:28:53.999")
+            // INT96 doesn't support pushdown
+            withSQLConf(
+              SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
+              SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
+              SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString
+            ) {
+              import testImplicits._
+              withTempPath {
+                file =>
+                  millisData
+                    .map(i => Tuple1(Timestamp.valueOf(i)))
+                    .toDF
+                    .write
+                    .format(dataSourceName)
+                    .save(file.getCanonicalPath)
+                  readParquetFile(file.getCanonicalPath) {
+                    df =>
+                      val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
+                      assertResult(None) {
+                        createParquetFilters(schema).createFilter(sources.IsNull("_1"))
+                      }
+                  }
               }
             }
-          }
         }
-      }
     }
   }
 

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -28,11 +28,10 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.CORRECTED
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.Utils
-
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate}
 import org.apache.parquet.filter2.predicate.FilterApi._
@@ -40,10 +39,10 @@ import org.apache.parquet.filter2.predicate.Operators
 import org.apache.parquet.filter2.predicate.Operators.{Column => _, _}
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat, ParquetOutputFormat}
 import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
 import java.time.LocalDate
-
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
@@ -65,6 +64,35 @@ abstract class GltuenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
   override protected def readResourceParquetFile(name: String): DataFrame = {
     spark.read.parquet(
       getWorkspaceFilePath("sql", "core", "src", "test", "resources").toString + "/" + name)
+  }
+
+  test(GlutenTestConstants.GLUTEN_TEST + "filter pushdown - timestamp") {
+    Seq(true, false).foreach { java8Api =>
+      Seq(CORRECTED, LEGACY).foreach { rebaseMode =>
+        val millisData = Seq(
+          "1000-06-14 08:28:53.123",
+          "1582-06-15 08:28:53.001",
+          "1900-06-16 08:28:53.0",
+          "2018-06-17 08:28:53.999")
+        // INT96 doesn't support pushdown
+        withSQLConf(
+          SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
+          SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
+          SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString) {
+          import testImplicits._
+          withTempPath { file =>
+            millisData.map(i => Tuple1(Timestamp.valueOf(i))).toDF
+              .write.format(dataSourceName).save(file.getCanonicalPath)
+            readParquetFile(file.getCanonicalPath) { df =>
+              val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
+              assertResult(None) {
+                createParquetFilters(schema).createFilter(sources.IsNull("_1"))
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   test(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -168,12 +168,14 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
   }
 
   test("avoid unnecessary filter binding for subfield during scan") {
-    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")
       sql(
-        "CREATE TABLE test_subfield (name STRING, favorite_color STRING, label STRUCT<label_1:STRING, label_2:STRING>)" +
-          " USING hive OPTIONS(fileFormat 'parquet')")
-      sql("INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a', 'label_2', 'label-b'))");
+        "CREATE TABLE test_subfield (name STRING, favorite_color STRING," +
+          " label STRUCT<label_1:STRING, label_2:STRING>) USING hive OPTIONS(fileFormat 'parquet')")
+      sql(
+        "INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a'," +
+          "'label_2', 'label-b'))");
       val df = spark.sql("select * from test_subfield where name='test_1'")
       checkAnswer(df, Seq(Row("test_1", "red", Row("label-a", "label-b"))))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -166,4 +166,20 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
       ignoreIfNotExists = true,
       purge = false)
   }
+  test("avoid unnecessary filter binding for subfield during scan") {
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      sql("DROP TABLE IF EXISTS test_subfield")
+      sql(
+        "CREATE TABLE test_subfield (name STRING, favorite_color STRING, label STRUCT<label_1:STRING, label_2:STRING>)" +
+          " USING hive OPTIONS(fileFormat 'parquet')")
+      sql("INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a', 'label_2', 'label-b'))");
+      val df = spark.sql("select * from test_subfield where name='test_1'")
+      checkAnswer(df, Seq(Row("test_1", "red", Row("label-a", "label-b"))))
+      checkOperatorMatch[HiveTableScanExecTransformer](df)
+    }
+    spark.sessionState.catalog.dropTable(
+      TableIdentifier("test_subfield"),
+      ignoreIfNotExists = true,
+      purge = false)
+  }
 }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -166,6 +166,7 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
       ignoreIfNotExists = true,
       purge = false)
   }
+
   test("avoid unnecessary filter binding for subfield during scan") {
     withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -641,6 +641,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Non-vectorized reader - with partition data column - SPARK-38977: schema pruning with correlated NOT IN subquery")
     .disableByReason("Blocked by ORC Velox upstream not ready")
   enableSuite[GlutenParquetColumnIndexSuite]
+    // Rewrite by just removing test timestamp.
+    .exclude("test reading unaligned pages - test all types")
   enableSuite[GlutenParquetCompressionCodecPrecedenceSuite]
   enableSuite[GlutenParquetDeltaByteArrayEncodingSuite]
   enableSuite[GlutenParquetDeltaEncodingInteger]
@@ -661,6 +663,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
+    // Rewrite for supported INT96 - timestamp.
+    .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Exception bebaviour.
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")
@@ -678,6 +682,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite.
     .exclude("Filter applied on merged Parquet schema with new column should work")
     .exclude("SPARK-23852: Broken Parquet push-down for partially-written stats")
+    // Rewrite for supported INT96 - timestamp.
+    .exclude("filter pushdown - timestamp")
     .exclude("filter pushdown - date")
     // Exception bebaviour.
     .exclude("SPARK-25207: exception when duplicate fields in case-insensitive mode")

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetColumnIndexSuite.scala
@@ -16,6 +16,30 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.sql.GlutenSQLTestsBaseTrait
+import org.apache.spark.sql.{DataFrame, GlutenSQLTestsBaseTrait}
 
-class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {}
+class GlutenParquetColumnIndexSuite extends ParquetColumnIndexSuite with GlutenSQLTestsBaseTrait {
+  private val actions: Seq[DataFrame => DataFrame] = Seq(
+    "_1 = 500",
+    "_1 = 500 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1500",
+    "_1 = 500 or _1 = 501 or _1 = 1000 or _1 = 1500",
+    "_1 >= 500 and _1 < 1000",
+    "(_1 >= 500 and _1 < 1000) or (_1 >= 1500 and _1 < 1600)"
+  ).map(f => (df: DataFrame) => df.filter(f))
+
+  test("Gluten: test reading unaligned pages - test all types") {
+    val df = spark
+      .range(0, 2000)
+      .selectExpr(
+        "id as _1",
+        "cast(id as short) as _3",
+        "cast(id as int) as _4",
+        "cast(id as float) as _5",
+        "cast(id as double) as _6",
+        "cast(id as decimal(20,0)) as _7",
+        "cast(cast(1618161925000 + id * 1000 * 60 * 60 * 24 as timestamp) as date) as _9"
+      )
+    checkUnalignedPages(df)(actions: _*)
+  }
+}

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -28,7 +28,8 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.CORRECTED
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.{CORRECTED, LEGACY}
+import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType.INT96
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.Utils
@@ -36,11 +37,12 @@ import org.apache.spark.util.Utils
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate, Operators}
 import org.apache.parquet.filter2.predicate.FilterApi._
+import org.apache.parquet.filter2.predicate.Operators
 import org.apache.parquet.filter2.predicate.Operators.{Column => _, Eq, Gt, GtEq, Lt, LtEq, NotEq}
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat, ParquetOutputFormat}
 import org.apache.parquet.hadoop.util.HadoopInputFile
 
-import java.sql.Date
+import java.sql.{Date, Timestamp}
 import java.time.LocalDate
 
 import scala.reflect.ClassTag
@@ -64,6 +66,44 @@ abstract class GltuenParquetFilterSuite extends ParquetFilterSuite with GlutenSQ
   override protected def readResourceParquetFile(name: String): DataFrame = {
     spark.read.parquet(
       getWorkspaceFilePath("sql", "core", "src", "test", "resources").toString + "/" + name)
+  }
+
+  test(GlutenTestConstants.GLUTEN_TEST + "filter pushdown - timestamp") {
+    Seq(true, false).foreach {
+      java8Api =>
+        Seq(CORRECTED, LEGACY).foreach {
+          rebaseMode =>
+            val millisData = Seq(
+              "1000-06-14 08:28:53.123",
+              "1582-06-15 08:28:53.001",
+              "1900-06-16 08:28:53.0",
+              "2018-06-17 08:28:53.999")
+            // INT96 doesn't support pushdown
+            withSQLConf(
+              SQLConf.DATETIME_JAVA8API_ENABLED.key -> java8Api.toString,
+              SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key -> rebaseMode.toString,
+              SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> INT96.toString
+            ) {
+              import testImplicits._
+              withTempPath {
+                file =>
+                  millisData
+                    .map(i => Tuple1(Timestamp.valueOf(i)))
+                    .toDF
+                    .write
+                    .format(dataSourceName)
+                    .save(file.getCanonicalPath)
+                  readParquetFile(file.getCanonicalPath) {
+                    df =>
+                      val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)
+                      assertResult(None) {
+                        createParquetFilters(schema).createFilter(sources.IsNull("_1"))
+                      }
+                  }
+              }
+            }
+        }
+    }
   }
 
   test(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Gluten tried to do a filter binding against subfield but actually not all subfields have corresponding filter. For example, `select * from table where a > 0` where `table` has cols `a` and `b`, so there is no need to do filter binding for `b` at all.


## How was this patch tested?

UT added

