### PR TITLE
[VL] Remove ColumnarToRow for Gluten columnar table cache

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpandFallbackPolicy.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpandFallbackPolicy.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarBroadcastExchangeExec, ColumnarShuffleExchangeExec, ColumnarToRowExec, CommandResultExec, LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, BroadcastQueryStageExec, ColumnarAQEShuffleReadExec, QueryStageExec, ShuffleQueryStageExec}
-import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
 
@@ -164,12 +163,10 @@ case class ExpandFallbackPolicy(isAdaptiveContext: Boolean, originalPlan: SparkP
         transformPostOverrides.transformColumnarToRowExec(c2r)
       case c2r @ ColumnarToRowExec(_: ColumnarAQEShuffleReadExec) =>
         transformPostOverrides.transformColumnarToRowExec(c2r)
-      case ColumnarToRowExec(q: QueryStageExec) if InMemoryTableScanHelper.isGlutenTableCache(q) =>
-        q
-      case ColumnarToRowExec(i: InMemoryTableScanExec)
-          if InMemoryTableScanHelper.isGlutenTableCache(i) =>
-        // `InMemoryTableScanExec` itself supports columnar to row
-        i
+      // `InMemoryTableScanExec` itself supports columnar to row
+      case ColumnarToRowExec(child: SparkPlan)
+          if InMemoryTableScanHelper.isGlutenTableCache(child) =>
+        child
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove unnecessary ColumnarToRow for table cache, as it is internally supported. Mentioned at https://github.com/oap-project/gluten/pull/3368#discussion_r1354339248. Also includes some small code refactor.

## How was this patch tested?

New UT.

