### PR TITLE
[Core] Shuffle the configured directories before use

### DIFF
--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -16,6 +16,7 @@
  */
 
 #include "shuffle/LocalPartitionWriter.h"
+#include <random>
 #include <thread>
 #include "shuffle/Utils.h"
 #include "utils/DebugOut.h"
@@ -32,6 +33,11 @@ std::string LocalPartitionWriterBase::nextSpilledFileDir() {
 
 arrow::Status LocalPartitionWriterBase::setLocalDirs() {
   ARROW_ASSIGN_OR_RAISE(configuredDirs_, getConfiguredLocalDirs());
+  // Shuffle the configured local directories. This prevents each task from using the same directory for spilled files.
+  std::random_device rd;
+  std::default_random_engine engine(rd());
+  std::shuffle(configuredDirs_.begin(), configuredDirs_.end(), engine);
+
   subDirSelection_.assign(configuredDirs_.size(), 0);
 
   // Both data_file and shuffle_index_file should be set through jni.


### PR DESCRIPTION
Make the configured directories in random order, to avoid each task creating local spilled files in the same directory.