### PR TITLE
[GLUTEN-3302][VL] Change all kinds of JniWrapper's create with required ExectionCtx to avoid race condition

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
+++ b/backends-velox/src/main/java/io/glutenproject/spark/sql/execution/datasources/velox/DatasourceJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.spark.sql.execution.datasources.velox;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 import io.glutenproject.init.JniUtils;
 
@@ -35,8 +34,8 @@ public class DatasourceJniWrapper extends JniInitialized implements ExecutionCtx
     this.ctx = ctx;
   }
 
-  public static DatasourceJniWrapper create() {
-    return new DatasourceJniWrapper(ExecutionCtxs.contextInstance());
+  public static DatasourceJniWrapper create(ExecutionCtx ctx) {
+    return new DatasourceJniWrapper(ctx);
   }
 
   @Override

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorHandler.scala
@@ -18,6 +18,7 @@ package io.glutenproject.backendsapi.velox
 
 import io.glutenproject.GlutenNumaBindingInfo
 import io.glutenproject.backendsapi.IteratorApi
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.execution._
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
@@ -152,7 +153,7 @@ class IteratorHandler extends IteratorApi with Logging {
       new util.ArrayList[GeneralInIterator](inputIterators.map {
         iter => new ColumnarBatchInIterator(iter.asJava)
       }.asJava)
-    val transKernel = NativePlanEvaluator.create()
+    val transKernel = NativePlanEvaluator.create(ExecutionCtxs.contextInstance())
     val resIter: GeneralOutIterator =
       transKernel.createKernelWithBatchIterator(inputPartition.plan, columnarNativeIterators)
     pipelineTime += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - beforeBuild)
@@ -201,7 +202,7 @@ class IteratorHandler extends IteratorApi with Logging {
 
     val beforeBuild = System.nanoTime()
 
-    val transKernel = NativePlanEvaluator.create()
+    val transKernel = NativePlanEvaluator.create(ExecutionCtxs.contextInstance())
     val columnarNativeIterator =
       new util.ArrayList[GeneralInIterator](inputIterators.map {
         iter => new ColumnarBatchInIterator(iter.asJava)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecHandler.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi.velox
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.SparkPlanExecApi
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.execution._
 import io.glutenproject.expression._
 import io.glutenproject.expression.ConverterUtils.FunctionConfig
@@ -296,7 +297,7 @@ class SparkPlanExecHandler extends SparkPlanExecApi {
           } else {
             val handleArray = input.map(ColumnarBatches.getNativeHandle).toArray
             val serializeResult = ColumnarBatchSerializerJniWrapper
-              .create()
+              .create(ExecutionCtxs.contextInstance())
               .serialize(
                 handleArray,
                 NativeMemoryManagers

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -90,7 +90,7 @@ object RowToVeloxColumnarExec {
 
     val arrowSchema =
       SparkArrowUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)
-    val jniWrapper = NativeRowToColumnarJniWrapper.create()
+    val jniWrapper = NativeRowToColumnarJniWrapper.create(ExecutionCtxs.contextInstance())
     val allocator = ArrowBufferAllocators.contextInstance()
     val cSchema = ArrowSchema.allocateNew(allocator)
     var closed = false

--- a/backends-velox/src/main/scala/io/glutenproject/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/VeloxColumnarToRowExec.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.vectorized.NativeColumnarToRowJniWrapper
@@ -97,7 +98,7 @@ object VeloxColumnarToRowExec {
     }
 
     // TODO:: pass the jni jniWrapper and arrowSchema  and serializeSchema method by broadcast
-    val jniWrapper = NativeColumnarToRowJniWrapper.create()
+    val jniWrapper = NativeColumnarToRowJniWrapper.create(ExecutionCtxs.contextInstance())
     var closed = false
     val c2rId = jniWrapper.nativeColumnarToRowInit(
       NativeMemoryManagers.contextInstance("ColumnarToRow").getNativeInstanceHandle)

--- a/backends-velox/src/main/scala/io/glutenproject/utils/DatasourceUtil.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/DatasourceUtil.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.utils
 
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.spark.sql.execution.datasources.velox.DatasourceJniWrapper
@@ -38,7 +39,7 @@ object DatasourceUtil {
 
   def readSchema(file: FileStatus): Option[StructType] = {
     val allocator = ArrowBufferAllocators.contextInstance()
-    val datasourceJniWrapper = DatasourceJniWrapper.create()
+    val datasourceJniWrapper = DatasourceJniWrapper.create(ExecutionCtxs.contextInstance())
     val dsHandle = datasourceJniWrapper.nativeInitDatasource(
       file.getPath.toString,
       -1,

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.velox
 
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.exception.GlutenException
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.execution.datasource.GlutenRowSplitter
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
@@ -50,7 +51,7 @@ trait VeloxFormatWriterInjects extends GlutenFormatWriterInjectsBase {
       SparkArrowUtil.toArrowSchema(dataSchema, SQLConf.get.sessionLocalTimeZone)
     val cSchema = ArrowSchema.allocateNew(ArrowBufferAllocators.contextInstance())
     var dsHandle = -1L
-    val datasourceJniWrapper = DatasourceJniWrapper.create()
+    val datasourceJniWrapper = DatasourceJniWrapper.create(ExecutionCtxs.contextInstance())
     val allocator = ArrowBufferAllocators.contextInstance()
     try {
       ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedVeloxColumnarShuffleWriter.scala
@@ -18,6 +18,7 @@ package org.apache.spark.shuffle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exec.ExectionCtxs
 import io.glutenproject.memory.memtarget.spark.Spiller
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.vectorized._
@@ -47,7 +48,7 @@ class CelebornHashBasedVeloxColumnarShuffleWriter[K, V](
     client,
     writeMetrics) {
 
-  private val jniWrapper = ShuffleWriterJniWrapper.create()
+  private val jniWrapper = ShuffleWriterJniWrapper.create(ExecutionCtxs.contextInstance())
 
   private var splitResult: SplitResult = _
 

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.columnarbatch;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 
 public class ColumnarBatchJniWrapper extends JniInitialized implements ExecutionCtxAware {
@@ -28,11 +27,7 @@ public class ColumnarBatchJniWrapper extends JniInitialized implements Execution
     this.ctx = ctx;
   }
 
-  public static ColumnarBatchJniWrapper create() {
-    return new ColumnarBatchJniWrapper(ExecutionCtxs.contextInstance());
-  }
-
-  public static ColumnarBatchJniWrapper forCtx(ExecutionCtx ctx) {
+  public static ColumnarBatchJniWrapper create(ExecutionCtx ctx) {
     return new ColumnarBatchJniWrapper(ctx);
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -116,7 +116,7 @@ public class ColumnarBatches {
       NativeMemoryManager nmm, ColumnarBatch batch, int[] columnIndices) {
     final IndicatorVector iv = getIndicatorVector(batch);
     long outputBatchHandle =
-        ColumnarBatchJniWrapper.create()
+        ColumnarBatchJniWrapper.create(ExecutionCtxs.contextInstance())
             .select(nmm.getNativeInstanceHandle(), iv.handle(), columnIndices);
     return create(iv.ctx(), outputBatchHandle);
   }
@@ -163,7 +163,7 @@ public class ColumnarBatches {
         ArrowArray cArray = ArrowArray.allocateNew(allocator);
         ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
         CDataDictionaryProvider provider = new CDataDictionaryProvider()) {
-      ColumnarBatchJniWrapper.forCtx(iv.ctx())
+      ColumnarBatchJniWrapper.create(iv.ctx())
           .exportToArrow(iv.handle(), cSchema.memoryAddress(), cArray.memoryAddress());
 
       Data.exportSchema(
@@ -202,7 +202,7 @@ public class ColumnarBatches {
       ArrowAbiUtil.exportFromSparkColumnarBatch(
           ArrowBufferAllocators.contextInstance(), input, cSchema, cArray);
       long handle =
-          ColumnarBatchJniWrapper.forCtx(ctx)
+          ColumnarBatchJniWrapper.create(ctx)
               .createWithArrowArray(cSchema.memoryAddress(), cArray.memoryAddress());
       ColumnarBatch output = ColumnarBatches.create(ctx, handle);
 
@@ -315,7 +315,7 @@ public class ColumnarBatches {
     Preconditions.checkState(
         ctxs.length == 1, "All input batches should be managed by same ExecutionCtx.");
     final long[] handles = Arrays.stream(ivs).mapToLong(IndicatorVector::handle).toArray();
-    return ColumnarBatchJniWrapper.forCtx(ctxs[0]).compose(handles);
+    return ColumnarBatchJniWrapper.create(ctxs[0]).compose(handles);
   }
 
   public static ColumnarBatch create(ExecutionCtx ctx, long nativeHandle) {

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/IndicatorVector.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/IndicatorVector.java
@@ -43,15 +43,15 @@ public class IndicatorVector extends ColumnVector {
   }
 
   public String getType() {
-    return ColumnarBatchJniWrapper.forCtx(ctx).getType(handle);
+    return ColumnarBatchJniWrapper.create(ctx).getType(handle);
   }
 
   public long getNumColumns() {
-    return ColumnarBatchJniWrapper.forCtx(ctx).numColumns(handle);
+    return ColumnarBatchJniWrapper.create(ctx).numColumns(handle);
   }
 
   public long getNumRows() {
-    return ColumnarBatchJniWrapper.forCtx(ctx).numRows(handle);
+    return ColumnarBatchJniWrapper.create(ctx).numRows(handle);
   }
 
   public long refCnt() {
@@ -69,7 +69,7 @@ public class IndicatorVector extends ColumnVector {
       return;
     }
     if (refCnt.decrementAndGet() == 0) {
-      ColumnarBatchJniWrapper.forCtx(ctx).close(handle);
+      ColumnarBatchJniWrapper.create(ctx).close(handle);
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializerJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ColumnarBatchSerializerJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 
 public class ColumnarBatchSerializerJniWrapper extends JniInitialized implements ExecutionCtxAware {
@@ -28,11 +27,7 @@ public class ColumnarBatchSerializerJniWrapper extends JniInitialized implements
     this.ctx = ctx;
   }
 
-  public static ColumnarBatchSerializerJniWrapper create() {
-    return new ColumnarBatchSerializerJniWrapper(ExecutionCtxs.contextInstance());
-  }
-
-  public static ColumnarBatchSerializerJniWrapper forCtx(ExecutionCtx ctx) {
+  public static ColumnarBatchSerializerJniWrapper create(ExecutionCtx ctx) {
     return new ColumnarBatchSerializerJniWrapper(ctx);
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeColumnarToRowJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 
 public class NativeColumnarToRowJniWrapper extends JniInitialized implements ExecutionCtxAware {
@@ -28,11 +27,7 @@ public class NativeColumnarToRowJniWrapper extends JniInitialized implements Exe
     this.ctx = ctx;
   }
 
-  public static NativeColumnarToRowJniWrapper create() {
-    return new NativeColumnarToRowJniWrapper(ExecutionCtxs.contextInstance());
-  }
-
-  public static NativeColumnarToRowJniWrapper forCtx(ExecutionCtx ctx) {
+  public static NativeColumnarToRowJniWrapper create(ExecutionCtx ctx) {
     return new NativeColumnarToRowJniWrapper(ctx);
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -48,11 +48,11 @@ public class NativePlanEvaluator {
   private final PlanEvaluatorJniWrapper jniWrapper;
 
   private NativePlanEvaluator(ExecutionCtx ctx) {
-    jniWrapper = PlanEvaluatorJniWrapper.forCtx(ctx);
+    jniWrapper = PlanEvaluatorJniWrapper.create(ctx);
   }
 
-  public static NativePlanEvaluator create() {
-    return new NativePlanEvaluator(ExecutionCtxs.contextInstance());
+  public static NativePlanEvaluator create(ExecutionCtx ctx) {
+    return new NativePlanEvaluator(ctx);
   }
 
   public static NativePlanEvaluator createForValidation() {

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativeRowToColumnarJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativeRowToColumnarJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 
 public class NativeRowToColumnarJniWrapper extends JniInitialized implements ExecutionCtxAware {
@@ -28,8 +27,8 @@ public class NativeRowToColumnarJniWrapper extends JniInitialized implements Exe
     this.ctx = ctx;
   }
 
-  public static NativeRowToColumnarJniWrapper create() {
-    return new NativeRowToColumnarJniWrapper(ExecutionCtxs.contextInstance());
+  public static NativeRowToColumnarJniWrapper create(ExecutionCtx ctx) {
+    return new NativeRowToColumnarJniWrapper(ctx);
   }
 
   @Override

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 import io.glutenproject.validate.NativePlanValidationInfo;
 
@@ -34,11 +33,7 @@ public class PlanEvaluatorJniWrapper extends JniInitialized implements Execution
     this.ctx = ctx;
   }
 
-  public static PlanEvaluatorJniWrapper create() {
-    return new PlanEvaluatorJniWrapper(ExecutionCtxs.contextInstance());
-  }
-
-  public static PlanEvaluatorJniWrapper forCtx(ExecutionCtx ctx) {
+  public static PlanEvaluatorJniWrapper create(ExecutionCtx ctx) {
     return new PlanEvaluatorJniWrapper(ctx);
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 
 public class ShuffleReaderJniWrapper extends JniInitialized implements ExecutionCtxAware {
@@ -28,8 +27,8 @@ public class ShuffleReaderJniWrapper extends JniInitialized implements Execution
     this.ctx = ctx;
   }
 
-  public static ShuffleReaderJniWrapper create() {
-    return new ShuffleReaderJniWrapper(ExecutionCtxs.contextInstance());
+  public static ShuffleReaderJniWrapper create(ExecutionCtx ctx) {
+    return new ShuffleReaderJniWrapper(ctx);
   }
 
   @Override

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -18,7 +18,6 @@ package io.glutenproject.vectorized;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
-import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 
 import java.io.IOException;
@@ -30,8 +29,8 @@ public class ShuffleWriterJniWrapper extends JniInitialized implements Execution
     this.ctx = ctx;
   }
 
-  public static ShuffleWriterJniWrapper create() {
-    return new ShuffleWriterJniWrapper(ExecutionCtxs.contextInstance());
+  public static ShuffleWriterJniWrapper create(ExecutionCtx ctx) {
+    return new ShuffleWriterJniWrapper(ctx);
   }
 
   @Override

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -95,7 +95,7 @@ private class ColumnarBatchSerializerInstance(
       }
     val compressionCodecBackend =
       GlutenConfig.getConf.columnarShuffleCodecBackend.orNull
-    val jniWrapper = ShuffleReaderJniWrapper.create()
+    val jniWrapper = ShuffleReaderJniWrapper.create(ExecutionCtxs.contextInstance())
     val shuffleReaderHandle = jniWrapper.make(
       cSchema.memoryAddress(),
       NativeMemoryManagers.contextInstance("ShuffleReader").getNativeInstanceHandle,
@@ -128,7 +128,7 @@ private class ColumnarBatchSerializerInstance(
       private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
         ExecutionCtxs.contextInstance(),
         ShuffleReaderJniWrapper
-          .create()
+          .create(ExecutionCtxs.contextInstance())
           .readStream(shuffleReaderHandle, byteIn))
 
       private var cb: ColumnarBatch = _

--- a/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala
@@ -18,6 +18,7 @@ package org.apache.spark.shuffle
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.memory.memtarget.spark.Spiller
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.vectorized._
@@ -80,7 +81,7 @@ class ColumnarShuffleWriter[K, V](
 
   private val reallocThreshold = GlutenConfig.getConf.columnarShuffleReallocThreshold
 
-  private val jniWrapper = ShuffleWriterJniWrapper.create()
+  private val jniWrapper = ShuffleWriterJniWrapper.create(ExecutionCtxs.contextInstance())
 
   private var nativeShuffleWriter: Long = -1L
 

--- a/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
+++ b/gluten-data/src/main/scala/org/apache/spark/sql/execution/utils/ExecUtil.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.utils
 
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.exec.ExecutionCtxs
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.vectorized.{ArrowWritableColumnVector, NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper, NativePartitioning}
@@ -41,7 +42,7 @@ import org.apache.spark.util.{MutablePair, TaskResources}
 object ExecUtil {
 
   def convertColumnarToRow(batch: ColumnarBatch): Iterator[InternalRow] = {
-    val jniWrapper = NativeColumnarToRowJniWrapper.create()
+    val jniWrapper = NativeColumnarToRowJniWrapper.create(ExecutionCtxs.contextInstance())
     var info: NativeColumnarToRowInfo = null
     val batchHandle = ColumnarBatches.getNativeHandle(batch)
     val c2rHandle = jniWrapper.nativeColumnarToRowInit(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previous implementation need hold TaskResources' object lock in every JniWrapper#create method, but that method may be used in TaskResources internal, it cause race condition in some cases.

Fixes: \#3302

