### PR TITLE
[VL] Add warn log when spill config not configured

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -177,7 +177,9 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
     LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";
     uint64_t total = shrunken + spilledOut;
     DLOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
-    return shrunken + spilledOut;
+    return total;
+  } else {
+    LOG(WARNING) << kSpillStrategy << " was not configured.";
   }
 
   DLOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -179,7 +179,7 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
     DLOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
     return total;
   } else {
-    LOG(WARNING) << kSpillStrategy << " was not configured.";
+    LOG(WARNING) << "Disable spill to disk since " << kSpillStrategy << " was not configured.";
   }
 
   DLOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -179,7 +179,7 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
     DLOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
     return total;
   } else {
-    LOG(WARNING) << "Disable spill to disk since " << kSpillStrategy << " was not configured.";
+    LOG(WARNING) << "Spill-to-disk was disabled since " << kSpillStrategy << " was not configured.";
   }
 
   DLOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add warn log when spill-to-disk configuration is not configured.

## How was this patch tested?

No need
