### PR TITLE
[GLUTEN-3400][CH] Update backend named literal code

### DIFF
--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1615,7 +1615,10 @@ std::pair<DataTypePtr, Field> SerializedPlanParser::parseLiteral(const substrait
 const ActionsDAG::Node * SerializedPlanParser::parseExpression(ActionsDAGPtr actions_dag, const substrait::Expression & rel)
 {
     auto add_column = [&](const DataTypePtr & type, const Field & field) -> auto
-    { return &actions_dag->addColumn(ColumnWithTypeAndName(type->createColumnConst(1, field), type, getUniqueName(toString(field)))); };
+    {
+        return &actions_dag->addColumn(
+            ColumnWithTypeAndName(type->createColumnConst(1, field), type, getUniqueName(toString(field).substr(0, 10))));
+    };
 
     switch (rel.rex_type_case())
     {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#3400)

## How was this patch tested?

Test by UT and gluten-perf




name | before | after | diff
-- | -- | -- | --
q01 | 5126.00 | 5048.71 | 1.02
q02 | 3309.43 | 3183.57 | 1.04
q03 | 7167.43 | 6660.57 | 1.08
q04 | 4204.00 | 4163.43 | 1.01
q05 | 10623.43 | 10472.57 | 1.01
q06 | 2022.14 | 2023.71 | 1.00
q07 | 6966.29 | 6862.14 | 1.02
q08 | 12116.86 | 7194.57 | 1.68
q09 | 17585.71 | 11460.57 | 1.53
q10 | 7336.57 | 7024.86 | 1.04
q11 | 2416.29 | 2475.29 | 0.98
q12 | 4678.14 | 4663.57 | 1.00
q13 | 4614.57 | 4492.00 | 1.03
q14 | 3590.43 | 3589.43 | 1.00
q15 | 6266.29 | 6291.14 | 1.00
q16 | 6313.57 | 6100.00 | 1.04
q17 | 18222.00 | 12309.71 | 1.48
q18 | 19538.14 | 19063.71 | 1.02
q19 | 4779.86 | 4795.29 | 1.00
q20 | 12642.86 | 5918.00 | 2.14
q22 | 1494.57 | 1417.57 | 1.05
Total | 161014.57 | 135234.59 | 1.19


</body>

</html>




