### PR TITLE
[VL] Fix single partitioning evict error

### DIFF
--- a/cpp/core/memory/Evictable.h
+++ b/cpp/core/memory/Evictable.h
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <arrow/status.h>
+
+namespace gluten {
+
+class Evictable {
+ public:
+  virtual ~Evictable() = default;
+
+  virtual arrow::Status evictFixedSize(int64_t size, int64_t* actual) = 0;
+};
+
+} // namespace gluten

--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -23,6 +23,7 @@
 
 #include "memory/ArrowMemoryPool.h"
 #include "memory/ColumnarBatch.h"
+#include "memory/Evictable.h"
 #include "shuffle/options.h"
 #include "utils/compression.h"
 
@@ -82,13 +83,9 @@ class ShuffleMemoryPool : public arrow::MemoryPool {
   uint64_t bytesAllocated_ = 0;
 };
 
-class ShuffleWriter {
+class ShuffleWriter : public Evictable {
  public:
   static constexpr int64_t kMinMemLimit = 128LL * 1024 * 1024;
-  /**
-   * Evict fixed size of partition data from memory
-   */
-  virtual arrow::Status evictFixedSize(int64_t size, int64_t* actual) = 0;
 
   virtual arrow::Status split(std::shared_ptr<ColumnarBatch> cb, int64_t memLimit) = 0;
 

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -263,6 +263,8 @@ void getUncompressedBuffersOneByOne(
             codec->Decompress(
                 compressLength, compressBuffer->data(), uncompressLength, uncompressBuffer->mutable_data()));
         VELOX_DCHECK_EQ(actualDecompressLength, uncompressLength);
+        // Prevent unused variable warning in optimized build.
+        ((void)actualDecompressLength);
       }
       buffers.emplace_back(convertToVeloxBuffer(uncompressBuffer));
     }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1469,7 +1469,7 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
           // Apart from kPreAlloc and kStop states, spill should not be triggered by allocating payload buffers. All
           // cached data should be evicted.
           return arrow::Status::Invalid(
-              "Not all cached payload evicted." + std::to_string(afterEvict) + " bytes remains.");
+              "Not all cached payload evicted. " + std::to_string(afterEvict) + " bytes remains.");
         }
         *size = beforeEvict - afterEvict;
       } else {

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -151,11 +151,6 @@ std::shared_ptr<arrow::Array> makeBinaryArray(
   return arrow::MakeArray(arrow::ArrayData::Make(type, 1, {nullptr, std::move(offsetBuffer), valueBuffer}));
 }
 
-inline void writeInt64(std::shared_ptr<arrow::Buffer> buffer, int64_t& offset, int64_t value) {
-  memcpy(buffer->mutable_data() + offset, &value, sizeof(int64_t));
-  offset += sizeof(int64_t);
-}
-
 int64_t getMaxCompressedBufferSize(
     const std::vector<std::shared_ptr<arrow::Buffer>>& buffers,
     arrow::util::Codec* codec) {

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1464,7 +1464,8 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
     } else {
       RETURN_NOT_OK(partitionWriter_->spill());
       if (auto afterEvict = cachedPayloadSize()) {
-        if (splitState_ != SplitState::kPreAlloc && splitState_ != SplitState::kStop) {
+        if (options_.partitioning_name != "single" && splitState_ != SplitState::kPreAlloc &&
+            splitState_ != SplitState::kStop) {
           // Apart from kPreAlloc and kStop states, spill should not be triggered by allocating payload buffers. All
           // cached data should be evicted.
           return arrow::Status::Invalid(

--- a/cpp/velox/tests/utils/SelfEvictedMemoryPool.h
+++ b/cpp/velox/tests/utils/SelfEvictedMemoryPool.h
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <arrow/memory_pool.h>
+#include "memory/Evictable.h"
+
+namespace gluten {
+
+class SelfEvictedMemoryPool : public arrow::MemoryPool {
+ public:
+  explicit SelfEvictedMemoryPool(arrow::MemoryPool* pool) : pool_(pool) {}
+
+  void setCapacity(int64_t capacity) {
+    capacity_ = capacity;
+  }
+
+  int64_t capacity() const {
+    return capacity_;
+  }
+
+  void setEvictable(Evictable* evictable) {
+    evictable_ = evictable;
+  }
+
+  arrow::MemoryPool* delegated() {
+    return pool_;
+  }
+
+  arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
+    RETURN_NOT_OK(CheckEvict(size));
+    return pool_->Allocate(size, alignment, out);
+  }
+
+  arrow::Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment, uint8_t** ptr) override {
+    if (new_size > old_size) {
+      RETURN_NOT_OK(CheckEvict(new_size - old_size));
+    }
+    return pool_->Reallocate(old_size, new_size, alignment, ptr);
+  }
+
+  void Free(uint8_t* buffer, int64_t size, int64_t alignment) override {
+    return pool_->Free(buffer, size, alignment);
+  }
+
+  int64_t bytes_allocated() const override {
+    return pool_->bytes_allocated();
+  }
+
+  int64_t max_memory() const override {
+    return pool_->max_memory();
+  }
+
+  std::string backend_name() const override {
+    return pool_->backend_name();
+  }
+
+  int64_t total_bytes_allocated() const override {
+    return pool_->total_bytes_allocated();
+  }
+
+  int64_t num_allocations() const override {
+    throw pool_->num_allocations();
+  }
+
+ private:
+  arrow::Status CheckEvict(int64_t size) {
+    if (size > capacity_ - pool_->bytes_allocated()) {
+      // Self evict.
+      int64_t actual;
+      RETURN_NOT_OK(evictable_->evictFixedSize(size, &actual));
+      if (size > capacity_ - pool_->bytes_allocated()) {
+        return arrow::Status::OutOfMemory(
+            "Failed to allocate after evict. Capacity: ",
+            capacity_,
+            ", Requested: ",
+            size,
+            ", Evicted: ",
+            actual,
+            ", Allocated: ",
+            pool_->bytes_allocated());
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::MemoryPool* pool_;
+  Evictable* evictable_;
+  uint64_t capacity_{std::numeric_limits<uint64_t>::max()};
+};
+
+} // namespace gluten


### PR DESCRIPTION
For single partitioning, the SplitState is always `kInit` during split. Therefore, the check of whether cached payloads are clear should not be applied to single partitioning.

This PR also adds `Evictable` interface and `SelfEvictedMemoryPool`, which can be used in unit test to mock the behavior of invoking the `evictFixedSize` API by Spark's memory management during memory allocation failure.
Below code demonstrates how to use in UT:
```
auto pool = defaultArrowPool().get();
auto mockingPool = SelfEvictedMemoryPool(pool);
auto evictable = Evictable(&mockingPool);
mockingPool.setEvictable(&evictable);

mockingPool.setCapcity(100); // When trying to allocate > 100 bytes, it will call evictable->evictFixedSize to trigger self-evict

```