### PR TITLE
[VL] Fix Generate fail when required child output is not same with child output

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -529,4 +529,19 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       }
     }
   }
+
+  test("Fix Generate fail when required child output is not same with child output") {
+    withTable("t") {
+      spark
+        .range(10)
+        .selectExpr("id as c1", "id as c2")
+        .write
+        .format("parquet")
+        .saveAsTable("t")
+
+      runQueryAndCompare("SELECT c1, explode(array(c2)) FROM t") {
+        checkOperatorMatch[GenerateExecTransformer]
+      }
+    }
+  }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Before this fix, it would fail:
```
SELECT c1, explode(array(c2)) FROM t
```

```
java.lang.RuntimeException: Failed to create kernel with iterator vector
	at io.glutenproject.vectorized.PlanEvaluatorJniWrapper.nativeCreateKernelWithIterator(Native Method)
	at io.glutenproject.vectorized.NativePlanEvaluator.createKernelWithBatchIterator(NativePlanEvaluator.java:85)
	at io.glutenproject.backendsapi.velox.IteratorHandler.genFirstStageIterator(IteratorHandler.scala:157)
	at io.glutenproject.execution.GlutenWholeStageColumnarRDD.compute(GlutenWholeStageColumnarRDD.scala:118)
```

## How was this patch tested?

add test
