### PR TITLE
[VL] In OAP Velox fork, simplify shrinking/spilling code for Velox memory pool

### DIFF
--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -78,8 +78,6 @@ std::shared_ptr<ResultIterator> VeloxRuntime::createResultIterator(
   printSessionConf(sessionConf);
 #endif
 
-  auto veloxPool = getAggregateVeloxPool(memoryManager);
-
   VeloxPlanConverter veloxPlanConverter(inputs, getLeafVeloxPool(memoryManager).get(), sessionConf);
   veloxPlan_ = veloxPlanConverter.toVeloxPlan(substraitPlan_);
 
@@ -94,12 +92,12 @@ std::shared_ptr<ResultIterator> VeloxRuntime::createResultIterator(
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter = std::make_unique<WholeStageResultIteratorMiddleStage>(
-        veloxPool, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
+        memoryManager, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
     auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
     return resultIter;
   } else {
     auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
-        veloxPool, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
+        memoryManager, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
     auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
     return resultIter;
   }

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -89,15 +89,16 @@ std::shared_ptr<ResultIterator> VeloxRuntime::createResultIterator(
   // Separate the scan ids and stream ids, and get the scan infos.
   getInfoAndIds(veloxPlanConverter.splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
+  auto* vmm = toVeloxMemoryManager(memoryManager);
   if (scanInfos.size() == 0) {
     // Source node is not required.
     auto wholestageIter = std::make_unique<WholeStageResultIteratorMiddleStage>(
-        memoryManager, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
+        vmm, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
     auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
     return resultIter;
   } else {
     auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
-        memoryManager, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
+        vmm, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
     auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
     return resultIter;
   }

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -38,18 +38,18 @@ class VeloxRuntime final : public Runtime {
   explicit VeloxRuntime(const std::unordered_map<std::string, std::string>& confMap);
 
   static std::shared_ptr<facebook::velox::memory::MemoryPool> getAggregateVeloxPool(MemoryManager* memoryManager) {
-    if (auto veloxMemoryManager = dynamic_cast<VeloxMemoryManager*>(memoryManager)) {
-      return veloxMemoryManager->getAggregateMemoryPool();
-    } else {
-      GLUTEN_CHECK(false, "Should use VeloxMemoryManager here.");
-    }
+    return toVeloxMemoryManager(memoryManager)->getAggregateMemoryPool();
   }
 
   static std::shared_ptr<facebook::velox::memory::MemoryPool> getLeafVeloxPool(MemoryManager* memoryManager) {
+    return toVeloxMemoryManager(memoryManager)->getLeafMemoryPool();
+  }
+
+  static VeloxMemoryManager* toVeloxMemoryManager(MemoryManager* memoryManager) {
     if (auto veloxMemoryManager = dynamic_cast<VeloxMemoryManager*>(memoryManager)) {
-      return veloxMemoryManager->getLeafMemoryPool();
+      return veloxMemoryManager;
     } else {
-      GLUTEN_CHECK(false, "Should use VeloxMemoryManager here.");
+      GLUTEN_CHECK(false, "Velox memory manager should be used for Velox runtime.");
     }
   }
 

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -34,7 +34,7 @@ namespace gluten {
 class WholeStageResultIterator : public ColumnarBatchIterator {
  public:
   WholeStageResultIterator(
-      std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
+      VeloxMemoryManager* memoryManager,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::unordered_map<std::string, std::string>& confMap,
       const SparkTaskInfo& taskInfo);
@@ -96,7 +96,7 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
       const std::unordered_map<std::string, facebook::velox::RuntimeMetric>& runtimeStats,
       const std::string& metricId);
 
-  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
+  VeloxMemoryManager* memoryManager_;
 
   // spill
   std::string spillStrategy_;
@@ -113,7 +113,7 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
 class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator {
  public:
   WholeStageResultIteratorFirstStage(
-      std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
+      VeloxMemoryManager* memoryManager,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::vector<facebook::velox::core::PlanNodeId>& scanNodeIds,
       const std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
@@ -137,7 +137,7 @@ class WholeStageResultIteratorFirstStage final : public WholeStageResultIterator
 class WholeStageResultIteratorMiddleStage final : public WholeStageResultIterator {
  public:
   WholeStageResultIteratorMiddleStage(
-      std::shared_ptr<facebook::velox::memory::MemoryPool> pool,
+      VeloxMemoryManager* memoryManager,
       const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
       const std::vector<facebook::velox::core::PlanNodeId>& streamIds,
       const std::string spillDir,

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -122,7 +122,7 @@ class ListenableArbitrator : public velox::memory::MemoryArbitrator {
   }
 
   gluten::AllocationListener* listener_;
-  std::mutex mutex_;
+  std::recursive_mutex mutex_;
   inline static std::string kind_ = "GLUTEN";
 };
 

--- a/cpp/velox/memory/VeloxMemoryManager.h
+++ b/cpp/velox/memory/VeloxMemoryManager.h
@@ -45,6 +45,10 @@ class VeloxMemoryManager final : public MemoryManager {
     return veloxLeafPool_;
   }
 
+  facebook::velox::memory::MemoryManager* getMemoryManager() const {
+    return veloxMemoryManager_.get();
+  }
+
   arrow::MemoryPool* getArrowMemoryPool() override {
     return arrowPool_.get();
   }

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/zhztheplayer/velox.git
-VELOX_BRANCH=wip-clean
+VELOX_REPO=https://github.com/oap-project/velox.git
+VELOX_BRANCH=update
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/zhztheplayer/velox.git
-VELOX_BRANCH=wip-update
+VELOX_BRANCH=wip-clean
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=update
+VELOX_REPO=https://github.com/zhztheplayer/velox.git
+VELOX_BRANCH=wip-update
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
@@ -34,8 +34,9 @@ public class LoggingReservationListener implements ReservationListener {
     long before = getUsedBytes();
     long reserved = delegated.reserve(size);
     long after = getUsedBytes();
-    LOGGER.info(String.format("Reservation[%s]: %d + %d(%d) = %d",
-        this.toString(), before, reserved, size, after));
+    LOGGER.info(
+        String.format(
+            "Reservation[%s]: %d + %d(%d) = %d", this.toString(), before, reserved, size, after));
     return reserved;
   }
 
@@ -44,8 +45,10 @@ public class LoggingReservationListener implements ReservationListener {
     long before = getUsedBytes();
     long unreserved = delegated.unreserve(size);
     long after = getUsedBytes();
-    LOGGER.info(String.format("Unreservationp[%s]: %d - %d(%d) = %d",
-        this.toString(), before, unreserved, size, after));
+    LOGGER.info(
+        String.format(
+            "Unreservationp[%s]: %d - %d(%d) = %d",
+            this.toString(), before, unreserved, size, after));
     return unreserved;
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
@@ -47,7 +47,7 @@ public class LoggingReservationListener implements ReservationListener {
     long after = getUsedBytes();
     LOGGER.info(
         String.format(
-            "Unreservationp[%s]: %d - %d(%d) = %d",
+            "Unreservation[%s]: %d - %d(%d) = %d",
             this.toString(), before, unreserved, size, after));
     return unreserved;
   }

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
@@ -34,7 +34,8 @@ public class LoggingReservationListener implements ReservationListener {
     long before = getUsedBytes();
     long reserved = delegated.reserve(size);
     long after = getUsedBytes();
-    LOGGER.info(String.format("Reservation: %d + %d(%d) = %d", before, reserved, size, after));
+    LOGGER.info(String.format("Reservation[%s]: %d + %d(%d) = %d",
+        this.toString(), before, reserved, size, after));
     return reserved;
   }
 
@@ -43,7 +44,8 @@ public class LoggingReservationListener implements ReservationListener {
     long before = getUsedBytes();
     long unreserved = delegated.unreserve(size);
     long after = getUsedBytes();
-    LOGGER.info(String.format("Unreservation: %d - %d(%d) = %d", before, unreserved, size, after));
+    LOGGER.info(String.format("Unreservationp[%s]: %d - %d(%d) = %d",
+        this.toString(), before, unreserved, size, after));
     return unreserved;
   }
 

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/LoggingReservationListener.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.memory.nmm;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// For debugging purpose only
+public class LoggingReservationListener implements ReservationListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LoggingReservationListener.class);
+
+  private final ReservationListener delegated;
+
+  public LoggingReservationListener(ReservationListener delegated) {
+    this.delegated = delegated;
+  }
+
+  @Override
+  public long reserve(long size) {
+    long before = getUsedBytes();
+    long reserved = delegated.reserve(size);
+    long after = getUsedBytes();
+    LOGGER.info(String.format("Reservation: %d + %d(%d) = %d", before, reserved, size, after));
+    return reserved;
+  }
+
+  @Override
+  public long unreserve(long size) {
+    long before = getUsedBytes();
+    long unreserved = delegated.unreserve(size);
+    long after = getUsedBytes();
+    LOGGER.info(String.format("Unreservation: %d - %d(%d) = %d", before, unreserved, size, after));
+    return unreserved;
+  }
+
+  @Override
+  public long getUsedBytes() {
+    return delegated.getUsedBytes();
+  }
+}

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -91,7 +91,9 @@ public class NativeMemoryManager implements TaskResource {
     if (listener.getUsedBytes() != 0) {
       LOGGER.warn(
           name
-              + " Reservation listener still reserved non-zero bytes, which may cause "
+              + " Reservation listener "
+              + listener.toString() + " "
+              + "still reserved non-zero bytes, which may cause "
               + "memory leak, size: "
               + Utils.bytesToString(listener.getUsedBytes()));
     }

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManager.java
@@ -92,7 +92,8 @@ public class NativeMemoryManager implements TaskResource {
       LOGGER.warn(
           name
               + " Reservation listener "
-              + listener.toString() + " "
+              + listener.toString()
+              + " "
               + "still reserved non-zero bytes, which may cause "
               + "memory leak, size: "
               + Utils.bytesToString(listener.getUsedBytes()));


### PR DESCRIPTION
I've done some work to minimize the for-pick PR https://github.com/facebookincubator/velox/pull/5790, the change included in this patch would be needed for Gluten then.