### PR TITLE
[GLUTEN-3302][VL] Fix dead lock of BackendJniWrapper static loading

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -315,7 +315,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   gluten::getJniCommonState()->close();
 }
 
-JNIEXPORT jlong JNICALL Java_io_glutenproject_init_ExecutionCtxJniWrapper_createExecutionCtx( // NOLINT
+JNIEXPORT jlong JNICALL Java_io_glutenproject_exec_ExecutionCtxJniWrapper_createExecutionCtx( // NOLINT
     JNIEnv* env,
     jclass) {
   JNI_METHOD_START
@@ -324,7 +324,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_init_ExecutionCtxJniWrapper_create
   JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT void JNICALL Java_io_glutenproject_init_ExecutionCtxJniWrapper_releaseExecutionCtx( // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_exec_ExecutionCtxJniWrapper_releaseExecutionCtx( // NOLINT
     JNIEnv* env,
     jclass,
     jlong ctxHandle) {

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -315,7 +315,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   gluten::getJniCommonState()->close();
 }
 
-JNIEXPORT jlong JNICALL Java_io_glutenproject_init_BackendJniWrapper_createExecutionCtx( // NOLINT
+JNIEXPORT jlong JNICALL Java_io_glutenproject_init_ExecutionCtxJniWrapper_createExecutionCtx( // NOLINT
     JNIEnv* env,
     jclass) {
   JNI_METHOD_START
@@ -324,7 +324,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_init_BackendJniWrapper_createExecu
   JNI_METHOD_END(kInvalidResourceHandle)
 }
 
-JNIEXPORT void JNICALL Java_io_glutenproject_init_BackendJniWrapper_releaseExecutionCtx( // NOLINT
+JNIEXPORT void JNICALL Java_io_glutenproject_init_ExecutionCtxJniWrapper_releaseExecutionCtx( // NOLINT
     JNIEnv* env,
     jclass,
     jlong ctxHandle) {

--- a/gluten-data/src/main/java/io/glutenproject/exec/ExecutionCtxJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/exec/ExecutionCtxJniWrapper.java
@@ -14,19 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.exec
+package io.glutenproject.exec;
 
-import org.apache.spark.util.TaskResource
+import io.glutenproject.init.JniInitialized;
 
-class ExecutionCtx private[exec] () extends TaskResource {
+public class ExecutionCtxJniWrapper extends JniInitialized {
 
-  private val handle = ExecutionCtxJniWrapper.createExecutionCtx()
+  private ExecutionCtxJniWrapper() {}
 
-  def getHandle: Long = handle
+  public static native long createExecutionCtx();
 
-  override def release(): Unit = ExecutionCtxJniWrapper.releaseExecutionCtx(handle)
-
-  override def priority(): Int = 10
-
-  override def resourceName(): String = s"ExecutionCtx_" + handle
+  public static native void releaseExecutionCtx(long handle);
 }

--- a/gluten-data/src/main/java/io/glutenproject/init/BackendJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/init/BackendJniWrapper.java
@@ -16,13 +16,9 @@
  */
 package io.glutenproject.init;
 
-public class BackendJniWrapper extends JniInitialized {
+public class BackendJniWrapper {
 
   private BackendJniWrapper() {}
 
   public static native void initializeBackend(byte[] configPlan);
-
-  public static native long createExecutionCtx();
-
-  public static native void releaseExecutionCtx(long handle);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

BackendJniWrapper extend JniInitialized and JniInitializer invoke BackendJniWrapper#initializeBackend static method too, it will cause dead lock on static object lock.

PR #3929 change BackendJniWrapper#createExecutionCtx usage and let BackendJniWrapper init first in some case trigger this issue. Before 3929, JniInitializer's static lock was hold by other JniWrapper initialization which extend JniInitializer, it's safe to hold BackendJniWrapper static lock.

(Fixes: \#3302)
