### PR TITLE
[Gluten-3312][CH] Introduce a config to control empty as default for CSV

### DIFF
--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.cpp
@@ -48,7 +48,7 @@ FormatFile::InputFormatPtr TextFormatFile::createInputFormat(const DB::Block & h
 
     std::string text_field_delimiter = file_info.text().field_delimiter();
     format_settings.hive_text.fields_delimiter = file_info.text().field_delimiter()[0];
-    format_settings.csv.empty_as_default = false;
+    format_settings.csv.empty_as_default = file_info.text().empty_as_default();
     format_settings.csv.allow_whitespace_or_tab_as_delimiter = true;
     format_settings.csv.use_default_on_bad_values = true;
     format_settings.csv.skip_trailing_empty_lines = true;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -167,6 +167,7 @@ public class LocalFilesNode implements Serializable {
                   .setEscape(escape)
                   .setNullValue(nullValue)
                   .setMaxBlockSize(GlutenConfig.getConf().textInputMaxBlockSize())
+                  .setEmptyAsDefault(GlutenConfig.getConf().textIputEmptyAsDefault())
                   .build();
           fileBuilder.setText(textReadOptions);
           break;

--- a/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -143,6 +143,7 @@ message ReadRel {
         uint64 header = 5;
         string escape = 6;
         string null_value = 7;
+        bool empty_as_default = 8;
       }
       message JsonReadOptions {
         uint64 max_block_size = 1;

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -263,6 +263,7 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def taskPartitionId: Int = conf.getConf(BENCHMARK_TASK_PARTITIONID)
   def taskId: Long = conf.getConf(BENCHMARK_TASK_TASK_ID)
   def textInputMaxBlockSize: Long = conf.getConf(TEXT_INPUT_ROW_MAX_BLOCK_SIZE)
+  def textIputEmptyAsDefault: Boolean = conf.getConf(TEXT_INPUT_EMPTY_AS_DEFAULT)
   def enableParquetRowGroupMaxMinIndex: Boolean =
     conf.getConf(ENABLE_PARQUET_ROW_GROUP_MAX_MIN_INDEX)
 
@@ -1210,6 +1211,13 @@ object GlutenConfig {
       .doc("the max block size for text input rows")
       .longConf
       .createWithDefault(8192);
+
+  val TEXT_INPUT_EMPTY_AS_DEFAULT =
+    buildConf("spark.gluten.sql.text.input.empty.as.default")
+      .internal()
+      .doc("treat empty fields in CSV input as default values.")
+      .booleanConf
+      .createWithDefault(false);
 
   val ENABLE_PARQUET_ROW_GROUP_MAX_MIN_INDEX =
     buildConf("spark.gluten.sql.parquet.maxmin.index")


### PR DESCRIPTION

## What changes were proposed in this pull request?

add the configuration spark.gluten.sql.text.input.empty.as.default representing the meaning of treat empty fields in CSV input as default values


