### PR TITLE
[VL] Align names of decimal compare functions

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -237,18 +237,17 @@ std::string SubstraitParser::findVeloxFunction(
 std::string SubstraitParser::mapToVeloxFunction(const std::string& substraitFunction, bool isDecimal) {
   auto it = substraitVeloxFunctionMap_.find(substraitFunction);
   if (isDecimal) {
-    if (substraitFunction == "round" || substraitFunction == "lt" || substraitFunction == "lte" ||
-        substraitFunction == "gt" || substraitFunction == "gte") {
-      return "decimal_" + substraitFunction;
+    if (substraitFunction == "lt" || substraitFunction == "lte" || substraitFunction == "gt" ||
+        substraitFunction == "gte" || substraitFunction == "equal") {
+      return "decimal_" + it->second;
     }
-    if (substraitFunction == "equal") {
-      return "decimal_eq";
+    if (substraitFunction == "round") {
+      return "decimal_round";
     }
   }
   if (it != substraitVeloxFunctionMap_.end()) {
     return it->second;
   }
-
   // If not finding the mapping from Substrait function name to Velox function
   // name, the original Substrait function name will be used.
   return substraitFunction;

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1116,7 +1116,7 @@ void SubstraitToVeloxPlanConverter::extractJoinKeys(
       if (funcName == "and") {
         expressions.push_back(&args[0].value());
         expressions.push_back(&args[1].value());
-      } else if (funcName == "eq" || funcName == "equalto" || funcName == "decimal_eq") {
+      } else if (funcName == "eq" || funcName == "equalto" || funcName == "decimal_equalto") {
         VELOX_CHECK(std::all_of(args.cbegin(), args.cend(), [](const ::substrait::FunctionArgument& arg) {
           return arg.value().has_selection();
         }));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use aligned function names with Velox upstream.

## How was this patch tested?

under test

