### PR TITLE
[VL] Copy compress small partition buffer

### DIFF
--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -194,6 +194,7 @@ set(SPARK_COLUMNAR_PLUGIN_SRCS
         memory/ArrowMemoryPool.cc
         memory/ColumnarBatch.cc
         operators/writer/ArrowWriter.cc
+        shuffle/options.cc
         shuffle/ShuffleReader.cc
         shuffle/ShuffleWriter.cc
         shuffle/Partitioner.cc

--- a/cpp/core/compute/ExecutionCtx.h
+++ b/cpp/core/compute/ExecutionCtx.h
@@ -138,7 +138,7 @@ class ExecutionCtx : public std::enable_shared_from_this<ExecutionCtx> {
 
   virtual ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
-      ReaderOptions options,
+      ShuffleReaderOptions options,
       arrow::MemoryPool* pool,
       MemoryManager* memoryManager) = 0;
   virtual std::shared_ptr<ShuffleReader> getShuffleReader(ResourceHandle) = 0;

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -810,7 +810,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   }
 
   shuffleWriterOptions.task_attempt_id = (int64_t)taskAttemptId;
-  shuffleWriterOptions.buffer_compress_threshold = bufferCompressThreshold;
+  shuffleWriterOptions.compression_threshold = bufferCompressThreshold;
 
   auto partitionWriterTypeC = env->GetStringUTFChars(partitionWriterTypeJstr, JNI_FALSE);
   auto partitionWriterType = std::string(partitionWriterTypeC);
@@ -984,20 +984,18 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleReaderJniWrapper
     jlong cSchema,
     jlong memoryManagerHandle,
     jstring compressionType,
-    jstring compressionBackend,
-    jstring compressionMode) {
+    jstring compressionBackend) {
   JNI_METHOD_START
   auto ctx = gluten::getExecutionCtx(env, wrapper);
   auto memoryManager = jniCastOrThrow<MemoryManager>(memoryManagerHandle);
 
   auto pool = memoryManager->getArrowMemoryPool();
-  ReaderOptions options = ReaderOptions::defaults();
+  ShuffleReaderOptions options = ShuffleReaderOptions::defaults();
   options.ipc_read_options.memory_pool = pool;
   options.ipc_read_options.use_threads = false;
   if (compressionType != nullptr) {
     options.compression_type = getCompressionType(env, compressionType);
     options.codec_backend = getCodecBackend(env, compressionBackend);
-    options.compression_mode = getCompressionMode(env, compressionMode);
   }
   std::shared_ptr<arrow::Schema> schema =
       gluten::arrowGetOrThrow(arrow::ImportSchema(reinterpret_cast<struct ArrowSchema*>(cSchema)));

--- a/cpp/core/shuffle/ShuffleReader.cc
+++ b/cpp/core/shuffle/ShuffleReader.cc
@@ -30,7 +30,7 @@ using namespace gluten;
 class ShuffleReaderOutStream : public ColumnarBatchIterator {
  public:
   ShuffleReaderOutStream(
-      const ReaderOptions& options,
+      const ShuffleReaderOptions& options,
       const std::shared_ptr<arrow::Schema>& schema,
       const std::shared_ptr<arrow::io::InputStream>& in,
       const std::function<void(int64_t)> ipcTimeAccumulator)
@@ -65,7 +65,7 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
   }
 
  private:
-  ReaderOptions options_;
+  ShuffleReaderOptions options_;
   std::shared_ptr<arrow::io::InputStream> in_;
   std::function<void(int64_t)> ipcTimeAccumulator_;
   std::shared_ptr<arrow::Schema> writeSchema_;
@@ -74,11 +74,10 @@ class ShuffleReaderOutStream : public ColumnarBatchIterator {
 
 namespace gluten {
 
-ReaderOptions ReaderOptions::defaults() {
-  return {};
-}
-
-ShuffleReader::ShuffleReader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, arrow::MemoryPool* pool)
+ShuffleReader::ShuffleReader(
+    std::shared_ptr<arrow::Schema> schema,
+    ShuffleReaderOptions options,
+    arrow::MemoryPool* pool)
     : pool_(pool), options_(std::move(options)), schema_(schema) {}
 
 std::shared_ptr<ResultIterator> ShuffleReader::readStream(std::shared_ptr<arrow::io::InputStream> in) {

--- a/cpp/core/shuffle/ShuffleReader.h
+++ b/cpp/core/shuffle/ShuffleReader.h
@@ -23,22 +23,14 @@
 #include <arrow/ipc/options.h>
 
 #include "compute/ResultIterator.h"
+#include "options.h"
 #include "utils/compression.h"
 
 namespace gluten {
 
-struct ReaderOptions {
-  arrow::ipc::IpcReadOptions ipc_read_options = arrow::ipc::IpcReadOptions::Defaults();
-  arrow::Compression::type compression_type = arrow::Compression::type::LZ4_FRAME;
-  CodecBackend codec_backend = CodecBackend::NONE;
-  CompressionMode compression_mode = CompressionMode::BUFFER;
-
-  static ReaderOptions defaults();
-};
-
 class ShuffleReader {
  public:
-  explicit ShuffleReader(std::shared_ptr<arrow::Schema> schema, ReaderOptions options, arrow::MemoryPool* pool);
+  explicit ShuffleReader(std::shared_ptr<arrow::Schema> schema, ShuffleReaderOptions options, arrow::MemoryPool* pool);
 
   virtual ~ShuffleReader() = default;
 
@@ -67,7 +59,7 @@ class ShuffleReader {
   int64_t ipcTime_ = 0;
   int64_t deserializeTime_ = 0;
 
-  ReaderOptions options_;
+  ShuffleReaderOptions options_;
 
  private:
   std::shared_ptr<arrow::Schema> schema_;

--- a/cpp/core/shuffle/ShuffleWriter.cc
+++ b/cpp/core/shuffle/ShuffleWriter.cc
@@ -31,10 +31,6 @@ namespace gluten {
 #define SPLIT_BUFFER_SIZE 16 * 1024 * 1024
 #endif
 
-ShuffleWriterOptions ShuffleWriterOptions::defaults() {
-  return {};
-}
-
 std::shared_ptr<arrow::Schema> ShuffleWriter::writeSchema() {
   if (writeSchema_ != nullptr) {
     return writeSchema_;

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -23,46 +23,10 @@
 
 #include "memory/ArrowMemoryPool.h"
 #include "memory/ColumnarBatch.h"
+#include "shuffle/options.h"
 #include "utils/compression.h"
 
 namespace gluten {
-
-namespace {
-static constexpr int32_t kDefaultShuffleWriterBufferSize = 4096;
-static constexpr int32_t kDefaultNumSubDirs = 64;
-static constexpr int32_t kDefaultBufferCompressThreshold = 1024;
-static constexpr int32_t kDefaultBufferAlignment = 64;
-static constexpr double kDefaultBufferReallocThreshold = 0.25;
-} // namespace
-
-enum PartitionWriterType { kLocal, kCeleborn };
-
-struct ShuffleWriterOptions {
-  int32_t buffer_size = kDefaultShuffleWriterBufferSize;
-  int32_t push_buffer_max_size = kDefaultShuffleWriterBufferSize;
-  int32_t num_sub_dirs = kDefaultNumSubDirs;
-  int32_t buffer_compress_threshold = kDefaultBufferCompressThreshold;
-  double buffer_realloc_threshold = kDefaultBufferReallocThreshold;
-  arrow::Compression::type compression_type = arrow::Compression::LZ4_FRAME;
-  CodecBackend codec_backend = CodecBackend::NONE;
-  CompressionMode compression_mode = CompressionMode::BUFFER;
-  bool buffered_write = false;
-  bool write_eos = true;
-
-  std::string data_file;
-  PartitionWriterType partition_writer_type = kLocal;
-
-  int64_t thread_id = -1;
-  int64_t task_attempt_id = -1;
-
-  arrow::MemoryPool* memory_pool;
-
-  arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
-
-  std::string partitioning_name;
-
-  static ShuffleWriterOptions defaults();
-};
 
 class ShuffleMemoryPool : public arrow::MemoryPool {
  public:

--- a/cpp/core/shuffle/options.cc
+++ b/cpp/core/shuffle/options.cc
@@ -15,27 +15,11 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "options.h"
+gluten::ShuffleReaderOptions gluten::ShuffleReaderOptions::defaults() {
+  return {};
+}
 
-#include "shuffle/ShuffleWriter.h"
-#include "shuffle/options.h"
-
-namespace gluten {
-
-class ShuffleWriter::PartitionWriter {
- public:
-  PartitionWriter(ShuffleWriter* shuffleWriter) : shuffleWriter_(shuffleWriter) {}
-  virtual ~PartitionWriter() = default;
-
-  virtual arrow::Status init() = 0;
-
-  virtual arrow::Status processPayload(uint32_t partitionId, std::unique_ptr<arrow::ipc::IpcPayload> payload) = 0;
-
-  virtual arrow::Status spill() = 0;
-
-  virtual arrow::Status stop() = 0;
-
-  ShuffleWriter* shuffleWriter_;
-};
-
-} // namespace gluten
+gluten::ShuffleWriterOptions gluten::ShuffleWriterOptions::defaults() {
+  return {};
+}

--- a/cpp/core/shuffle/options.h
+++ b/cpp/core/shuffle/options.h
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <arrow/ipc/options.h>
+#include "utils/compression.h"
+
+static constexpr int32_t kDefaultShuffleWriterBufferSize = 4096;
+static constexpr int32_t kDefaultNumSubDirs = 64;
+static constexpr int32_t kDefaultCompressionThreshold = 100;
+static constexpr int32_t kDefaultBufferAlignment = 64;
+static constexpr double kDefaultBufferReallocThreshold = 0.25;
+
+namespace gluten {
+
+enum PartitionWriterType { kLocal, kCeleborn };
+
+struct ShuffleReaderOptions {
+  arrow::ipc::IpcReadOptions ipc_read_options = arrow::ipc::IpcReadOptions::Defaults();
+  arrow::Compression::type compression_type = arrow::Compression::type::LZ4_FRAME;
+  CodecBackend codec_backend = CodecBackend::NONE;
+
+  static ShuffleReaderOptions defaults();
+};
+
+struct ShuffleWriterOptions {
+  int32_t buffer_size = kDefaultShuffleWriterBufferSize;
+  int32_t push_buffer_max_size = kDefaultShuffleWriterBufferSize;
+  int32_t num_sub_dirs = kDefaultNumSubDirs;
+  int32_t compression_threshold = kDefaultCompressionThreshold;
+  double buffer_realloc_threshold = kDefaultBufferReallocThreshold;
+  arrow::Compression::type compression_type = arrow::Compression::LZ4_FRAME;
+  CodecBackend codec_backend = CodecBackend::NONE;
+  CompressionMode compression_mode = CompressionMode::BUFFER;
+  bool buffered_write = false;
+  bool write_eos = true;
+
+  std::string data_file;
+  PartitionWriterType partition_writer_type = kLocal;
+
+  int64_t thread_id = -1;
+  int64_t task_attempt_id = -1;
+
+  arrow::MemoryPool* memory_pool;
+
+  arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
+
+  std::string partitioning_name;
+
+  static ShuffleWriterOptions defaults();
+};
+
+} // namespace gluten

--- a/cpp/velox/compute/VeloxExecutionCtx.cc
+++ b/cpp/velox/compute/VeloxExecutionCtx.cc
@@ -219,7 +219,7 @@ void VeloxExecutionCtx::releaseDatasource(ResourceHandle handle) {
 
 ResourceHandle VeloxExecutionCtx::createShuffleReader(
     std::shared_ptr<arrow::Schema> schema,
-    ReaderOptions options,
+    ShuffleReaderOptions options,
     arrow::MemoryPool* pool,
     MemoryManager* memoryManager) {
   auto ctxVeloxPool = getLeafVeloxPool(memoryManager);

--- a/cpp/velox/compute/VeloxExecutionCtx.h
+++ b/cpp/velox/compute/VeloxExecutionCtx.h
@@ -107,7 +107,7 @@ class VeloxExecutionCtx final : public ExecutionCtx {
 
   ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
-      ReaderOptions options,
+      ShuffleReaderOptions options,
       arrow::MemoryPool* pool,
       MemoryManager* memoryManager) override;
   std::shared_ptr<ShuffleReader> getShuffleReader(ResourceHandle handle) override;

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -314,10 +314,11 @@ void getUncompressedBuffers(
     const arrow::RecordBatch& batch,
     arrow::MemoryPool* arrowPool,
     arrow::util::Codec* codec,
-    CompressionMode compressionMode,
     std::vector<BufferPtr>& buffers) {
+  // Get compression mode from first byte.
   auto lengthBuffer = readColumnBuffer(batch, 1);
-  const int64_t* lengthPtr = reinterpret_cast<const int64_t*>(lengthBuffer->data());
+  auto compressionMode = (CompressionMode)*lengthBuffer->data();
+  const int64_t* lengthPtr = reinterpret_cast<const int64_t*>(lengthBuffer->data() + 1);
   auto valueBuffer = readColumnBuffer(batch, 2);
   if (compressionMode == CompressionMode::BUFFER) {
     getUncompressedBuffersOneByOne(arrowPool, codec, lengthPtr, valueBuffer, buffers);
@@ -330,7 +331,6 @@ RowVectorPtr readRowVector(
     const arrow::RecordBatch& batch,
     RowTypePtr rowType,
     CodecBackend codecBackend,
-    CompressionMode compressionMode,
     int64_t& decompressTime,
     int64_t& deserializeTime,
     arrow::MemoryPool* arrowPool,
@@ -352,7 +352,7 @@ RowVectorPtr readRowVector(
   } else {
     TIME_NANO_START(decompressTime);
     auto codec = createArrowIpcCodec(compressType, codecBackend);
-    getUncompressedBuffers(batch, arrowPool, codec.get(), compressionMode, buffers);
+    getUncompressedBuffers(batch, arrowPool, codec.get(), buffers);
     TIME_NANO_END(decompressTime);
   }
 
@@ -368,7 +368,7 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
   VeloxShuffleReaderOutStream(
       arrow::MemoryPool* pool,
       const std::shared_ptr<facebook::velox::memory::MemoryPool>& veloxPool,
-      const ReaderOptions& options,
+      const ShuffleReaderOptions& options,
       const RowTypePtr& rowType,
       const std::function<void(int64_t)> decompressionTimeAccumulator,
       const std::function<void(int64_t)> deserializeTimeAccumulator,
@@ -391,15 +391,8 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
     int64_t decompressTime = 0LL;
     int64_t deserializeTime = 0LL;
 
-    auto vp = readRowVector(
-        *rb,
-        rowType_,
-        options_.codec_backend,
-        options_.compression_mode,
-        decompressTime,
-        deserializeTime,
-        pool_,
-        veloxPool_.get());
+    auto vp =
+        readRowVector(*rb, rowType_, options_.codec_backend, decompressTime, deserializeTime, pool_, veloxPool_.get());
 
     decompressionTimeAccumulator_(decompressTime);
     deserializeTimeAccumulator_(deserializeTime);
@@ -409,7 +402,7 @@ class VeloxShuffleReaderOutStream : public ColumnarBatchIterator {
  private:
   arrow::MemoryPool* pool_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
-  ReaderOptions options_;
+  ShuffleReaderOptions options_;
   facebook::velox::RowTypePtr rowType_;
 
   std::function<void(int64_t)> decompressionTimeAccumulator_;
@@ -456,7 +449,7 @@ std::string getCompressionType(arrow::Compression::type type) {
 
 VeloxShuffleReader::VeloxShuffleReader(
     std::shared_ptr<arrow::Schema> schema,
-    ReaderOptions options,
+    ShuffleReaderOptions options,
     arrow::MemoryPool* pool,
     std::shared_ptr<memory::MemoryPool> veloxPool)
     : ShuffleReader(schema, options, pool), veloxPool_(std::move(veloxPool)) {
@@ -465,7 +458,6 @@ VeloxShuffleReader::VeloxShuffleReader(
     std::ostringstream oss;
     oss << "VeloxShuffleReader create, compression_type:" << getCompressionType(options.compression_type);
     oss << " codec_backend:" << getCodecBackend(options.codec_backend);
-    oss << " compression_mode:" << getCompressionMode(options.compression_mode);
     LOG(INFO) << oss.str();
   }
 }

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -27,7 +27,7 @@ class VeloxShuffleReader final : public ShuffleReader {
  public:
   VeloxShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
-      ReaderOptions options,
+      ShuffleReaderOptions options,
       arrow::MemoryPool* pool,
       std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool);
 

--- a/cpp/velox/tests/ExecutionCtxTest.cc
+++ b/cpp/velox/tests/ExecutionCtxTest.cc
@@ -98,7 +98,7 @@ class DummyExecutionCtx final : public ExecutionCtx {
   void releaseDatasource(ResourceHandle handle) override {}
   ResourceHandle createShuffleReader(
       std::shared_ptr<arrow::Schema> schema,
-      ReaderOptions options,
+      ShuffleReaderOptions options,
       arrow::MemoryPool* pool,
       MemoryManager* memoryManager) override {
     return kInvalidResourceHandle;

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -123,7 +123,7 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
     setenv(kGlutenSparkLocalDirs.c_str(), configDirs.c_str(), 1);
 
     shuffleWriterOptions_ = ShuffleWriterOptions::defaults();
-    shuffleWriterOptions_.buffer_compress_threshold = 0;
+    shuffleWriterOptions_.compression_threshold = 0;
     shuffleWriterOptions_.memory_pool = arrowPool_.get();
 
     ShuffleTestParams params = GetParam();
@@ -229,9 +229,8 @@ class VeloxShuffleWriterTest : public ::testing::TestWithParam<ShuffleTestParams
   }
 
   void getRowVectors(std::shared_ptr<arrow::Schema> schema, std::vector<velox::RowVectorPtr>& vectors) {
-    ReaderOptions options;
+    ShuffleReaderOptions options;
     options.compression_type = shuffleWriterOptions_.compression_type;
-    options.compression_mode = shuffleWriterOptions_.compression_mode;
     auto reader = std::make_shared<VeloxShuffleReader>(schema, options, arrowPool_.get(), pool_);
     auto iter = reader->readStream(file_);
     while (iter->hasNext()) {
@@ -376,7 +375,7 @@ TEST_P(VeloxShuffleWriterTest, singlePartCompressSmallBuffer) {
   shuffleWriterOptions_.buffer_size = 10;
   shuffleWriterOptions_.partitioning_name = "single";
   shuffleWriterOptions_.compression_type = arrow::Compression::LZ4_FRAME;
-  shuffleWriterOptions_.buffer_compress_threshold = 1024;
+  shuffleWriterOptions_.compression_threshold = 1024;
 
   GLUTEN_ASSIGN_OR_THROW(
       auto shuffleWriter, VeloxShuffleWriter::create(1, partitionWriterCreator_, shuffleWriterOptions_, pool_))

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -85,8 +85,7 @@ private class CelebornColumnarBatchSerializerInstance(
         cSchema.memoryAddress(),
         NativeMemoryManagers.contextInstance("ShuffleReader").getNativeInstanceHandle,
         compressionCodec,
-        compressionCodecBackend,
-        GlutenConfig.getConf.columnarShuffleCompressionMode
+        compressionCodecBackend
       )
     // Close shuffle reader instance as lately as the end of task processing,
     // since the native reader could hold a reference to memory pool that

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleReaderJniWrapper.java
@@ -40,8 +40,7 @@ public class ShuffleReaderJniWrapper implements ExecutionCtxAware {
       long cSchema,
       long memoryManagerHandle,
       String compressionType,
-      String compressionCodecBackend,
-      String compressionMode);
+      String compressionCodecBackend);
 
   public native long readStream(long shuffleReaderHandle, JniByteInputStream jniIn);
 

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -100,8 +100,7 @@ private class ColumnarBatchSerializerInstance(
       cSchema.memoryAddress(),
       NativeMemoryManagers.contextInstance("ShuffleReader").getNativeInstanceHandle,
       compressionCodec,
-      compressionCodecBackend,
-      GlutenConfig.getConf.columnarShuffleCompressionMode
+      compressionCodecBackend
     )
     // Close shuffle reader instance as lately as the end of task processing,
     // since the native reader could hold a reference to memory pool that

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenCoalesceShufflePartitionsSuite.scala
@@ -267,7 +267,7 @@ class GlutenCoalesceShufflePartitionsSuite
 
               case None =>
                 assert(shuffleReads.length === 2)
-                shuffleReads.foreach(read => assert(read.outputPartitioning.numPartitions === 3))
+                shuffleReads.foreach(read => assert(read.outputPartitioning.numPartitions === 2))
             }
         }
         // Change the original value 16384 to 40000 for gluten. The test depends on the calculation
@@ -320,7 +320,7 @@ class GlutenCoalesceShufflePartitionsSuite
 
               case None =>
                 assert(shuffleReads.length === 2)
-                shuffleReads.foreach(read => assert(read.outputPartitioning.numPartitions === 3))
+                shuffleReads.foreach(read => assert(read.outputPartitioning.numPartitions === 2))
             }
         }
 
@@ -374,7 +374,7 @@ class GlutenCoalesceShufflePartitionsSuite
 
               case None =>
                 assert(shuffleReads.length === 2)
-                shuffleReads.foreach(read => assert(read.outputPartitioning.numPartitions === 4))
+                shuffleReads.foreach(read => assert(read.outputPartitioning.numPartitions === 3))
             }
         }
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -802,8 +802,10 @@ object GlutenConfig {
   val COLUMNAR_SHUFFLE_BUFFER_COMPRESS_THRESHOLD =
     buildConf("spark.gluten.sql.columnar.shuffle.bufferCompressThreshold")
       .internal()
+      .doc("If number of rows in a batch falls below this threshold," +
+        " will copy all buffers into one buffer to compress.")
       .intConf
-      .createWithDefault(1024)
+      .createWithDefault(100)
 
   val COLUMNAR_MAX_BATCH_SIZE =
     buildConf(GLUTEN_MAX_BATCH_SIZE_KEY)


### PR DESCRIPTION
1. Currently, buffer size < 1024B (default threshold) will not be compressed. If partition buffers are small (e.g. < 100 rows), it's likely that the data is not compressed and result in the shuffle data size larger than Vanilla spark. This PR change the default threshold unit and make the default threshold value 100 rows. Partition buffers that fall below the threshold will be copied into one buffer and compress.
2. Change Columnar shuffle metrics "data size total" from collecting input Velox RowVector size to uncompressed size and remove the "uncompressed size" metric.