### PR TITLE
[VL] Add EvictGuard to avoid spilling recursively in ShuffleWriter

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -319,6 +319,28 @@ std::shared_ptr<arrow::RecordBatch> makeUncompressedRecordBatch(
   }
   return arrow::RecordBatch::Make(writeSchema, 1, {arrays});
 }
+
+class EvictGuard {
+ public:
+  explicit EvictGuard(SplitState& splitState) : splitState_(splitState) {
+    oldState_ = splitState;
+    splitState_ = SplitState::kUnevictable;
+  }
+
+  ~EvictGuard() {
+    splitState_ = oldState_;
+  }
+
+  // For safety and clarity.
+  EvictGuard(const EvictGuard&) = delete;
+  EvictGuard& operator=(const EvictGuard&) = delete;
+  EvictGuard(EvictGuard&&) = delete;
+  EvictGuard& operator=(EvictGuard&&) = delete;
+
+ private:
+  SplitState& splitState_;
+  SplitState oldState_;
+};
 } // namespace
 
 // VeloxShuffleWriter
@@ -1424,6 +1446,12 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const velox::RowVec
   }
 
   arrow::Status VeloxShuffleWriter::evictFixedSize(int64_t size, int64_t * actual) {
+    if (splitState_ == SplitState::kUnevictable) {
+      *actual = 0;
+      return arrow::Status::OK();
+    }
+    EvictGuard{splitState_};
+
     int64_t currentEvicted = 0;
 
     // If OOM happens during stop(), the reclaim order is shrink->spill,

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -95,7 +95,7 @@ namespace gluten {
 
 #endif // end of VELOX_SHUFFLE_WRITER_PRINT
 
-enum SplitState { kInit, kPreAlloc, kSplit, kStop };
+enum SplitState { kInit, kPreAlloc, kSplit, kStop, kUnevictable };
 
 class VeloxShuffleWriter final : public ShuffleWriter {
   enum { kValidityBufferIndex = 0, kLengthBufferIndex = 1, kValueBufferIndex = 2 };


### PR DESCRIPTION
ShuffleWriter supports spilling initiated both internally and by other operators. However, it shouldn't self-trigger a spill during the spilling process. Because during a spill, it can invoke memory allocation APIs that triggers another spill, like when resizing the partition buffers."

This PR prevents the following call stack:

[Spill triggered by some op] -> ShuffleWriter.spill -> reserveMemory -> trigger spill another time -> ShuffleWriter.spill