### PR TITLE
[GLUTEN-3511][CORE] Support to add custom aggregate functions for extension

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -92,7 +92,6 @@ class GlutenClickHouseHiveTableSuite()
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceshuffledhashjoin", "true")
       .set("spark.gluten.sql.parquet.maxmin.index", "true")
       .set(
         "spark.sql.warehouse.dir",

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseNativeWriteTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseNativeWriteTableSuite.scala
@@ -72,7 +72,6 @@ class GlutenClickHouseNativeWriteTableSuite
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceshuffledhashjoin", "true")
       // TODO: support default ANSI policy
       .set("spark.sql.storeAssignmentPolicy", "legacy")
 //       .set("spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level", "debug")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseSyntheticDataSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseSyntheticDataSuite.scala
@@ -77,7 +77,6 @@ class GlutenClickHouseSyntheticDataSuite
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceShuffledHashJoin", "true")
       .set("spark.sql.warehouse.dir", warehouse)
       .set("spark.sql.legacy.createHiveTableByDefault", "false")
       .set("spark.shuffle.manager", "sort")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSAbstractSuite.scala
@@ -174,7 +174,6 @@ abstract class GlutenClickHouseTPCDSAbstractSuite
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceShuffledHashJoin", "true")
       .set("spark.sql.warehouse.dir", warehouse)
       .set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
     /* .set("spark.sql.catalogImplementation", "hive")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
@@ -518,7 +518,6 @@ abstract class GlutenClickHouseTPCHAbstractSuite
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceShuffledHashJoin", "true")
       .set("spark.sql.warehouse.dir", warehouse)
       .set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
     /* .set("spark.sql.catalogImplementation", "hive")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickhouseFunctionSuite.scala
@@ -65,7 +65,6 @@ class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceshuffledhashjoin", "true")
       // TODO: support default ANSI policy
       .set("spark.sql.storeAssignmentPolicy", "legacy")
       //       .set("spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level", "debug")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -68,7 +68,6 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       .set("spark.gluten.sql.columnar.iterator", "true")
       .set("spark.gluten.sql.columnar.hashagg.enablefinal", "true")
       .set("spark.gluten.sql.enable.native.validation", "false")
-      .set("spark.gluten.sql.columnar.forceshuffledhashjoin", "true")
       .set("spark.sql.warehouse.dir", warehouse)
       .set("spark.shuffle.manager", "sort")
       .set("spark.io.compression.codec", "snappy")

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.execution.extension
+
+import io.glutenproject.expression._
+import io.glutenproject.extension.ExpressionExtensionTrait
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+
+import scala.collection.mutable.ListBuffer
+
+case class CustomAggExpressionTransformer() extends ExpressionExtensionTrait {
+
+  lazy val expressionSigs = Seq(
+    Sig[CustomSum]("custom_sum")
+  )
+
+  /** Generate the extension expressions list, format: Sig[XXXExpression]("XXXExpressionName") */
+  override def expressionSigList: Seq[Sig] = expressionSigs
+
+  /** Get the attribute index of the extension aggregate functions. */
+  override def getAttrsForExtensionAggregateExpr(
+      aggregateFunc: AggregateFunction,
+      mode: AggregateMode,
+      exp: AggregateExpression,
+      aggregateAttributeList: Seq[Attribute],
+      aggregateAttr: ListBuffer[Attribute],
+      resIndex: Int): Int = {
+    var reIndex = resIndex
+    aggregateFunc match {
+      case CustomSum(_, _) =>
+        mode match {
+          case Partial | PartialMerge =>
+            val aggBufferAttr = aggregateFunc.inputAggBufferAttributes
+            if (aggBufferAttr.size == 2) {
+              // decimal sum check sum.resultType
+              aggregateAttr += ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
+              val isEmptyAttr = ConverterUtils.getAttrFromExpr(aggBufferAttr(1))
+              aggregateAttr += isEmptyAttr
+              reIndex += 2
+              reIndex
+            } else {
+              val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
+              aggregateAttr += attr
+              reIndex += 1
+              reIndex
+            }
+          case Final =>
+            aggregateAttr += aggregateAttributeList(reIndex)
+            reIndex += 1
+            reIndex
+          case other =>
+            throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
+        }
+    }
+  }
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/GlutenCustomAggExpressionSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/GlutenCustomAggExpressionSuite.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.execution.extension
+
+import io.glutenproject.execution.{GlutenClickHouseTPCHAbstractSuite, HashAggregateExecBaseTransformer}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase
+import org.apache.spark.sql.catalyst.expressions.aggregate.CustomSum
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+
+class GlutenCustomAggExpressionSuite
+  extends GlutenClickHouseTPCHAbstractSuite
+  with AdaptiveSparkPlanHelper {
+
+  override protected val resourcePath: String =
+    "../../../../gluten-core/src/test/resources/tpch-data"
+
+  override protected val tablesPath: String = basePath + "/tpch-data"
+  override protected val tpchQueries: String =
+    rootPath + "../../../../gluten-core/src/test/resources/tpch-queries"
+  override protected val queriesResults: String = rootPath + "queries-output"
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(
+        "spark.gluten.sql.columnar.extended.expressions.transformer",
+        "io.glutenproject.execution.extension.CustomAggExpressionTransformer")
+  }
+
+  override protected def createTPCHNotNullTables(): Unit = {
+    createTPCHParquetTables(tablesPath)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val (expressionInfo, builder) =
+      FunctionRegistryBase.build[CustomSum]("custom_sum", None)
+    spark.sessionState.functionRegistry.registerFunction(
+      FunctionIdentifier.apply("custom_sum"),
+      expressionInfo,
+      builder
+    )
+  }
+
+  test("test custom aggregate function") {
+    val sql =
+      s"""
+         |SELECT
+         |    l_returnflag,
+         |    l_linestatus,
+         |    custom_sum(l_quantity) AS sum_qty,
+         |    sum(l_extendedprice) AS sum_base_price
+         |FROM
+         |    lineitem
+         |WHERE
+         |    l_shipdate <= date'1998-09-02' - interval 1 day
+         |GROUP BY
+         |    l_returnflag,
+         |    l_linestatus
+         |ORDER BY
+         |    l_returnflag,
+         |    l_linestatus;
+         |""".stripMargin
+    compareResultsAgainstVanillaSpark(
+      sql,
+      true,
+      {
+        df =>
+          val hashAggExec = collect(df.queryExecution.executedPlan) {
+            case hash: HashAggregateExecBaseTransformer => hash
+          }
+          assert(hashAggExec.size == 2)
+
+          assert(hashAggExec(0).aggregateExpressions(0).aggregateFunction.isInstanceOf[CustomSum])
+          assert(hashAggExec(1).aggregateExpressions(0).aggregateFunction.isInstanceOf[CustomSum])
+      }
+    )
+  }
+}

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CustomSum.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CustomSum.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions.aggregate
+
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.trees.TreePattern.{SUM, TreePattern}
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.catalyst.util.TypeUtils
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+/**
+ * Port the `Sum` aggregate function from Vanilla Spark 3.2, only changes class name to CustomSum.
+ */
+case class CustomSum(child: Expression, failOnError: Boolean = SQLConf.get.ansiEnabled)
+  extends DeclarativeAggregate
+  with ImplicitCastInputTypes
+  with UnaryLike[Expression] {
+
+  def this(child: Expression) = this(child, failOnError = SQLConf.get.ansiEnabled)
+
+  override def nullable: Boolean = true
+
+  // Return data type.
+  override def dataType: DataType = resultType
+
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(TypeCollection(NumericType, YearMonthIntervalType, DayTimeIntervalType))
+
+  override def checkInputDataTypes(): TypeCheckResult =
+    TypeUtils.checkForAnsiIntervalOrNumericType(child.dataType, "sum")
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(SUM)
+
+  private lazy val resultType = child.dataType match {
+    case DecimalType.Fixed(precision, scale) =>
+      DecimalType.bounded(precision + 10, scale)
+    case _: IntegralType => LongType
+    case it: YearMonthIntervalType => it
+    case it: DayTimeIntervalType => it
+    case _ => DoubleType
+  }
+
+  private lazy val sum = AttributeReference("sum", resultType)()
+
+  private lazy val isEmpty = AttributeReference("isEmpty", BooleanType, nullable = false)()
+
+  private lazy val zero = Literal.default(resultType)
+
+  override lazy val aggBufferAttributes = resultType match {
+    case _: DecimalType => sum :: isEmpty :: Nil
+    case _ => sum :: Nil
+  }
+
+  override lazy val initialValues: Seq[Expression] = resultType match {
+    case _: DecimalType => Seq(zero, Literal(true, BooleanType))
+    case _ => Seq(Literal(null, resultType))
+  }
+
+  override lazy val updateExpressions: Seq[Expression] = {
+    resultType match {
+      case _: DecimalType =>
+        // For decimal type, the initial value of `sum` is 0. We need to keep `sum` unchanged if
+        // the input is null, as SUM function ignores null input. The `sum` can only be null if
+        // overflow happens under non-ansi mode.
+        val sumExpr = if (child.nullable) {
+          If(child.isNull, sum, sum + KnownNotNull(child).cast(resultType))
+        } else {
+          sum + child.cast(resultType)
+        }
+        // The buffer becomes non-empty after seeing the first not-null input.
+        val isEmptyExpr = if (child.nullable) {
+          isEmpty && child.isNull
+        } else {
+          Literal(false, BooleanType)
+        }
+        Seq(sumExpr, isEmptyExpr)
+      case _ =>
+        // For non-decimal type, the initial value of `sum` is null, which indicates no value.
+        // We need `coalesce(sum, zero)` to start summing values. And we need an outer `coalesce`
+        // in case the input is nullable. The `sum` can only be null if there is no value, as
+        // non-decimal type can produce overflowed value under non-ansi mode.
+        if (child.nullable) {
+          Seq(coalesce(coalesce(sum, zero) + child.cast(resultType), sum))
+        } else {
+          Seq(coalesce(sum, zero) + child.cast(resultType))
+        }
+    }
+  }
+
+  /**
+   * For decimal type: If isEmpty is false and if sum is null, then it means we have had an
+   * overflow.
+   *
+   * update of the sum is as follows: Check if either portion of the left.sum or right.sum has
+   * overflowed If it has, then the sum value will remain null. If it did not have overflow, then
+   * add the sum.left and sum.right
+   *
+   * isEmpty: Set to false if either one of the left or right is set to false. This means we have
+   * seen atleast a value that was not null.
+   */
+  override lazy val mergeExpressions: Seq[Expression] = {
+    resultType match {
+      case _: DecimalType =>
+        val bufferOverflow = !isEmpty.left && sum.left.isNull
+        val inputOverflow = !isEmpty.right && sum.right.isNull
+        Seq(
+          If(
+            bufferOverflow || inputOverflow,
+            Literal.create(null, resultType),
+            // If both the buffer and the input do not overflow, just add them, as they can't be
+            // null. See the comments inside `updateExpressions`: `sum` can only be null if
+            // overflow happens.
+            KnownNotNull(sum.left) + KnownNotNull(sum.right)
+          ),
+          isEmpty.left && isEmpty.right
+        )
+      case _ => Seq(coalesce(coalesce(sum.left, zero) + sum.right, sum.left))
+    }
+  }
+
+  /**
+   * If the isEmpty is true, then it means there were no values to begin with or all the values were
+   * null, so the result will be null. If the isEmpty is false, then if sum is null that means an
+   * overflow has happened. So now, if ansi is enabled, then throw exception, if not then return
+   * null. If sum is not null, then return the sum.
+   */
+  override lazy val evaluateExpression: Expression = resultType match {
+    case d: DecimalType =>
+      If(isEmpty, Literal.create(null, resultType), CheckOverflowInSum(sum, d, !failOnError))
+    case _ => sum
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): CustomSum =
+    copy(child = newChild)
+
+  // The flag `failOnError` won't be shown in the `toString` or `toAggString` methods
+  override def flatArguments: Iterator[Any] = Iterator(child)
+}

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.cpp
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.cpp
@@ -14,26 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <Parser/aggregate_function_parser/CommonAggregateFunctionParser.h>
 #include <Parser/AggregateFunctionParser.h>
 
 
 namespace local_engine
 {
-
-#define REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(cls_name, substait_name, ch_name) \
-    class AggregateFunctionParser##cls_name : public AggregateFunctionParser \
-    { \
-    public: \
-        AggregateFunctionParser##cls_name(SerializedPlanParser * plan_parser_) : AggregateFunctionParser(plan_parser_) \
-        { \
-        } \
-        ~AggregateFunctionParser##cls_name() override = default; \
-        String getName() const override { return  #substait_name; } \
-        static constexpr auto name = #substait_name; \
-        String getCHFunctionName(const CommonFunctionInfo &) const override { return #ch_name; } \
-        String getCHFunctionName(const DB::DataTypes &) const override { return #ch_name; } \
-    }; \
-    static const AggregateFunctionParserRegister<AggregateFunctionParser##cls_name> register_##cls_name = AggregateFunctionParserRegister<AggregateFunctionParser##cls_name>();
 
 REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Sum, sum, sum)
 REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(Avg, avg, avg)

--- a/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.h
+++ b/cpp-ch/local-engine/Parser/aggregate_function_parser/CommonAggregateFunctionParser.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Parser/AggregateFunctionParser.h>
+
+
+namespace local_engine
+{
+
+#define REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(cls_name, substait_name, ch_name) \
+    class AggregateFunctionParser##cls_name : public AggregateFunctionParser \
+    { \
+    public: \
+        AggregateFunctionParser##cls_name(SerializedPlanParser * plan_parser_) : AggregateFunctionParser(plan_parser_) \
+        { \
+        } \
+        ~AggregateFunctionParser##cls_name() override = default; \
+        String getName() const override { return  #substait_name; } \
+        static constexpr auto name = #substait_name; \
+        String getCHFunctionName(const CommonFunctionInfo &) const override { return #ch_name; } \
+        String getCHFunctionName(const DB::DataTypes &) const override { return #ch_name; } \
+    }; \
+    static const AggregateFunctionParserRegister<AggregateFunctionParser##cls_name> register_##cls_name = AggregateFunctionParserRegister<AggregateFunctionParser##cls_name>();
+
+}

--- a/cpp-ch/local-engine/Parser/example_udf/customSum.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/customSum.cpp
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Parser/FunctionParser.h>
+
+#include <Parser/aggregate_function_parser/CommonAggregateFunctionParser.h>
+#include <Parser/AggregateFunctionParser.h>
+
+
+namespace local_engine
+{
+// Only for ut to test custom aggregate function
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(CustomSum, custom_sum, sum)
+}

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -453,7 +453,7 @@ $spark_cmd \
   --conf spark.gluten.sql.columnar.loadarrow=false \
   --conf spark.gluten.sql.columnar.hashagg.enablefinal=true \
   --conf spark.gluten.sql.enable.native.validation=false \
-  --conf spark.gluten.sql.columnar.forceshuffledhashjoin=true \
+  --conf spark.gluten.sql.columnar.forceShuffledHashJoin=true \
   --conf spark.gluten.sql.columnar.backend.ch.runtime_config.hdfs.libhdfs3_conf=$hdfs_conf \
   --conf spark.gluten.sql.columnar.backend.ch.runtime_config.logger.level=debug \
   --conf spark.plugins=io.glutenproject.GlutenPlugin \

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -448,6 +448,18 @@ abstract class HashAggregateExecBaseTransformer(
     val mode = exp.mode
     val aggregateFunc = exp.aggregateFunction
     aggregateFunc match {
+      case extendedAggFunc
+          if ExpressionMappings.expressionExtensionTransformer.extensionExpressionsMapping.contains(
+            extendedAggFunc.getClass) =>
+        // get attributes from the extended aggregate functions
+        ExpressionMappings.expressionExtensionTransformer
+          .getAttrsForExtensionAggregateExpr(
+            aggregateFunc,
+            mode,
+            exp,
+            aggregateAttributeList,
+            aggregateAttr,
+            index)
       case _: Average | _: First | _: Last =>
         mode match {
           case Partial | PartialMerge =>
@@ -457,9 +469,11 @@ abstract class HashAggregateExecBaseTransformer(
               aggregateAttr += attr
             }
             resIndex += 2
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -474,14 +488,17 @@ abstract class HashAggregateExecBaseTransformer(
               val isEmptyAttr = ConverterUtils.getAttrFromExpr(aggBufferAttr(1))
               aggregateAttr += isEmptyAttr
               resIndex += 2
+              resIndex
             } else {
               val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
               aggregateAttr += attr
               resIndex += 1
+              resIndex
             }
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -493,9 +510,11 @@ abstract class HashAggregateExecBaseTransformer(
             val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
             aggregateAttr += attr
             resIndex += 1
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -509,9 +528,11 @@ abstract class HashAggregateExecBaseTransformer(
             val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
             aggregateAttr += attr
             resIndex += 1
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -529,9 +550,11 @@ abstract class HashAggregateExecBaseTransformer(
               aggregateAttr += attr
             }
             resIndex += expectedBufferSize
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -549,9 +572,11 @@ abstract class HashAggregateExecBaseTransformer(
               aggregateAttr += attr
             }
             resIndex += expectedBufferSize
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -564,9 +589,11 @@ abstract class HashAggregateExecBaseTransformer(
               aggregateAttr += attr
             }
             resIndex += 3
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -581,9 +608,11 @@ abstract class HashAggregateExecBaseTransformer(
               aggregateAttr += attr
             }
             resIndex += aggBufferAttr.size
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -596,9 +625,11 @@ abstract class HashAggregateExecBaseTransformer(
               aggregateAttr += attr
             }
             resIndex += aggBufferAttr.size
+            resIndex
           case Final =>
             aggregateAttr += aggregateAttributeList(resIndex)
             resIndex += 1
+            resIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -606,7 +637,6 @@ abstract class HashAggregateExecBaseTransformer(
         throw new UnsupportedOperationException(
           s"Unsupported aggregate function in getAttrForAggregateExpr")
     }
-    resIndex
   }
 
   protected def modeToKeyWord(aggregateMode: AggregateMode): String = {

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -20,6 +20,9 @@ import io.glutenproject.expression.{ExpressionTransformer, Sig}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, AggregateMode}
+
+import scala.collection.mutable.ListBuffer
 
 trait ExpressionExtensionTrait {
 
@@ -34,21 +37,25 @@ trait ExpressionExtensionTrait {
   def replaceWithExtensionExpressionTransformer(
       substraitExprName: String,
       expr: Expression,
-      attributeSeq: Seq[Attribute]): ExpressionTransformer
+      attributeSeq: Seq[Attribute]): ExpressionTransformer = {
+    throw new UnsupportedOperationException(s"${expr.getClass} or $expr is not supported.")
+  }
+
+  /** Get the attribute index of the extension aggregate functions. */
+  def getAttrsForExtensionAggregateExpr(
+      aggregateFunc: AggregateFunction,
+      mode: AggregateMode,
+      exp: AggregateExpression,
+      aggregateAttributeList: Seq[Attribute],
+      aggregateAttr: ListBuffer[Attribute],
+      resIndex: Int): Int = {
+    throw new UnsupportedOperationException(
+      s"Aggregate function ${aggregateFunc.getClass} is not supported.")
+  }
 }
 
 case class DefaultExpressionExtensionTransformer() extends ExpressionExtensionTrait with Logging {
 
   /** Generate the extension expressions list, format: Sig[XXXExpression]("XXXExpressionName") */
   override def expressionSigList: Seq[Sig] = Seq.empty[Sig]
-
-  /** Replace extension expression to transformer. */
-  override def replaceWithExtensionExpressionTransformer(
-      substraitExprName: String,
-      expr: Expression,
-      attributeSeq: Seq[Attribute]): ExpressionTransformer = {
-    logWarning(s"${expr.getClass} or $expr is not currently supported.")
-    throw new UnsupportedOperationException(
-      s"${expr.getClass} or $expr is not currently supported.")
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When transforming HashAggregateExec, it needs to get attributes from the aggregate function, but if there are some custom aggregate functions, it can not handle these custom aggregate functions when transforming.

Reuse ExpressionExtensionTrait to support this feature, add a new function called getAttrsForExtensionAggregateExpr to handle this.

Close #3511.

(Fixes: #3511)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

