### PR TITLE
[VL] Fix failed to get iterator exception

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -149,6 +149,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
 
     Iterators
       .wrap(resIter.asScala)
+      .protectInvocationFlow()
       .recycleIterator {
         updateNativeMetrics(resIter.getMetrics)
         updateInputMetrics(TaskContext.get().taskMetrics().inputMetrics)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The native Parquet writer may call `hasNext `more than once. However, in the current code, when the first `hasNext `call returns false, the resources are released. As a result, when the second `hasNext `call is made, it throws the following exception. This PR adds protection to allow multiple hasNext calls on the Scala side.

```
o.glutenproject.exception.GlutenException: java.lang.RuntimeException: failed to get batch iterator
        at io.glutenproject.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:39)
        at scala.collection.convert.Wrappers$JIteratorWrapper.hasNext(Wrappers.scala:45)
        at io.glutenproject.utils.IteratorCompleter.hasNext(Iterators.scala:68)
        at io.glutenproject.utils.PayloadCloser.hasNext(Iterators.scala:34)
        at io.glutenproject.utils.PipelineTimeAccumulator.hasNext(Iterators.scala:97)
        at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
        at org.apache.spark.sql.execution.datasources.FileFormatDataWriter.writeWithIterator(FileFormatDataWriter.scala:102)
        at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$executeTask$1(FileFormatWriter.scala:414)
        at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1525)
        at org.apache.spark.sql.execution.datasources.FileFormatWriter$.executeTask(FileFormatWriter.scala:423)
        at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$write$17(FileFormatWriter.scala:331)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
        at org.apache.spark.scheduler.Task.run(Task.scala:131)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1491)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: failed to get batch iterator
        at io.glutenproject.vectorized.ColumnarBatchOutIterator.nativeHasNext(Native Method)
        at io.glutenproject.vectorized.ColumnarBatchOutIterator.hasNextInternal(ColumnarBatchOutIterator.java:65)
        at io.glutenproject.vectorized.GeneralOutIterator.hasNext(GeneralOutIterator.java:37)
        ... 19 more

```
## How was this patch tested?

Local test

