### PR TITLE
[VL] Pull data-source JNI wrapper up to common module

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/utils/DatasourceUtil.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/DatasourceUtil.scala
@@ -16,9 +16,9 @@
  */
 package io.glutenproject.utils
 
+import io.glutenproject.datasource.velox.DatasourceJniWrapper
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
-import io.glutenproject.spark.sql.execution.datasources.velox.DatasourceJniWrapper
 
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkSchemaUtil

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/VeloxColumnarBatchIterator.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/VeloxColumnarBatchIterator.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources
 
-import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.exception.GlutenException
 
 import org.apache.spark.sql.execution.datasources.VeloxWriteQueue.EOS_BATCH
@@ -28,7 +27,7 @@ import org.apache.arrow.vector.types.pojo.Schema
 import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
 
 class VeloxColumnarBatchIterator(schema: Schema, allocator: BufferAllocator)
-  extends Iterator[Long]
+  extends Iterator[ColumnarBatch]
   with AutoCloseable {
   private val writeQueue = new ArrayBlockingQueue[ColumnarBatch](64)
   private var currentBatch: Option[ColumnarBatch] = None
@@ -59,8 +58,16 @@ class VeloxColumnarBatchIterator(schema: Schema, allocator: BufferAllocator)
     true
   }
 
-  override def next(): Long = {
-    ColumnarBatches.getNativeHandle(currentBatch.get)
+  override def next(): ColumnarBatch = {
+    try {
+      currentBatch match {
+        case Some(b) => b
+        case _ =>
+          throw new IllegalStateException("VeloxParquetWriter: Fatal: Call hasNext() first!")
+      }
+    } finally {
+      currentBatch = None
+    }
   }
 
   override def close(): Unit = {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/VeloxWriteQueue.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/VeloxWriteQueue.scala
@@ -16,7 +16,8 @@
  */
 package org.apache.spark.sql.execution.datasources
 
-import io.glutenproject.spark.sql.execution.datasources.velox.DatasourceJniWrapper
+import io.glutenproject.datasource.velox.DatasourceJniWrapper
+import io.glutenproject.vectorized.{CloseableColumnBatchIterator, ColumnarBatchInIterator}
 
 import org.apache.spark.sql.execution.datasources.VeloxWriteQueue.EOS_BATCH
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -28,6 +29,9 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 import java.util.regex.Pattern
 
+import scala.collection.JavaConverters._
+
+// TODO: This probably can be removed: Velox's Parquet writer already supports push-based write.
 class VeloxWriteQueue(
     dsHandle: Long,
     schema: Schema,
@@ -41,7 +45,9 @@ class VeloxWriteQueue(
   private val writeThread = new Thread(
     () => {
       try {
-        datasourceJniWrapper.write(dsHandle, scanner)
+        datasourceJniWrapper.write(
+          dsHandle,
+          new ColumnarBatchInIterator(new CloseableColumnBatchIterator(scanner).asJava))
       } catch {
         case e: Throwable =>
           writeException.set(e)

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -17,11 +17,11 @@
 package org.apache.spark.sql.execution.datasources.velox
 
 import io.glutenproject.columnarbatch.ColumnarBatches
+import io.glutenproject.datasource.velox.DatasourceJniWrapper
 import io.glutenproject.exception.GlutenException
 import io.glutenproject.execution.datasource.GlutenRowSplitter
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
-import io.glutenproject.spark.sql.execution.datasources.velox.DatasourceJniWrapper
 import io.glutenproject.utils.{ArrowAbiUtil, DatasourceUtil}
 
 import org.apache.spark.sql.SparkSession

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.util.TaskResources
 
 import com.google.common.base.Preconditions
 import org.apache.arrow.c.ArrowSchema
@@ -67,7 +68,13 @@ trait VeloxFormatWriterInjects extends GlutenFormatWriterInjectsBase {
     }
 
     val writeQueue =
-      new VeloxWriteQueue(dsHandle, arrowSchema, allocator, datasourceJniWrapper, originPath)
+      new VeloxWriteQueue(
+        TaskResources.getLocalTaskContext(),
+        dsHandle,
+        arrowSchema,
+        allocator,
+        datasourceJniWrapper,
+        originPath)
 
     new OutputWriter {
       override def write(row: InternalRow): Unit = {

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -70,10 +70,6 @@ static jmethodID serializedColumnarBatchIteratorNext;
 static jclass nativeColumnarToRowInfoClass;
 static jmethodID nativeColumnarToRowInfoConstructor;
 
-static jclass veloxColumnarBatchScannerClass;
-static jmethodID veloxColumnarBatchScannerHasNext;
-static jmethodID veloxColumnarBatchScannerNext;
-
 static jclass shuffleReaderMetricsClass;
 static jmethodID shuffleReaderMetricsSetDecompressTime;
 static jmethodID shuffleReaderMetricsSetIpcTime;
@@ -281,13 +277,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   reserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "reserve", "(J)J");
   unreserveMemoryMethod = getMethodIdOrError(env, javaReservationListenerClass, "unreserve", "(J)J");
 
-  veloxColumnarBatchScannerClass =
-      createGlobalClassReference(env, "Lorg/apache/spark/sql/execution/datasources/VeloxColumnarBatchIterator;");
-
-  veloxColumnarBatchScannerHasNext = getMethodId(env, veloxColumnarBatchScannerClass, "hasNext", "()Z");
-
-  veloxColumnarBatchScannerNext = getMethodId(env, veloxColumnarBatchScannerClass, "next", "()J");
-
   shuffleReaderMetricsClass =
       createGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ShuffleReaderMetrics;");
   shuffleReaderMetricsSetDecompressTime =
@@ -309,7 +298,6 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   env->DeleteGlobalRef(serializedColumnarBatchIteratorClass);
   env->DeleteGlobalRef(nativeColumnarToRowInfoClass);
   env->DeleteGlobalRef(byteArrayClass);
-  env->DeleteGlobalRef(veloxColumnarBatchScannerClass);
   env->DeleteGlobalRef(shuffleReaderMetricsClass);
   gluten::getJniErrorState()->close();
   gluten::getJniCommonState()->close();

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -1107,6 +1107,9 @@ JNIEXPORT void JNICALL Java_io_glutenproject_datasource_velox_DatasourceJniWrapp
   auto iter = makeJniColumnarBatchIterator(env, jIter, ctx, nullptr);
   while (true) {
     auto batch = iter->next();
+    if (!batch) {
+      break;
+    }
     datasource->write(batch);
   }
   JNI_METHOD_END()

--- a/gluten-data/src/main/java/io/glutenproject/datasource/velox/DatasourceJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/datasource/velox/DatasourceJniWrapper.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.spark.sql.execution.datasources.velox;
+package io.glutenproject.datasource.velox;
 
 import io.glutenproject.exec.ExecutionCtx;
 import io.glutenproject.exec.ExecutionCtxAware;
 import io.glutenproject.exec.ExecutionCtxs;
 import io.glutenproject.init.JniInitialized;
 import io.glutenproject.init.JniUtils;
-
-import org.apache.spark.sql.execution.datasources.VeloxColumnarBatchIterator;
+import io.glutenproject.vectorized.ColumnarBatchInIterator;
 
 import java.util.Map;
 
@@ -57,5 +56,5 @@ public class DatasourceJniWrapper extends JniInitialized implements ExecutionCtx
 
   public native void close(long dsHandle);
 
-  public native void write(long dsHandle, VeloxColumnarBatchIterator iterator);
+  public native void write(long dsHandle, ColumnarBatchInIterator iterator);
 }


### PR DESCRIPTION
Previously we mixed the use of Velox-related code in common JNI wrapper code. This is to clean up the code to make write API backend-independent.