### PR TITLE
[VL] Register row_constructor_with_null

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -240,6 +240,7 @@ set(VELOX_SRCS
     memory/VeloxColumnarBatch.cc
     memory/VeloxMemoryManager.cc
     operators/functions/RegistrationAllFunctions.cc
+    operators/functions/RowConstructorWithNull.cc
     operators/serializer/VeloxColumnarToRowConverter.cc
     operators/serializer/VeloxColumnarBatchSerializer.cc
     operators/serializer/VeloxRowToColumnarConverter.cc

--- a/cpp/velox/operators/functions/RegistrationAllFunctions.cc
+++ b/cpp/velox/operators/functions/RegistrationAllFunctions.cc
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "RegistrationAllFunctions.h"
-#include "Arithmetic.h"
-#include "RowConstructor.h"
+#include "operators/functions/RegistrationAllFunctions.h"
+#include "operators/functions/Arithmetic.h"
+#include "operators/functions/RowConstructorWithNull.h"
+#include "operators/functions/RowFunctionWithNull.h"
 
+#include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -43,13 +45,21 @@ void registerFunctionOverwrite() {
       velox::functions::sparksql::xxhash64WithSeedSignatures(),
       velox::functions::sparksql::makeXxHash64WithSeed);
 
-  facebook::velox::functions::registerUnaryNumeric<RoundFunction>({"round"});
-  facebook::velox::registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});
-  facebook::velox::registerFunction<RoundFunction, int16_t, int16_t, int32_t>({"round"});
-  facebook::velox::registerFunction<RoundFunction, int32_t, int32_t, int32_t>({"round"});
-  facebook::velox::registerFunction<RoundFunction, int64_t, int64_t, int32_t>({"round"});
-  facebook::velox::registerFunction<RoundFunction, double, double, int32_t>({"round"});
-  facebook::velox::registerFunction<RoundFunction, float, float, int32_t>({"round"});
+  velox::functions::registerUnaryNumeric<RoundFunction>({"round"});
+  velox::registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});
+  velox::registerFunction<RoundFunction, int16_t, int16_t, int32_t>({"round"});
+  velox::registerFunction<RoundFunction, int32_t, int32_t, int32_t>({"round"});
+  velox::registerFunction<RoundFunction, int64_t, int64_t, int32_t>({"round"});
+  velox::registerFunction<RoundFunction, double, double, int32_t>({"round"});
+  velox::registerFunction<RoundFunction, float, float, int32_t>({"round"});
+
+  velox::exec::registerVectorFunction(
+      "row_constructor_with_null",
+      std::vector<std::shared_ptr<velox::exec::FunctionSignature>>{},
+      std::make_unique<RowFunctionWithNull>());
+  velox::exec::registerFunctionCallToSpecialForm(
+      RowConstructorWithNullCallToSpecialForm::kRowConstructorWithNull,
+      std::make_unique<RowConstructorWithNullCallToSpecialForm>());
 }
 } // namespace
 

--- a/cpp/velox/operators/functions/RowConstructorWithNull.cc
+++ b/cpp/velox/operators/functions/RowConstructorWithNull.cc
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RowConstructorWithNull.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace gluten {
+facebook::velox::TypePtr RowConstructorWithNullCallToSpecialForm::resolveType(
+    const std::vector<facebook::velox::TypePtr>& argTypes) {
+  auto numInput = argTypes.size();
+  std::vector<std::string> names(numInput);
+  std::vector<facebook::velox::TypePtr> types(numInput);
+  for (auto i = 0; i < numInput; i++) {
+    types[i] = argTypes[i];
+    names[i] = fmt::format("c{}", i + 1);
+  }
+  return facebook::velox::ROW(std::move(names), std::move(types));
+}
+
+facebook::velox::exec::ExprPtr RowConstructorWithNullCallToSpecialForm::constructSpecialForm(
+    const std::string& name,
+    const facebook::velox::TypePtr& type,
+    std::vector<facebook::velox::exec::ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const facebook::velox::core::QueryConfig& config) {
+  auto rowConstructorVectorFunction =
+      facebook::velox::exec::vectorFunctionFactories().withRLock([&config, &name](auto& functionMap) {
+        auto functionIterator = functionMap.find(name);
+        return functionIterator->second.factory(name, {}, config);
+      });
+
+  return std::make_shared<facebook::velox::exec::Expr>(
+      type, std::move(compiledChildren), rowConstructorVectorFunction, name, trackCpuUsage);
+}
+
+facebook::velox::exec::ExprPtr RowConstructorWithNullCallToSpecialForm::constructSpecialForm(
+    const facebook::velox::TypePtr& type,
+    std::vector<facebook::velox::exec::ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const facebook::velox::core::QueryConfig& config) {
+  return constructSpecialForm(kRowConstructorWithNull, type, std::move(compiledChildren), trackCpuUsage, config);
+}
+} // namespace gluten

--- a/cpp/velox/operators/functions/RowConstructorWithNull.h
+++ b/cpp/velox/operators/functions/RowConstructorWithNull.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/SpecialForm.h"
+
+namespace gluten {
+class RowConstructorWithNullCallToSpecialForm : public facebook::velox::exec::FunctionCallToSpecialForm {
+ public:
+  facebook::velox::TypePtr resolveType(const std::vector<facebook::velox::TypePtr>& argTypes) override;
+
+  facebook::velox::exec::ExprPtr constructSpecialForm(
+      const facebook::velox::TypePtr& type,
+      std::vector<facebook::velox::exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const facebook::velox::core::QueryConfig& config) override;
+
+  static constexpr const char* kRowConstructorWithNull = "row_constructor_with_null";
+
+ protected:
+  facebook::velox::exec::ExprPtr constructSpecialForm(
+      const std::string& name,
+      const facebook::velox::TypePtr& type,
+      std::vector<facebook::velox::exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const facebook::velox::core::QueryConfig& config);
+};
+} // namespace gluten

--- a/cpp/velox/operators/functions/RowFunctionWithNull.h
+++ b/cpp/velox/operators/functions/RowFunctionWithNull.h
@@ -23,9 +23,9 @@
 namespace gluten {
 
 /**
- * A customized RowConstructor function to set struct as null when one of its argument is null.
+ * A customized RowFunction to set struct as null when one of its argument is null.
  */
-class RowConstructor final : public facebook::velox::exec::VectorFunction {
+class RowFunctionWithNull final : public facebook::velox::exec::VectorFunction {
   void apply(
       const facebook::velox::SelectivityVector& rows,
       std::vector<facebook::velox::VectorPtr>& args,

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/rui-mo/velox.git
-VELOX_BRANCH=test
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=update
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=update
+VELOX_REPO=https://github.com/rui-mo/velox.git
+VELOX_BRANCH=test
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removes https://github.com/oap-project/velox/commit/556839d927ca77f4288ca89977dab70a7f9493d7 by registering `row_constructor_with_null` in Gluten.
https://github.com/oap-project/velox/pull/420

## How was this patch tested?

Verified on Jenkins.

