### PR TITLE
[CORE] Do not fallback eagerly with ColumnarToRowExec

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/FallbackSuite.scala
@@ -122,4 +122,17 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
         assert(aqeRead.isDefined)
     }
   }
+
+  test("Do not fallback eagerly with ColumnarToRowExec") {
+    withSQLConf(GlutenConfig.COLUMNAR_WHOLESTAGE_FALLBACK_THRESHOLD.key -> "1") {
+      runQueryAndCompare("select count(*) from tmp1") {
+        df =>
+          assert(
+            collect(df.queryExecution.executedPlan) {
+              case h: HashAggregateExecTransformer => h
+            }.size == 2,
+            df.queryExecution.executedPlan)
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It has no meaning to add ColumnarToRow eagerly if we will add it finally. So we ignore the ColumnarToRow to avoid fallback eagerly. It is useful if people set fallback threshold to 1.
For example: 1 is better than 2

```
1. We first run native operator then add ColumnarToRow
      ColumnarExchange
            |
  HashAggregateTransformer
            |
      ColumnarToRow

2. We first add ColumnarToRow then run vanilla Spark operator
     ColumnarExchange
            |
      ColumnarToRow
            |
      HashAggregate
```

## How was this patch tested?

add test
