### PR TITLE
[VL] Add config for glog verbose level and severity level

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -60,6 +60,9 @@ const std::string kEnableUserExceptionStacktrace =
     "spark.gluten.sql.columnar.backend.velox.enableUserExceptionStacktrace";
 const std::string kEnableUserExceptionStacktraceDefault = "true";
 
+const std::string kGlogVerboseLevel = "spark.gluten.sql.columnar.backend.velox.glogVerboseLevel";
+const std::string kGlogVerboseLevelDefault = "0";
+
 const std::string kEnableSystemExceptionStacktrace =
     "spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace";
 const std::string kEnableSystemExceptionStacktraceDefault = "true";
@@ -116,6 +119,12 @@ void VeloxBackend::printConf(const std::unordered_map<std::string, std::string>&
 }
 
 void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf) {
+  // Init glog and verbose level.
+  auto vlogLevel = stoi(getConfigValue(conf, kGlogVerboseLevel, kGlogVerboseLevelDefault));
+  FLAGS_v = vlogLevel;
+  FLAGS_logtostderr = true;
+  google::InitGoogleLogging("gluten");
+
   // Avoid creating too many shared leaf pools.
   FLAGS_velox_memory_num_shared_leaf_pools = 0;
 

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -63,6 +63,9 @@ const std::string kEnableUserExceptionStacktraceDefault = "true";
 const std::string kGlogVerboseLevel = "spark.gluten.sql.columnar.backend.velox.glogVerboseLevel";
 const std::string kGlogVerboseLevelDefault = "0";
 
+const std::string kGlogSeverityLevel = "spark.gluten.sql.columnar.backend.velox.glogMinLogLevel";
+const std::string kGlogSeverityLevelDefault = "0";
+
 const std::string kEnableSystemExceptionStacktrace =
     "spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace";
 const std::string kEnableSystemExceptionStacktraceDefault = "true";
@@ -119,11 +122,15 @@ void VeloxBackend::printConf(const std::unordered_map<std::string, std::string>&
 }
 
 void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf) {
-  // Init glog and verbose level.
-  auto vlogLevel = stoi(getConfigValue(conf, kGlogVerboseLevel, kGlogVerboseLevelDefault));
-  FLAGS_v = vlogLevel;
-  FLAGS_logtostderr = true;
-  google::InitGoogleLogging("gluten");
+  // Init glog and log level.
+  {
+    auto vlogLevel = stoi(getConfigValue(conf, kGlogVerboseLevel, kGlogVerboseLevelDefault));
+    auto severityLogLevel = stoi(getConfigValue(conf, kGlogSeverityLevel, kGlogSeverityLevelDefault));
+    FLAGS_v = vlogLevel;
+    FLAGS_minloglevel = severityLogLevel;
+    FLAGS_logtostderr = true;
+    google::InitGoogleLogging("gluten");
+  }
 
   // Avoid creating too many shared leaf pools.
   FLAGS_velox_memory_num_shared_leaf_pools = 0;

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -63,7 +63,7 @@ const std::string kEnableUserExceptionStacktraceDefault = "true";
 const std::string kGlogVerboseLevel = "spark.gluten.sql.columnar.backend.velox.glogVerboseLevel";
 const std::string kGlogVerboseLevelDefault = "0";
 
-const std::string kGlogSeverityLevel = "spark.gluten.sql.columnar.backend.velox.glogMinLogLevel";
+const std::string kGlogSeverityLevel = "spark.gluten.sql.columnar.backend.velox.glogSeverityLevel";
 const std::string kGlogSeverityLevelDefault = "0";
 
 const std::string kEnableSystemExceptionStacktrace =

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -153,12 +153,12 @@ class ConditionalSuspendedSection {
 int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
   std::string poolName{pool_->root()->name() + "/" + pool_->name()};
   std::string logPrefix{"Spill[" + poolName + "]: "};
-  DLOG(INFO) << logPrefix << "Trying to reclaim " << size << " bytes of data...";
-  DLOG(INFO) << logPrefix << "Pool has reserved " << pool_->currentBytes() << "/" << pool_->root()->reservedBytes()
-             << "/" << pool_->root()->capacity() << "/" << pool_->root()->maxCapacity() << " bytes.";
-  DLOG(INFO) << logPrefix << "Shrinking...";
+  VLOG(2) << logPrefix << "Trying to reclaim " << size << " bytes of data...";
+  VLOG(2) << logPrefix << "Pool has reserved " << pool_->currentBytes() << "/" << pool_->root()->reservedBytes() << "/"
+          << pool_->root()->capacity() << "/" << pool_->root()->maxCapacity() << " bytes.";
+  VLOG(2) << logPrefix << "Shrinking...";
   int64_t shrunken = pool_->shrinkManaged(pool_.get(), size);
-  DLOG(INFO) << logPrefix << shrunken << " bytes released from shrinking.";
+  VLOG(2) << logPrefix << shrunken << " bytes released from shrinking.";
 
   // todo return the actual spilled size?
   if (spillStrategy_ == "auto") {
@@ -177,13 +177,13 @@ int64_t WholeStageResultIterator::spillFixedSize(int64_t size) {
     uint64_t spilledOut = pool_->reclaim(remaining, status);
     LOG(INFO) << logPrefix << "Successfully spilled out " << spilledOut << " bytes.";
     uint64_t total = shrunken + spilledOut;
-    DLOG(INFO) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
+    VLOG(2) << logPrefix << "Successfully reclaimed total " << total << " bytes.";
     return total;
   } else {
     LOG(WARNING) << "Spill-to-disk was disabled since " << kSpillStrategy << " was not configured.";
   }
 
-  DLOG(INFO) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";
+  VLOG(2) << logPrefix << "Successfully reclaimed total " << shrunken << " bytes.";
   return shrunken;
 }
 

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -49,9 +49,6 @@ jint JNI_OnLoad(JavaVM* vm, void*) {
     return JNI_ERR;
   }
 
-  // logging
-  google::InitGoogleLogging("gluten");
-  FLAGS_logtostderr = true;
   gluten::getJniCommonState()->ensureInitialized(env);
   gluten::getJniErrorState()->ensureInitialized(env);
   gluten::initVeloxJniFileSystem(env);

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -197,12 +197,12 @@ MemoryUsageStats collectMemoryUsageStatsInternal(const velox::memory::MemoryPool
 int64_t shrinkVeloxMemoryPool(velox::memory::MemoryPool* pool, int64_t size) {
   std::string poolName{pool->root()->name() + "/" + pool->name()};
   std::string logPrefix{"Shrink[" + poolName + "]: "};
-  DLOG(INFO) << logPrefix << "Trying to shrink " << size << " bytes of data...";
-  DLOG(INFO) << logPrefix << "Pool has reserved " << pool->currentBytes() << "/" << pool->root()->reservedBytes() << "/"
-             << pool->root()->capacity() << "/" << pool->root()->maxCapacity() << " bytes.";
-  DLOG(INFO) << logPrefix << "Shrinking...";
+  VLOG(2) << logPrefix << "Trying to shrink " << size << " bytes of data...";
+  VLOG(2) << logPrefix << "Pool has reserved " << pool->currentBytes() << "/" << pool->root()->reservedBytes() << "/"
+          << pool->root()->capacity() << "/" << pool->root()->maxCapacity() << " bytes.";
+  VLOG(2) << logPrefix << "Shrinking...";
   int64_t shrunken = pool->shrinkManaged(pool, size);
-  DLOG(INFO) << logPrefix << shrunken << " bytes released from shrinking.";
+  VLOG(2) << logPrefix << shrunken << " bytes released from shrinking.";
   return shrunken;
 }
 } // namespace

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1472,7 +1472,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
         }
         *size = beforeEvict - afterEvict;
       } else {
-        DLOG(INFO) << "Evicted all partitions. " << std::to_string(beforeEvict) << " bytes released" << std::endl;
+        VLOG(2) << "Evicted all partitions. " << std::to_string(beforeEvict) << " bytes released" << std::endl;
         *size = beforeEvict;
       }
     }
@@ -1584,7 +1584,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
       RETURN_NOT_OK(shrinkPartitionBuffer(pid));
     }
     auto shrunken = beforeShrink - partitionBufferPool_->bytes_allocated();
-    DLOG(INFO) << shrunken << " bytes released from shrinking.";
+    VLOG(2) << shrunken << " bytes released from shrinking.";
     return shrunken;
   }
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1015,16 +1015,17 @@ object GlutenConfig {
   val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
       .internal()
-      .doc("Set glog verbose level in Velox backend.")
+      .doc("Set glog verbose level in Velox backend, used for control VLOG().")
       .intConf
-      .createOptional
+      .createWithDefault(0)
 
   val COLUMNAR_VELOX_GLOG_SEVERITY_LEVEL =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel")
       .internal()
-      .doc("Set glog severity level in Velox backend.")
+      .doc("Set glog severity level in Velox backend, used for control LOG(severity), " +
+        "0 for INFO, 1 for WARNING.")
       .intConf
-      .createOptional
+      .createWithDefault(0)
 
   val COLUMNAR_VELOX_SPILL_STRATEGY =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillStrategy")

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1019,6 +1019,13 @@ object GlutenConfig {
       .intConf
       .createOptional
 
+  val COLUMNAR_VELOX_GLOG_SEVERITY_LEVEL =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel")
+      .internal()
+      .doc("Set glog severity level in Velox backend.")
+      .intConf
+      .createOptional
+
   val COLUMNAR_VELOX_SPILL_STRATEGY =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillStrategy")
       .internal()

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1241,4 +1241,11 @@ object GlutenConfig {
         + "partial aggregation may be early abandoned.")
       .intConf
       .createOptional
+
+  val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
+    buildConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
+      .internal()
+      .doc("Set glog verbose level in Velox backend.")
+      .intConf
+      .createOptional
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1012,6 +1012,13 @@ object GlutenConfig {
       .intConf
       .createWithDefault(2)
 
+  val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
+      .internal()
+      .doc("Set glog verbose level in Velox backend.")
+      .intConf
+      .createOptional
+
   val COLUMNAR_VELOX_SPILL_STRATEGY =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillStrategy")
       .internal()
@@ -1239,13 +1246,6 @@ object GlutenConfig {
       .internal()
       .doc("If partial aggregation aggregationPct greater than this value, "
         + "partial aggregation may be early abandoned.")
-      .intConf
-      .createOptional
-
-  val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
-    buildConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
-      .internal()
-      .doc("Set glog verbose level in Velox backend.")
       .intConf
       .createOptional
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1015,15 +1015,14 @@ object GlutenConfig {
   val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")
       .internal()
-      .doc("Set glog verbose level in Velox backend, used for control VLOG().")
+      .doc("Set glog verbose level in Velox backend, same as FLAGS_v.")
       .intConf
       .createWithDefault(0)
 
   val COLUMNAR_VELOX_GLOG_SEVERITY_LEVEL =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel")
       .internal()
-      .doc("Set glog severity level in Velox backend, used for control LOG(severity), " +
-        "0 for INFO, 1 for WARNING.")
+      .doc("Set glog severity level in Velox backend, same as FLAGS_minloglevel.")
       .intConf
       .createWithDefault(0)
 


### PR DESCRIPTION
Add new config `spark.gluten.sql.columnar.backend.velox.glogVerboseLevel` to control native glog verbose level and `spark.gluten.sql.columnar.backend.velox.glogSeverityLevel` to control native glog severity, default value is same as glog, [doc](https://github.com/google/glog).
By this config, user can easily control both Gluten and Velox log level at runtime.

Also change DLOG to VLOG to enable such logs without recompile, more bigger number in VLOG means more detailed message.