### PR TITLE
[CELEBORN] Optimize the performance of Celeborn's pushPartitionData

### DIFF
--- a/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornHashBasedColumnarShuffleWriter.scala
@@ -51,6 +51,8 @@ abstract class CelebornHashBasedColumnarShuffleWriter[K, V](
 
   protected val mapId: Int = context.partitionId()
 
+  protected val clientPushBufferMaxSize: Int = celebornConf.clientPushBufferMaxSize
+
   protected val celebornPartitionPusher = new CelebornPartitionPusher(
     shuffleId,
     numMappers,
@@ -58,7 +60,7 @@ abstract class CelebornHashBasedColumnarShuffleWriter[K, V](
     context,
     mapId,
     client,
-    celebornConf)
+    clientPushBufferMaxSize)
 
   protected val blockManager: BlockManager = SparkEnv.get.blockManager
 

--- a/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornPartitionPusher.scala
+++ b/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornPartitionPusher.scala
@@ -31,13 +31,13 @@ class CelebornPartitionPusher(
     val context: TaskContext,
     val mapId: Int,
     val client: ShuffleClient,
-    val celebornConf: CelebornConf)
+    val clientPushBufferMaxSize: Int)
   extends Logging {
 
   @throws[IOException]
   def pushPartitionData(partitionId: Int, buffer: Array[Byte], length: Int): Int = {
     logDebug(s"Push record, size ${buffer.length}.")
-    if (buffer.length > celebornConf.clientPushBufferMaxSize) {
+    if (buffer.length > clientPushBufferMaxSize) {
       client.pushData(
         shuffleId,
         mapId,

--- a/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornPartitionPusher.scala
+++ b/gluten-celeborn/common/src/main/scala/org/apache/spark/shuffle/CelebornPartitionPusher.scala
@@ -20,7 +20,6 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 
 import org.apache.celeborn.client.ShuffleClient
-import org.apache.celeborn.common.CelebornConf
 
 import java.io.IOException
 

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornHashBasedColumnarShuffleWriter.scala
@@ -78,7 +78,7 @@ class VeloxCelebornHashBasedColumnarShuffleWriter[K, V](
             customizedCompressionCodec,
             bufferCompressThreshold,
             GlutenConfig.getConf.columnarShuffleCompressionMode,
-            celebornConf.clientPushBufferMaxSize,
+            clientPushBufferMaxSize,
             celebornPartitionPusher,
             NativeMemoryManagers
               .create(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimize the performance of Celeborn's pushPartitionData

## How was this patch tested?
Observing from the flame graph, it can be seen that the celebornConf.clientPushBufferMaxSize parameter in the pushPartitionData method is causing significant performance overhead.

![image](https://github.com/oap-project/gluten/assets/107825064/febe8512-ef20-48a2-ae9c-3ac2eef7e9fb)

