### PR TITLE
[VL] Add stream insertion operator for SparkTaskInfo on native side

### DIFF
--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -42,6 +42,10 @@ struct SparkTaskInfo {
   // Same as TID.
   int64_t taskId{0};
 
+  std::string toString() const {
+    return "[Stage: " + std::to_string(stageId) + " TID: " + std::to_string(taskId) + "]";
+  }
+
   friend std::ostream& operator<<(std::ostream& os, const SparkTaskInfo& taskInfo) {
     os << "[Stage: " << taskInfo.stageId << " TID: " << taskInfo.taskId << "]";
     return os;

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -42,8 +42,9 @@ struct SparkTaskInfo {
   // Same as TID.
   int64_t taskId{0};
 
-  std::string toString() const {
-    return "[Stage: " + std::to_string(stageId) + " TID: " + std::to_string(taskId) + "]";
+  friend std::ostream& operator<<(std::ostream& os, const SparkTaskInfo& taskInfo) {
+    os << "[Stage: " << taskInfo.stageId << " TID: " << taskInfo.taskId << "]";
+    return os;
   }
 };
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -81,8 +81,9 @@ const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
 WholeStageResultIterator::WholeStageResultIterator(
     std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
     const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
-    const std::unordered_map<std::string, std::string>& confMap)
-    : veloxPlan_(planNode), confMap_(confMap), pool_(pool) {
+    const std::unordered_map<std::string, std::string>& confMap,
+    const SparkTaskInfo& taskInfo)
+    : veloxPlan_(planNode), confMap_(confMap), taskInfo_(taskInfo), pool_(pool) {
 #ifdef ENABLE_HDFS
   updateHdfsTokens();
 #endif
@@ -404,8 +405,8 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
     const std::vector<velox::core::PlanNodeId>& streamIds,
     const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap,
-    const SparkTaskInfo taskInfo)
-    : WholeStageResultIterator(pool, planNode, confMap),
+    const SparkTaskInfo& taskInfo)
+    : WholeStageResultIterator(pool, planNode, confMap, taskInfo),
       scanNodeIds_(scanNodeIds),
       scanInfos_(scanInfos),
       streamIds_(streamIds) {
@@ -451,7 +452,7 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten stage-{} task-{}", taskInfo.stageId, taskInfo.taskId),
+      fmt::format("Gluten stage-{} task-{}", taskInfo_.stageId, taskInfo_.taskId),
       std::move(planFragment),
       0,
       std::move(queryCtx));
@@ -500,14 +501,14 @@ WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
     const std::vector<velox::core::PlanNodeId>& streamIds,
     const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap,
-    const SparkTaskInfo taskInfo)
-    : WholeStageResultIterator(pool, planNode, confMap), streamIds_(streamIds) {
+    const SparkTaskInfo& taskInfo)
+    : WholeStageResultIterator(pool, planNode, confMap, taskInfo), streamIds_(streamIds) {
   std::unordered_set<velox::core::PlanNodeId> emptySet;
   velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten stage-{} task-{}", taskInfo.stageId, taskInfo.taskId),
+      fmt::format("Gluten stage-{} task-{}", taskInfo_.stageId, taskInfo_.taskId),
       std::move(planFragment),
       0,
       std::move(queryCtx));

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -452,10 +452,7 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten stage-{} task-{}", taskInfo_.stageId, taskInfo_.taskId),
-      std::move(planFragment),
-      0,
-      std::move(queryCtx));
+      fmt::format("Gluten {}", taskInfo_.toString()), std::move(planFragment), 0, std::move(queryCtx));
 
   if (!task_->supportsSingleThreadedExecution()) {
     throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());
@@ -508,10 +505,7 @@ WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten stage-{} task-{}", taskInfo_.stageId, taskInfo_.taskId),
-      std::move(planFragment),
-      0,
-      std::move(queryCtx));
+      fmt::format("Gluten {}", taskInfo_.toString()), std::move(planFragment), 0, std::move(queryCtx));
 
   if (!task_->supportsSingleThreadedExecution()) {
     throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -36,7 +36,8 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
   WholeStageResultIterator(
       std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
-      const std::unordered_map<std::string, std::string>& confMap);
+      const std::unordered_map<std::string, std::string>& confMap,
+      const SparkTaskInfo& taskInfo);
 
   virtual ~WholeStageResultIterator() {
     if (task_ != nullptr && task_->isRunning()) {
@@ -68,6 +69,8 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
 
   /// A map of custom configs.
   std::unordered_map<std::string, std::string> confMap_;
+
+  const SparkTaskInfo taskInfo_;
 
  private:
   /// Get the Spark confs to Velox query context.
@@ -117,7 +120,7 @@ class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator
       const std::vector<facebook::velox::core::PlanNodeId>& streamIds,
       const std::string spillDir,
       const std::unordered_map<std::string, std::string>& confMap,
-      const SparkTaskInfo taskInfo);
+      const SparkTaskInfo& taskInfo);
 
  private:
   std::vector<facebook::velox::core::PlanNodeId> scanNodeIds_;
@@ -139,7 +142,7 @@ class WholeStageResultIteratorMiddleStage final : public WholeStageResultIterato
       const std::vector<facebook::velox::core::PlanNodeId>& streamIds,
       const std::string spillDir,
       const std::unordered_map<std::string, std::string>& confMap,
-      const SparkTaskInfo taskInfo);
+      const SparkTaskInfo& taskInfo);
 
  private:
   bool noMoreSplits_ = false;


### PR DESCRIPTION
Overload `<<` operator for SparkTaskInfo, after that, it can be used as `LOG(INFO) << taskInfo;`, hence, build mapping between java log and native log.
```
I1020 10:07:57.491497 2704501 VeloxExecutionCtx.cc:82] [Stage: 9 TID: 9]
23/10/20 10:07:57 WARN [Executor task launch worker for task 0.0 in stage 9.0 (TID 9)] xxx
```

Also pass it to WholeStageIterator as member variable.