### PR TITLE
[VL] Remove unnecessary registerConnectorFactory for HiveConnector

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -231,7 +231,6 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
 #endif
 
   auto properties = std::make_shared<const velox::core::MemConfig>(configurationValues);
-  velox::connector::registerConnectorFactory(std::make_shared<velox::connector::hive::HiveConnectorFactory>());
   auto hiveConnector =
       velox::connector::getConnectorFactory(velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());


### PR DESCRIPTION
```
W1019 12:38:42.899380 996562 Connector.cpp:39] ConnectorFactory with name hive is already registered.
```