### PR TITLE
[VL] Add generate metrics

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -330,4 +330,10 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
 
   override def genHashJoinTransformerMetricsUpdater(
       metrics: Map[String, SQLMetric]): MetricsUpdater = new HashJoinMetricsUpdater(metrics)
+
+  override def genGenerateTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
+    Map.empty
+
+  override def genGenerateTransformerMetricsUpdater(
+      metrics: Map[String, SQLMetric]): MetricsUpdater = new NoopMetricsUpdater
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
@@ -477,4 +477,11 @@ class MetricsHandler extends MetricsApi with Logging {
 
   override def genHashJoinTransformerMetricsUpdater(
       metrics: Map[String, SQLMetric]): MetricsUpdater = new HashJoinMetricsUpdaterImpl(metrics)
+
+  override def genGenerateTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] = {
+    Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+  }
+
+  override def genGenerateTransformerMetricsUpdater(
+      metrics: Map[String, SQLMetric]): MetricsUpdater = new GenerateMetricsUpdater(metrics)
 }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
@@ -94,6 +94,10 @@ trait MetricsApi extends Serializable {
 
   def genHashJoinTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
 
+  def genGenerateTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
+
+  def genGenerateTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
+
   def genColumnarInMemoryTableMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -22,7 +22,7 @@ import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.expression.ExpressionTransformer
 import io.glutenproject.extension.ValidationResult
-import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
+import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.`type`.TypeNode
 import io.glutenproject.substrait.SubstraitContext
@@ -57,7 +57,13 @@ case class GenerateExecTransformer(
   extends UnaryExecNode
   with TransformSupport {
 
+  @transient
+  override lazy val metrics =
+    BackendsApiManager.getMetricsApiInstance.genGenerateTransformerMetrics(sparkContext)
+
   override def output: Seq[Attribute] = requiredChildOutput ++ generatorOutput
+
+  override def producedAttributes: AttributeSet = AttributeSet(generatorOutput)
 
   override protected def doExecute(): RDD[InternalRow] = {
     throw new UnsupportedOperationException(s"GenerateExecTransformer doesn't support doExecute")
@@ -244,5 +250,7 @@ case class GenerateExecTransformer(
     }
   }
 
-  override def metricsUpdater(): MetricsUpdater = new NoopMetricsUpdater
+  override def metricsUpdater(): MetricsUpdater = {
+    BackendsApiManager.getMetricsApiInstance.genGenerateTransformerMetricsUpdater(metrics)
+  }
 }

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/GenerateMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/GenerateMetricsUpdater.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.metrics
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+class GenerateMetricsUpdater(val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+  override def updateNativeMetrics(operatorMetrics: IOperatorMetrics): Unit = {
+    if (operatorMetrics != null) {
+      val nativeMetrics = operatorMetrics.asInstanceOf[OperatorMetrics]
+      metrics("numOutputRows") += nativeMetrics.outputRows
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds output row metric for generate to align with vanilla Spark.

## How was this patch tested?

<img width="458" alt="image" src="https://github.com/oap-project/gluten/assets/12025282/dad3ea79-69c3-4142-b59b-05df05f72059">
