### PR TITLE
[VL] Improving VeloxShuffleWriter performance by just iterating valid partitions

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -266,15 +266,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   template <typename T>
   arrow::Status splitFixedType(const uint8_t* srcAddr, const std::vector<uint8_t*>& dstAddrs) {
-    assert(numPartitions_ == dstAddrs.size());
-    void* startAddrs[numPartitions_];
-    size_t size = dstAddrs.size();
-    for (auto i = 0; i != size; ++i) {
-      startAddrs[i] = dstAddrs[i] + partitionBufferIdxBase_[i] * sizeof(T);
-    }
-
-    for (uint32_t pid = 0; pid < numPartitions_; ++pid) {
-      auto dstPidBase = reinterpret_cast<T*>(startAddrs[pid]);
+    for (auto& pid : partitionUsed_) {
+      auto dstPidBase = (T*)(dstAddrs[pid] + partitionBufferIdxBase_[pid] * sizeof(T));
       auto pos = partition2RowOffset_[pid];
       auto end = partition2RowOffset_[pid + 1];
       for (; pos < end; ++pos) {
@@ -346,6 +339,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   // subscript: Partition ID
   // value: how many rows does this partition have
   std::vector<uint32_t> partition2RowCount_;
+
+  std::vector<uint32_t> partitionUsed_;
 
   // Partition ID -> Buffer Size(unit is row)
   std::vector<uint32_t> partition2BufferSize_;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `numPartitions_` is set to `4096` for many jobs in our environment(`Meituan`), and the number of rows in a batch is also `4096`. 

The above configuration will result in some partitions not having rows, we need not iterate for all partitions(4096) but only the used partitions.

In order to avoid unnecessary iteration, I added a member data `partitionUsed` representing the partitions having values and then changed the loop based on all partitions to based on `partitionUsed`.

The performance will not be influenced if the `numPartitions_` configured a small value because the number of valid partitions will never be larger than the number of all partitions.

wait for a test under `meituan`'s environment, I will add the test result later.

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

