### PR TITLE
[VL] Wrong #numCols() result for offloaded columnar batch whose vector count is zero

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -261,7 +261,11 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
                 .deserialize(deserializerHandle, cachedBatch.bytes)
             val batch = ColumnarBatches.create(ExecutionCtxs.contextInstance(), batchHandle)
             if (shouldPruning) {
-              ColumnarBatches.select(nmm, batch, requestedColumnIndices.toArray)
+              try {
+                ColumnarBatches.select(nmm, batch, requestedColumnIndices.toArray)
+              } finally {
+                batch.close()
+              }
             } else {
               batch
             }

--- a/cpp/core/compute/ExecutionCtx.h
+++ b/cpp/core/compute/ExecutionCtx.h
@@ -62,6 +62,7 @@ class ExecutionCtx : public std::enable_shared_from_this<ExecutionCtx> {
 
   virtual ResourceHandle addBatch(std::shared_ptr<ColumnarBatch>) = 0;
   virtual std::shared_ptr<ColumnarBatch> getBatch(ResourceHandle) = 0;
+  virtual ResourceHandle createOrGetEmptySchemaBatch(int32_t numRows) = 0;
   virtual void releaseBatch(ResourceHandle) = 0;
   virtual ResourceHandle select(MemoryManager*, ResourceHandle, std::vector<int32_t>) = 0;
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -708,6 +708,16 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
   JNI_METHOD_END(kInvalidResourceHandle)
 }
 
+JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_getForEmptySchema( // NOLINT
+    JNIEnv* env,
+    jobject wrapper,
+    jint numRows) {
+  JNI_METHOD_START
+  auto ctx = gluten::getExecutionCtx(env, wrapper);
+  return ctx->createOrGetEmptySchemaBatch(static_cast<int32_t>(numRows));
+  JNI_METHOD_END(kInvalidResourceHandle)
+}
+
 JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrapper_select( // NOLINT
     JNIEnv* env,
     jobject wrapper,

--- a/cpp/core/memory/ColumnarBatch.cc
+++ b/cpp/core/memory/ColumnarBatch.cc
@@ -46,6 +46,12 @@ std::ostream& operator<<(std::ostream& os, const ColumnarBatch& columnarBatch) {
   return os << "NumColumns: " << std::to_string(columnarBatch.numColumns())
             << "NumRows: " << std::to_string(columnarBatch.numRows());
 }
+std::shared_ptr<ColumnarBatch> createZeroColumnBatch(int32_t numRows) {
+  return std::make_shared<ArrowColumnarBatch>(arrow::RecordBatch::Make(
+      std::make_shared<arrow::Schema>(std::vector<std::shared_ptr<arrow::Field>>()),
+      numRows,
+      std::vector<std::shared_ptr<arrow::Array>>()));
+}
 
 ArrowColumnarBatch::ArrowColumnarBatch(std::shared_ptr<arrow::RecordBatch> batch)
     : ColumnarBatch(batch->num_columns(), batch->num_rows()), batch_(std::move(batch)) {}

--- a/cpp/core/memory/ColumnarBatch.h
+++ b/cpp/core/memory/ColumnarBatch.h
@@ -127,4 +127,6 @@ class CompositeColumnarBatch final : public ColumnarBatch {
   std::shared_ptr<ColumnarBatch> compositeBatch_ = nullptr;
 };
 
+std::shared_ptr<ColumnarBatch> createZeroColumnBatch(int32_t numRows);
+
 } // namespace gluten

--- a/cpp/velox/compute/VeloxExecutionCtx.cc
+++ b/cpp/velox/compute/VeloxExecutionCtx.cc
@@ -163,7 +163,6 @@ VeloxExecutionCtx::select(MemoryManager* memoryManager, ResourceHandle handle, s
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
   auto veloxBatch = gluten::VeloxColumnarBatch::from(ctxVeloxPool.get(), batch);
   auto outputBatch = veloxBatch->select(ctxVeloxPool.get(), std::move(columnIndices));
-  releaseBatch(handle);
   return columnarBatchHolder_.insert(outputBatch);
 }
 

--- a/cpp/velox/compute/VeloxExecutionCtx.cc
+++ b/cpp/velox/compute/VeloxExecutionCtx.cc
@@ -144,6 +144,15 @@ std::shared_ptr<ColumnarBatch> VeloxExecutionCtx::getBatch(ResourceHandle handle
   return columnarBatchHolder_.lookup(handle);
 }
 
+ResourceHandle VeloxExecutionCtx::createOrGetEmptySchemaBatch(int32_t numRows) {
+  auto& lookup = emptySchemaBatchLoopUp_;
+  if (lookup.find(numRows) == lookup.end()) {
+    const std::shared_ptr<ColumnarBatch>& batch = gluten::createZeroColumnBatch(numRows);
+    lookup.emplace(numRows, addBatch(batch)); // the batch will be released after Spark task ends
+  }
+  return lookup.at(numRows);
+}
+
 void VeloxExecutionCtx::releaseBatch(ResourceHandle handle) {
   columnarBatchHolder_.erase(handle);
 }
@@ -152,7 +161,7 @@ ResourceHandle
 VeloxExecutionCtx::select(MemoryManager* memoryManager, ResourceHandle handle, std::vector<int32_t> columnIndices) {
   auto batch = columnarBatchHolder_.lookup(handle);
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);
-  auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(batch);
+  auto veloxBatch = gluten::VeloxColumnarBatch::from(ctxVeloxPool.get(), batch);
   auto outputBatch = veloxBatch->select(ctxVeloxPool.get(), std::move(columnIndices));
   releaseBatch(handle);
   return columnarBatchHolder_.insert(outputBatch);

--- a/cpp/velox/compute/VeloxExecutionCtx.h
+++ b/cpp/velox/compute/VeloxExecutionCtx.h
@@ -73,6 +73,7 @@ class VeloxExecutionCtx final : public ExecutionCtx {
 
   ResourceHandle addBatch(std::shared_ptr<ColumnarBatch> ptr) override;
   std::shared_ptr<ColumnarBatch> getBatch(ResourceHandle handle) override;
+  ResourceHandle createOrGetEmptySchemaBatch(int32_t numRows) override;
   void releaseBatch(ResourceHandle handle) override;
   ResourceHandle select(MemoryManager* memoryManager, ResourceHandle batch, std::vector<int32_t> columnIndices)
       override;
@@ -142,6 +143,8 @@ class VeloxExecutionCtx final : public ExecutionCtx {
   ResourceMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
 
   std::shared_ptr<const facebook::velox::core::PlanNode> veloxPlan_;
+
+  std::unordered_map<int32_t, ResourceHandle> emptySchemaBatchLoopUp_;
 };
 
 } // namespace gluten

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -33,7 +33,7 @@ VeloxPlanConverter::VeloxPlanConverter(
     const std::vector<std::shared_ptr<ResultIterator>>& inputIters,
     velox::memory::MemoryPool* veloxPool,
     const std::unordered_map<std::string, std::string>& confMap)
-    : inputIters_(inputIters), substraitVeloxPlanConverter_(veloxPool, confMap) {}
+    : inputIters_(inputIters), substraitVeloxPlanConverter_(veloxPool, confMap), pool_(veloxPool) {}
 
 void VeloxPlanConverter::setInputPlanNode(const ::substrait::FetchRel& fetchRel) {
   if (fetchRel.has_input()) {
@@ -145,7 +145,7 @@ void VeloxPlanConverter::setInputPlanNode(const ::substrait::ReadRel& sread) {
     veloxTypeList.push_back(toVeloxType(subType->type));
   }
   auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
-  auto vectorStream = std::make_shared<RowVectorStream>(std::move(inputIters_[iterIdx]), outputType);
+  auto vectorStream = std::make_shared<RowVectorStream>(pool_, std::move(inputIters_[iterIdx]), outputType);
   auto valuesNode = std::make_shared<ValueStreamNode>(nextPlanNodeId(), outputType, std::move(vectorStream));
   substraitVeloxPlanConverter_.insertInputNode(iterIdx, valuesNode, planNodeId_);
 }

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <velox/common/memory/MemoryPool.h>
 #include "compute/ResultIterator.h"
 #include "memory/VeloxMemoryManager.h"
 #include "substrait/SubstraitToVeloxPlan.h"
@@ -71,6 +72,8 @@ class VeloxPlanConverter {
   std::vector<std::shared_ptr<ResultIterator>> inputIters_;
 
   SubstraitToVeloxPlanConverter substraitVeloxPlanConverter_;
+
+  facebook::velox::memory::MemoryPool* pool_;
 };
 
 } // namespace gluten

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -55,13 +55,14 @@ VeloxColumnarBatchSerializer::VeloxColumnarBatchSerializer(
 std::shared_ptr<arrow::Buffer> VeloxColumnarBatchSerializer::serializeColumnarBatches(
     const std::vector<std::shared_ptr<ColumnarBatch>>& batches) {
   VELOX_DCHECK(batches.size() != 0, "Should serialize at least 1 vector");
-  auto firstRowVector = std::dynamic_pointer_cast<VeloxColumnarBatch>(batches[0])->getRowVector();
+  const std::shared_ptr<VeloxColumnarBatch>& vb = VeloxColumnarBatch::from(veloxPool_.get(), batches[0]);
+  auto firstRowVector = vb->getRowVector();
   auto numRows = firstRowVector->size();
   auto arena = std::make_unique<StreamArena>(veloxPool_.get());
   auto rowType = asRowType(firstRowVector->type());
   auto serializer = serde_->createSerializer(rowType, numRows, arena.get(), /* serdeOptions */ nullptr);
   for (auto& batch : batches) {
-    auto rowVector = std::dynamic_pointer_cast<VeloxColumnarBatch>(batch)->getRowVector();
+    auto rowVector = VeloxColumnarBatch::from(veloxPool_.get(), batch)->getRowVector();
     numRows = rowVector->size();
     std::vector<IndexRange> rows(numRows);
     for (int i = 0; i < numRows; i++) {

--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -54,7 +54,7 @@ void VeloxColumnarToRowConverter::refreshStates(facebook::velox::RowVectorPtr ro
 }
 
 void VeloxColumnarToRowConverter::convert(std::shared_ptr<ColumnarBatch> cb) {
-  auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
+  auto veloxBatch = VeloxColumnarBatch::from(veloxPool_.get(), cb);
   refreshStates(veloxBatch->getRowVector());
 
   // Initialize the offsets_ , lengths_

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -117,7 +117,7 @@ void VeloxParquetDatasource::close() {
 }
 
 void VeloxParquetDatasource::write(const std::shared_ptr<ColumnarBatch>& cb) {
-  auto veloxBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
+  auto veloxBatch = VeloxColumnarBatch::from(pool_.get(), cb);
   VELOX_DCHECK(veloxBatch != nullptr, "Write batch should be VeloxColumnarBatch");
   parquetWriter_->write(veloxBatch->getFlattenedRowVector());
 }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -533,7 +533,7 @@ std::shared_ptr<arrow::Buffer> VeloxShuffleWriter::generateComplexTypeBuffers(ve
 
 arrow::Status VeloxShuffleWriter::split(std::shared_ptr<ColumnarBatch> cb, int64_t memLimit) {
   if (options_.partitioning_name == "single") {
-    auto veloxColumnBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
+    auto veloxColumnBatch = VeloxColumnarBatch::from(veloxPool_.get(), cb);
     VELOX_DCHECK_NOT_NULL(veloxColumnBatch);
     auto& rv = *veloxColumnBatch->getFlattenedRowVector();
     RETURN_NOT_OK(initFromRowVector(rv));
@@ -567,12 +567,12 @@ arrow::Status VeloxShuffleWriter::split(std::shared_ptr<ColumnarBatch> cb, int64
     START_TIMING(cpuWallTimingList_[CpuWallTimingCompute]);
     RETURN_NOT_OK(partitioner_->compute(pidArr, pidBatch->numRows(), row2Partition_, partition2RowCount_));
     END_TIMING();
-    auto rvBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(batches[1]);
+    auto rvBatch = VeloxColumnarBatch::from(veloxPool_.get(), batches[1]);
     auto& rv = *rvBatch->getFlattenedRowVector();
     RETURN_NOT_OK(initFromRowVector(rv));
     RETURN_NOT_OK(doSplit(rv, memLimit));
   } else {
-    auto veloxColumnBatch = std::dynamic_pointer_cast<VeloxColumnarBatch>(cb);
+    auto veloxColumnBatch = VeloxColumnarBatch::from(veloxPool_.get(), cb);
     VELOX_DCHECK_NOT_NULL(veloxColumnBatch);
     velox::RowVectorPtr rv;
     START_TIMING(cpuWallTimingList_[CpuWallTimingFlattenRV]);

--- a/cpp/velox/tests/ExecutionCtxTest.cc
+++ b/cpp/velox/tests/ExecutionCtxTest.cc
@@ -51,6 +51,9 @@ class DummyExecutionCtx final : public ExecutionCtx {
   std::shared_ptr<ColumnarBatch> getBatch(ResourceHandle handle) override {
     return std::shared_ptr<ColumnarBatch>();
   }
+  ResourceHandle createOrGetEmptySchemaBatch(int32_t numRows) override {
+    return kInvalidResourceHandle;
+  }
   void releaseBatch(ResourceHandle handle) override {}
   ResourceHandle createColumnar2RowConverter(MemoryManager* memoryManager) override {
     return kInvalidResourceHandle;

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -797,6 +797,8 @@ case class ColumnarOverrideRules(session: SparkSession)
       }
     tagBeforeTransformHitsRules :::
       List(
+        (spark: SparkSession) => PlanOneRowRelation(spark),
+        (_: SparkSession) => FallbackEmptySchemaRelation(),
         (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => TransformPreOverrides(isAdaptiveContext),
         (_: SparkSession) => EnsureLocalSortRequirements

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -797,8 +797,6 @@ case class ColumnarOverrideRules(session: SparkSession)
       }
     tagBeforeTransformHitsRules :::
       List(
-        (spark: SparkSession) => PlanOneRowRelation(spark),
-        (_: SparkSession) => FallbackEmptySchemaRelation(),
         (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => TransformPreOverrides(isAdaptiveContext),
         (_: SparkSession) => EnsureLocalSortRequirements

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -21,7 +21,7 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
 import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import io.glutenproject.utils.PhysicalPlanSelector
-import org.apache.commons.lang3.exception.ExceptionUtils
+
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
@@ -37,6 +37,8 @@ import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.EvalPythonExec
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
+
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 import scala.util.control.Breaks.{break, breakable}
 

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -21,11 +21,9 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
 import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import io.glutenproject.utils.PhysicalPlanSelector
-
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.FullOuter
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -39,9 +37,6 @@ import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.EvalPythonExec
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
-import org.apache.spark.sql.types.StringType
-
-import org.apache.commons.lang3.exception.ExceptionUtils
 
 import scala.util.control.Breaks.{break, breakable}
 
@@ -212,53 +207,6 @@ case class FallbackMultiCodegens(session: SparkSession) extends Rule[SparkPlan] 
     if (physicalJoinOptimize) {
       tagNotTransformableForMultiCodegens(plan)
     } else plan
-  }
-}
-
-/**
- * This rule plans [[RDDScanExec]] with a fake schema to make gluten work, because gluten does not
- * support empty output relation, see [[FallbackEmptySchemaRelation]].
- */
-case class PlanOneRowRelation(spark: SparkSession) extends Rule[SparkPlan] {
-  override def apply(plan: SparkPlan): SparkPlan = {
-    if (!GlutenConfig.getConf.enableOneRowRelationColumnar) {
-      return plan
-    }
-
-    plan.transform {
-      // We should make sure the output does not change, e.g.
-      // Window
-      //   OneRowRelation
-      case u: UnaryExecNode
-          if u.child.isInstanceOf[RDDScanExec] &&
-            u.child.asInstanceOf[RDDScanExec].name == "OneRowRelation" &&
-            u.outputSet != u.child.outputSet =>
-        val rdd = spark.sparkContext.parallelize(InternalRow(null) :: Nil, 1)
-        val attr = AttributeReference("fake_column", StringType)()
-        u.withNewChildren(RDDScanExec(attr :: Nil, rdd, "OneRowRelation") :: Nil)
-    }
-  }
-}
-
-case class FallbackEmptySchemaRelation() extends Rule[SparkPlan] {
-  override def apply(plan: SparkPlan): SparkPlan = plan.transformDown {
-    case p =>
-      if (BackendsApiManager.getSettings.fallbackOnEmptySchema(p)) {
-        if (p.children.exists(_.output.isEmpty)) {
-          // Some backends are not eligible to offload plan with zero-column input.
-          // If any child have empty output, mark the plan and that child as UNSUPPORTED.
-          TransformHints.tagNotTransformable(p, "at least one of its children has empty output")
-          p.children.foreach {
-            child =>
-              if (child.output.isEmpty) {
-                TransformHints.tagNotTransformable(
-                  child,
-                  "at least one of its children has empty output")
-              }
-          }
-        }
-      }
-      p
   }
 }
 

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -241,12 +241,11 @@ case class PlanOneRowRelation(spark: SparkSession) extends Rule[SparkPlan] {
 }
 
 /**
- * FIXME To be removed: Since Velox backend is the only one to use the strategy,
- *  and we already support offloading zero-column batch in ColumnarBatchInIterator via
- *  PR #3309.
+ * FIXME To be removed: Since Velox backend is the only one to use the strategy, and we already
+ * support offloading zero-column batch in ColumnarBatchInIterator via PR #3309.
  *
- * We'd make sure all Velox operators be able to handle zero-column input correctly
- * then remove the rule together with [[PlanOneRowRelation]].
+ * We'd make sure all Velox operators be able to handle zero-column input correctly then remove the
+ * rule together with [[PlanOneRowRelation]].
  */
 case class FallbackEmptySchemaRelation() extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = plan.transformDown {

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatchJniWrapper.java
@@ -38,6 +38,8 @@ public class ColumnarBatchJniWrapper extends JniInitialized implements Execution
 
   public native long createWithArrowArray(long cSchema, long cArray);
 
+  public native long getForEmptySchema(int numRows);
+
   public native String getType(long batchHandle);
 
   public native long numColumns(long batchHandle);

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -57,6 +57,41 @@ public class ColumnarBatches {
 
   private ColumnarBatches() {}
 
+  enum BatchType {
+    LIGHT,
+    HEAVY
+  }
+
+  private static BatchType identifyBatchType(ColumnarBatch batch) {
+    if (batch.numCols() == 0) {
+      // zero-column batch considered as heavy batch
+      return BatchType.HEAVY;
+    }
+    final ColumnVector col0 = batch.column(0);
+
+    if (col0 instanceof IndicatorVector) {
+      // it's likely a light batch
+      for (int i = 1; i < batch.numCols(); i++) {
+        ColumnVector col = batch.column(i);
+        if (!(col instanceof PlaceholderVector)) {
+          throw new IllegalStateException(
+              "Light batch should consist of one indicator vector "
+                  + "and (numCols - 1) placeholder vectors");
+        }
+      }
+      return BatchType.LIGHT;
+    }
+
+    // it's likely a heavy batch
+    for (int i = 0; i < batch.numCols(); i++) {
+      ColumnVector col = batch.column(i);
+      if (!(col instanceof ArrowWritableColumnVector)) {
+        throw new IllegalStateException("Heavy batch should consist of arrow vectors");
+      }
+    }
+    return BatchType.HEAVY;
+  }
+
   private static void transferVectors(ColumnarBatch from, ColumnarBatch target) {
     try {
       if (target.numCols() != from.numCols()) {
@@ -73,17 +108,7 @@ public class ColumnarBatches {
 
   /** Heavy batch: Data is readable from JVM and formatted as Arrow data. */
   public static boolean isHeavyBatch(ColumnarBatch batch) {
-    if (batch.numCols() == 0) {
-      throw new IllegalArgumentException(
-          "Cannot decide if a batch that " + "has no column is Arrow columnar batch or not");
-    }
-    for (int i = 0; i < batch.numCols(); i++) {
-      ColumnVector col = batch.column(i);
-      if (!(col instanceof ArrowWritableColumnVector)) {
-        return false;
-      }
-    }
-    return true;
+    return identifyBatchType(batch) == BatchType.HEAVY;
   }
 
   /**
@@ -91,21 +116,7 @@ public class ColumnarBatches {
    * used to bind the batch to a native side implementation.
    */
   public static boolean isLightBatch(ColumnarBatch batch) {
-    if (batch.numCols() == 0) {
-      throw new IllegalArgumentException(
-          "Cannot decide if a batch that has " + "no column is light columnar batch or not");
-    }
-    ColumnVector col0 = batch.column(0);
-    if (!(col0 instanceof IndicatorVector)) {
-      return false;
-    }
-    for (int i = 1; i < batch.numCols(); i++) {
-      ColumnVector col = batch.column(i);
-      if (!(col instanceof PlaceholderVector)) {
-        return false;
-      }
-    }
-    return true;
+    return identifyBatchType(batch) == BatchType.LIGHT;
   }
 
   /**
@@ -114,11 +125,20 @@ public class ColumnarBatches {
    */
   public static ColumnarBatch select(
       NativeMemoryManager nmm, ColumnarBatch batch, int[] columnIndices) {
-    final IndicatorVector iv = getIndicatorVector(batch);
-    long outputBatchHandle =
-        ColumnarBatchJniWrapper.create()
-            .select(nmm.getNativeInstanceHandle(), iv.handle(), columnIndices);
-    return create(iv.ctx(), outputBatchHandle);
+    switch (identifyBatchType(batch)) {
+      case LIGHT:
+        final IndicatorVector iv = getIndicatorVector(batch);
+        long outputBatchHandle =
+            ColumnarBatchJniWrapper.create()
+                .select(nmm.getNativeInstanceHandle(), iv.handle(), columnIndices);
+        return create(iv.ctx(), outputBatchHandle);
+      case HEAVY:
+        return new ColumnarBatch(
+            Arrays.stream(columnIndices).mapToObj(batch::column).toArray(ColumnVector[]::new),
+            batch.numRows());
+      default:
+        throw new IllegalStateException();
+    }
   }
 
   /**
@@ -196,6 +216,9 @@ public class ColumnarBatches {
     if (!isHeavyBatch(input)) {
       throw new IllegalArgumentException("batch is not Arrow columnar batch");
     }
+    if (input.numCols() == 0) {
+      throw new IllegalArgumentException("batch with zero columns cannot be offloaded");
+    }
     final ExecutionCtx ctx = ExecutionCtxs.contextInstance();
     try (ArrowArray cArray = ArrowArray.allocateNew(allocator);
         ArrowSchema cSchema = ArrowSchema.allocateNew(allocator)) {
@@ -258,6 +281,10 @@ public class ColumnarBatches {
     if (!isHeavyBatch(input)) {
       throw new UnsupportedOperationException("Input batch is not heavy batch");
     }
+    if (input.numCols() == 0) {
+      throw new IllegalArgumentException(
+          "batch with zero columns doesn't have meaningful " + "reference count");
+    }
     long refCnt = -1L;
     for (int i = 0; i < input.numCols(); i++) {
       ArrowWritableColumnVector col = ((ArrowWritableColumnVector) input.column(i));
@@ -277,13 +304,14 @@ public class ColumnarBatches {
   }
 
   private static long getRefCnt(ColumnarBatch input) {
-    if (isLightBatch(input)) {
-      return getRefCntLight(input);
+    switch (identifyBatchType(input)) {
+      case LIGHT:
+        return getRefCntLight(input);
+      case HEAVY:
+        return getRefCntHeavy(input);
+      default:
+        throw new IllegalStateException();
     }
-    if (isHeavyBatch(input)) {
-      return getRefCntLight(input);
-    }
-    throw new IllegalStateException();
   }
 
   public static void forceClose(ColumnarBatch input) {
@@ -323,7 +351,7 @@ public class ColumnarBatches {
     int numColumns = Math.toIntExact(iv.getNumColumns());
     int numRows = Math.toIntExact(iv.getNumRows());
     if (numColumns == 0) {
-      return new ColumnarBatch(new ColumnVector[] {iv}, numRows);
+      return new ColumnarBatch(new ColumnVector[0], numRows);
     }
     final ColumnVector[] columnVectors = new ColumnVector[numColumns];
     columnVectors[0] = iv;
@@ -336,19 +364,20 @@ public class ColumnarBatches {
   }
 
   public static void retain(ColumnarBatch b) {
-    if (isLightBatch(b)) {
-      IndicatorVector iv = (IndicatorVector) b.column(0);
-      iv.retain();
-      return;
+    switch (identifyBatchType(b)) {
+      case LIGHT:
+        IndicatorVector iv = (IndicatorVector) b.column(0);
+        iv.retain();
+        return;
+      case HEAVY:
+        for (int i = 0; i < b.numCols(); i++) {
+          ArrowWritableColumnVector col = ((ArrowWritableColumnVector) b.column(i));
+          col.retain();
+        }
+        return;
+      default:
+        throw new IllegalStateException();
     }
-    if (isHeavyBatch(b)) {
-      for (int i = 0; i < b.numCols(); i++) {
-        ArrowWritableColumnVector col = ((ArrowWritableColumnVector) b.column(i));
-        col.retain();
-      }
-      return;
-    }
-    throw new IllegalStateException("Unreachable code");
   }
 
   public static void release(ColumnarBatch b) {

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -67,8 +67,8 @@ public class ColumnarBatches {
       // zero-column batch considered as heavy batch
       return BatchType.HEAVY;
     }
-    final ColumnVector col0 = batch.column(0);
 
+    final ColumnVector col0 = batch.column(0);
     if (col0 instanceof IndicatorVector) {
       // it's likely a light batch
       for (int i = 1; i < batch.numCols(); i++) {

--- a/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
+++ b/gluten-data/src/main/java/io/glutenproject/columnarbatch/ColumnarBatches.java
@@ -158,10 +158,6 @@ public class ColumnarBatches {
    * method will close the input column batch after loaded.
    */
   public static ColumnarBatch ensureLoaded(BufferAllocator allocator, ColumnarBatch batch) {
-    if (batch.numCols() == 0) {
-      // No need to load batch if no column.
-      return batch;
-    }
     if (isHeavyBatch(batch)) {
       return batch;
     }


### PR DESCRIPTION
This will be a follow-up to https://github.com/oap-project/gluten/pull/3290, discussion https://github.com/oap-project/gluten/pull/3290#discussion_r1336963596.

Current method to offload zero-column batch doesn't result in real issues in tests, but it can still be risky since conflicted states about column count are created on the offloaded columnar batches.

The PR removes the risky code by adding a per-task cache for the zero-column batches to let the batch-offloading procedure pick instances directly from it. The cache will be released after task ends.