### PR TITLE
[GLUTEN-3221][CH]fix readDecimal func for r2c when reading negative decimal data

### DIFF
--- a/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/cpp-ch/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -164,6 +164,12 @@ Field VariableLengthDataReader::readDecimal(const char * buffer, size_t length) 
     assert(sizeof(Decimal128) >= length);
 
     char decimal128_fix_data[sizeof(Decimal128)] = {};
+
+    if (Int8 (buffer[0]) < 0)
+    {
+        memset(decimal128_fix_data, int('\xff'), sizeof(Decimal128));
+    }
+
     memcpy(decimal128_fix_data + sizeof(Decimal128) - length, buffer, length); // padding
     String buf(decimal128_fix_data, sizeof(Decimal128));
     BackingDataLengthCalculator::swapDecimalEndianBytes(buf); // Big-endian to Little-endian

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -20,6 +20,7 @@ import io.glutenproject.execution.HashAggregateExecBaseTransformer
 
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SQLTestData.DecimalData
 
 class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenSQLTestsTrait {
 
@@ -199,6 +200,16 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
         find(df.queryExecution.executedPlan)(
           _.isInstanceOf[HashAggregateExecBaseTransformer]).isDefined)
     }
+  }
+
+  test("gluten issues 3221") {
+    val df = spark.sparkContext
+      .parallelize(DecimalData(-32.82, 1)
+        :: Nil)
+      .toDF()
+    df.createOrReplaceTempView("decimal_negative")
+
+    checkAnswer(df.agg(sum($"a".cast("double"))), Row(-32.82))
   }
 
   test("gluten 3213") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#3221)

## How was this patch tested?

add a new test case in GlutenDataFrameAggregateSuite

