### PR TITLE
[VL] Adapt to latest rebased velox (10/25)

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxDataTypeValidationSuite.scala
@@ -262,7 +262,7 @@ class VeloxDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
 
     // Validation: Window.
     runQueryAndCompare(
-      "select row_number() over (partition by date order by date) from type1 order by int, date") {
+      "select row_number() over (partition by date order by int) from type1 order by int, date") {
       checkOperatorMatch[WindowExecTransformer]
     }
 

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -96,7 +96,7 @@ std::shared_ptr<velox::core::QueryCtx> WholeStageResultIterator::createNewVeloxQ
   connectorConfigs[kHiveConnectorId] = createConnectorConfig();
   std::shared_ptr<velox::core::QueryCtx> ctx = std::make_shared<velox::core::QueryCtx>(
       nullptr,
-      getQueryContextConf(),
+      facebook::velox::core::QueryConfig{getQueryContextConf()},
       connectorConfigs,
       gluten::VeloxBackend::get()->getAsyncDataCache(),
       pool_,

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/PHILO-HE/velox.git
-VELOX_BRANCH=update-10-25
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=update
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=update
+VELOX_REPO=https://github.com/PHILO-HE/velox.git
+VELOX_BRANCH=update-10-25
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
Fixed issues when using latest rebased velox (10/25).
1. Latest velox doesn't allow redundant or overlapped partition/sort keys. Considering this is not a common use case, just modified a UT to skip this case. Also filed an issue: https://github.com/oap-project/gluten/issues/3528
2. As a deprecated constructor for `QueryCtx` is removed, fixed a native compile issue caused by it.