### PR TITLE
[GLUTEN-3388][VL] Remove datediff function name mapping

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -360,7 +360,6 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"strpos", "instr"},
     {"ends_with", "endswith"},
     {"starts_with", "startswith"},
-    {"datediff", "date_diff"},
     {"named_struct", "row_constructor"},
     {"bit_or", "bitwise_or_agg"},
     {"bit_or_merge", "bitwise_or_agg_merge"},


### PR DESCRIPTION
## What changes were proposed in this pull request?

Will be merged when velox code is aligned with upstream.

Fixes: #3388

