### PR TITLE
[CORE] Use collection interface in method parameter and return type

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
@@ -28,7 +28,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.storage.CHShuffleReadStreamFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -88,8 +87,8 @@ public class StorageJoinBuilder {
 
   /** create table named struct */
   private static NamedStruct toNameStruct(List<Attribute> output) {
-    ArrayList<TypeNode> typeList = ConverterUtils.collectAttributeTypeNodes(output);
-    ArrayList<String> nameList = ConverterUtils.collectAttributeNamesWithExprId(output);
+    List<TypeNode> typeList = ConverterUtils.collectAttributeTypeNodes(output);
+    List<String> nameList = ConverterUtils.collectAttributeNamesWithExprId(output);
     Type.Struct.Builder structBuilder = Type.Struct.newBuilder();
     for (TypeNode typeNode : typeList) {
       structBuilder.addTypes(typeNode.toProtobuf());

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util
+import java.util.{ArrayList => JArrayList}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -68,9 +68,9 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
                 .makeExtensionTable(p.minParts, p.maxParts, p.database, p.table, p.tablePath),
               SoftAffinityUtil.getNativeMergeTreePartitionLocations(p))
           case f: FilePartition =>
-            val paths = new util.ArrayList[String]()
-            val starts = new util.ArrayList[JLong]()
-            val lengths = new util.ArrayList[JLong]()
+            val paths = new JArrayList[String]()
+            val starts = new JArrayList[JLong]()
+            val lengths = new JArrayList[JLong]()
             val partitionColumns = mutable.ArrayBuffer.empty[Map[String, String]]
             f.files.foreach {
               file =>
@@ -122,7 +122,7 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
     val resIter: GeneralOutIterator = GlutenTimeMetric.millis(pipelineTime) {
       _ =>
         val transKernel = new CHNativeExpressionEvaluator()
-        val inBatchIters = new util.ArrayList[GeneralInIterator](inputIterators.map {
+        val inBatchIters = new JArrayList[GeneralInIterator](inputIterators.map {
           iter => new ColumnarNativeIterator(genCloseableColumnBatchIterator(iter).asJava)
         }.asJava)
         transKernel.createKernelWithBatchIterator(inputPartition.plan, inBatchIters, false)
@@ -180,7 +180,7 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
       _ =>
         val transKernel = new CHNativeExpressionEvaluator()
         val columnarNativeIterator =
-          new java.util.ArrayList[GeneralInIterator](inputIterators.map {
+          new JArrayList[GeneralInIterator](inputIterators.map {
             iter => new ColumnarNativeIterator(genCloseableColumnBatchIterator(iter).asJava)
           }.asJava)
         // we need to complete dependency RDD's firstly

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -26,14 +26,15 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
-import java.{lang, util}
+import java.lang.{Long => JLong}
+import java.util.{List => JList, Map => JMap}
 
 class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
   override def metricsUpdatingFunction(
       child: SparkPlan,
-      relMap: util.HashMap[lang.Long, util.ArrayList[lang.Long]],
-      joinParamsMap: util.HashMap[lang.Long, JoinParams],
-      aggParamsMap: util.HashMap[lang.Long, AggregationParams]): IMetrics => Unit = {
+      relMap: JMap[JLong, JList[JLong]],
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit = {
     MetricsUtil.updateNativeMetrics(child, relMap, joinParamsMap, aggParamsMap)
   }
 

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -55,7 +55,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import com.google.common.collect.Lists
 import org.apache.commons.lang3.ClassUtils
 
-import java.{lang, util}
+import java.lang.{Long => JLong}
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -64,7 +65,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
   /** Transform GetArrayItem to Substrait. */
   override def genGetArrayItemExpressionNode(
       substraitExprName: String,
-      functionMap: java.util.HashMap[String, java.lang.Long],
+      functionMap: JMap[String, JLong],
       leftNode: ExpressionNode,
       rightNode: ExpressionNode,
       original: GetArrayItem): ExpressionNode = {
@@ -436,9 +437,9 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
   /** Generate window function node */
   override def genWindowFunctionsNode(
       windowExpression: Seq[NamedExpression],
-      windowExpressionNodes: util.ArrayList[WindowFunctionNode],
+      windowExpressionNodes: JList[WindowFunctionNode],
       originalInputAttributes: Seq[Attribute],
-      args: util.HashMap[String, lang.Long]): Unit = {
+      args: JMap[String, JLong]): Unit = {
 
     windowExpression.map {
       windowExpr =>
@@ -451,7 +452,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
             val frame = aggWindowFunc.frame.asInstanceOf[SpecifiedWindowFrame]
             val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
               WindowFunctionsBuilder.create(args, aggWindowFunc).toInt,
-              new util.ArrayList[ExpressionNode](),
+              new JArrayList[ExpressionNode](),
               columnName,
               ConverterUtils.getTypeNode(aggWindowFunc.dataType, aggWindowFunc.nullable),
               WindowExecTransformer.getFrameBound(frame.upper),
@@ -467,7 +468,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
               throw new UnsupportedOperationException(s"Not currently supported: $aggregateFunc.")
             }
 
-            val childrenNodeList = new util.ArrayList[ExpressionNode]()
+            val childrenNodeList = new JArrayList[ExpressionNode]()
             aggregateFunc.children.foreach(
               expr =>
                 childrenNodeList.add(
@@ -505,7 +506,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
                 }
             }
 
-            val childrenNodeList = new util.ArrayList[ExpressionNode]()
+            val childrenNodeList = new JArrayList[ExpressionNode]()
             childrenNodeList.add(
               ExpressionConverter
                 .replaceWithExpressionTransformer(

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
@@ -23,6 +23,9 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 
+import java.lang.{Long => JLong}
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
+
 import scala.collection.JavaConverters._
 
 object MetricsUtil extends Logging {
@@ -56,9 +59,9 @@ object MetricsUtil extends Logging {
    */
   def updateNativeMetrics(
       child: SparkPlan,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): IMetrics => Unit = {
+      relMap: JMap[JLong, JList[JLong]],
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit = {
 
     val mut: MetricsUpdaterTree = treeifyMetricsUpdaters(child)
 
@@ -90,10 +93,10 @@ object MetricsUtil extends Logging {
    */
   def updateTransformerMetrics(
       mutNode: MetricsUpdaterTree,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      operatorIdx: java.lang.Long,
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): IMetrics => Unit = {
+      relMap: JMap[JLong, JList[JLong]],
+      operatorIdx: JLong,
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit = {
     imetrics =>
       try {
         val metrics = imetrics.asInstanceOf[NativeMetrics]
@@ -129,13 +132,13 @@ object MetricsUtil extends Logging {
    */
   def updateTransformerMetricsInternal(
       mutNode: MetricsUpdaterTree,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      operatorIdx: java.lang.Long,
+      relMap: JMap[JLong, JList[JLong]],
+      operatorIdx: JLong,
       metrics: NativeMetrics,
       metricsIdx: Int,
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): (java.lang.Long, Int) = {
-    val nodeMetricsList = new java.util.ArrayList[MetricsData]()
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): (JLong, Int) = {
+    val nodeMetricsList = new JArrayList[MetricsData]()
     var curMetricsIdx = metricsIdx
     relMap
       .get(operatorIdx)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -42,10 +42,11 @@ import org.apache.spark.sql.utils.OASPackageBridge.InputMetricsWrapper
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ExecutorManager
 
+import java.lang.{Long => JLong}
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.time.ZoneOffset
-import java.util
+import java.util.{ArrayList => JArrayList}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -67,14 +68,14 @@ class IteratorApiImpl extends IteratorApi with Logging {
 
     def constructSplitInfo(schema: StructType, files: Array[PartitionedFile]) = {
       val paths = mutable.ArrayBuffer.empty[String]
-      val starts = mutable.ArrayBuffer.empty[java.lang.Long]
-      val lengths = mutable.ArrayBuffer.empty[java.lang.Long]
+      val starts = mutable.ArrayBuffer.empty[JLong]
+      val lengths = mutable.ArrayBuffer.empty[JLong]
       val partitionColumns = mutable.ArrayBuffer.empty[Map[String, String]]
       files.foreach {
         file =>
           paths.append(URLDecoder.decode(file.filePath.toString, StandardCharsets.UTF_8.name()))
-          starts.append(java.lang.Long.valueOf(file.start))
-          lengths.append(java.lang.Long.valueOf(file.length))
+          starts.append(JLong.valueOf(file.start))
+          lengths.append(JLong.valueOf(file.length))
 
           val partitionColumn = mutable.Map.empty[String, String]
           for (i <- 0 until file.partitionValues.numFields) {
@@ -90,7 +91,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
                 case _: TimestampType =>
                   TimestampFormatter
                     .getFractionFormatter(ZoneOffset.UTC)
-                    .format(pn.asInstanceOf[java.lang.Long])
+                    .format(pn.asInstanceOf[JLong])
                 case _ => pn.toString
               }
             }
@@ -139,7 +140,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
       inputIterators: Seq[Iterator[ColumnarBatch]] = Seq()): Iterator[ColumnarBatch] = {
     val beforeBuild = System.nanoTime()
     val columnarNativeIterators =
-      new util.ArrayList[GeneralInIterator](inputIterators.map {
+      new JArrayList[GeneralInIterator](inputIterators.map {
         iter => new ColumnarBatchInIterator(iter.asJava)
       }.asJava)
     val transKernel = NativePlanEvaluator.create()
@@ -183,7 +184,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
 
     val transKernel = NativePlanEvaluator.create()
     val columnarNativeIterator =
-      new util.ArrayList[GeneralInIterator](inputIterators.map {
+      new JArrayList[GeneralInIterator](inputIterators.map {
         iter => new ColumnarBatchInIterator(iter.asJava)
       }.asJava)
     val nativeResultIterator =

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
@@ -25,14 +25,15 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
-import java.{lang, util}
+import java.lang.{Long => JLong}
+import java.util.{List => JList, Map => JMap}
 
 class MetricsApiImpl extends MetricsApi with Logging {
   override def metricsUpdatingFunction(
       child: SparkPlan,
-      relMap: util.HashMap[lang.Long, util.ArrayList[lang.Long]],
-      joinParamsMap: util.HashMap[lang.Long, JoinParams],
-      aggParamsMap: util.HashMap[lang.Long, AggregationParams]): IMetrics => Unit = {
+      relMap: JMap[JLong, JList[JLong]],
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit = {
     MetricsUtil.updateNativeMetrics(child, relMap, joinParamsMap, aggParamsMap)
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -56,6 +56,9 @@ import org.apache.commons.lang3.ClassUtils
 
 import javax.ws.rs.core.UriBuilder
 
+import java.lang.{Long => JLong}
+import java.util.{Map => JMap}
+
 import scala.collection.mutable.ArrayBuffer
 
 class SparkPlanExecApiImpl extends SparkPlanExecApi {
@@ -67,7 +70,7 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
    */
   override def genGetArrayItemExpressionNode(
       substraitExprName: String,
-      functionMap: java.util.HashMap[String, java.lang.Long],
+      functionMap: JMap[String, JLong],
       leftNode: ExpressionNode,
       rightNode: ExpressionNode,
       original: GetArrayItem): ExpressionNode = {

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/TransformerApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/TransformerApiImpl.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, PartitionDi
 import org.apache.spark.sql.types._
 import org.apache.spark.util.collection.BitSet
 
-import java.util
+import java.util.{Map => JMap}
 
 class TransformerApiImpl extends TransformerApi with Logging {
 
@@ -65,7 +65,7 @@ class TransformerApiImpl extends TransformerApi with Logging {
   }
 
   override def postProcessNativeConfig(
-      nativeConfMap: util.Map[String, String],
+      nativeConfMap: JMap[String, String],
       backendPrefix: String): Unit = {
     // TODO: IMPLEMENT SPECIAL PROCESS FOR VELOX BACKEND
   }

--- a/backends-velox/src/main/scala/io/glutenproject/expression/ExpressionTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/expression/ExpressionTransformer.scala
@@ -25,6 +25,9 @@ import org.apache.spark.sql.types.{IntegerType, LongType}
 
 import com.google.common.collect.Lists
 
+import java.lang.{Integer => JInteger, Long => JLong}
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
+
 import scala.language.existentials
 
 case class VeloxAliasTransformer(
@@ -49,7 +52,7 @@ case class VeloxNamedStructTransformer(
       child =>
         expressionNodes.add(
           replaceWithExpressionTransformer(child, attributeSeq).doTransform(args)))
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
     val functionName = ConverterUtils
       .makeFuncName(substraitExprName, Seq(original.dataType), FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)
@@ -71,7 +74,7 @@ case class VeloxGetStructFieldTransformer(
         node.getFieldLiteral(ordinal)
       case node: SelectionNode =>
         // Append the nested index to selection node.
-        node.addNestedChildIdx(java.lang.Integer.valueOf(ordinal))
+        node.addNestedChildIdx(JInteger.valueOf(ordinal))
       case other =>
         throw new UnsupportedOperationException(s"$other is not supported.")
     }
@@ -94,7 +97,7 @@ case class VeloxHashExpressionTransformer(
       case HiveHash(_) =>
         (ExpressionBuilder.makeIntLiteral(0), IntegerType)
     }
-    val nodes = new java.util.ArrayList[ExpressionNode]()
+    val nodes = new JArrayList[ExpressionNode]()
     // Seed as the first argument
     nodes.add(seedNode)
     exps.foreach(
@@ -102,7 +105,7 @@ case class VeloxHashExpressionTransformer(
         nodes.add(expression.doTransform(args))
       })
     val childrenTypes = seedType +: original.children.map(child => child.dataType)
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
     val functionName =
       ConverterUtils.makeFuncName(substraitExprName, childrenTypes, FunctionConfig.OPT)
     val functionId = ExpressionBuilder.newScalarFunction(functionMap, functionName)

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/AggregateFunctionNode.java
@@ -24,16 +24,17 @@ import io.substrait.proto.FunctionArgument;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class AggregateFunctionNode implements Serializable {
   private final Long functionId;
-  private final ArrayList<ExpressionNode> expressionNodes = new ArrayList<>();
+  private final List<ExpressionNode> expressionNodes = new ArrayList<>();
   private final String phase;
   private final TypeNode outputTypeNode;
 
   AggregateFunctionNode(
       Long functionId,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       String phase,
       TypeNode outputTypeNode) {
     this.functionId = functionId;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ExpressionBuilder.java
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -239,7 +238,7 @@ public class ExpressionBuilder {
 
   public static AggregateFunctionNode makeAggregateFunction(
       Long functionId,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       String phase,
       TypeNode outputTypeNode) {
     return new AggregateFunctionNode(functionId, expressionNodes, phase, outputTypeNode);
@@ -261,7 +260,7 @@ public class ExpressionBuilder {
 
   public static WindowFunctionNode makeWindowFunction(
       Integer functionId,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       String columnName,
       TypeNode outputTypeNode,
       String upperBound,

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/IfThenNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/IfThenNode.java
@@ -20,18 +20,17 @@ import io.substrait.proto.Expression;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class IfThenNode implements ExpressionNode, Serializable {
 
-  private final ArrayList<ExpressionNode> ifNodes = new ArrayList<>();
-  private final ArrayList<ExpressionNode> thenNodes = new ArrayList<>();
+  private final List<ExpressionNode> ifNodes = new ArrayList<>();
+  private final List<ExpressionNode> thenNodes = new ArrayList<>();
 
   private final ExpressionNode elseValue;
 
   public IfThenNode(
-      ArrayList<ExpressionNode> ifNodes,
-      ArrayList<ExpressionNode> thenNodes,
-      ExpressionNode elseValue) {
+      List<ExpressionNode> ifNodes, List<ExpressionNode> thenNodes, ExpressionNode elseValue) {
     this.ifNodes.addAll(ifNodes);
     this.thenNodes.addAll(thenNodes);
     this.elseValue = elseValue;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/SelectionNode.java
@@ -20,12 +20,13 @@ import io.substrait.proto.Expression;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class SelectionNode implements ExpressionNode, Serializable {
   private final Integer fieldIndex;
 
   // The nested indices of child field. For case like a.b.c, the index of c is put at last.
-  private final ArrayList<Integer> nestedChildIndices = new ArrayList<>();
+  private final List<Integer> nestedChildIndices = new ArrayList<>();
 
   SelectionNode(Integer fieldIndex) {
     this.fieldIndex = fieldIndex;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/StringMapNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/StringMapNode.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class StringMapNode implements ExpressionNode, Serializable {
-  private final Map<String, String> values = new HashMap();
+  private final Map<String, String> values = new HashMap<>();
 
   public StringMapNode(Map<String, String> values) {
     this.values.putAll(values);

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/WindowFunctionNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/WindowFunctionNode.java
@@ -24,10 +24,11 @@ import io.substrait.proto.WindowType;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class WindowFunctionNode implements Serializable {
   private final Integer functionId;
-  private final ArrayList<ExpressionNode> expressionNodes = new ArrayList<>();
+  private final List<ExpressionNode> expressionNodes = new ArrayList<>();
 
   private final String columnName;
   private final TypeNode outputTypeNode;
@@ -40,7 +41,7 @@ public class WindowFunctionNode implements Serializable {
 
   WindowFunctionNode(
       Integer functionId,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       String columnName,
       TypeNode outputTypeNode,
       String upperBound,

--- a/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanBuilder.java
@@ -24,6 +24,7 @@ import io.glutenproject.substrait.rel.RelNode;
 import io.glutenproject.substrait.type.TypeNode;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class PlanBuilder {
@@ -33,16 +34,14 @@ public class PlanBuilder {
   private PlanBuilder() {}
 
   public static PlanNode makePlan(
-      ArrayList<FunctionMappingNode> mappingNodes,
-      ArrayList<RelNode> relNodes,
-      ArrayList<String> outNames) {
+      List<FunctionMappingNode> mappingNodes, List<RelNode> relNodes, List<String> outNames) {
     return new PlanNode(mappingNodes, relNodes, outNames);
   }
 
   public static PlanNode makePlan(
-      ArrayList<FunctionMappingNode> mappingNodes,
-      ArrayList<RelNode> relNodes,
-      ArrayList<String> outNames,
+      List<FunctionMappingNode> mappingNodes,
+      List<RelNode> relNodes,
+      List<String> outNames,
       TypeNode outputSchema,
       AdvancedExtensionNode extension) {
     return new PlanNode(mappingNodes, relNodes, outNames, outputSchema, extension);
@@ -53,20 +52,20 @@ public class PlanBuilder {
   }
 
   public static PlanNode makePlan(
-      SubstraitContext subCtx, ArrayList<RelNode> relNodes, ArrayList<String> outNames) {
+      SubstraitContext subCtx, List<RelNode> relNodes, List<String> outNames) {
     return makePlan(subCtx, relNodes, outNames, null, null);
   }
 
   public static PlanNode makePlan(
       SubstraitContext subCtx,
-      ArrayList<RelNode> relNodes,
-      ArrayList<String> outNames,
+      List<RelNode> relNodes,
+      List<String> outNames,
       TypeNode outputSchema,
       AdvancedExtensionNode extension) {
     if (subCtx == null) {
       throw new NullPointerException("ColumnarWholestageTransformer cannot doTansform.");
     }
-    ArrayList<FunctionMappingNode> mappingNodes = new ArrayList<>();
+    List<FunctionMappingNode> mappingNodes = new ArrayList<>();
 
     for (Map.Entry<String, Long> entry : subCtx.registeredFunction().entrySet()) {
       FunctionMappingNode mappingNode =

--- a/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/plan/PlanNode.java
@@ -27,28 +27,26 @@ import io.substrait.proto.RelRoot;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class PlanNode implements Serializable {
-  private final ArrayList<FunctionMappingNode> mappingNodes = new ArrayList<>();
-  private final ArrayList<RelNode> relNodes = new ArrayList<>();
-  private final ArrayList<String> outNames = new ArrayList<>();
+  private final List<FunctionMappingNode> mappingNodes = new ArrayList<>();
+  private final List<RelNode> relNodes = new ArrayList<>();
+  private final List<String> outNames = new ArrayList<>();
 
   private TypeNode outputSchema = null;
   private AdvancedExtensionNode extension = null;
 
-  PlanNode(
-      ArrayList<FunctionMappingNode> mappingNodes,
-      ArrayList<RelNode> relNodes,
-      ArrayList<String> outNames) {
+  PlanNode(List<FunctionMappingNode> mappingNodes, List<RelNode> relNodes, List<String> outNames) {
     this.mappingNodes.addAll(mappingNodes);
     this.relNodes.addAll(relNodes);
     this.outNames.addAll(outNames);
   }
 
   PlanNode(
-      ArrayList<FunctionMappingNode> mappingNodes,
-      ArrayList<RelNode> relNodes,
-      ArrayList<String> outNames,
+      List<FunctionMappingNode> mappingNodes,
+      List<RelNode> relNodes,
+      List<String> outNames,
       TypeNode outputSchema,
       AdvancedExtensionNode extension) {
     this.mappingNodes.addAll(mappingNodes);

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/AggregateRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/AggregateRelNode.java
@@ -26,20 +26,21 @@ import io.substrait.proto.RelCommon;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class AggregateRelNode implements RelNode, Serializable {
   private final RelNode input;
-  private final ArrayList<ExpressionNode> groupings = new ArrayList<>();
-  private final ArrayList<AggregateFunctionNode> aggregateFunctionNodes = new ArrayList<>();
+  private final List<ExpressionNode> groupings = new ArrayList<>();
+  private final List<AggregateFunctionNode> aggregateFunctionNodes = new ArrayList<>();
 
-  private final ArrayList<ExpressionNode> filters = new ArrayList<>();
+  private final List<ExpressionNode> filters = new ArrayList<>();
   private final AdvancedExtensionNode extensionNode;
 
   AggregateRelNode(
       RelNode input,
-      ArrayList<ExpressionNode> groupings,
-      ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
-      ArrayList<ExpressionNode> filters) {
+      List<ExpressionNode> groupings,
+      List<AggregateFunctionNode> aggregateFunctionNodes,
+      List<ExpressionNode> filters) {
     this.input = input;
     this.groupings.addAll(groupings);
     this.aggregateFunctionNodes.addAll(aggregateFunctionNodes);
@@ -49,9 +50,9 @@ public class AggregateRelNode implements RelNode, Serializable {
 
   AggregateRelNode(
       RelNode input,
-      ArrayList<ExpressionNode> groupings,
-      ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
-      ArrayList<ExpressionNode> filters,
+      List<ExpressionNode> groupings,
+      List<AggregateFunctionNode> aggregateFunctionNodes,
+      List<ExpressionNode> filters,
       AdvancedExtensionNode extensionNode) {
     this.input = input;
     this.groupings.addAll(groupings);

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExpandRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExpandRelNode.java
@@ -25,23 +25,22 @@ import io.substrait.proto.RelCommon;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class ExpandRelNode implements RelNode, Serializable {
   private final RelNode input;
-  private final ArrayList<ArrayList<ExpressionNode>> projections = new ArrayList<>();
+  private final List<List<ExpressionNode>> projections = new ArrayList<>();
 
   private final AdvancedExtensionNode extensionNode;
 
   public ExpandRelNode(
-      RelNode input,
-      ArrayList<ArrayList<ExpressionNode>> projections,
-      AdvancedExtensionNode extensionNode) {
+      RelNode input, List<List<ExpressionNode>> projections, AdvancedExtensionNode extensionNode) {
     this.input = input;
     this.projections.addAll(projections);
     this.extensionNode = extensionNode;
   }
 
-  public ExpandRelNode(RelNode input, ArrayList<ArrayList<ExpressionNode>> projections) {
+  public ExpandRelNode(RelNode input, List<List<ExpressionNode>> projections) {
     this.input = input;
     this.projections.addAll(projections);
     this.extensionNode = null;
@@ -59,7 +58,7 @@ public class ExpandRelNode implements RelNode, Serializable {
       expandBuilder.setInput(input.toProtobuf());
     }
 
-    for (ArrayList<ExpressionNode> projectList : projections) {
+    for (List<ExpressionNode> projectList : projections) {
       ExpandRel.ExpandField.Builder expandFieldBuilder = ExpandRel.ExpandField.newBuilder();
       ExpandRel.SwitchingField.Builder switchingField = ExpandRel.SwitchingField.newBuilder();
       for (ExpressionNode exprNode : projectList) {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/GenerateRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/GenerateRelNode.java
@@ -24,22 +24,22 @@ import io.substrait.proto.Rel;
 import io.substrait.proto.RelCommon;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.List;
 
 public class GenerateRelNode implements RelNode, Serializable {
   private final RelNode input;
   private final ExpressionNode generator;
-  private final ArrayList<ExpressionNode> childOutput;
+  private final List<ExpressionNode> childOutput;
   private final AdvancedExtensionNode extensionNode;
 
-  GenerateRelNode(RelNode input, ExpressionNode generator, ArrayList<ExpressionNode> childOutput) {
+  GenerateRelNode(RelNode input, ExpressionNode generator, List<ExpressionNode> childOutput) {
     this(input, generator, childOutput, null);
   }
 
   GenerateRelNode(
       RelNode input,
       ExpressionNode generator,
-      ArrayList<ExpressionNode> childOutput,
+      List<ExpressionNode> childOutput,
       AdvancedExtensionNode extensionNode) {
     this.input = input;
     this.generator = generator;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ProjectRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ProjectRelNode.java
@@ -25,14 +25,15 @@ import io.substrait.proto.RelCommon;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class ProjectRelNode implements RelNode, Serializable {
   private final RelNode input;
-  private final ArrayList<ExpressionNode> expressionNodes = new ArrayList<>();
+  private final List<ExpressionNode> expressionNodes = new ArrayList<>();
   private final AdvancedExtensionNode extensionNode;
   private final int emitStartIndex;
 
-  ProjectRelNode(RelNode input, ArrayList<ExpressionNode> expressionNodes, int emitStartIndex) {
+  ProjectRelNode(RelNode input, List<ExpressionNode> expressionNodes, int emitStartIndex) {
     this.input = input;
     this.expressionNodes.addAll(expressionNodes);
     this.extensionNode = null;
@@ -41,7 +42,7 @@ public class ProjectRelNode implements RelNode, Serializable {
 
   ProjectRelNode(
       RelNode input,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       AdvancedExtensionNode extensionNode,
       int emitStartIndex) {
     this.input = input;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -31,12 +31,13 @@ import org.apache.spark.sql.types.StructType;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class ReadRelNode implements RelNode, Serializable {
-  private final ArrayList<TypeNode> types = new ArrayList<>();
-  private final ArrayList<String> names = new ArrayList<>();
-  private final ArrayList<ColumnTypeNode> columnTypeNodes = new ArrayList<>();
+  private final List<TypeNode> types = new ArrayList<>();
+  private final List<String> names = new ArrayList<>();
+  private final List<ColumnTypeNode> columnTypeNodes = new ArrayList<>();
   private final SubstraitContext context;
   private final ExpressionNode filterNode;
   private final Long iteratorIndex;
@@ -44,8 +45,8 @@ public class ReadRelNode implements RelNode, Serializable {
   private Map<String, String> properties;
 
   ReadRelNode(
-      ArrayList<TypeNode> types,
-      ArrayList<String> names,
+      List<TypeNode> types,
+      List<String> names,
       SubstraitContext context,
       ExpressionNode filterNode,
       Long iteratorIndex) {
@@ -57,12 +58,12 @@ public class ReadRelNode implements RelNode, Serializable {
   }
 
   ReadRelNode(
-      ArrayList<TypeNode> types,
-      ArrayList<String> names,
+      List<TypeNode> types,
+      List<String> names,
       SubstraitContext context,
       ExpressionNode filterNode,
       Long iteratorIndex,
-      ArrayList<ColumnTypeNode> columnTypeNodes) {
+      List<ColumnTypeNode> columnTypeNodes) {
     this.types.addAll(types);
     this.names.addAll(names);
     this.context = context;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -29,7 +29,7 @@ import io.substrait.proto.JoinRel;
 import io.substrait.proto.SortField;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /** Contains helper functions for constructing substrait relations. */
 public class RelBuilder {
@@ -53,7 +53,7 @@ public class RelBuilder {
 
   public static RelNode makeProjectRel(
       RelNode input,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
@@ -62,7 +62,7 @@ public class RelBuilder {
 
   public static RelNode makeProjectRel(
       RelNode input,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       SubstraitContext context,
       Long operatorId,
       int emitStartIndex) {
@@ -72,7 +72,7 @@ public class RelBuilder {
 
   public static RelNode makeProjectRel(
       RelNode input,
-      ArrayList<ExpressionNode> expressionNodes,
+      List<ExpressionNode> expressionNodes,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId,
@@ -83,9 +83,9 @@ public class RelBuilder {
 
   public static RelNode makeAggregateRel(
       RelNode input,
-      ArrayList<ExpressionNode> groupings,
-      ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
-      ArrayList<ExpressionNode> filters,
+      List<ExpressionNode> groupings,
+      List<AggregateFunctionNode> aggregateFunctionNodes,
+      List<ExpressionNode> filters,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
@@ -94,9 +94,9 @@ public class RelBuilder {
 
   public static RelNode makeAggregateRel(
       RelNode input,
-      ArrayList<ExpressionNode> groupings,
-      ArrayList<AggregateFunctionNode> aggregateFunctionNodes,
-      ArrayList<ExpressionNode> filters,
+      List<ExpressionNode> groupings,
+      List<AggregateFunctionNode> aggregateFunctionNodes,
+      List<ExpressionNode> filters,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {
@@ -105,8 +105,8 @@ public class RelBuilder {
   }
 
   public static RelNode makeReadRel(
-      ArrayList<TypeNode> types,
-      ArrayList<String> names,
+      List<TypeNode> types,
+      List<String> names,
       ExpressionNode filter,
       SubstraitContext context,
       Long operatorId) {
@@ -115,9 +115,9 @@ public class RelBuilder {
   }
 
   public static RelNode makeReadRel(
-      ArrayList<TypeNode> types,
-      ArrayList<String> names,
-      ArrayList<ColumnTypeNode> columnTypeNodes,
+      List<TypeNode> types,
+      List<String> names,
+      List<ColumnTypeNode> columnTypeNodes,
       ExpressionNode filter,
       SubstraitContext context,
       Long operatorId) {
@@ -126,8 +126,8 @@ public class RelBuilder {
   }
 
   public static RelNode makeReadRel(
-      ArrayList<TypeNode> types,
-      ArrayList<String> names,
+      List<TypeNode> types,
+      List<String> names,
       ExpressionNode filter,
       Long iteratorIndex,
       SubstraitContext context,
@@ -137,15 +137,15 @@ public class RelBuilder {
   }
 
   public static RelNode makeReadRel(
-      ArrayList<Attribute> attributes, SubstraitContext context, Long operatorId) {
+      List<Attribute> attributes, SubstraitContext context, Long operatorId) {
     if (operatorId >= 0) {
       // If the operator id is negative, will not register the rel to operator.
       // Currently, only for the special handling in join.
       context.registerRelToOperator(operatorId);
     }
 
-    ArrayList<TypeNode> typeList = ConverterUtils.collectAttributeTypeNodes(attributes);
-    ArrayList<String> nameList = ConverterUtils.collectAttributeNamesWithExprId(attributes);
+    List<TypeNode> typeList = ConverterUtils.collectAttributeTypeNodes(attributes);
+    List<String> nameList = ConverterUtils.collectAttributeNamesWithExprId(attributes);
 
     // The iterator index will be added in the path of LocalFiles.
     Long iteratorIndex = context.nextIteratorIndex();
@@ -184,7 +184,7 @@ public class RelBuilder {
 
   public static RelNode makeExpandRel(
       RelNode input,
-      ArrayList<ArrayList<ExpressionNode>> projections,
+      List<List<ExpressionNode>> projections,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {
@@ -194,7 +194,7 @@ public class RelBuilder {
 
   public static RelNode makeExpandRel(
       RelNode input,
-      ArrayList<ArrayList<ExpressionNode>> projections,
+      List<List<ExpressionNode>> projections,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
@@ -203,7 +203,7 @@ public class RelBuilder {
 
   public static RelNode makeSortRel(
       RelNode input,
-      ArrayList<SortField> sorts,
+      List<SortField> sorts,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {
@@ -212,7 +212,7 @@ public class RelBuilder {
   }
 
   public static RelNode makeSortRel(
-      RelNode input, ArrayList<SortField> sorts, SubstraitContext context, Long operatorId) {
+      RelNode input, List<SortField> sorts, SubstraitContext context, Long operatorId) {
     context.registerRelToOperator(operatorId);
     return new SortRelNode(input, sorts);
   }
@@ -236,9 +236,9 @@ public class RelBuilder {
 
   public static RelNode makeWindowRel(
       RelNode input,
-      ArrayList<WindowFunctionNode> windowFunctionNodes,
-      ArrayList<ExpressionNode> partitionExpressions,
-      ArrayList<SortField> sorts,
+      List<WindowFunctionNode> windowFunctionNodes,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {
@@ -249,9 +249,9 @@ public class RelBuilder {
 
   public static RelNode makeWindowRel(
       RelNode input,
-      ArrayList<WindowFunctionNode> windowFunctionNodes,
-      ArrayList<ExpressionNode> partitionExpressions,
-      ArrayList<SortField> sorts,
+      List<WindowFunctionNode> windowFunctionNodes,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
@@ -263,7 +263,7 @@ public class RelBuilder {
   public static RelNode makeGenerateRel(
       RelNode input,
       ExpressionNode generator,
-      ArrayList<ExpressionNode> childOutput,
+      List<ExpressionNode> childOutput,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
@@ -273,7 +273,7 @@ public class RelBuilder {
   public static RelNode makeGenerateRel(
       RelNode input,
       ExpressionNode generator,
-      ArrayList<ExpressionNode> childOutput,
+      List<ExpressionNode> childOutput,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/SortRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/SortRelNode.java
@@ -25,20 +25,20 @@ import io.substrait.proto.SortRel;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class SortRelNode implements RelNode, Serializable {
   private final RelNode input;
-  private final ArrayList<SortField> sorts = new ArrayList<>();
+  private final List<SortField> sorts = new ArrayList<>();
   private final AdvancedExtensionNode extensionNode;
 
-  public SortRelNode(
-      RelNode input, ArrayList<SortField> sorts, AdvancedExtensionNode extensionNode) {
+  public SortRelNode(RelNode input, List<SortField> sorts, AdvancedExtensionNode extensionNode) {
     this.input = input;
     this.sorts.addAll(sorts);
     this.extensionNode = extensionNode;
   }
 
-  public SortRelNode(RelNode input, ArrayList<SortField> sorts) {
+  public SortRelNode(RelNode input, List<SortField> sorts) {
     this.input = input;
     this.sorts.addAll(sorts);
     this.extensionNode = null;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/WindowRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/WindowRelNode.java
@@ -27,19 +27,20 @@ import io.substrait.proto.WindowRel;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class WindowRelNode implements RelNode, Serializable {
   private final RelNode input;
-  private final ArrayList<WindowFunctionNode> windowFunctionNodes = new ArrayList<>();
-  private final ArrayList<ExpressionNode> partitionExpressions = new ArrayList<>();
-  private final ArrayList<SortField> sorts = new ArrayList<>();
+  private final List<WindowFunctionNode> windowFunctionNodes = new ArrayList<>();
+  private final List<ExpressionNode> partitionExpressions = new ArrayList<>();
+  private final List<SortField> sorts = new ArrayList<>();
   private final AdvancedExtensionNode extensionNode;
 
   public WindowRelNode(
       RelNode input,
-      ArrayList<WindowFunctionNode> windowFunctionNodes,
-      ArrayList<ExpressionNode> partitionExpressions,
-      ArrayList<SortField> sorts) {
+      List<WindowFunctionNode> windowFunctionNodes,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts) {
     this.input = input;
     this.windowFunctionNodes.addAll(windowFunctionNodes);
     this.partitionExpressions.addAll(partitionExpressions);
@@ -49,9 +50,9 @@ public class WindowRelNode implements RelNode, Serializable {
 
   public WindowRelNode(
       RelNode input,
-      ArrayList<WindowFunctionNode> windowFunctionNodes,
-      ArrayList<ExpressionNode> partitionExpressions,
-      ArrayList<SortField> sorts,
+      List<WindowFunctionNode> windowFunctionNodes,
+      List<ExpressionNode> partitionExpressions,
+      List<SortField> sorts,
       AdvancedExtensionNode extensionNode) {
     this.input = input;
     this.windowFunctionNodes.addAll(windowFunctionNodes);

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/MapNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/MapNode.java
@@ -20,6 +20,7 @@ import io.substrait.proto.Type;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class MapNode implements TypeNode, Serializable {
   private final Boolean nullable;
@@ -34,7 +35,7 @@ public class MapNode implements TypeNode, Serializable {
 
   // It's used in ExplodeTransformer to determine output datatype from children.
   public TypeNode getNestedType() {
-    ArrayList<TypeNode> types = new ArrayList<>();
+    List<TypeNode> types = new ArrayList<>();
     types.add(keyType);
     types.add(valType);
     return TypeBuilder.makeStruct(false, types);

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/StructNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/StructNode.java
@@ -20,24 +20,25 @@ import io.substrait.proto.Type;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 public class StructNode implements TypeNode, Serializable {
   private final Boolean nullable;
-  private final ArrayList<TypeNode> types = new ArrayList<>();
-  private final ArrayList<String> names = new ArrayList<>();
+  private final List<TypeNode> types = new ArrayList<>();
+  private final List<String> names = new ArrayList<>();
 
-  public StructNode(Boolean nullable, ArrayList<TypeNode> types, ArrayList<String> names) {
+  public StructNode(Boolean nullable, List<TypeNode> types, List<String> names) {
     this.nullable = nullable;
     this.types.addAll(types);
     this.names.addAll(names);
   }
 
-  public StructNode(Boolean nullable, ArrayList<TypeNode> types) {
+  public StructNode(Boolean nullable, List<TypeNode> types) {
     this.nullable = nullable;
     this.types.addAll(types);
   }
 
-  public ArrayList<TypeNode> getFieldTypes() {
+  public List<TypeNode> getFieldTypes() {
     return types;
   }
 

--- a/gluten-core/src/main/java/io/glutenproject/substrait/type/TypeBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/type/TypeBuilder.java
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.substrait.type;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class TypeBuilder {
   private TypeBuilder() {}
@@ -77,12 +77,11 @@ public class TypeBuilder {
     return new TimestampTypeNode(nullable);
   }
 
-  public static TypeNode makeStruct(
-      Boolean nullable, ArrayList<TypeNode> types, ArrayList<String> names) {
+  public static TypeNode makeStruct(Boolean nullable, List<TypeNode> types, List<String> names) {
     return new StructNode(nullable, types, names);
   }
 
-  public static TypeNode makeStruct(Boolean nullable, ArrayList<TypeNode> types) {
+  public static TypeNode makeStruct(Boolean nullable, List<TypeNode> types) {
     return new StructNode(nullable, types);
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
@@ -23,6 +23,9 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
+import java.lang.{Long => JLong}
+import java.util.{List => JList, Map => JMap}
+
 trait MetricsApi extends Serializable {
 
   def genWholeStageTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
@@ -30,9 +33,9 @@ trait MetricsApi extends Serializable {
 
   def metricsUpdatingFunction(
       child: SparkPlan,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): IMetrics => Unit
+      relMap: JMap[JLong, JList[JLong]],
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit
 
   def genBatchScanTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -41,7 +41,10 @@ import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import java.util
+import java.lang.{Long => JLong}
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
+
+import scala.collection.JavaConverters._
 
 trait SparkPlanExecApi {
 
@@ -134,7 +137,7 @@ trait SparkPlanExecApi {
   /** Transform GetArrayItem to Substrait. */
   def genGetArrayItemExpressionNode(
       substraitExprName: String,
-      functionMap: java.util.HashMap[String, java.lang.Long],
+      functionMap: JMap[String, JLong],
       leftNode: ExpressionNode,
       rightNode: ExpressionNode,
       original: GetArrayItem): ExpressionNode
@@ -342,9 +345,9 @@ trait SparkPlanExecApi {
   /** default function to generate window function node */
   def genWindowFunctionsNode(
       windowExpression: Seq[NamedExpression],
-      windowExpressionNodes: util.ArrayList[WindowFunctionNode],
+      windowExpressionNodes: JList[WindowFunctionNode],
       originalInputAttributes: Seq[Attribute],
-      args: util.HashMap[String, java.lang.Long]): Unit = {
+      args: JMap[String, JLong]): Unit = {
 
     windowExpression.map {
       windowExpr =>
@@ -357,7 +360,7 @@ trait SparkPlanExecApi {
             val frame = aggWindowFunc.frame.asInstanceOf[SpecifiedWindowFrame]
             val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
               WindowFunctionsBuilder.create(args, aggWindowFunc).toInt,
-              new util.ArrayList[ExpressionNode](),
+              new JArrayList[ExpressionNode](),
               columnName,
               ConverterUtils.getTypeNode(aggWindowFunc.dataType, aggWindowFunc.nullable),
               WindowExecTransformer.getFrameBound(frame.upper),
@@ -373,13 +376,12 @@ trait SparkPlanExecApi {
               throw new UnsupportedOperationException(s"Not currently supported: $aggregateFunc.")
             }
 
-            val childrenNodeList = new util.ArrayList[ExpressionNode]()
-            aggregateFunc.children.foreach(
-              expr =>
-                childrenNodeList.add(
-                  ExpressionConverter
-                    .replaceWithExpressionTransformer(expr, originalInputAttributes)
-                    .doTransform(args)))
+            val childrenNodeList = aggregateFunc.children
+              .map(
+                ExpressionConverter
+                  .replaceWithExpressionTransformer(_, originalInputAttributes)
+                  .doTransform(args))
+              .asJava
 
             val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
               AggregateFunctionsBuilder.create(args, aggExpression.aggregateFunction).toInt,
@@ -394,7 +396,7 @@ trait SparkPlanExecApi {
           case wf @ (Lead(_, _, _, _) | Lag(_, _, _, _)) =>
             val offset_wf = wf.asInstanceOf[FrameLessOffsetWindowFunction]
             val frame = offset_wf.frame.asInstanceOf[SpecifiedWindowFrame]
-            val childrenNodeList = new util.ArrayList[ExpressionNode]()
+            val childrenNodeList = new JArrayList[ExpressionNode]()
             childrenNodeList.add(
               ExpressionConverter
                 .replaceWithExpressionTransformer(
@@ -425,12 +427,12 @@ trait SparkPlanExecApi {
             windowExpressionNodes.add(windowFunctionNode)
           case wf @ NthValue(input, offset: Literal, _) =>
             val frame = wExpression.windowSpec.frameSpecification.asInstanceOf[SpecifiedWindowFrame]
-            val childrenNodeList = new util.ArrayList[ExpressionNode]()
+            val childrenNodeList = new JArrayList[ExpressionNode]()
             childrenNodeList.add(
               ExpressionConverter
                 .replaceWithExpressionTransformer(input, attributeSeq = originalInputAttributes)
                 .doTransform(args))
-            childrenNodeList.add(new LiteralTransformer(offset).doTransform(args))
+            childrenNodeList.add(LiteralTransformer(offset).doTransform(args))
             val windowFunctionNode = ExpressionBuilder.makeWindowFunction(
               WindowFunctionsBuilder.create(args, wf).toInt,
               childrenNodeList,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -43,7 +43,7 @@ import com.google.protobuf.{Any, StringValue}
 import io.substrait.proto.JoinRel
 
 import java.lang.{Long => JLong}
-import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
+import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
 
@@ -226,7 +226,7 @@ trait HashJoinLikeExecTransformer
           (transformContext.root, transformContext.outputAttributes, false)
         case _ =>
           val readRel = RelBuilder.makeReadRel(
-            new JArrayList[Attribute](plan.output.asJava),
+            plan.output.asJava,
             substraitContext,
             -1
           ) /* A special handling in Join to delay the rel registration. */
@@ -335,7 +335,7 @@ object HashJoinLikeExecTransformer {
       leftType: DataType,
       rightNode: ExpressionNode,
       rightType: DataType,
-      functionMap: JHashMap[String, JLong]): ExpressionNode = {
+      functionMap: JMap[String, JLong]): ExpressionNode = {
     val functionId = ExpressionBuilder.newScalarFunction(
       functionMap,
       ConverterUtils.makeFuncName(ExpressionNames.EQUAL, Seq(leftType, rightType)))
@@ -349,7 +349,7 @@ object HashJoinLikeExecTransformer {
   def makeAndExpression(
       leftNode: ExpressionNode,
       rightNode: ExpressionNode,
-      functionMap: JHashMap[String, JLong]): ExpressionNode = {
+      functionMap: JMap[String, JLong]): ExpressionNode = {
     val functionId = ExpressionBuilder.newScalarFunction(
       functionMap,
       ConverterUtils.makeFuncName(ExpressionNames.AND, Seq(BooleanType, BooleanType)))

--- a/gluten-core/src/main/scala/io/glutenproject/execution/JoinUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/JoinUtils.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.execution
 
 import io.glutenproject.expression.{AttributeReferenceTransformer, ConverterUtils, ExpressionConverter}
-import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
+import io.glutenproject.substrait.`type`.TypeBuilder
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 import io.glutenproject.substrait.extensions.{AdvancedExtensionNode, ExtensionBuilder}
@@ -30,8 +30,6 @@ import org.apache.spark.sql.types.DataType
 import com.google.protobuf.Any
 import io.substrait.proto.JoinRel
 
-import java.util
-
 import scala.collection.JavaConverters._
 
 object JoinUtils {
@@ -43,7 +41,7 @@ object JoinUtils {
     // is also used in execution phase. In this case an empty typeUrlPrefix need to be passed,
     // so that it can be correctly parsed into json string on the cpp side.
     Any.pack(
-      TypeBuilder.makeStruct(false, new util.ArrayList[TypeNode](inputTypeNodes.asJava)).toProtobuf,
+      TypeBuilder.makeStruct(false, inputTypeNodes.asJava).toProtobuf,
       /* typeUrlPrefix */ "")
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -33,8 +33,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import com.google.protobuf.StringValue
 import io.substrait.proto.JoinRel
 
-import java.util.{ArrayList => JArrayList}
-
 import scala.collection.JavaConverters._
 
 /** Performs a sort merge join of two child relations. */
@@ -258,7 +256,7 @@ case class SortMergeJoinExecTransformer(
           (transformContext.root, transformContext.outputAttributes, false)
         case _ =>
           val readRel = RelBuilder.makeReadRel(
-            new JArrayList[Attribute](plan.output.asJava),
+            plan.output.asJava,
             context,
             -1
           ) /* A special handling in Join to delay the rel registration. */

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ArrayExpressionTransformer.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.types._
 
 import com.google.common.collect.Lists
 
+import scala.collection.JavaConverters._
+
 case class CreateArrayTransformer(
     substraitExprName: String,
     children: Seq[ExpressionTransformer],
@@ -40,12 +42,7 @@ case class CreateArrayTransformer(
       throw new UnsupportedOperationException(s"$original not supported yet.")
     }
 
-    val childNodes = new java.util.ArrayList[ExpressionNode]()
-    children.foreach(
-      child => {
-        val childNode = child.doTransform(args)
-        childNodes.add(childNode)
-      })
+    val childNodes = children.map(_.doTransform(args)).asJava
 
     val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
     val functionName = ConverterUtils.makeFuncName(
@@ -87,11 +84,11 @@ case class GetArrayItemTransformer(
       ConverterUtils.getTypeNode(original.right.dataType, original.right.nullable))
 
     BackendsApiManager.getSparkPlanExecApiInstance.genGetArrayItemExpressionNode(
-      substraitExprName: String,
-      functionMap: java.util.HashMap[String, java.lang.Long],
-      leftNode: ExpressionNode,
-      rightNode: ExpressionNode,
-      original: GetArrayItem
+      substraitExprName,
+      functionMap,
+      leftNode,
+      rightNode,
+      original
     )
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
@@ -25,6 +25,9 @@ import org.apache.spark.sql.types._
 
 import com.google.common.collect.Lists
 
+import java.lang.{Long => JLong}
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
+
 import scala.collection.JavaConverters._
 
 /** The extract trait for 'GetDateField' from Date */
@@ -37,7 +40,7 @@ case class ExtractDateTransformer(
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     val childNode = child.doTransform(args)
 
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
     val functionName = ConverterUtils.makeFuncName(
       substraitExprName,
       original.children.map(_.dataType),
@@ -67,7 +70,7 @@ case class DateDiffTransformer(
     val endDateNode = endDate.doTransform(args)
     val startDateNode = startDate.doTransform(args)
 
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
     val functionName = ConverterUtils.makeFuncName(
       substraitExprName,
       Seq(StringType, original.startDate.dataType, original.endDate.dataType),
@@ -96,20 +99,20 @@ case class FromUnixTimeTransformer(
     val secNode = sec.doTransform(args)
     val formatNode = format.doTransform(args)
 
-    val dataTypes = if (timeZoneId != None) {
+    val dataTypes = if (timeZoneId.isDefined) {
       Seq(original.sec.dataType, original.format.dataType, StringType)
     } else {
       Seq(original.sec.dataType, original.format.dataType)
     }
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
     val functionId = ExpressionBuilder.newScalarFunction(
       functionMap,
       ConverterUtils.makeFuncName(substraitExprName, dataTypes))
 
-    val expressionNodes = new java.util.ArrayList[ExpressionNode]()
+    val expressionNodes = new JArrayList[ExpressionNode]()
     expressionNodes.add(secNode)
     expressionNodes.add(formatNode)
-    if (timeZoneId != None) {
+    if (timeZoneId.isDefined) {
       expressionNodes.add(ExpressionBuilder.makeStringLiteral(timeZoneId.get))
     }
 
@@ -133,12 +136,12 @@ case class ToUnixTimestampTransformer(
 
   override def doTransform(args: java.lang.Object): ExpressionNode = {
     val dataTypes = Seq(original.timeExp.dataType, StringType)
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
     val functionId = ExpressionBuilder.newScalarFunction(
       functionMap,
       ConverterUtils.makeFuncName(substraitExprName, dataTypes))
 
-    val expressionNodes = new java.util.ArrayList[ExpressionNode]()
+    val expressionNodes = new JArrayList[ExpressionNode]()
     val timeExpNode = timeExp.doTransform(args)
     expressionNodes.add(timeExpNode)
     val formatNode = format.doTransform(args)
@@ -160,8 +163,8 @@ case class TruncTimestampTransformer(
     val timestampNode = timestamp.doTransform(args)
     val formatNode = format.doTransform(args)
 
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val dataTypes = if (timeZoneId != None) {
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
+    val dataTypes = if (timeZoneId.isDefined) {
       Seq(original.format.dataType, original.timestamp.dataType, StringType)
     } else {
       Seq(original.format.dataType, original.timestamp.dataType)
@@ -171,10 +174,10 @@ case class TruncTimestampTransformer(
       functionMap,
       ConverterUtils.makeFuncName(substraitExprName, dataTypes))
 
-    val expressionNodes = new java.util.ArrayList[ExpressionNode]()
+    val expressionNodes = new JArrayList[ExpressionNode]()
     expressionNodes.add(formatNode)
     expressionNodes.add(timestampNode)
-    if (timeZoneId != None) {
+    if (timeZoneId.isDefined) {
       expressionNodes.add(ExpressionBuilder.makeStringLiteral(timeZoneId.get))
     }
 
@@ -197,8 +200,8 @@ case class MonthsBetweenTransformer(
     val data2Node = date2.doTransform(args)
     val roundOffNode = roundOff.doTransform(args)
 
-    val functionMap = args.asInstanceOf[java.util.HashMap[String, java.lang.Long]]
-    val dataTypes = if (timeZoneId != None) {
+    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
+    val dataTypes = if (timeZoneId.isDefined) {
       Seq(original.date1.dataType, original.date2.dataType, original.roundOff.dataType, StringType)
     } else {
       Seq(original.date1.dataType, original.date2.dataType, original.roundOff.dataType)
@@ -208,11 +211,11 @@ case class MonthsBetweenTransformer(
       functionMap,
       ConverterUtils.makeFuncName(substraitExprName, dataTypes))
 
-    val expressionNodes = new java.util.ArrayList[ExpressionNode]()
+    val expressionNodes = new JArrayList[ExpressionNode]()
     expressionNodes.add(date1Node)
     expressionNodes.add(data2Node)
     expressionNodes.add(roundOffNode)
-    if (timeZoneId != None) {
+    if (timeZoneId.isDefined) {
       expressionNodes.add(ExpressionBuilder.makeStringLiteral(timeZoneId.get))
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/LambdaFunctionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/LambdaFunctionTransformer.scala
@@ -20,8 +20,6 @@ import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode}
 
 import org.apache.spark.sql.catalyst.expressions.LambdaFunction
 
-import java.util.ArrayList
-
 case class LambdaFunctionTransformer(
     substraitExprName: String,
     function: ExpressionTransformer,
@@ -42,7 +40,7 @@ case class LambdaFunctionTransformer(
         substraitExprName,
         Seq(original.dataType),
         ConverterUtils.FunctionConfig.OPT))
-    val expressionNodes = new ArrayList[ExpressionNode]
+    val expressionNodes = new java.util.ArrayList[ExpressionNode]
     expressionNodes.add(function.doTransform(args))
     arguments.foreach(argument => expressionNodes.add(argument.doTransform(args)))
     val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/StructExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/StructExpressionTransformer.scala
@@ -31,7 +31,7 @@ case class GetStructFieldTransformer(
     original: GetStructField)
   extends ExpressionTransformer {
 
-  override def doTransform(args: Object): ExpressionNode = {
+  override def doTransform(args: java.lang.Object): ExpressionNode = {
     val childNode = childTransformer.doTransform(args)
     childNode match {
       case node: StructLiteralNode =>

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -22,7 +22,7 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import java.lang.{Integer => JInt, Long => JLong}
 import java.security.InvalidParameterException
-import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList}
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
 case class JoinParams() {
   // Whether the input of streamed side is a ReadRel represented iterator.
@@ -69,7 +69,7 @@ class SubstraitContext extends Serializable {
   private val iteratorNodes = new JHashMap[JLong, LocalFilesNode]()
 
   // A map stores the relationship between Spark operator id and its respective Substrait Rel ids.
-  private val operatorToRelsMap = new JHashMap[JLong, JArrayList[JLong]]()
+  private val operatorToRelsMap: JMap[JLong, JList[JLong]] = new JHashMap[JLong, JList[JLong]]()
 
   // Only for debug conveniently
   private val operatorToPlanNameMap = new JHashMap[JLong, String]()
@@ -181,7 +181,7 @@ class SubstraitContext extends Serializable {
    * Return the registered map.
    * @return
    */
-  def registeredRelMap: JHashMap[JLong, JArrayList[JLong]] = operatorToRelsMap
+  def registeredRelMap: JMap[JLong, JList[JLong]] = operatorToRelsMap
 
   /**
    * Register the join params to certain operator id.

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveS
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
 
-import java.util.{IdentityHashMap, Set}
+import java.util
 import java.util.Collections.newSetFromMap
 
 import scala.collection.mutable
@@ -124,7 +124,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
     try {
       // Initialize a reference-unique set of Operators to avoid accdiental overwrites and to allow
       // intentional overwriting of IDs generated in previous AQE iteration
-      val operators = newSetFromMap[QueryPlan[_]](new IdentityHashMap())
+      val operators = newSetFromMap[QueryPlan[_]](new util.IdentityHashMap())
       // Initialize an array of ReusedExchanges to help find Adaptively Optimized Out
       // Exchanges as part of SPARK-42753
       val reusedExchanges = ArrayBuffer.empty[ReusedExchangeExec]
@@ -224,7 +224,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
   private def generateOperatorIDs(
       plan: QueryPlan[_],
       startOperatorID: Int,
-      visited: Set[QueryPlan[_]],
+      visited: util.Set[QueryPlan[_]],
       reusedExchanges: ArrayBuffer[ReusedExchangeExec],
       addReusedExchanges: Boolean): Int = {
     var currentOperationID = startOperatorID

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types.StructType
 
 import com.google.protobuf.Any
 
-import java.util.ArrayList
+import java.util.{ArrayList => JArrayList, List => JList}
 
 case class EvalPythonExecTransformer(
     udfs: Seq[PythonUDF],
@@ -72,7 +72,7 @@ case class EvalPythonExecTransformer(
     val args = context.registeredFunction
     val operatorId = context.nextOperatorId(this.nodeName)
 
-    val expressionNodes = new java.util.ArrayList[ExpressionNode]
+    val expressionNodes = new JArrayList[ExpressionNode]
     child.output.zipWithIndex.foreach(
       x => expressionNodes.add(ExpressionBuilder.makeSelection(x._2)))
     udfs.foreach(
@@ -94,7 +94,7 @@ case class EvalPythonExecTransformer(
 
     val args = context.registeredFunction
     val operatorId = context.nextOperatorId(this.nodeName)
-    val expressionNodes = new java.util.ArrayList[ExpressionNode]
+    val expressionNodes = new JArrayList[ExpressionNode]
     child.output.zipWithIndex.foreach(
       x => expressionNodes.add(ExpressionBuilder.makeSelection(x._2)))
     udfs.foreach(
@@ -106,7 +106,7 @@ case class EvalPythonExecTransformer(
     val relNode = if (childCtx != null) {
       getRelNode(childCtx.root, expressionNodes, context, operatorId, child.output, false)
     } else {
-      val attrList = new java.util.ArrayList[Attribute]()
+      val attrList = new JArrayList[Attribute]()
       for (attr <- child.output) {
         attrList.add(attr)
       }
@@ -119,7 +119,7 @@ case class EvalPythonExecTransformer(
 
   def getRelNode(
       input: RelNode,
-      expressionNodes: ArrayList[ExpressionNode],
+      expressionNodes: JList[ExpressionNode],
       context: SubstraitContext,
       operatorId: Long,
       inputAttributes: Seq[Attribute],
@@ -128,7 +128,7 @@ case class EvalPythonExecTransformer(
       RelBuilder.makeProjectRel(input, expressionNodes, context, operatorId)
     } else {
       // Use a extension node to send the input types through Substrait plan for validation.
-      val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
+      val inputTypeNodeList = new JArrayList[TypeNode]()
       for (attr <- inputAttributes) {
         inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
       }

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
@@ -22,6 +22,9 @@ import io.glutenproject.substrait.{AggregationParams, JoinParams}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.SparkPlan
 
+import java.lang.{Long => JLong}
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
+
 object MetricsUtil extends Logging {
 
   /**
@@ -38,9 +41,9 @@ object MetricsUtil extends Logging {
    */
   def updateNativeMetrics(
       child: SparkPlan,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): IMetrics => Unit = {
+      relMap: JMap[JLong, JList[JLong]],
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit = {
     def treeifyMetricsUpdaters(plan: SparkPlan): MetricsUpdaterTree = {
       plan match {
         case j: HashJoinLikeExecTransformer =>
@@ -59,7 +62,7 @@ object MetricsUtil extends Logging {
     updateTransformerMetrics(
       mut,
       relMap,
-      java.lang.Long.valueOf(relMap.size() - 1),
+      JLong.valueOf(relMap.size() - 1),
       joinParamsMap,
       aggParamsMap)
   }
@@ -72,8 +75,7 @@ object MetricsUtil extends Logging {
    * @return
    *   the merged metrics
    */
-  private def mergeMetrics(
-      operatorMetrics: java.util.ArrayList[OperatorMetrics]): OperatorMetrics = {
+  private def mergeMetrics(operatorMetrics: JList[OperatorMetrics]): OperatorMetrics = {
     if (operatorMetrics.size() == 0) {
       return null
     }
@@ -165,13 +167,13 @@ object MetricsUtil extends Logging {
    */
   def updateTransformerMetricsInternal(
       mutNode: MetricsUpdaterTree,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      operatorIdx: java.lang.Long,
+      relMap: JMap[JLong, JList[JLong]],
+      operatorIdx: JLong,
       metrics: Metrics,
       metricsIdx: Int,
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): (java.lang.Long, Int) = {
-    val operatorMetrics = new java.util.ArrayList[OperatorMetrics]()
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): (JLong, Int) = {
+    val operatorMetrics = new JArrayList[OperatorMetrics]()
     var curMetricsIdx = metricsIdx
     relMap
       .get(operatorIdx)
@@ -205,7 +207,7 @@ object MetricsUtil extends Logging {
         u.updateNativeMetrics(opMetrics)
     }
 
-    var newOperatorIdx: java.lang.Long = operatorIdx - 1
+    var newOperatorIdx: JLong = operatorIdx - 1
     var newMetricsIdx: Int =
       if (
         mutNode.updater.isInstanceOf[LimitMetricsUpdater] &&
@@ -256,10 +258,10 @@ object MetricsUtil extends Logging {
    */
   def updateTransformerMetrics(
       mutNode: MetricsUpdaterTree,
-      relMap: java.util.HashMap[java.lang.Long, java.util.ArrayList[java.lang.Long]],
-      operatorIdx: java.lang.Long,
-      joinParamsMap: java.util.HashMap[java.lang.Long, JoinParams],
-      aggParamsMap: java.util.HashMap[java.lang.Long, AggregationParams]): IMetrics => Unit = {
+      relMap: JMap[JLong, JList[JLong]],
+      operatorIdx: JLong,
+      joinParamsMap: JMap[JLong, JoinParams],
+      aggParamsMap: JMap[JLong, AggregationParams]): IMetrics => Unit = {
     imetrics =>
       try {
         val metrics = imetrics.asInstanceOf[Metrics]


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is recommended to use abstract interfaces for method parameters and return type instead of concrete implementations.

After modifying the method parameters and return type to abstract interface types, many codes can be rewritten in a more functional style. This PR also includes these modifications as well.


## How was this patch tested?

Existing test cases
