### PR TITLE
[VL] Fix uncompressed size metrics

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsHandler.scala
@@ -255,7 +255,7 @@ class MetricsHandler extends MetricsApi with Logging {
         .createMetric(sparkContext, "number of output rows"),
       "inputBatches" -> SQLMetrics
         .createMetric(sparkContext, "number of input batches"),
-      "uncompressedDataSize" -> SQLMetrics.createMetric(sparkContext, "uncompressed data size")
+      "uncompressedDataSize" -> SQLMetrics.createSizeMetric(sparkContext, "uncompressed data size")
     )
 
   override def genWindowTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -246,7 +246,7 @@ class ShuffleWriter {
   int64_t peakMemoryAllocated_ = 0;
 
   std::vector<int64_t> partitionLengths_;
-  std::vector<int64_t> rawPartitionLengths_;
+  std::vector<int64_t> rawPartitionLengths_; // Uncompressed size.
 
   std::unique_ptr<arrow::util::Codec> codec_;
 

--- a/cpp/core/shuffle/Utils.cc
+++ b/cpp/core/shuffle/Utils.cc
@@ -146,6 +146,13 @@ int64_t gluten::getBufferSizes(const std::shared_ptr<arrow::Array>& array) {
       });
 }
 
+int64_t gluten::getBufferSizes(const std::vector<std::shared_ptr<arrow::Buffer>>& buffers) {
+  return std::accumulate(
+      std::cbegin(buffers), std::cend(buffers), 0LL, [](int64_t sum, const std::shared_ptr<arrow::Buffer>& buf) {
+        return buf == nullptr ? sum : sum + buf->size();
+      });
+}
+
 arrow::Status gluten::writeEos(arrow::io::OutputStream* os) {
   // write EOS
   constexpr int32_t kIpcContinuationToken = -1;

--- a/cpp/core/shuffle/Utils.h
+++ b/cpp/core/shuffle/Utils.h
@@ -56,6 +56,8 @@ arrow::Result<std::vector<std::shared_ptr<arrow::DataType>>> toShuffleWriterType
 
 int64_t getBufferSizes(const std::shared_ptr<arrow::Array>& array);
 
+int64_t getBufferSizes(const std::vector<std::shared_ptr<arrow::Buffer>>& buffers);
+
 arrow::Status writeEos(arrow::io::OutputStream* os);
 
 } // namespace gluten


### PR DESCRIPTION
After the refactor of split partition buffer compression, the buffers are compressed before creating IPC payload. Therefore, using IpcPayload's `raw_body_length` to count uncompressed buffer size is not correct.