### PR TITLE
[VL] Refine shuffle writer return types and namespace

### DIFF
--- a/cpp/core/shuffle/ShuffleWriter.h
+++ b/cpp/core/shuffle/ShuffleWriter.h
@@ -97,10 +97,6 @@ class ShuffleWriter : public Evictable {
 
   virtual arrow::Status stop() = 0;
 
-  virtual std::shared_ptr<arrow::Schema> writeSchema();
-
-  virtual std::shared_ptr<arrow::Schema> compressWriteSchema();
-
   virtual std::shared_ptr<arrow::Schema>& schema() {
     return schema_;
   }
@@ -190,6 +186,10 @@ class ShuffleWriter : public Evictable {
 
   virtual ~ShuffleWriter() = default;
 
+  std::shared_ptr<arrow::Schema> writeSchema();
+
+  std::shared_ptr<arrow::Schema> compressWriteSchema();
+
   int32_t numPartitions_;
 
   std::shared_ptr<PartitionWriterCreator> partitionWriterCreator_;
@@ -204,7 +204,6 @@ class ShuffleWriter : public Evictable {
   int64_t totalWriteTime_ = 0;
   int64_t totalEvictTime_ = 0;
   int64_t totalCompressTime_ = 0;
-  int64_t peakMemoryAllocated_ = 0;
 
   std::vector<int64_t> partitionLengths_;
   std::vector<int64_t> rawPartitionLengths_; // Uncompressed size.

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -246,6 +246,7 @@ set(VELOX_SRCS
     operators/serializer/VeloxRowToColumnarConverter.cc
     operators/writer/VeloxParquetDatasource.cc
     shuffle/VeloxShuffleReader.cc
+    shuffle/VeloxShuffleUtils.cc
     shuffle/VeloxShuffleWriter.cc
     substrait/SubstraitParser.cc
     substrait/SubstraitToVeloxExpr.cc

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -121,7 +121,7 @@ VectorPtr readFlatVectorStringView(
   auto nulls = buffers[bufferIdx++];
   auto lengthBuffer = buffers[bufferIdx++];
   auto valueBuffer = buffers[bufferIdx++];
-  const auto* rawLength = lengthBuffer->as<BinaryArrayLengthType>();
+  const auto* rawLength = lengthBuffer->as<BinaryArrayLengthBufferType>();
 
   std::vector<BufferPtr> stringBuffers;
   auto values = AlignedBuffer::allocate<char>(sizeof(StringView) * length, pool);

--- a/cpp/velox/shuffle/VeloxShuffleUtils.cc
+++ b/cpp/velox/shuffle/VeloxShuffleUtils.cc
@@ -15,22 +15,28 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "shuffle/VeloxShuffleUtils.h"
+#include <arrow/buffer.h>
+#include <arrow/util/compression.h>
 
-#include <arrow/type.h>
-
-namespace gluten {
-
-using BinaryArrayLengthBufferType = uint32_t;
-using IpcOffsetBufferType = arrow::LargeStringType::offset_type;
-
-static const size_t kSizeOfBinaryArrayLengthBuffer = sizeof(BinaryArrayLengthBufferType);
-static const size_t kSizeOfIpcOffsetBuffer = sizeof(IpcOffsetBufferType);
-
-int64_t getBuffersSize(const std::vector<std::shared_ptr<arrow::Buffer>>& buffers);
-
-int64_t getMaxCompressedBufferSize(
+int64_t gluten::getMaxCompressedBufferSize(
     const std::vector<std::shared_ptr<arrow::Buffer>>& buffers,
-    arrow::util::Codec* codec);
+    arrow::util::Codec* codec) {
+  int64_t totalSize = 0;
+  for (auto& buffer : buffers) {
+    if (buffer != nullptr && buffer->size() != 0) {
+      totalSize += codec->MaxCompressedLen(buffer->size(), nullptr);
+    }
+  }
+  return totalSize;
+}
 
-} // namespace gluten
+int64_t gluten::getBuffersSize(const std::vector<std::shared_ptr<arrow::Buffer>>& buffers) {
+  int64_t totalSize = 0;
+  for (auto& buffer : buffers) {
+    if (buffer != nullptr) {
+      totalSize += buffer->size();
+    }
+  }
+  return totalSize;
+}

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -29,20 +29,12 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorStream.h"
 
-#include <arrow/filesystem/filesystem.h>
-#include <arrow/filesystem/localfs.h>
-#include <arrow/io/api.h>
+#include <arrow/array/util.h>
 #include <arrow/ipc/writer.h>
 #include <arrow/memory_pool.h>
 #include <arrow/record_batch.h>
+#include <arrow/result.h>
 #include <arrow/type.h>
-#include <arrow/type_traits.h>
-#include <arrow/util/bit_util.h>
-#include <arrow/util/checked_cast.h>
-#include "arrow/array/builder_base.h"
-
-#include "arrow/array/util.h"
-#include "arrow/result.h"
 
 #include "memory/VeloxMemoryManager.h"
 #include "shuffle/PartitionWriterCreator.h"
@@ -285,11 +277,11 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
   arrow::Status evictPartitionsOnDemand(int64_t* size);
 
-  std::shared_ptr<arrow::RecordBatch> makeRecordBatch(
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> makeRecordBatch(
       uint32_t numRows,
       const std::vector<std::shared_ptr<arrow::Buffer>>& buffers);
 
-  std::shared_ptr<arrow::Buffer> generateComplexTypeBuffers(facebook::velox::RowVectorPtr vector);
+  arrow::Result<std::shared_ptr<arrow::Buffer>> generateComplexTypeBuffers(facebook::velox::RowVectorPtr vector);
 
   arrow::Status resetValidityBuffer(uint32_t partitionId);
 

--- a/cpp/velox/tests/VeloxShuffleWriterTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterTest.cc
@@ -16,12 +16,9 @@
  */
 
 #include <arrow/c/bridge.h>
-#include <arrow/compute/api.h>
 #include <arrow/datum.h>
 #include <arrow/io/api.h>
 #include <arrow/pretty_print.h>
-#include <arrow/record_batch.h>
-#include <arrow/util/io_util.h>
 #include <iostream>
 
 #include "memory/VeloxColumnarBatch.h"
@@ -960,7 +957,7 @@ TEST_P(VeloxShuffleWriterTest, PreAllocPartitionBuffer1) {
   ASSERT_NOT_OK(shuffleWriter_->evictFixedSize(cachedPayloadSize, &evicted));
   // Check only cached data being spilled.
   ASSERT_EQ(evicted, cachedPayloadSize);
-  ARROW_CHECK_EQ(shuffleWriter_->partitionBufferSize(), partitionBufferBeforeEvict);
+  VELOX_CHECK_EQ(shuffleWriter_->partitionBufferSize(), partitionBufferBeforeEvict);
 
   // Split more data with null. New buffer size is larger.
   ASSERT_NOT_OK(splitRowVectorStatus(*shuffleWriter_, inputVector1_));

--- a/cpp/velox/utils/Common.h
+++ b/cpp/velox/utils/Common.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "velox/common/base/SimdUtil.h"
+#include "velox/common/time/CpuWallTimer.h"
 
 namespace gluten {
 
@@ -34,15 +35,17 @@ static inline void fastCopy(void* dst, const void* src, size_t n) {
   facebook::velox::simd::memcpy(dst, src, n);
 }
 
-#define START_TIMING(timing) \
-  {                          \
-    auto ptiming = &timing;  \
-    facebook::velox::DeltaCpuWallTimer timer{[ptiming](const CpuWallTiming& delta) { ptiming->add(delta); }};
+#define START_TIMING(timing)                  \
+  {                                           \
+    auto ptiming = &timing;                   \
+    facebook::velox::DeltaCpuWallTimer timer{ \
+        [ptiming](const facebook::velox::CpuWallTiming& delta) { ptiming->add(delta); }};
 
 #define END_TIMING() }
 
-#define SCOPED_TIMER(timing) \
-  auto ptiming = &timing;    \
-  facebook::velox::DeltaCpuWallTimer timer{[ptiming](const CpuWallTiming& delta) { ptiming->add(delta); }};
+#define SCOPED_TIMER(timing)                \
+  auto ptiming = &timing;                   \
+  facebook::velox::DeltaCpuWallTimer timer{ \
+      [ptiming](const facebook::velox::CpuWallTiming& delta) { ptiming->add(delta); }};
 
 } // namespace gluten

--- a/cpp/velox/utils/VeloxArrowUtils.h
+++ b/cpp/velox/utils/VeloxArrowUtils.h
@@ -21,16 +21,10 @@
 
 #include <arrow/memory_pool.h>
 #include <arrow/type.h>
-#include <arrow/util/logging.h>
-#include <sys/mman.h>
-#include <numeric>
-#include "memory/ArrowMemoryPool.h"
 #include "memory/ColumnarBatch.h"
-#include "utils/macros.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/common/memory/MemoryPool.h"
 #include "velox/type/Type.h"
-
-#include <velox/common/memory/MemoryPool.h>
-#include <iostream>
 
 namespace gluten {
 
@@ -44,6 +38,8 @@ std::shared_ptr<arrow::Schema> toArrowSchema(
     facebook::velox::memory::MemoryPool* pool);
 
 facebook::velox::TypePtr fromArrowSchema(const std::shared_ptr<arrow::Schema>& schema);
+
+arrow::Result<std::shared_ptr<arrow::Buffer>> toArrowBuffer(facebook::velox::BufferPtr buffer, arrow::MemoryPool* pool);
 
 /**
  * For testing.


### PR DESCRIPTION
Currently, there are inconsistencies in the shuffle writer code related to namespaces and return types.

1. **Namespace Usage:** In some instances, the prefix velox:: is used, such as `velox::RowVector`. In others, there is no prefixed namespace, simply using `RowVector`. It would be better to consistently use the full namespace: `facebook::velox::RowVector`.
2. **Return Types:** Some parts of the code return `arrow::Status` or `arrow::Result`, while others throw exceptions. This inconsistency complicates our C++ unit tests, making it unclear whether to check for exceptions or inspect the returned status code. A uniform approach should be adopted, returning `arrow::Status` and `arrow::Result` where applicable.