### PR TITLE
[GLUTEN-3596][VL] Clear the buffer before calling UnsafeRowFast.serialize API

### DIFF
--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -146,6 +146,7 @@ std::pair<char*, int> VeloxColumnarBatch::getRowBytes(int32_t rowId) const {
   auto fast = std::make_unique<facebook::velox::row::UnsafeRowFast>(rowVector_);
   auto size = fast->rowSize(rowId);
   char* rowBytes = new char[size];
+  std::memset(rowBytes, 0, size);
   fast->serialize(0, rowBytes);
   return std::make_pair(rowBytes, size);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reset the buffer before calling the serialize API when getting the first row bytes.

https://github.com/oap-project/gluten/issues/3596

## How was this patch tested?
S3 env test

