### PR TITLE
[CORE] Remove unnecessary case match in getAttrForAggregateExpr

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
@@ -19,10 +19,7 @@ package io.glutenproject.execution.extension
 import io.glutenproject.expression._
 import io.glutenproject.extension.ExpressionExtensionTrait
 
-import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-
-import scala.collection.mutable.ListBuffer
 
 case class CustomAggExpressionTransformer() extends ExpressionExtensionTrait {
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
@@ -32,41 +32,4 @@ case class CustomAggExpressionTransformer() extends ExpressionExtensionTrait {
 
   /** Generate the extension expressions list, format: Sig[XXXExpression]("XXXExpressionName") */
   override def expressionSigList: Seq[Sig] = expressionSigs
-
-  /** Get the attribute index of the extension aggregate functions. */
-  override def getAttrsForExtensionAggregateExpr(
-      aggregateFunc: AggregateFunction,
-      mode: AggregateMode,
-      exp: AggregateExpression,
-      aggregateAttributeList: Seq[Attribute],
-      aggregateAttr: ListBuffer[Attribute],
-      resIndex: Int): Int = {
-    var reIndex = resIndex
-    aggregateFunc match {
-      case CustomSum(_, _) =>
-        mode match {
-          case Partial | PartialMerge =>
-            val aggBufferAttr = aggregateFunc.inputAggBufferAttributes
-            if (aggBufferAttr.size == 2) {
-              // decimal sum check sum.resultType
-              aggregateAttr += ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
-              val isEmptyAttr = ConverterUtils.getAttrFromExpr(aggBufferAttr(1))
-              aggregateAttr += isEmptyAttr
-              reIndex += 2
-              reIndex
-            } else {
-              val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
-              aggregateAttr += attr
-              reIndex += 1
-              reIndex
-            }
-          case Final =>
-            aggregateAttr += aggregateAttributeList(reIndex)
-            reIndex += 1
-            reIndex
-          case other =>
-            throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
-        }
-    }
-  }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -20,9 +20,6 @@ import io.glutenproject.expression.{ExpressionTransformer, Sig}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, AggregateMode}
-
-import scala.collection.mutable.ListBuffer
 
 trait ExpressionExtensionTrait {
 
@@ -39,18 +36,6 @@ trait ExpressionExtensionTrait {
       expr: Expression,
       attributeSeq: Seq[Attribute]): ExpressionTransformer = {
     throw new UnsupportedOperationException(s"${expr.getClass} or $expr is not supported.")
-  }
-
-  /** Get the attribute index of the extension aggregate functions. */
-  def getAttrsForExtensionAggregateExpr(
-      aggregateFunc: AggregateFunction,
-      mode: AggregateMode,
-      exp: AggregateExpression,
-      aggregateAttributeList: Seq[Attribute],
-      aggregateAttr: ListBuffer[Attribute],
-      resIndex: Int): Int = {
-    throw new UnsupportedOperationException(
-      s"Aggregate function ${aggregateFunc.getClass} is not supported.")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are many processes in the `getAttrForAggregateExprs` method that construct aggregateAttr and index for specific aggFuncs. In fact, the patterns of these processes are consistent. They iterate over `inputAggBufferAttributes` of aggFunc, transform them, and insert them into `aggregateAttr`. Then, they increase the count in index for each insertion. The logic for validating the supported modes of different aggFuncs is the only specific part, which can be extracted separately.


## How was this patch tested?

Exists CI
