### PR TITLE
[VL] Fix cache output if selectedAttributes has wrong ordering with cacheAttributes

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -226,7 +226,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
     val requestedColumnIndices = selectedAttributes.map {
       a => cacheAttributes.map(_.exprId).indexOf(a.exprId)
     }
-    val shouldPruning = selectedAttributes.size != cacheAttributes.size
+    val shouldSelectAttributes = cacheAttributes != selectedAttributes
     val localSchema = toStructType(cacheAttributes)
     val timezoneId = SQLConf.get.sessionLocalTimeZone
     input.mapPartitions {
@@ -260,7 +260,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
                 .create()
                 .deserialize(deserializerHandle, cachedBatch.bytes)
             val batch = ColumnarBatches.create(Runtimes.contextInstance(), batchHandle)
-            if (shouldPruning) {
+            if (shouldSelectAttributes) {
               try {
                 ColumnarBatches.select(nmm, batch, requestedColumnIndices.toArray)
               } finally {


### PR DESCRIPTION

## What changes were proposed in this pull request?

This pr fixes a bug when the consumer side selects the different ordering attributes with the original cached plan. We should reorganize the columnar batch.

## How was this patch tested?

add test
