### PR TITLE
[VL] Shuffle splitter store string length instead of offset

### DIFF
--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -42,6 +42,7 @@ namespace {
 DEFINE_bool(skip_input, false, "Skip specifying input files.");
 DEFINE_bool(gen_orc_input, false, "Generate orc files from parquet as input files.");
 DEFINE_bool(with_shuffle, false, "Add shuffle split at end.");
+DEFINE_string(partitioning, "rr", "Short partitioning name. Valid options are rr, hash, range, single");
 DEFINE_bool(zstd, false, "Use ZSTD as shuffle compression codec");
 DEFINE_bool(qat_gzip, false, "Use QAT GZIP as shuffle compression codec");
 DEFINE_bool(qat_zstd, false, "Use QAT ZSTD as shuffle compression codec");
@@ -64,7 +65,7 @@ std::shared_ptr<VeloxShuffleWriter> createShuffleWriter(VeloxMemoryManager* memo
 
   auto options = ShuffleWriterOptions::defaults();
   options.memory_pool = memoryManager->getArrowMemoryPool();
-  options.partitioning_name = "rr"; // Round-Robin partitioning
+  options.partitioning_name = FLAGS_partitioning;
   if (FLAGS_zstd) {
     options.codec_backend = CodecBackend::NONE;
     options.compression_type = arrow::Compression::ZSTD;

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -118,20 +118,20 @@ VectorPtr readFlatVectorStringView(
     std::shared_ptr<const Type> type,
     memory::MemoryPool* pool) {
   auto nulls = buffers[bufferIdx++];
-  auto offsetBuffers = buffers[bufferIdx++];
-  auto valueBuffers = buffers[bufferIdx++];
-  const int32_t* rawLength = offsetBuffers->as<int32_t>();
+  auto offsetBuffer = buffers[bufferIdx++];
+  auto valueBuffer = buffers[bufferIdx++];
+  const int32_t* rawLength = offsetBuffer->as<int32_t>();
 
   std::vector<BufferPtr> stringBuffers;
   auto values = AlignedBuffer::allocate<char>(sizeof(StringView) * length, pool);
   auto rawValues = values->asMutable<StringView>();
-  auto rawChars = valueBuffers->as<char>();
+  auto rawChars = valueBuffer->as<char>();
   auto offset = 0;
   for (int32_t i = 0; i < length; ++i) {
     rawValues[i] = StringView(rawChars + offset, rawLength[i]);
     offset += rawLength[i];
   }
-  stringBuffers.emplace_back(valueBuffers);
+  stringBuffers.emplace_back(valueBuffer);
   if (nulls == nullptr || nulls->size() == 0) {
     return std::make_shared<FlatVector<StringView>>(
         pool, type, BufferPtr(nullptr), length, std::move(values), std::move(stringBuffers));

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -118,9 +118,9 @@ VectorPtr readFlatVectorStringView(
     std::shared_ptr<const Type> type,
     memory::MemoryPool* pool) {
   auto nulls = buffers[bufferIdx++];
-  auto offsetBuffer = buffers[bufferIdx++];
+  auto lengthBuffer = buffers[bufferIdx++];
   auto valueBuffer = buffers[bufferIdx++];
-  const int32_t* rawLength = offsetBuffer->as<int32_t>();
+  const int32_t* rawLength = lengthBuffer->as<int32_t>();
 
   std::vector<BufferPtr> stringBuffers;
   auto values = AlignedBuffer::allocate<char>(sizeof(StringView) * length, pool);

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -120,14 +120,16 @@ VectorPtr readFlatVectorStringView(
   auto nulls = buffers[bufferIdx++];
   auto offsetBuffers = buffers[bufferIdx++];
   auto valueBuffers = buffers[bufferIdx++];
-  const int32_t* rawOffset = offsetBuffers->as<int32_t>();
+  const int32_t* rawLength = offsetBuffers->as<int32_t>();
 
   std::vector<BufferPtr> stringBuffers;
   auto values = AlignedBuffer::allocate<char>(sizeof(StringView) * length, pool);
   auto rawValues = values->asMutable<StringView>();
   auto rawChars = valueBuffers->as<char>();
+  auto offset = 0;
   for (int32_t i = 0; i < length; ++i) {
-    rawValues[i] = StringView(rawChars + rawOffset[i], rawOffset[i + 1] - rawOffset[i]);
+    rawValues[i] = StringView(rawChars + offset, rawLength[i]);
+    offset += rawLength[i];
   }
   stringBuffers.emplace_back(valueBuffers);
   if (nulls == nullptr || nulls->size() == 0) {

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -98,7 +98,7 @@ namespace gluten {
 enum SplitState { kInit, kPreAlloc, kSplit, kStop };
 
 class VeloxShuffleWriter final : public ShuffleWriter {
-  enum { kValidityBufferIndex = 0, kOffsetBufferIndex = 1, kValueBufferIndex = 2 };
+  enum { kValidityBufferIndex = 0, kLengthBufferIndex = 1, kValueBufferIndex = 2 };
 
  public:
   struct BinaryBuf {


### PR DESCRIPTION
Issue: #3267 

If the data to compress has lots of duplicated values, both LZ4 and ZSTD perform high compression ratio( ~10 - 20). If no duplicated values, LZ4 can result in no compression and ZSTD compression ratio is ~2.

For fixed-length binary types, Spark UnsafeRow stores its value, offset in UnsafeRow and length. If the data schema consists of several columns of fixed-width data type and fixed-length string types, the offsets and lengths of a string field are identical for all rows. But currently, Gluten use arrow-like format for shuffle output, which stores value offsets in the string column and is considered unfriendly for data compression.

The metrics below compares the data size of splitting 2 columns of fixed-length binary type and 1 column of integer type. Before this PR, Gluten is 53.3 GB vs Vanilla Spark 47.9 GB. After this PR, Gluten is 46 GB.

Vanilla Spark shuffle bytes written = 47.9 GB:
![image](https://github.com/oap-project/gluten/assets/52736607/63d33532-9f30-4adb-bc90-7b832ccd65e4)


Gluten shuffle bytes written Before = 53.3 GB:
![image](https://github.com/oap-project/gluten/assets/52736607/d6dfe5b4-5a1e-4f58-b385-7ee1a3f03722)

Gluten shuffle bytes written After = 46 GB:
![image](https://github.com/oap-project/gluten/assets/52736607/c6d9a144-6fd8-447a-975b-30bc74218917)
