### PR TITLE
[VL] Refine setting shuffle writer local directories

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -834,8 +834,9 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     env->ReleaseStringUTFChars(dataFileJstr, dataFileC);
 
     auto localDirs = env->GetStringUTFChars(localDirsJstr, JNI_FALSE);
-    setenv(gluten::kGlutenSparkLocalDirs.c_str(), localDirs, 1);
+    shuffleWriterOptions.local_dirs = std::string(localDirs);
     env->ReleaseStringUTFChars(localDirsJstr, localDirs);
+
     partitionWriterCreator = std::make_shared<LocalPartitionWriterCreator>();
   } else if (partitionWriterType == "celeborn") {
     shuffleWriterOptions.partition_writer_type = PartitionWriterType::kCeleborn;

--- a/cpp/core/shuffle/Utils.cc
+++ b/cpp/core/shuffle/Utils.cc
@@ -16,6 +16,8 @@
  */
 
 #include "shuffle/Utils.h"
+#include "options.h"
+#include "utils/StringUtil.h"
 
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -37,31 +39,6 @@ std::string gluten::getSpilledShuffleFileDir(const std::string& configuredDir, i
   ss << std::setfill('0') << std::setw(2) << std::hex << subDirId;
   auto dir = arrow::fs::internal::ConcatAbstractPath(configuredDir, ss.str());
   return dir;
-}
-
-arrow::Result<std::vector<std::string>> gluten::getConfiguredLocalDirs() {
-  auto joinedDirsC = std::getenv(kGlutenSparkLocalDirs.c_str());
-  if (joinedDirsC != nullptr && strcmp(joinedDirsC, "") > 0) {
-    auto joinedDirs = std::string(joinedDirsC);
-    std::string delimiter = ",";
-
-    size_t pos;
-    std::vector<std::string> res;
-    while ((pos = joinedDirs.find(delimiter)) != std::string::npos) {
-      auto dir = joinedDirs.substr(0, pos);
-      if (dir.length() > 0) {
-        res.push_back(std::move(dir));
-      }
-      joinedDirs.erase(0, pos + delimiter.length());
-    }
-    if (joinedDirs.length() > 0) {
-      res.push_back(std::move(joinedDirs));
-    }
-    return res;
-  } else {
-    ARROW_ASSIGN_OR_RAISE(auto arrow_tmp_dir, arrow::internal::TemporaryDir::Make("columnar-shuffle-"));
-    return std::vector<std::string>{arrow_tmp_dir->path().ToString()};
-  }
 }
 
 arrow::Result<std::string> gluten::createTempShuffleFile(const std::string& dir) {

--- a/cpp/core/shuffle/Utils.h
+++ b/cpp/core/shuffle/Utils.h
@@ -34,8 +34,6 @@ std::string generateUuid();
 
 std::string getSpilledShuffleFileDir(const std::string& configuredDir, int32_t subDirId);
 
-arrow::Result<std::vector<std::string>> getConfiguredLocalDirs();
-
 arrow::Result<std::string> createTempShuffleFile(const std::string& dir);
 
 arrow::Result<std::vector<std::shared_ptr<arrow::DataType>>> toShuffleWriterTypeId(

--- a/cpp/core/shuffle/options.h
+++ b/cpp/core/shuffle/options.h
@@ -61,6 +61,7 @@ struct ShuffleWriterOptions {
 
   std::string partitioning_name{};
   std::string data_file{};
+  std::string local_dirs{};
   arrow::MemoryPool* memory_pool{};
 
   static ShuffleWriterOptions defaults();

--- a/cpp/core/utils/StringUtil.cc
+++ b/cpp/core/utils/StringUtil.cc
@@ -24,6 +24,9 @@
 #include "exception.h"
 
 std::vector<std::string> gluten::splitByDelim(const std::string& s, const char delimiter) {
+  if (s.empty()) {
+    return {};
+  }
   std::vector<std::string> result;
   size_t start = 0;
   size_t end = s.find(delimiter);
@@ -39,6 +42,9 @@ std::vector<std::string> gluten::splitByDelim(const std::string& s, const char d
 }
 
 std::vector<std::string> gluten::splitPaths(const std::string& s) {
+  if (s.empty()) {
+    return {};
+  }
   auto splits = splitByDelim(s, ',');
   std::vector<std::string> paths;
   for (auto i = 0; i < splits.size(); ++i) {

--- a/cpp/core/utils/StringUtil.cc
+++ b/cpp/core/utils/StringUtil.cc
@@ -41,7 +41,7 @@ std::vector<std::string> gluten::splitByDelim(const std::string& s, const char d
   return result;
 }
 
-std::vector<std::string> gluten::splitPaths(const std::string& s) {
+std::vector<std::string> gluten::splitPaths(const std::string& s, bool checkExists) {
   if (s.empty()) {
     return {};
   }
@@ -50,7 +50,7 @@ std::vector<std::string> gluten::splitPaths(const std::string& s) {
   for (auto i = 0; i < splits.size(); ++i) {
     if (!splits[i].empty()) {
       std::filesystem::path path(splits[i]);
-      if (!std::filesystem::exists(path)) {
+      if (checkExists && !std::filesystem::exists(path)) {
         throw gluten::GlutenException("File path not exists: " + splits[i]);
       }
       if (path.is_relative()) {

--- a/cpp/core/utils/StringUtil.h
+++ b/cpp/core/utils/StringUtil.h
@@ -21,6 +21,6 @@ namespace gluten {
 
 std::vector<std::string> splitByDelim(const std::string& s, const char delimiter);
 
-std::vector<std::string> splitPaths(const std::string& s);
+std::vector<std::string> splitPaths(const std::string& s, bool checkExists = false);
 
 } // namespace gluten

--- a/cpp/core/utils/macros.h
+++ b/cpp/core/utils/macros.h
@@ -99,14 +99,6 @@
   }                                    \
   std::cout << std::endl;
 
-#define THROW_NOT_OK(expr)                  \
-  do {                                      \
-    auto __s = (expr);                      \
-    if (!__s.ok()) {                        \
-      throw GlutenException(__s.message()); \
-    }                                       \
-  } while (false);
-
 #define TIME_TO_STRING(time) (time > 10000 ? time / 1000 : time) << (time > 10000 ? " ms" : " us")
 
 #define TIME_NANO_TO_STRING(time) \

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -75,6 +75,8 @@ std::shared_ptr<VeloxShuffleWriter> createShuffleWriter(VeloxMemoryManager* memo
     options.compression_type = arrow::Compression::GZIP;
   }
 
+  GLUTEN_THROW_NOT_OK(setLocalDirsAndDataFileFromEnv(options));
+
   GLUTEN_ASSIGN_OR_THROW(
       auto shuffleWriter,
       VeloxShuffleWriter::create(

--- a/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
+++ b/cpp/velox/benchmarks/ShuffleSplitBenchmark.cc
@@ -115,9 +115,9 @@ class BenchmarkShuffleSplit {
 
     auto options = ShuffleWriterOptions::defaults();
     options.buffer_size = kPartitionBufferSize;
-    options.buffered_write = true;
     options.memory_pool = pool.get();
     options.partitioning_name = "rr";
+    GLUTEN_THROW_NOT_OK(setLocalDirsAndDataFileFromEnv(options));
 
     std::shared_ptr<VeloxShuffleWriter> shuffleWriter;
     int64_t elapseRead = 0;

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.cc
@@ -19,6 +19,8 @@
 #include "compute/VeloxBackend.h"
 #include "compute/VeloxRuntime.h"
 #include "config/GlutenConfig.h"
+#include "shuffle/Utils.h"
+#include "utils/StringUtil.h"
 #include "velox/dwio/common/Options.h"
 
 using namespace facebook;
@@ -149,4 +151,28 @@ void setCpu(uint32_t cpuindex) {
     std::cerr << "Error binding CPU " << std::to_string(cpuindex) << std::endl;
     exit(EXIT_FAILURE);
   }
+}
+
+arrow::Status setLocalDirsAndDataFileFromEnv(gluten::ShuffleWriterOptions& options) {
+  auto joinedDirsC = std::getenv(gluten::kGlutenSparkLocalDirs.c_str());
+  if (joinedDirsC != nullptr && strcmp(joinedDirsC, "") > 0) {
+    // Set local dirs.
+    auto joinedDirs = std::string(joinedDirsC);
+    options.local_dirs = joinedDirs;
+    // Split local dirs and use thread id to choose one directory for data file.
+    auto localDirs = gluten::splitPaths(joinedDirs);
+    size_t id = std::hash<std::thread::id>{}(std::this_thread::get_id()) % localDirs.size();
+    ARROW_ASSIGN_OR_RAISE(options.data_file, gluten::createTempShuffleFile(localDirs[id]));
+  } else {
+    // Otherwise create 1 temp dir and data file.
+    static const std::string kBenchmarkDirsPrefix = "columnar-shuffle-benchmark-";
+    {
+      // Because tmpDir will be deleted in the dtor, allow it to be deleted upon exiting the block and then recreate it
+      // in createTempShuffleFile.
+      ARROW_ASSIGN_OR_RAISE(auto tmpDir, arrow::internal::TemporaryDir::Make(kBenchmarkDirsPrefix))
+      options.local_dirs = tmpDir->path().ToString();
+    }
+    ARROW_ASSIGN_OR_RAISE(options.data_file, gluten::createTempShuffleFile(options.local_dirs));
+  }
+  return arrow::Status::OK();
 }

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.h
@@ -29,6 +29,7 @@
 #include "compute/ProtobufUtils.h"
 #include "memory/VeloxColumnarBatch.h"
 #include "memory/VeloxMemoryManager.h"
+#include "shuffle/options.h"
 #include "utils/exception.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
@@ -105,3 +106,5 @@ inline std::shared_ptr<gluten::ColumnarBatch> convertBatch(std::shared_ptr<glute
 bool endsWith(const std::string& data, const std::string& suffix);
 
 void setCpu(uint32_t cpuindex);
+
+arrow::Status setLocalDirsAndDataFileFromEnv(gluten::ShuffleWriterOptions& options);

--- a/cpp/velox/udf/UdfLoader.cc
+++ b/cpp/velox/udf/UdfLoader.cc
@@ -20,6 +20,7 @@
 #include <velox/expression/SignatureBinder.h>
 #include <velox/expression/VectorFunction.h>
 #include <velox/type/fbhive/HiveTypeParser.h>
+#include <filesystem>
 #include <vector>
 #include "substrait/VeloxToSubstraitType.h"
 
@@ -42,7 +43,7 @@ void* loadSymFromLibrary(void* handle, const std::string& libPath, const std::st
 } // namespace
 
 void gluten::UdfLoader::loadUdfLibraries(const std::string& libPaths) {
-  const auto& paths = splitPaths(libPaths);
+  const auto& paths = splitPaths(libPaths, /*checkExists=*/true);
   loadUdfLibraries0(paths);
 }
 

--- a/cpp/velox/utils/tests/VeloxShuffleWriterTestBase.h
+++ b/cpp/velox/utils/tests/VeloxShuffleWriterTestBase.h
@@ -30,8 +30,6 @@
 
 namespace gluten {
 
-namespace {} // namespace
-
 struct ShuffleTestParams {
   PartitionWriterType partition_writer_type;
   arrow::Compression::type compression_type;


### PR DESCRIPTION
Currently, shuffle writer local directories are setting through environment variable "GLUTEN_SPARK_LOCAL_DIRS", which is a historical issue and should be refined.

This PR removes setting/getting local directories through environment variable from JNI code path and keep the environment variable "GLUTEN_SPARK_LOCAL_DIRS" only for generic benchmark simulating spilling multiple disks.