### PR TITLE
[WIP][GLUTEN-3456][VL] Add config to disable columnar table cache if input is row-based

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -700,6 +700,13 @@ object GlutenConfig {
       .booleanConf
       .createWithDefault(true)
 
+  val COLUMNAR_TABLE_CACHE_ALLOW_ROW_BASED_ENABLED =
+    buildConf("spark.gluten.sql.columnar.tableCacheAllowRowBasedInput")
+      .internal()
+      .doc("Enable columnar table cache if the input is row-based.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COLUMNAR_PHYSICAL_JOIN_OPTIMIZATION_THROTTLE =
     buildConf("spark.gluten.sql.columnar.physicalJoinOptimizationLevel")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This config is a trade-off that to disable columnar table cache to prevent regression if the input is row-based. In general, if we use cache then there are multi-consumers to reference the cached plan, so it still has benefis for consumer side even if we add a row to columnar to do the cache.

Note that, if we disable columnar table cache then all the consumer plan will add row to columanr.

## How was this patch tested?

Pass CI
