### PR TITLE
[GLUTEN-3480] Fix incorrect metrics values for ch backend

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -154,6 +154,8 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
       "extraTime" -> SQLMetrics.createTimingMetric(sparkContext, "extra operators time"),
       "inputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for data"),
       "outputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for output"),
+      "resizeInputRows" -> SQLMetrics.createMetric(sparkContext, "number of resize input rows"),
+      "resizeOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of resize output rows"),
       "preProjectTime" ->
         SQLMetrics.createTimingMetric(sparkContext, "time of preProjection"),
       "aggregatingTime" ->

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -63,6 +63,9 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         assert(plans(2).metrics("pruningTime").value === -1)
         assert(plans(2).metrics("filesSize").value === 17777735)
 
+        assert(plans(1).metrics("inputRows").value === 591673)
+        assert(plans(1).metrics("resizeInputRows").value === 4)
+        assert(plans(1).metrics("resizeOutputRows").value === 4)
         assert(plans(1).metrics("outputRows").value === 4)
         assert(plans(1).metrics("outputVectors").value === 1)
 
@@ -87,6 +90,9 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           assert(plans(2).metrics("pruningTime").value === -1)
           assert(plans(2).metrics("filesSize").value === 17777735)
 
+          assert(plans(1).metrics("inputRows").value === 591673)
+          assert(plans(1).metrics("resizeInputRows").value === 4)
+          assert(plans(1).metrics("resizeOutputRows").value === 4)
           assert(plans(1).metrics("outputRows").value === 4)
           assert(plans(1).metrics("outputVectors").value === 1)
 
@@ -246,7 +252,17 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
   }
 
   test("TPCH Q21") {
-    runTPCHQuery(21, noFallBack = false) { df => }
+    runTPCHQuery(21, noFallBack = false) {
+      df =>
+        val plans = collect(df.queryExecution.executedPlan) {
+          case scanExec: BasicScanExecTransformer => scanExec
+          case filterExec: FilterExecTransformerBase => filterExec
+        }
+        assert(plans(2).metrics("inputRows").value === 600572)
+        assert(plans(2).metrics("outputRows").value === 379809)
+
+        assert(plans(3).metrics("outputRows").value === 600572)
+    }
   }
 
   test("TPCH Q22") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix incorrect metrics values for ch backend:
1. When there is a r2c operation, it will call iter.hasNext more than once, so the native metrics will be added more than once;
2. Add the resize metrics for ch agg operation.

Close #3480.

(Fixes: #3480)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

