### PR TITLE
[CORE] Simplify TransformSupport

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -335,5 +335,5 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
     Map.empty
 
   override def genGenerateTransformerMetricsUpdater(
-      metrics: Map[String, SQLMetric]): MetricsUpdater = new NoopMetricsUpdater
+      metrics: Map[String, SQLMetric]): MetricsUpdater = NoopMetricsUpdater
 }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHFilterExecTransformer.scala
@@ -28,8 +28,7 @@ import java.util
 import scala.collection.JavaConverters._
 
 case class CHFilterExecTransformer(condition: Expression, child: SparkPlan)
-  extends FilterExecTransformerBase(condition, child)
-  with TransformSupport {
+  extends FilterExecTransformerBase(condition, child) {
 
   override protected def doValidateInternal(): ValidationResult = {
     val leftCondition = getLeftCondition

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
@@ -38,7 +38,7 @@ object MetricsUtil extends Logging {
       case t: TransformSupport =>
         MetricsUpdaterTree(t.metricsUpdater(), t.children.map(treeifyMetricsUpdaters))
       case _ =>
-        MetricsUpdaterTree(new NoopMetricsUpdater, Seq())
+        MetricsUpdaterTree(NoopMetricsUpdater, Seq())
     }
   }
 
@@ -104,7 +104,7 @@ object MetricsUtil extends Logging {
             s"Updating native metrics failed due to the wrong size of metrics data: " +
               s"$numNativeMetrics")
           ()
-        } else if (mutNode.updater.isInstanceOf[NoopMetricsUpdater]) {
+        } else if (mutNode.updater == NoopMetricsUpdater) {
           ()
         } else {
           updateTransformerMetricsInternal(
@@ -155,7 +155,7 @@ object MetricsUtil extends Logging {
 
     mutNode.children.foreach {
       child =>
-        if (!child.updater.isInstanceOf[NoopMetricsUpdater]) {
+        if (child.updater != NoopMetricsUpdater) {
           val result = updateTransformerMetricsInternal(
             child,
             relMap,

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -28,8 +28,7 @@ import java.util
 import scala.collection.JavaConverters._
 
 case class FilterExecTransformer(condition: Expression, child: SparkPlan)
-  extends FilterExecTransformerBase(condition, child)
-  with TransformSupport {
+  extends FilterExecTransformerBase(condition, child) {
 
   override protected def doValidateInternal(): ValidationResult = {
     val leftCondition = getLeftCondition

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import com.google.common.collect.Lists
 
-trait BasicScanExecTransformer extends TransformSupport with SupportFormat {
+trait BasicScanExecTransformer extends LeafTransformSupport with SupportFormat {
 
   // The key of merge schema option in Parquet reader.
   protected val mergeSchemaOptionKey = "mergeschema"

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
@@ -25,7 +24,6 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
-import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExecShim, FileScan}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.StructType
@@ -86,8 +84,6 @@ class BatchScanExecTransformer(
     super.doValidateInternal()
   }
 
-  override def supportsColumnar(): Boolean = GlutenConfig.getConf.enableColumnarIterator
-
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     doExecuteColumnarInternal()
   }
@@ -101,18 +97,6 @@ class BatchScanExecTransformer(
   override def hashCode(): Int = Objects.hash(batch, runtimeFilters)
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[BatchScanExecTransformer]
-
-  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
-    Seq()
-  }
-
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = {
-    Seq((this, null))
-  }
-
-  override def getStreamedLeafPlan: SparkPlan = {
-    this
-  }
 
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genBatchScanTransformerMetricsUpdater(metrics)

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.extension.ValidationResult
@@ -29,7 +28,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, DynamicPruningExpression, Expression, PlanExpression, Predicate}
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.execution.{FileSourceScanExecShim, InSubqueryExec, ScalarSubquery, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.{FileSourceScanExecShim, InSubqueryExec, ScalarSubquery, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDirectory}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
@@ -78,14 +77,6 @@ class FileSourceScanExecTransformer(
       Map.empty[String, SQLMetric]
     }
 
-  override lazy val supportsColumnar: Boolean = {
-    /*
-    relation.fileFormat
-      .supportBatch(relation.sparkSession, schema) && GlutenConfig.getConf.enableColumnarIterator
-     */
-    GlutenConfig.getConf.enableColumnarIterator
-  }
-
   override def filterExprs(): Seq[Expression] = dataFilters
 
   override def outputAttributes(): Seq[Attribute] = output
@@ -116,18 +107,6 @@ class FileSourceScanExecTransformer(
   override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSourceScanExecTransformer]
 
   override def hashCode(): Int = super.hashCode()
-
-  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
-    Seq()
-  }
-
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = {
-    Seq((this, null))
-  }
-
-  override def getStreamedLeafPlan: SparkPlan = {
-    this
-  }
 
   override protected def doValidateInternal(): ValidationResult = {
     // Bucketing table has `bucketId` in filename, should apply this in backends

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -28,7 +28,6 @@ import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import io.glutenproject.utils.SubstraitUtil
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
@@ -192,23 +191,6 @@ trait HashJoinLikeExecTransformer
       }
   }
 
-  override def supportsColumnar: Boolean = true
-
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = buildPlan match {
-    case c: TransformSupport =>
-      val childPlans = c.getBuildPlans
-      childPlans :+ (this, null)
-    case _ =>
-      Seq((this, null))
-  }
-
-  override def getStreamedLeafPlan: SparkPlan = streamedPlan match {
-    case c: TransformSupport =>
-      c.getStreamedLeafPlan
-    case _ =>
-      this
-  }
-
   override protected def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     // Firstly, need to check if the Substrait plan for this operator can be successfully generated.
@@ -345,11 +327,6 @@ trait HashJoinLikeExecTransformer
 
   def genJoinParameters(): (Int, Int, String) = {
     (0, 0, "")
-  }
-
-  override protected def doExecute(): RDD[InternalRow] = {
-    throw new UnsupportedOperationException(
-      s"${this.getClass.getSimpleName} doesn't support doExecute")
   }
 }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -26,9 +26,8 @@ import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import com.google.protobuf.Any
@@ -36,45 +35,16 @@ import com.google.protobuf.Any
 import java.util
 
 case class LimitTransformer(child: SparkPlan, offset: Long, count: Long)
-  extends UnaryExecNode
-  with TransformSupport {
+  extends UnaryTransformSupport {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genLimitTransformerMetrics(sparkContext)
 
-  override def supportsColumnar: Boolean = true
-
   override def output: Seq[Attribute] = child.output
-
-  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = child match {
-    case c: TransformSupport =>
-      c.columnarInputRDDs
-    case _ =>
-      Seq(child.executeColumnar())
-  }
-
-  override def getStreamedLeafPlan: SparkPlan = child match {
-    case c: TransformSupport =>
-      c.getStreamedLeafPlan
-    case _ =>
-      this
-  }
-
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = child match {
-    case c: TransformSupport =>
-      val childPlans = c.getBuildPlans
-      childPlans :+ (this, null)
-    case _ =>
-      Seq((this, null))
-  }
 
   override protected def withNewChildInternal(newChild: SparkPlan): LimitTransformer =
     copy(child = newChild)
-
-  override protected def doExecute(): RDD[InternalRow] = {
-    throw new UnsupportedOperationException(s"ColumnarSortExec doesn't support doExecute")
-  }
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     throw new UnsupportedOperationException(s"This operator doesn't support doExecuteColumnar().")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -317,7 +317,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
   override def metricsUpdater(): MetricsUpdater = {
     child match {
       case transformer: TransformSupport => transformer.metricsUpdater()
-      case _ => new NoopMetricsUpdater
+      case _ => NoopMetricsUpdater
     }
   }
 
@@ -328,7 +328,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
         case _ => false
       }
       .map(_.asInstanceOf[TransformSupport].metricsUpdater())
-      .getOrElse(new NoopMetricsUpdater)
+      .getOrElse(NoopMetricsUpdater)
   }
 
   // Recreate the broadcast build side rdd with matched partition number.

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -50,6 +50,13 @@ case class WholeStageTransformContext(root: PlanNode, substraitContext: Substrai
 
 trait TransformSupport extends GlutenPlan {
 
+  final override def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      s"${this.getClass.getSimpleName} doesn't support doExecute")
+  }
+
+  final override lazy val supportsColumnar: Boolean = true
+
   /**
    * Returns all the RDDs of ColumnarBatch which generates the input rows.
    *
@@ -58,10 +65,6 @@ trait TransformSupport extends GlutenPlan {
    */
   def columnarInputRDDs: Seq[RDD[ColumnarBatch]]
 
-  def getBuildPlans: Seq[(SparkPlan, SparkPlan)]
-
-  def getStreamedLeafPlan: SparkPlan
-
   def doTransform(context: SubstraitContext): TransformContext = {
     throw new UnsupportedOperationException(
       s"This operator doesn't support doTransform with SubstraitContext.")
@@ -69,7 +72,7 @@ trait TransformSupport extends GlutenPlan {
 
   def metricsUpdater(): MetricsUpdater
 
-  def getColumnarInputRDDs(plan: SparkPlan): Seq[RDD[ColumnarBatch]] = {
+  protected def getColumnarInputRDDs(plan: SparkPlan): Seq[RDD[ColumnarBatch]] = {
     plan match {
       case c: TransformSupport =>
         c.columnarInputRDDs
@@ -79,10 +82,20 @@ trait TransformSupport extends GlutenPlan {
   }
 }
 
+trait LeafTransformSupport extends TransformSupport with LeafExecNode {
+  final override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = Seq.empty
+}
+
+trait UnaryTransformSupport extends TransformSupport with UnaryExecNode {
+  final override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
+    getColumnarInputRDDs(child)
+  }
+}
+
 case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = false)(
     val transformStageId: Int
-) extends UnaryExecNode
-  with TransformSupport {
+) extends UnaryTransformSupport {
+  assert(child.isInstanceOf[TransformSupport])
 
   // For WholeStageCodegen-like operator, only pipeline time will be handled in graph plotting.
   // See SparkPlanGraph.scala:205 for reference.
@@ -108,8 +121,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def outputOrdering: Seq[SortOrder] = child.outputOrdering
-
-  override def supportsColumnar: Boolean = GlutenConfig.getConf.enableColumnarIterator
 
   override def otherCopyArgs: Seq[AnyRef] = Seq(transformStageId.asInstanceOf[Integer])
 
@@ -145,14 +156,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
   // make whole stage transformer clearly plotted in UI, like spark's whole stage codegen.
   // See buildSparkPlanGraphNode in SparkPlanGraph.scala of Spark.
   override def nodeName: String = s"WholeStageCodegenTransformer ($transformStageId)"
-
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = {
-    child.asInstanceOf[TransformSupport].getBuildPlans
-  }
-
-  override def doExecute(): RDD[InternalRow] = {
-    throw new UnsupportedOperationException("Row based execution is not supported")
-  }
 
   def doWholeStageTransform(): WholeStageTransformContext = {
     // invoke SparkPlan.prepare to do subquery preparation etc.
@@ -311,10 +314,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
     }
   }
 
-  override def getStreamedLeafPlan: SparkPlan = {
-    child.asInstanceOf[TransformSupport].getStreamedLeafPlan
-  }
-
   override def metricsUpdater(): MetricsUpdater = {
     child match {
       case transformer: TransformSupport => transformer.metricsUpdater()
@@ -322,19 +321,14 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
     }
   }
 
-  def leafMetricsUpdater(): MetricsUpdater = {
-    getStreamedLeafPlan match {
-      case transformer: TransformSupport => transformer.metricsUpdater()
-      case _ => new NoopMetricsUpdater
-    }
-  }
-
-  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = child match {
-    case c: TransformSupport =>
-      c.columnarInputRDDs
-    case _ =>
-      throw new IllegalStateException(
-        "WholeStageTransformerExec's child should be a TransformSupport ")
+  private def leafMetricsUpdater(): MetricsUpdater = {
+    child
+      .find {
+        case t: TransformSupport if t.children.forall(!_.isInstanceOf[TransformSupport]) => true
+        case _ => false
+      }
+      .map(_.asInstanceOf[TransformSupport].metricsUpdater())
+      .getOrElse(new NoopMetricsUpdater)
   }
 
   // Recreate the broadcast build side rdd with matched partition number.

--- a/gluten-core/src/main/scala/io/glutenproject/metrics/MetricsUpdater.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/metrics/MetricsUpdater.scala
@@ -36,6 +36,6 @@ trait MetricsUpdater extends Serializable {
 
 final case class MetricsUpdaterTree(updater: MetricsUpdater, children: Seq[MetricsUpdaterTree])
 
-class NoopMetricsUpdater extends MetricsUpdater {
+object NoopMetricsUpdater extends MetricsUpdater {
   override def metrics: Map[String, SQLMetric] = Map.empty
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/hive/HiveTableScanExecTransformer.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.hive
 
-import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.{BasicScanExecTransformer, TransformContext}
 import io.glutenproject.extension.ValidationResult
@@ -70,22 +69,8 @@ class HiveTableScanExecTransformer(
     Seq.empty
   }
 
-  override def columnarInputRDDs: Seq[RDD[ColumnarBatch]] = {
-    Seq.empty
-  }
-
-  override def getBuildPlans: Seq[(SparkPlan, SparkPlan)] = {
-    Seq((this, null))
-  }
-
-  override def getStreamedLeafPlan: SparkPlan = {
-    this
-  }
-
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genHiveTableScanTransformerMetricsUpdater(metrics)
-
-  override def supportsColumnar(): Boolean = GlutenConfig.getConf.enableColumnarIterator
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     doExecuteColumnarInternal()

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
@@ -50,7 +50,7 @@ object MetricsUtil extends Logging {
         case t: TransformSupport =>
           MetricsUpdaterTree(t.metricsUpdater(), t.children.map(treeifyMetricsUpdaters))
         case _ =>
-          MetricsUpdaterTree(new NoopMetricsUpdater, Seq())
+          MetricsUpdaterTree(NoopMetricsUpdater, Seq())
       }
     }
 
@@ -219,7 +219,7 @@ object MetricsUtil extends Logging {
 
     mutNode.children.foreach {
       child =>
-        if (!child.updater.isInstanceOf[NoopMetricsUpdater]) {
+        if (child.updater != NoopMetricsUpdater) {
           val result = updateTransformerMetricsInternal(
             child,
             relMap,
@@ -266,7 +266,7 @@ object MetricsUtil extends Logging {
         val numNativeMetrics = metrics.inputRows.length
         if (numNativeMetrics == 0) {
           ()
-        } else if (mutNode.updater.isInstanceOf[NoopMetricsUpdater]) {
+        } else if (mutNode.updater == NoopMetricsUpdater) {
           ()
         } else {
           updateTransformerMetricsInternal(

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -101,8 +101,6 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def enableOneRowRelationColumnar: Boolean = conf.getConf(COLUMNAR_ONE_ROW_RELATION_ENABLED)
 
-  def enableColumnarIterator: Boolean = conf.getConf(COLUMNAR_ITERATOR_ENABLED)
-
   def physicalJoinOptimizationThrottle: Integer =
     conf.getConf(COLUMNAR_PHYSICAL_JOIN_OPTIMIZATION_THROTTLE)
 
@@ -698,14 +696,6 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.columnar.tableCache")
       .internal()
       .doc("Enable or disable columnar table cache.")
-      .booleanConf
-      .createWithDefault(true)
-
-  val COLUMNAR_ITERATOR_ENABLED =
-    buildConf("spark.gluten.sql.columnar.iterator")
-      .internal()
-      .doc(
-        "This config is used for specifying whether to use a columnar iterator in WS transformer.")
       .booleanConf
       .createWithDefault(true)
 

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import io.glutenproject.GlutenConfig
-
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -35,8 +33,6 @@ class BatchScanExecShim(
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map()
-
-  override def supportsColumnar(): Boolean = GlutenConfig.getConf.enableColumnarIterator
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     throw new UnsupportedOperationException("Need to implement this method")

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import io.glutenproject.GlutenConfig
-
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -39,8 +37,6 @@ class BatchScanExecShim(
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] = Map()
-
-  override def supportsColumnar(): Boolean = GlutenConfig.getConf.enableColumnarIterator
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     throw new UnsupportedOperationException("Need to implement this method")


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Removes unused methods `getBuildPlans` and `getStreamedLeafPlan`
2. Add new triat `LeafTransformSupport` and `UnaryTransformSupport` to simplify `columnarInputRDDs`
3. Pull out `doExecute` and `supportsColumnar` to `TransformSupport`
4. remove `COLUMNAR_ITERATOR_ENABLED` config

## How was this patch tested?

Pass CI
