### PR TITLE
[GLUTEN-3364][VL] SplitPreloadPerDriver (SplitPreloadPerDriver = true, IOThreads > 0) causes unexpected crashes

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -19,7 +19,6 @@
 #include "VeloxBackend.h"
 
 #include <folly/executors/IOThreadPoolExecutor.h>
-#include <fstream>
 
 #include "operators/functions/RegistrationAllFunctions.h"
 #include "operators/plannodes/RowVectorStream.h"

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -55,8 +55,6 @@ DECLARE_bool(velox_exception_user_stacktrace_enabled);
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 DECLARE_bool(velox_memory_use_hugepages);
 
-DEFINE_bool(velox_memory_check_usage_leak, true, "Enable Velox's memory usage leak checking");
-
 using namespace facebook;
 
 namespace {
@@ -338,13 +336,6 @@ void VeloxBackend::initConnector(const facebook::velox::Config* conf) {
       LOG(INFO) << "STARTUP: Using split preloading, Split preload per driver: " << splitPreloadPerDriver
                 << ", IO threads: " << ioThreads;
       FLAGS_split_preload_per_driver = splitPreloadPerDriver;
-      // Split preload may cause fake "memory leak" during the time Velox memory manager is destructed,
-      // because splitting preload requires holding a ref to the task instance which holds a ref to
-      // connector memory pool (see HiveConnector.cpp). Disable leak checking in this case anyway since Velox's
-      // OOM exception is thrown from memory manager's destructor which may cause crash. In the other hand, we have
-      // similar leak checking in Java side which is less fatal for OOM case.
-      LOG(INFO) << "Warning: disabling memory leak checking since split preload is enabled";
-      FLAGS_velox_memory_check_usage_leak = false;
     }
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads);
   }

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -56,8 +56,7 @@ DECLARE_bool(velox_exception_user_stacktrace_enabled);
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 DECLARE_bool(velox_memory_use_hugepages);
 
-// Gluten's flag declarations
-DECLARE_bool(velox_memory_ignore_usage_leak);
+DEFINE_bool(velox_memory_check_usage_leak, true, "Enable Velox's memory usage leak checking");
 
 using namespace facebook;
 
@@ -346,7 +345,7 @@ void VeloxBackend::initConnector(const facebook::velox::Config* conf) {
       // OOM exception is thrown from memory manager's destructor which may cause crash. In the other hand, we have
       // similar leak checking in Java side which is less fatal for OOM case.
       LOG(INFO) << "Warning: disabling memory leak checking since split preload is enabled";
-      FLAGS_velox_memory_ignore_usage_leak = false;
+      FLAGS_velox_memory_check_usage_leak = false;
     }
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads);
   }

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -28,6 +28,9 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/core/Config.h"
 
+// Gluten's flag declarations
+DECLARE_bool(velox_memory_check_usage_leak);
+
 namespace gluten {
 /// As a static instance in per executor, initialized at executor startup.
 /// Should not put heavily work here.

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -58,7 +58,7 @@ class VeloxBackend {
 
   void init(const std::unordered_map<std::string, std::string>& conf);
   void initCache(const facebook::velox::Config* conf);
-  void initIOExecutor(const facebook::velox::Config* conf);
+  void initConnector(const facebook::velox::Config* conf);
   void initUdf(const facebook::velox::Config* conf);
 
   void initJolFilesystem(const facebook::velox::Config* conf);

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -28,9 +28,6 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/core/Config.h"
 
-// Gluten's flag declarations
-DECLARE_bool(velox_memory_check_usage_leak);
-
 namespace gluten {
 /// As a static instance in per executor, initialized at executor startup.
 /// Should not put heavily work here.

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -23,8 +23,6 @@
 #include "memory/ArrowMemoryPool.h"
 #include "utils/exception.h"
 
-DECLARE_bool(velox_memory_check_usage_leak);
-
 namespace gluten {
 
 using namespace facebook;
@@ -175,7 +173,7 @@ VeloxMemoryManager::VeloxMemoryManager(
       velox::memory::kMaxMemory,
       velox::memory::kMaxMemory,
       true, // memory usage tracking
-      FLAGS_velox_memory_check_usage_leak, // leak check
+      true, // leak check
       false, // debug
 #ifdef GLUTEN_ENABLE_HBM
       wrappedAlloc.get(),

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -23,6 +23,8 @@
 #include "memory/ArrowMemoryPool.h"
 #include "utils/exception.h"
 
+DECLARE_bool(velox_memory_check_usage_leak);
+
 namespace gluten {
 
 using namespace facebook;
@@ -173,7 +175,7 @@ VeloxMemoryManager::VeloxMemoryManager(
       velox::memory::kMaxMemory,
       velox::memory::kMaxMemory,
       true, // memory usage tracking
-      true, // leak check
+      FLAGS_velox_memory_check_usage_leak, // leak check
       false, // debug
 #ifdef GLUTEN_ENABLE_HBM
       wrappedAlloc.get(),

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -253,16 +253,15 @@ bool VeloxMemoryManager::tryDestructSafe() {
     if (pool->currentBytes() != 0) {
       return false;
     }
-    pool.reset();
   }
-  heldVeloxPools_.clear();
   if (veloxLeafPool_->currentBytes() != 0) {
     return false;
   }
-  veloxLeafPool_.reset();
   if (veloxAggregatePool_->currentBytes() != 0) {
     return false;
   }
+  heldVeloxPools_.clear();
+  veloxLeafPool_.reset();
   veloxAggregatePool_.reset();
 
   // Velox memory manager considered safe to destruct when no alive pools.

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -248,6 +248,7 @@ void VeloxMemoryManager::hold() {
 }
 
 bool VeloxMemoryManager::tryDestructSafe() {
+  // Velox memory pools considered safe to destruct when no alive allocations.
   for (auto& pool : heldVeloxPools_) {
     if (pool->currentBytes() != 0) {
       return false;
@@ -264,10 +265,13 @@ bool VeloxMemoryManager::tryDestructSafe() {
   }
   veloxAggregatePool_.reset();
 
+  // Velox memory manager considered safe to destruct when no alive pools.
   if (veloxMemoryManager_->numPools() != 0) {
     return false;
   }
   veloxMemoryManager_.reset();
+
+  // Applies similar rule for Arrow memory pool.
   if (arrowPool_->bytes_allocated() != 0) {
     return false;
   }

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -249,15 +249,15 @@ void VeloxMemoryManager::hold() {
 
 bool VeloxMemoryManager::tryDestructSafe() {
   // Velox memory pools considered safe to destruct when no alive allocations.
-  for (auto& pool : heldVeloxPools_) {
-    if (pool->currentBytes() != 0) {
+  for (const auto& pool : heldVeloxPools_) {
+    if (pool && pool->currentBytes() != 0) {
       return false;
     }
   }
-  if (veloxLeafPool_->currentBytes() != 0) {
+  if (veloxLeafPool_ && veloxLeafPool_->currentBytes() != 0) {
     return false;
   }
-  if (veloxAggregatePool_->currentBytes() != 0) {
+  if (veloxAggregatePool_ && veloxAggregatePool_->currentBytes() != 0) {
     return false;
   }
   heldVeloxPools_.clear();
@@ -265,13 +265,13 @@ bool VeloxMemoryManager::tryDestructSafe() {
   veloxAggregatePool_.reset();
 
   // Velox memory manager considered safe to destruct when no alive pools.
-  if (veloxMemoryManager_->numPools() != 0) {
+  if (veloxMemoryManager_ && veloxMemoryManager_->numPools() != 0) {
     return false;
   }
   veloxMemoryManager_.reset();
 
   // Applies similar rule for Arrow memory pool.
-  if (arrowPool_->bytes_allocated() != 0) {
+  if (arrowPool_ && arrowPool_->bytes_allocated() != 0) {
     return false;
   }
   arrowPool_.reset();

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -276,6 +276,8 @@ bool VeloxMemoryManager::tryDestructSafe() {
     return false;
   }
   arrowPool_.reset();
+
+  // Successfully destructed.
   return true;
 }
 

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -291,7 +291,7 @@ VeloxMemoryManager::~VeloxMemoryManager() {
       break;
     }
     uint32_t waitMs = 50 * static_cast<uint32_t>(pow(2, tryCount));
-    LOG(INFO) << "There are still outstanding Velox memory pools. Waiting for " << waitMs
+    LOG(INFO) << "There are still outstanding Velox memory allocations. Waiting for " << waitMs
               << " ms to let possible async tasks done... ";
     usleep(waitMs * 1000);
   }

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -27,11 +27,12 @@ namespace gluten {
 
 class VeloxMemoryManager final : public MemoryManager {
  public:
-  explicit VeloxMemoryManager(
+  VeloxMemoryManager(
       const std::string& name,
       std::shared_ptr<MemoryAllocator> allocator,
       std::unique_ptr<AllocationListener> listener);
 
+  ~VeloxMemoryManager() override;
   VeloxMemoryManager(const VeloxMemoryManager&) = delete;
   VeloxMemoryManager(VeloxMemoryManager&&) = delete;
   VeloxMemoryManager& operator=(const VeloxMemoryManager&) = delete;

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -61,6 +61,9 @@ class VeloxMemoryManager final : public MemoryManager {
   void hold() override;
 
  private:
+
+  bool tryDestructSafe();
+
   std::string name_;
 
 #ifdef GLUTEN_ENABLE_HBM

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -61,7 +61,6 @@ class VeloxMemoryManager final : public MemoryManager {
   void hold() override;
 
  private:
-
   bool tryDestructSafe();
 
   std::string name_;

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/NoopMemoryTarget.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/NoopMemoryTarget.java
@@ -16,21 +16,42 @@
  */
 package io.glutenproject.memory.memtarget;
 
-import io.glutenproject.memory.memtarget.spark.RegularMemoryConsumer;
-import io.glutenproject.memory.memtarget.spark.TreeMemoryConsumer;
+import io.glutenproject.memory.SimpleMemoryUsageRecorder;
+import io.glutenproject.proto.MemoryUsageStats;
 
-public interface MemoryTargetVisitor<T> {
-  T visit(OverAcquire overAcquire);
+public class NoopMemoryTarget implements MemoryTarget, KnownNameAndStats {
+  private final SimpleMemoryUsageRecorder recorder = new SimpleMemoryUsageRecorder();
+  private final String name = MemoryTargetUtil.toUniqueName("Noop");
 
-  T visit(RegularMemoryConsumer regularMemoryConsumer);
+  @Override
+  public long borrow(long size) {
+    recorder.inc(size);
+    return size;
+  }
 
-  T visit(ThrowOnOomMemoryTarget throwOnOomMemoryTarget);
+  @Override
+  public long repay(long size) {
+    recorder.inc(-size);
+    return size;
+  }
 
-  T visit(TreeMemoryConsumer treeMemoryConsumer);
+  @Override
+  public long usedBytes() {
+    return recorder.current();
+  }
 
-  T visit(TreeMemoryTargets.Node node);
+  @Override
+  public <T> T accept(MemoryTargetVisitor<T> visitor) {
+    return visitor.visit(this);
+  }
 
-  T visit(LoggingMemoryTarget loggingMemoryTarget);
+  @Override
+  public String name() {
+    return name;
+  }
 
-  T visit(NoopMemoryTarget noopMemoryTarget);
+  @Override
+  public MemoryUsageStats stats() {
+    return recorder.toStats();
+  }
 }

--- a/gluten-core/src/main/java/io/glutenproject/memory/memtarget/ThrowOnOomMemoryTarget.java
+++ b/gluten-core/src/main/java/io/glutenproject/memory/memtarget/ThrowOnOomMemoryTarget.java
@@ -114,4 +114,8 @@ public class ThrowOnOomMemoryTarget implements MemoryTarget {
       super(message);
     }
   }
+
+  public MemoryTarget target() {
+    return target;
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
@@ -19,12 +19,15 @@ package org.apache.spark.memory
 import io.glutenproject.memory.memtarget.{KnownNameAndStats, MemoryTarget, MemoryTargetVisitor, OverAcquire, ThrowOnOomMemoryTarget, TreeMemoryTargets}
 import io.glutenproject.memory.memtarget.spark.{RegularMemoryConsumer, TreeMemoryConsumer}
 import io.glutenproject.proto.MemoryUsageStats
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.util.Utils
+
 import com.google.common.base.Preconditions
 import org.apache.commons.lang3.StringUtils
 
 import java.util
+
 import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 

--- a/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
@@ -19,12 +19,15 @@ package org.apache.spark.memory
 import io.glutenproject.memory.memtarget.{KnownNameAndStats, LoggingMemoryTarget, MemoryTarget, MemoryTargetVisitor, NoopMemoryTarget, OverAcquire, ThrowOnOomMemoryTarget, TreeMemoryTargets}
 import io.glutenproject.memory.memtarget.spark.{RegularMemoryConsumer, TreeMemoryConsumer}
 import io.glutenproject.proto.MemoryUsageStats
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.util.Utils
+
 import com.google.common.base.Preconditions
 import org.apache.commons.lang3.StringUtils
 
 import java.util
+
 import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 

--- a/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
@@ -112,10 +112,10 @@ object SparkMemoryUtil {
       })
     }
 
-    prettyPrintStats(collectRootStats(target))
+    prettyPrintStats("Memory consumer stats: ", collectRootStats(target))
   }
 
-  def prettyPrintStats(stats: KnownNameAndStats): String = {
+  def prettyPrintStats(title: String, stats: KnownNameAndStats): String = {
     def asPrintable(name: String, mus: MemoryUsageStats): PrintableMemoryUsageStats = {
       def sortStats(stats: Seq[PrintableMemoryUsageStats]) = {
         stats.sortBy(_.used.getOrElse(Long.MinValue))(Ordering.Long.reverse)
@@ -137,10 +137,10 @@ object SparkMemoryUtil {
       )
     }
 
-    prettyPrintToString(asPrintable(stats.name(), stats.stats()))
+    prettyPrintToString(title, asPrintable(stats.name(), stats.stats()))
   }
 
-  private def prettyPrintToString(stats: PrintableMemoryUsageStats): String = {
+  private def prettyPrintToString(title: String, stats: PrintableMemoryUsageStats): String = {
 
     def getBytes(bytes: Option[Long]): String = {
       bytes.map(Utils.bytesToString).getOrElse("N/A")
@@ -151,7 +151,7 @@ object SparkMemoryUtil {
     }
 
     val sb = new StringBuilder()
-    sb.append(s"Memory consumer stats:")
+    sb.append(title)
 
     // determine padding widths
     var nameWidth = 0

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/ManagedReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/ManagedReservationListener.java
@@ -42,7 +42,6 @@ public class ManagedReservationListener implements ReservationListener {
       try {
         long granted = target.borrow(size);
         sharedUsage.inc(granted);
-        this.notifyAll();
         return granted;
       } catch (Exception e) {
         LOG.error("Error reserving memory from target", e);
@@ -57,7 +56,6 @@ public class ManagedReservationListener implements ReservationListener {
       long freed = target.repay(size);
       sharedUsage.inc(-freed);
       Preconditions.checkState(freed == size);
-      this.notifyAll();
       return freed;
     }
   }
@@ -65,19 +63,5 @@ public class ManagedReservationListener implements ReservationListener {
   @Override
   public long getUsedBytes() {
     return target.usedBytes();
-  }
-
-  @Override
-  public void waitUntilReleased(final long timeoutMs) throws InterruptedException {
-    final long startMs = System.currentTimeMillis();
-    synchronized (this) {
-      while (getUsedBytes() > 0L) {
-        long remainingMs = System.currentTimeMillis() - (startMs + timeoutMs);
-        if (remainingMs <= 0L) {
-          break;
-        }
-        this.wait(remainingMs);
-      }
-    }
   }
 }

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -16,13 +16,13 @@
  */
 package io.glutenproject.memory.nmm;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import io.glutenproject.GlutenConfig;
 import io.glutenproject.backendsapi.BackendsApiManager;
 import io.glutenproject.memory.alloc.NativeMemoryAllocators;
-
 import io.glutenproject.memory.memtarget.KnownNameAndStats;
 import io.glutenproject.proto.MemoryUsageStats;
+
+import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.spark.memory.SparkMemoryUtil;
 import org.apache.spark.util.TaskResource;
 import org.apache.spark.util.Utils;
@@ -95,26 +95,27 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
-    LOGGER.debug("About to release memory manager, usage dump: {}",
-        SparkMemoryUtil.prettyPrintStats(new KnownNameAndStats() {
-          @Override
-          public String name() {
-            return name;
-          }
+    LOGGER.debug(
+        "About to release memory manager, usage dump: {}",
+        SparkMemoryUtil.prettyPrintStats(
+            new KnownNameAndStats() {
+              @Override
+              public String name() {
+                return name;
+              }
 
-          @Override
-          public MemoryUsageStats stats() {
-            return collectMemoryUsage();
-          }
-        }));
+              @Override
+              public MemoryUsageStats stats() {
+                return collectMemoryUsage();
+              }
+            }));
     release(nativeInstanceHandle);
     if (listener.getUsedBytes() != 0) {
       LOGGER.warn(
-          String.format("%s Reservation listener %s still reserved non-zero bytes, " +
-                  "which may cause memory leak, size: %s",
-              name,
-              listener.toString(),
-              Utils.bytesToString(listener.getUsedBytes())));
+          String.format(
+              "%s Reservation listener %s still reserved non-zero bytes, "
+                  + "which may cause memory leak, size: %s",
+              name, listener.toString(), Utils.bytesToString(listener.getUsedBytes())));
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -119,6 +119,10 @@ public class NativeMemoryManager implements TaskResource {
               name, listener.toString(), Utils.bytesToString(listener.getUsedBytes())));
       // We are about to leak memory, wait 2s to let possible async task complete
       listener.waitUntilReleased(2000L);
+      if (listener.getUsedBytes() == 0) {
+        LOGGER.info(String.format(
+            "%s Reservation listener %s successfully released.", name, listener.toString()));
+      }
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -95,20 +95,19 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
-    LOGGER.warn(
-        "About to release memory manager, usage dump: {}",
-        SparkMemoryUtil.prettyPrintStats(
-            new KnownNameAndStats() {
-              @Override
-              public String name() {
-                return name;
-              }
+    LOGGER.warn(SparkMemoryUtil.prettyPrintStats(
+        "About to release memory manager, usage dump:",
+        new KnownNameAndStats() {
+          @Override
+          public String name() {
+            return name;
+          }
 
-              @Override
-              public MemoryUsageStats stats() {
-                return collectMemoryUsage();
-              }
-            }));
+          @Override
+          public MemoryUsageStats stats() {
+            return collectMemoryUsage();
+          }
+        }));
     release(nativeInstanceHandle);
     if (listener.getUsedBytes() != 0) {
       LOGGER.warn(

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -113,8 +113,11 @@ public class NativeMemoryManager implements TaskResource {
       LOGGER.warn(
           String.format(
               "%s Reservation listener %s still reserved non-zero bytes, "
-                  + "which may cause memory leak, size: %s",
+                  + "which may cause memory leak, size: %s. "
+                  + "Waiting 2s in case there are async tasks that still consuming memory... ",
               name, listener.toString(), Utils.bytesToString(listener.getUsedBytes())));
+      // We are about to leak memory, wait 2s to let possible async task complete
+      listener.waitUntilReleased(2000L);
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -120,8 +120,9 @@ public class NativeMemoryManager implements TaskResource {
       // We are about to leak memory, wait 2s to let possible async task complete
       listener.waitUntilReleased(2000L);
       if (listener.getUsedBytes() == 0) {
-        LOGGER.info(String.format(
-            "%s Reservation listener %s successfully released.", name, listener.toString()));
+        LOGGER.info(
+            String.format(
+                "%s Reservation listener %s successfully released.", name, listener.toString()));
       }
     }
   }

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -16,10 +16,14 @@
  */
 package io.glutenproject.memory.nmm;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.glutenproject.GlutenConfig;
 import io.glutenproject.backendsapi.BackendsApiManager;
 import io.glutenproject.memory.alloc.NativeMemoryAllocators;
 
+import io.glutenproject.memory.memtarget.KnownNameAndStats;
+import io.glutenproject.proto.MemoryUsageStats;
+import org.apache.spark.memory.SparkMemoryUtil;
 import org.apache.spark.util.TaskResource;
 import org.apache.spark.util.Utils;
 import org.slf4j.Logger;
@@ -54,8 +58,12 @@ public class NativeMemoryManager implements TaskResource {
     return this.nativeInstanceHandle;
   }
 
-  public byte[] collectMemoryUsage() {
-    return collectMemoryUsage(nativeInstanceHandle);
+  public MemoryUsageStats collectMemoryUsage() {
+    try {
+      return MemoryUsageStats.parseFrom(collectMemoryUsage(nativeInstanceHandle));
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public long shrink(long size) {
@@ -87,16 +95,26 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
+    LOGGER.debug("About to release memory manager, usage dump: {}",
+        SparkMemoryUtil.prettyPrintStats(new KnownNameAndStats() {
+          @Override
+          public String name() {
+            return name;
+          }
+
+          @Override
+          public MemoryUsageStats stats() {
+            return collectMemoryUsage();
+          }
+        }));
     release(nativeInstanceHandle);
     if (listener.getUsedBytes() != 0) {
       LOGGER.warn(
-          name
-              + " Reservation listener "
-              + listener.toString()
-              + " "
-              + "still reserved non-zero bytes, which may cause "
-              + "memory leak, size: "
-              + Utils.bytesToString(listener.getUsedBytes()));
+          String.format("%s Reservation listener %s still reserved non-zero bytes, " +
+                  "which may cause memory leak, size: %s",
+              name,
+              listener.toString(),
+              Utils.bytesToString(listener.getUsedBytes())));
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -114,16 +114,8 @@ public class NativeMemoryManager implements TaskResource {
       LOGGER.warn(
           String.format(
               "%s Reservation listener %s still reserved non-zero bytes, "
-                  + "which may cause memory leak, size: %s. "
-                  + "Waiting 2s in case there are async tasks that still consuming memory... ",
+                  + "which may cause memory leak, size: %s. ",
               name, listener.toString(), Utils.bytesToString(listener.getUsedBytes())));
-      // We are about to leak memory, wait 2s to let possible async task complete
-      listener.waitUntilReleased(2000L);
-      if (listener.getUsedBytes() == 0) {
-        LOGGER.info(
-            String.format(
-                "%s Reservation listener %s successfully released.", name, listener.toString()));
-      }
     }
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -95,7 +95,7 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
-    LOGGER.warn(
+    LOGGER.debug(
         SparkMemoryUtil.prettyPrintStats(
             "About to release memory manager, usage dump:",
             new KnownNameAndStats() {

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -95,7 +95,7 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
-    LOGGER.debug(
+    LOGGER.warn(
         "About to release memory manager, usage dump: {}",
         SparkMemoryUtil.prettyPrintStats(
             new KnownNameAndStats() {

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -95,19 +95,20 @@ public class NativeMemoryManager implements TaskResource {
 
   @Override
   public void release() throws Exception {
-    LOGGER.warn(SparkMemoryUtil.prettyPrintStats(
-        "About to release memory manager, usage dump:",
-        new KnownNameAndStats() {
-          @Override
-          public String name() {
-            return name;
-          }
+    LOGGER.warn(
+        SparkMemoryUtil.prettyPrintStats(
+            "About to release memory manager, usage dump:",
+            new KnownNameAndStats() {
+              @Override
+              public String name() {
+                return name;
+              }
 
-          @Override
-          public MemoryUsageStats stats() {
-            return collectMemoryUsage();
-          }
-        }));
+              @Override
+              public MemoryUsageStats stats() {
+                return collectMemoryUsage();
+              }
+            }));
     release(nativeInstanceHandle);
     if (listener.getUsedBytes() != 0) {
       LOGGER.warn(

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManagers.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManagers.java
@@ -106,13 +106,7 @@ public final class NativeMemoryManagers {
 
                           @Override
                           public MemoryUsageStats toStats() {
-                            final NativeMemoryManager nmm = getNativeMemoryManager();
-                            final byte[] usageProto = nmm.collectMemoryUsage();
-                            try {
-                              return MemoryUsageStats.parseFrom(usageProto);
-                            } catch (InvalidProtocolBufferException e) {
-                              throw new RuntimeException(e);
-                            }
+                            return getNativeMemoryManager().collectMemoryUsage();
                           }
 
                           private NativeMemoryManager getNativeMemoryManager() {

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManagers.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManagers.java
@@ -24,7 +24,6 @@ import io.glutenproject.memory.memtarget.Spiller;
 import io.glutenproject.memory.memtarget.Spillers;
 import io.glutenproject.proto.MemoryUsageStats;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.util.TaskResources;
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/ReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/ReservationListener.java
@@ -28,6 +28,4 @@ public interface ReservationListener {
   long unreserve(long size);
 
   long getUsedBytes();
-
-  void waitUntilReleased(long timeoutMs) throws InterruptedException;
 }

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/ReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/ReservationListener.java
@@ -16,28 +16,18 @@
  */
 package io.glutenproject.memory.nmm;
 
+import io.glutenproject.memory.SimpleMemoryUsageRecorder;
+import io.glutenproject.memory.memtarget.NoopMemoryTarget;
+
 public interface ReservationListener {
   ReservationListener NOOP =
-      new ReservationListener() {
-        @Override
-        public long reserve(long size) {
-          return 0L;
-        }
-
-        @Override
-        public long unreserve(long size) {
-          return 0L;
-        }
-
-        @Override
-        public long getUsedBytes() {
-          return 0;
-        }
-      };
+      new ManagedReservationListener(new NoopMemoryTarget(), new SimpleMemoryUsageRecorder());
 
   long reserve(long size);
 
   long unreserve(long size);
 
   long getUsedBytes();
+
+  void waitUntilReleased(long timeoutMs) throws InterruptedException;
 }


### PR DESCRIPTION
This fixes issue #3364.

~~After applying the patch, global memory pool will be used when IO threads > 0 for memory allocations in Hive connector. However side-effect that the allocations will be out-of-track by Spark memory manager will be brought.~~

Update: Switching to global memory pool doesn't help since the async executor holds task's memory pool anyway. Added a wait strategy (up to 1.5s) until async allocations are released. Some minor cleanups to connector initialization procedure.