### PR TITLE
[GLUTEN-3378][CORE] Move getLocalFilesNode logic to scan transformer

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -21,7 +21,7 @@ import io.glutenproject.backendsapi.IteratorApi
 import io.glutenproject.execution._
 import io.glutenproject.metrics.{GlutenTimeMetric, IMetrics, NativeMetrics}
 import io.glutenproject.substrait.plan.PlanNode
-import io.glutenproject.substrait.rel.{ExtensionTableBuilder, LocalFilesBuilder}
+import io.glutenproject.substrait.rel.{ExtensionTableBuilder, LocalFilesBuilder, ReadSplit}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.utils.{LogLevelUtil, SubstraitPlanPrinterUtil}
 import io.glutenproject.vectorized.{CHNativeExpressionEvaluator, CloseableCHColumnBatchIterator, GeneralInIterator, GeneralOutIterator}
@@ -41,10 +41,9 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.lang.{Long => JLong}
 import java.net.URI
-import java.util.{ArrayList => JArrayList}
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap, Map => JMap}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
 
@@ -53,57 +52,47 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
    *
    * @return
    */
-  override def genFilePartition(
-      index: Int,
-      partitions: Seq[InputPartition],
-      partitionSchemas: Seq[StructType],
-      fileFormats: Seq[ReadFileFormat],
-      wsCxt: WholeStageTransformContext): BaseGlutenPartition = {
-    val localFilesNodesWithLocations = partitions.indices.map(
-      i =>
-        partitions(i) match {
-          case p: GlutenMergeTreePartition =>
-            (
-              ExtensionTableBuilder
-                .makeExtensionTable(p.minParts, p.maxParts, p.database, p.table, p.tablePath),
-              SoftAffinityUtil.getNativeMergeTreePartitionLocations(p))
-          case f: FilePartition =>
-            val paths = new JArrayList[String]()
-            val starts = new JArrayList[JLong]()
-            val lengths = new JArrayList[JLong]()
-            val partitionColumns = mutable.ArrayBuffer.empty[Map[String, String]]
-            f.files.foreach {
-              file =>
-                paths.add(new URI(file.filePath).toASCIIString)
-                starts.add(JLong.valueOf(file.start))
-                lengths.add(JLong.valueOf(file.length))
-                // TODO: Support custom partition location
-                val partitionColumn = mutable.Map.empty[String, String]
-                partitionColumns.append(partitionColumn.toMap)
-            }
-            (
-              LocalFilesBuilder.makeLocalFiles(
-                f.index,
-                paths,
-                starts,
-                lengths,
-                partitionColumns.map(_.asJava).asJava,
-                fileFormats(i)),
-              SoftAffinityUtil.getFilePartitionLocations(f))
-          case _ =>
-            throw new UnsupportedOperationException(s"Unsupported input partition.")
-        })
-    wsCxt.substraitContext.initLocalFilesNodesIndex(0)
-    wsCxt.substraitContext.setLocalFilesNodes(localFilesNodesWithLocations.map(_._1))
-    val substraitPlan = wsCxt.root.toProtobuf
-    if (index == 0) {
-      logOnLevel(
-        GlutenConfig.getConf.substraitPlanLogLevel,
-        s"The substrait plan for partition $index:\n${SubstraitPlanPrinterUtil
-            .substraitPlanToJson(substraitPlan)}"
-      )
+  override def genReadSplit(
+      partition: InputPartition,
+      partitionSchemas: StructType,
+      fileFormat: ReadFileFormat): ReadSplit = {
+    partition match {
+      case p: GlutenMergeTreePartition =>
+        ExtensionTableBuilder
+          .makeExtensionTable(
+            p.minParts,
+            p.maxParts,
+            p.database,
+            p.table,
+            p.tablePath,
+            SoftAffinityUtil.getNativeMergeTreePartitionLocations(p).toList.asJava)
+      case f: FilePartition =>
+        val paths = new JArrayList[String]()
+        val starts = new JArrayList[JLong]()
+        val lengths = new JArrayList[JLong]()
+        val partitionColumns = new JArrayList[JMap[String, String]]
+        f.files.foreach {
+          file =>
+            paths.add(new URI(file.filePath).toASCIIString)
+            starts.add(JLong.valueOf(file.start))
+            lengths.add(JLong.valueOf(file.length))
+            // TODO: Support custom partition location
+            val partitionColumn = new JHashMap[String, String]()
+            partitionColumns.add(partitionColumn)
+        }
+        val preferredLocations =
+          SoftAffinityUtil.getFilePartitionLocations(paths.asScala.toArray, f.preferredLocations())
+        LocalFilesBuilder.makeLocalFiles(
+          f.index,
+          paths,
+          starts,
+          lengths,
+          partitionColumns,
+          fileFormat,
+          preferredLocations.toList.asJava)
+      case _ =>
+        throw new UnsupportedOperationException(s"Unsupported input partition.")
     }
-    GlutenPartition(index, substraitPlan.toByteArray, localFilesNodesWithLocations.head._2)
   }
 
   /**
@@ -244,17 +233,28 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
   override def genNativeFileScanRDD(
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
-      fileFormat: ReadFileFormat,
-      inputPartitions: Seq[InputPartition],
+      readSplits: Seq[ReadSplit],
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch] = {
     val substraitPlanPartition = GlutenTimeMetric.withMillisTime {
-      // generate each partition of all scan exec
-      inputPartitions.indices.map(
-        i => {
-          genFilePartition(i, Seq(inputPartitions(i)), null, Seq(fileFormat), wsCxt)
-        })
+      readSplits.zipWithIndex.map {
+        case (readSplit, index) =>
+          wsCxt.substraitContext.initReadSplitsIndex(0)
+          wsCxt.substraitContext.setReadSplits(Seq(readSplit))
+          val substraitPlan = wsCxt.root.toProtobuf
+          if (index == 0) {
+            logOnLevel(
+              GlutenConfig.getConf.substraitPlanLogLevel,
+              s"The substrait plan for partition $index:\n${SubstraitPlanPrinterUtil
+                  .substraitPlanToJson(substraitPlan)}"
+            )
+          }
+          GlutenPartition(
+            index,
+            substraitPlan.toByteArray,
+            readSplit.preferredLocations().asScala.toArray)
+      }
     }(t => logInfo(s"Generating the Substrait plan took: $t ms."))
 
     new NativeFileScanColumnarRDD(

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
@@ -246,7 +246,7 @@ case class ClickHouseAppendDataExec(
           database,
           tableName,
           tablePath)
-        dllCxt.substraitContext.setReadSplits(Seq(localFilesNode))
+        dllCxt.substraitContext.setSplitInfos(Seq(localFilesNode))
         dllCxt.substraitContext.setInsertOutputNode(insertOutputNode)
         val substraitPlan = dllCxt.root.toProtobuf
         logWarning(dllCxt.root.toProtobuf.toString)

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ClickHouseAppendDataExec.scala
@@ -239,13 +239,14 @@ case class ClickHouseAppendDataExec(
               starts,
               lengths,
               partitionColumns.map(_.asJava).asJava,
-              ReadFileFormat.UnknownFormat)
+              ReadFileFormat.UnknownFormat,
+              List.empty.asJava)
         val insertOutputNode = InsertOutputBuilder.makeInsertOutputNode(
           SnowflakeIdWorker.getInstance().nextId(),
           database,
           tableName,
           tablePath)
-        dllCxt.substraitContext.setLocalFilesNodes(Seq(localFilesNode))
+        dllCxt.substraitContext.setReadSplits(Seq(localFilesNode))
         dllCxt.substraitContext.setInsertOutputNode(insertOutputNode)
         val substraitPlan = dllCxt.root.toProtobuf
         logWarning(dllCxt.root.toProtobuf.toString)

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
@@ -115,7 +115,7 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
     val nativeFileScanRDD = BackendsApiManager.getIteratorApiInstance.genNativeFileScanRDD(
       spark.sparkContext,
       WholeStageTransformContext(planNode, substraitContext),
-      chFileScan.getReadSplits,
+      chFileScan.getSplitInfos,
       numOutputRows,
       numOutputVectors,
       scanTime

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
@@ -115,8 +115,7 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
     val nativeFileScanRDD = BackendsApiManager.getIteratorApiInstance.genNativeFileScanRDD(
       spark.sparkContext,
       WholeStageTransformContext(planNode, substraitContext),
-      fileFormat,
-      filePartitions,
+      chFileScan.getReadSplits,
       numOutputRows,
       numOutputVectors,
       scanTime

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -21,7 +21,7 @@ import io.glutenproject.backendsapi.IteratorApi
 import io.glutenproject.execution._
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
-import io.glutenproject.substrait.rel.{LocalFilesBuilder, ReadSplit}
+import io.glutenproject.substrait.rel.{LocalFilesBuilder, SplitInfo}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.utils.Iterators
 import io.glutenproject.vectorized._
@@ -58,10 +58,10 @@ class IteratorApiImpl extends IteratorApi with Logging {
    *
    * @return
    */
-  override def genReadSplit(
+  override def genSplitInfo(
       partition: InputPartition,
       partitionSchemas: StructType,
-      fileFormat: ReadFileFormat): ReadSplit = {
+      fileFormat: ReadFileFormat): SplitInfo = {
     partition match {
       case f: FilePartition =>
         val (paths, starts, lengths, partitionColumns) =
@@ -200,7 +200,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
   override def genNativeFileScanRDD(
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
-      readSplits: Seq[ReadSplit],
+      splitInfos: Seq[SplitInfo],
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch] = {

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -76,6 +76,8 @@ class IteratorApiImpl extends IteratorApi with Logging {
           partitionColumns,
           fileFormat,
           preferredLocations.toList.asJava)
+      case _ =>
+        throw new UnsupportedOperationException(s"Unsupported input partition.")
     }
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -21,7 +21,7 @@ import io.glutenproject.backendsapi.IteratorApi
 import io.glutenproject.execution._
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
-import io.glutenproject.substrait.rel.LocalFilesBuilder
+import io.glutenproject.substrait.rel.{LocalFilesBuilder, ReadSplit}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.utils.Iterators
 import io.glutenproject.vectorized._
@@ -46,11 +46,10 @@ import java.lang.{Long => JLong}
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.time.ZoneOffset
-import java.util.{ArrayList => JArrayList}
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap, Map => JMap}
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 class IteratorApiImpl extends IteratorApi with Logging {
 
@@ -59,71 +58,61 @@ class IteratorApiImpl extends IteratorApi with Logging {
    *
    * @return
    */
-  override def genFilePartition(
-      index: Int,
-      partitions: Seq[InputPartition],
-      partitionSchemas: Seq[StructType],
-      fileFormats: Seq[ReadFileFormat],
-      wsCxt: WholeStageTransformContext): BaseGlutenPartition = {
-
-    def constructSplitInfo(schema: StructType, files: Array[PartitionedFile]) = {
-      val paths = mutable.ArrayBuffer.empty[String]
-      val starts = mutable.ArrayBuffer.empty[JLong]
-      val lengths = mutable.ArrayBuffer.empty[JLong]
-      val partitionColumns = mutable.ArrayBuffer.empty[Map[String, String]]
-      files.foreach {
-        file =>
-          paths.append(URLDecoder.decode(file.filePath.toString, StandardCharsets.UTF_8.name()))
-          starts.append(JLong.valueOf(file.start))
-          lengths.append(JLong.valueOf(file.length))
-
-          val partitionColumn = mutable.Map.empty[String, String]
-          for (i <- 0 until file.partitionValues.numFields) {
-            val partitionColumnValue = if (file.partitionValues.isNullAt(i)) {
-              ExternalCatalogUtils.DEFAULT_PARTITION_NAME
-            } else {
-              val pn = file.partitionValues.get(i, schema.fields(i).dataType)
-              schema.fields(i).dataType match {
-                case _: BinaryType =>
-                  new String(pn.asInstanceOf[Array[Byte]], StandardCharsets.UTF_8)
-                case _: DateType =>
-                  DateFormatter.apply().format(pn.asInstanceOf[Integer])
-                case _: TimestampType =>
-                  TimestampFormatter
-                    .getFractionFormatter(ZoneOffset.UTC)
-                    .format(pn.asInstanceOf[JLong])
-                case _ => pn.toString
-              }
-            }
-            partitionColumn.put(schema.names(i), partitionColumnValue)
-          }
-          partitionColumns.append(partitionColumn.toMap)
-      }
-      (paths, starts, lengths, partitionColumns)
+  override def genReadSplit(
+      partition: InputPartition,
+      partitionSchemas: StructType,
+      fileFormat: ReadFileFormat): ReadSplit = {
+    partition match {
+      case f: FilePartition =>
+        val (paths, starts, lengths, partitionColumns) =
+          constructSplitInfo(partitionSchemas, f.files)
+        val preferredLocations =
+          SoftAffinityUtil.getFilePartitionLocations(paths.asScala.toArray, f.preferredLocations())
+        LocalFilesBuilder.makeLocalFiles(
+          f.index,
+          paths,
+          starts,
+          lengths,
+          partitionColumns,
+          fileFormat,
+          preferredLocations.toList.asJava)
     }
+  }
 
-    val localFilesNodesWithLocations = partitions.indices.map(
-      i =>
-        partitions(i) match {
-          case f: FilePartition =>
-            val fileFormat = fileFormats(i)
-            val partitionSchema = partitionSchemas(i)
-            val (paths, starts, lengths, partitionColumns) =
-              constructSplitInfo(partitionSchema, f.files)
-            (
-              LocalFilesBuilder.makeLocalFiles(
-                f.index,
-                paths.asJava,
-                starts.asJava,
-                lengths.asJava,
-                partitionColumns.map(_.asJava).asJava,
-                fileFormat),
-              SoftAffinityUtil.getFilePartitionLocations(f))
-        })
-    wsCxt.substraitContext.initLocalFilesNodesIndex(0)
-    wsCxt.substraitContext.setLocalFilesNodes(localFilesNodesWithLocations.map(_._1))
-    val substraitPlan = wsCxt.root.toProtobuf
-    GlutenPartition(index, substraitPlan.toByteArray, localFilesNodesWithLocations.head._2)
+  private def constructSplitInfo(schema: StructType, files: Array[PartitionedFile]) = {
+    val paths = new JArrayList[String]()
+    val starts = new JArrayList[JLong]
+    val lengths = new JArrayList[JLong]()
+    val partitionColumns = new JArrayList[JMap[String, String]]
+    files.foreach {
+      file =>
+        paths.add(URLDecoder.decode(file.filePath.toString, StandardCharsets.UTF_8.name()))
+        starts.add(JLong.valueOf(file.start))
+        lengths.add(JLong.valueOf(file.length))
+
+        val partitionColumn = new JHashMap[String, String]()
+        for (i <- 0 until file.partitionValues.numFields) {
+          val partitionColumnValue = if (file.partitionValues.isNullAt(i)) {
+            ExternalCatalogUtils.DEFAULT_PARTITION_NAME
+          } else {
+            val pn = file.partitionValues.get(i, schema.fields(i).dataType)
+            schema.fields(i).dataType match {
+              case _: BinaryType =>
+                new String(pn.asInstanceOf[Array[Byte]], StandardCharsets.UTF_8)
+              case _: DateType =>
+                DateFormatter.apply().format(pn.asInstanceOf[Integer])
+              case _: TimestampType =>
+                TimestampFormatter
+                  .getFractionFormatter(ZoneOffset.UTC)
+                  .format(pn.asInstanceOf[java.lang.Long])
+              case _ => pn.toString
+            }
+          }
+          partitionColumn.put(schema.names(i), partitionColumnValue)
+        }
+        partitionColumns.add(partitionColumn)
+    }
+    (paths, starts, lengths, partitionColumns)
   }
 
   /**
@@ -211,8 +200,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
   override def genNativeFileScanRDD(
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
-      fileFormat: ReadFileFormat,
-      inputPartitions: Seq[InputPartition],
+      readSplits: Seq[ReadSplit],
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch] = {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
@@ -23,7 +23,7 @@ import io.substrait.proto.ReadRel;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExtensionTableNode implements ReadSplit {
+public class ExtensionTableNode implements SplitInfo {
   private static final String MERGE_TREE = "MergeTree;";
   private Long minPartsNum;
   private Long maxPartsNum;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
@@ -21,23 +21,32 @@ import com.google.protobuf.StringValue;
 import io.substrait.proto.ReadRel;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
-public class ExtensionTableNode implements Serializable {
+public class ExtensionTableNode implements ReadSplit, Serializable {
   private static final String MERGE_TREE = "MergeTree;";
   private Long minPartsNum;
   private Long maxPartsNum;
-  private String database = null;
-  private String tableName = null;
-  private String relativePath = null;
+  private String database;
+  private String tableName;
+  private String relativePath;
   private StringBuffer extensionTableStr = new StringBuffer(MERGE_TREE);
+  private final List<String> preferredLocations = new ArrayList<>();
 
   ExtensionTableNode(
-      Long minPartsNum, Long maxPartsNum, String database, String tableName, String relativePath) {
+      Long minPartsNum,
+      Long maxPartsNum,
+      String database,
+      String tableName,
+      String relativePath,
+      List<String> preferredLocations) {
     this.minPartsNum = minPartsNum;
     this.maxPartsNum = maxPartsNum;
     this.database = database;
     this.tableName = tableName;
     this.relativePath = relativePath;
+    this.preferredLocations.addAll(preferredLocations);
     // MergeTree;{database}\n{table}\n{relative_path}\n{min_part}\n{max_part}\n
     extensionTableStr
         .append(database)
@@ -50,6 +59,11 @@ public class ExtensionTableNode implements Serializable {
         .append("\n")
         .append(this.maxPartsNum)
         .append("\n");
+  }
+
+  @Override
+  public List<String> preferredLocations() {
+    return this.preferredLocations;
   }
 
   public ReadRel.ExtensionTable toProtobuf() {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ExtensionTableNode.java
@@ -20,11 +20,10 @@ import com.google.protobuf.Any;
 import com.google.protobuf.StringValue;
 import io.substrait.proto.ReadRel;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExtensionTableNode implements ReadSplit, Serializable {
+public class ExtensionTableNode implements ReadSplit {
   private static final String MERGE_TREE = "MergeTree;";
   private Long minPartsNum;
   private Long maxPartsNum;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesBuilder.java
@@ -28,8 +28,10 @@ public class LocalFilesBuilder {
       List<Long> starts,
       List<Long> lengths,
       List<Map<String, String>> partitionColumns,
-      LocalFilesNode.ReadFileFormat fileFormat) {
-    return new LocalFilesNode(index, paths, starts, lengths, partitionColumns, fileFormat);
+      LocalFilesNode.ReadFileFormat fileFormat,
+      List<String> preferredLocations) {
+    return new LocalFilesNode(
+        index, paths, starts, lengths, partitionColumns, fileFormat, preferredLocations);
   }
 
   public static LocalFilesNode makeLocalFiles(String iterPath) {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -30,12 +30,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class LocalFilesNode implements Serializable {
+public class LocalFilesNode implements ReadSplit, Serializable {
   private final Integer index;
   private final List<String> paths = new ArrayList<>();
   private final List<Long> starts = new ArrayList<>();
   private final List<Long> lengths = new ArrayList<>();
   private final List<Map<String, String>> partitionColumns = new ArrayList<>();
+  private final List<String> preferredLocations = new ArrayList<>();
 
   // The format of file to read.
   public enum ReadFileFormat {
@@ -60,13 +61,15 @@ public class LocalFilesNode implements Serializable {
       List<Long> starts,
       List<Long> lengths,
       List<Map<String, String>> partitionColumns,
-      ReadFileFormat fileFormat) {
+      ReadFileFormat fileFormat,
+      List<String> preferredLocations) {
     this.index = index;
     this.paths.addAll(paths);
     this.starts.addAll(starts);
     this.lengths.addAll(lengths);
     this.fileFormat = fileFormat;
     this.partitionColumns.addAll(partitionColumns);
+    this.preferredLocations.addAll(preferredLocations);
   }
 
   LocalFilesNode(String iterPath) {
@@ -96,6 +99,11 @@ public class LocalFilesNode implements Serializable {
 
   public void setFileReadProperties(Map<String, String> fileReadProperties) {
     this.fileReadProperties = fileReadProperties;
+  }
+
+  @Override
+  public List<String> preferredLocations() {
+    return this.preferredLocations;
   }
 
   public ReadRel.LocalFiles toProtobuf() {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class LocalFilesNode implements ReadSplit {
+public class LocalFilesNode implements SplitInfo {
   private final Integer index;
   private final List<String> paths = new ArrayList<>();
   private final List<Long> starts = new ArrayList<>();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -25,12 +25,11 @@ import io.substrait.proto.Type;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class LocalFilesNode implements ReadSplit, Serializable {
+public class LocalFilesNode implements ReadSplit {
   private final Integer index;
   private final List<String> paths = new ArrayList<>();
   private final List<Long> starts = new ArrayList<>();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -132,17 +132,17 @@ public class ReadRelNode implements RelNode, Serializable {
         filesNode.setFileReadProperties(properties);
       }
       readBuilder.setLocalFiles(filesNode.toProtobuf());
-    } else if (context.getReadSplits() != null && !context.getReadSplits().isEmpty()) {
-      ReadSplit currentReadSplit = context.getCurrentReadSplit();
-      if (currentReadSplit instanceof LocalFilesNode) {
-        LocalFilesNode filesNode = (LocalFilesNode) currentReadSplit;
+    } else if (context.getSplitInfos() != null && !context.getSplitInfos().isEmpty()) {
+      SplitInfo currentSplitInfo = context.getCurrentSplitInfo();
+      if (currentSplitInfo instanceof LocalFilesNode) {
+        LocalFilesNode filesNode = (LocalFilesNode) currentSplitInfo;
         if (dataSchema != null) {
           filesNode.setFileSchema(dataSchema);
           filesNode.setFileReadProperties(properties);
         }
-        readBuilder.setLocalFiles(((LocalFilesNode) currentReadSplit).toProtobuf());
-      } else if (currentReadSplit instanceof ExtensionTableNode) {
-        readBuilder.setExtensionTable(((ExtensionTableNode) currentReadSplit).toProtobuf());
+        readBuilder.setLocalFiles(((LocalFilesNode) currentSplitInfo).toProtobuf());
+      } else if (currentSplitInfo instanceof ExtensionTableNode) {
+        readBuilder.setExtensionTable(((ExtensionTableNode) currentSplitInfo).toProtobuf());
       }
     }
     Rel.Builder builder = Rel.newBuilder();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -132,17 +132,17 @@ public class ReadRelNode implements RelNode, Serializable {
         filesNode.setFileReadProperties(properties);
       }
       readBuilder.setLocalFiles(filesNode.toProtobuf());
-    } else if (context.getLocalFilesNodes() != null && !context.getLocalFilesNodes().isEmpty()) {
-      Serializable currentLocalFileNode = context.getCurrentLocalFileNode();
-      if (currentLocalFileNode instanceof LocalFilesNode) {
-        LocalFilesNode filesNode = (LocalFilesNode) currentLocalFileNode;
+    } else if (context.getReadSplits() != null && !context.getReadSplits().isEmpty()) {
+      ReadSplit currentReadSplit = context.getCurrentReadSplit();
+      if (currentReadSplit instanceof LocalFilesNode) {
+        LocalFilesNode filesNode = (LocalFilesNode) currentReadSplit;
         if (dataSchema != null) {
           filesNode.setFileSchema(dataSchema);
           filesNode.setFileReadProperties(properties);
         }
-        readBuilder.setLocalFiles(((LocalFilesNode) currentLocalFileNode).toProtobuf());
-      } else if (currentLocalFileNode instanceof ExtensionTableNode) {
-        readBuilder.setExtensionTable(((ExtensionTableNode) currentLocalFileNode).toProtobuf());
+        readBuilder.setLocalFiles(((LocalFilesNode) currentReadSplit).toProtobuf());
+      } else if (currentReadSplit instanceof ExtensionTableNode) {
+        readBuilder.setExtensionTable(((ExtensionTableNode) currentReadSplit).toProtobuf());
       }
     }
     Rel.Builder builder = Rel.newBuilder();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadSplit.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadSplit.java
@@ -16,19 +16,12 @@
  */
 package io.glutenproject.substrait.rel;
 
+import com.google.protobuf.MessageOrBuilder;
+
 import java.util.List;
 
-public class ExtensionTableBuilder {
-  private ExtensionTableBuilder() {}
+public interface ReadSplit {
+  List<String> preferredLocations();
 
-  public static ExtensionTableNode makeExtensionTable(
-      Long minPartsNum,
-      Long maxPartsNum,
-      String database,
-      String tableName,
-      String relativePath,
-      List<String> preferredLocations) {
-    return new ExtensionTableNode(
-        minPartsNum, maxPartsNum, database, tableName, relativePath, preferredLocations);
-  }
+  MessageOrBuilder toProtobuf();
 }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadSplit.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadSplit.java
@@ -18,9 +18,16 @@ package io.glutenproject.substrait.rel;
 
 import com.google.protobuf.MessageOrBuilder;
 
+import java.io.Serializable;
 import java.util.List;
 
-public interface ReadSplit {
+/**
+ * A serializable representation of a read split for native engine, including the file path and
+ * other information of the scan table. It is returned by {@link
+ * io.glutenproject.execution.BasicScanExecTransformer#getReadSplits()}.
+ */
+public interface ReadSplit extends Serializable {
+  /** The preferred locations where the table files returned by this read split can run faster. */
   List<String> preferredLocations();
 
   MessageOrBuilder toProtobuf();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/SplitInfo.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/SplitInfo.java
@@ -24,9 +24,9 @@ import java.util.List;
 /**
  * A serializable representation of a read split for native engine, including the file path and
  * other information of the scan table. It is returned by {@link
- * io.glutenproject.execution.BasicScanExecTransformer#getReadSplits()}.
+ * io.glutenproject.execution.BasicScanExecTransformer#getSplitInfos()}.
  */
-public interface ReadSplit extends Serializable {
+public interface SplitInfo extends Serializable {
   /** The preferred locations where the table files returned by this read split can run faster. */
   List<String> preferredLocations();
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
@@ -21,6 +21,7 @@ import io.glutenproject.execution.{BaseGlutenPartition, BroadCastHashJoinContext
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+import io.glutenproject.substrait.rel.ReadSplit
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
@@ -38,12 +39,10 @@ trait IteratorApi {
    *
    * @return
    */
-  def genFilePartition(
-      index: Int,
-      partitions: Seq[InputPartition],
-      partitionSchema: Seq[StructType],
-      fileFormats: Seq[ReadFileFormat],
-      wsCxt: WholeStageTransformContext): BaseGlutenPartition
+  def genReadSplit(
+      partition: InputPartition,
+      partitionSchemas: StructType,
+      fileFormat: ReadFileFormat): ReadSplit
 
   /**
    * Generate Iterator[ColumnarBatch] for first stage. ("first" means it does not depend on other
@@ -82,8 +81,7 @@ trait IteratorApi {
   def genNativeFileScanRDD(
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
-      fileFormat: ReadFileFormat,
-      inputPartitions: Seq[InputPartition],
+      readSplits: Seq[ReadSplit],
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch]

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
@@ -21,7 +21,7 @@ import io.glutenproject.execution.{BaseGlutenPartition, BroadCastHashJoinContext
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.substrait.rel.ReadSplit
+import io.glutenproject.substrait.rel.SplitInfo
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
@@ -39,10 +39,10 @@ trait IteratorApi {
    *
    * @return
    */
-  def genReadSplit(
+  def genSplitInfo(
       partition: InputPartition,
       partitionSchemas: StructType,
-      fileFormat: ReadFileFormat): ReadSplit
+      fileFormat: ReadFileFormat): SplitInfo
 
   /**
    * Generate Iterator[ColumnarBatch] for first stage. ("first" means it does not depend on other
@@ -81,7 +81,7 @@ trait IteratorApi {
   def genNativeFileScanRDD(
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
-      readSplits: Seq[ReadSplit],
+      splitInfos: Seq[SplitInfo],
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch]

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -22,7 +22,7 @@ import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.`type`.ColumnTypeNode
 import io.glutenproject.substrait.{SubstraitContext, SupportFormat}
 import io.glutenproject.substrait.plan.PlanBuilder
-import io.glutenproject.substrait.rel.{ReadRelNode, SplitInfo, RelBuilder}
+import io.glutenproject.substrait.rel.{ReadRelNode, RelBuilder, SplitInfo}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -256,7 +256,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
             GlutenPartition(
               index,
               substraitPlan.toByteArray,
-              splitInfos.flatMap(_.preferredLocations().asScala).distinct.toArray)
+              splitInfos.flatMap(_.preferredLocations().asScala).toArray)
         }
         (wsCxt, substraitPlanPartitions)
       }(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -256,7 +256,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
             GlutenPartition(
               index,
               substraitPlan.toByteArray,
-              splitInfos.head.preferredLocations().asScala.toArray)
+              splitInfos.flatMap(_.preferredLocations().asScala).distinct.toArray)
         }
         (wsCxt, substraitPlanPartitions)
       }(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -25,7 +25,7 @@ import io.glutenproject.metrics.{GlutenTimeMetric, MetricsUpdater, NoopMetricsUp
 import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.plan.{PlanBuilder, PlanNode}
-import io.glutenproject.substrait.rel.{SplitInfo, RelNode}
+import io.glutenproject.substrait.rel.{RelNode, SplitInfo}
 import io.glutenproject.utils.SubstraitPlanPrinterUtil
 
 import org.apache.spark.{Dependency, OneToOneDependency, Partition, SparkConf, TaskContext}

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.substrait
 
 import io.glutenproject.substrait.ddlplan.InsertOutputNode
-import io.glutenproject.substrait.rel.LocalFilesNode
+import io.glutenproject.substrait.rel.{LocalFilesNode, ReadSplit}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import java.lang.{Integer => JInt, Long => JLong}
@@ -80,8 +80,8 @@ class SubstraitContext extends Serializable {
   // A map stores the relationship between aggregation operator id and its param.
   private val aggregationParamsMap = new JHashMap[JLong, AggregationParams]()
 
-  private var localFilesNodesIndex: JInt = 0
-  private var localFilesNodes: Seq[java.io.Serializable] = _
+  private var readSplitsIndex: JInt = 0
+  private var readSplits: Seq[ReadSplit] = _
   private var iteratorIndex: JLong = 0L
   private var fileFormat: JList[ReadFileFormat] = new JArrayList[ReadFileFormat]()
   private var insertOutputNode: InsertOutputNode = _
@@ -95,28 +95,28 @@ class SubstraitContext extends Serializable {
     iteratorNodes.put(index, localFilesNode)
   }
 
-  def initLocalFilesNodesIndex(localFilesNodesIndex: JInt): Unit = {
-    this.localFilesNodesIndex = localFilesNodesIndex
+  def initReadSplitsIndex(readSplitsIndex: JInt): Unit = {
+    this.readSplitsIndex = readSplitsIndex
   }
 
-  def getLocalFilesNodes: Seq[java.io.Serializable] = localFilesNodes
+  def getReadSplits: Seq[ReadSplit] = readSplits
 
   // FIXME Hongze 22/11/28
   // This makes calls to ReadRelNode#toProtobuf non-idempotent which doesn't seem to be
   // optimal in regard to the method name "toProtobuf".
-  def getCurrentLocalFileNode: java.io.Serializable = {
-    if (getLocalFilesNodes != null && getLocalFilesNodes.size > localFilesNodesIndex) {
-      val res = getLocalFilesNodes(localFilesNodesIndex)
-      localFilesNodesIndex += 1
+  def getCurrentReadSplit: ReadSplit = {
+    if (getReadSplits != null && getReadSplits.size > readSplitsIndex) {
+      val res = getReadSplits(readSplitsIndex)
+      readSplitsIndex += 1
       res
     } else {
       throw new IllegalStateException(
-        s"LocalFilesNodes index $localFilesNodesIndex exceeds the size of the LocalFilesNodes.")
+        s"LocalFilesNodes index $readSplitsIndex exceeds the size of the LocalFilesNodes.")
     }
   }
 
-  def setLocalFilesNodes(localFilesNodes: Seq[java.io.Serializable]): Unit = {
-    this.localFilesNodes = localFilesNodes
+  def setReadSplits(readSplits: Seq[ReadSplit]): Unit = {
+    this.readSplits = readSplits
   }
 
   def getInputIteratorNode(index: JLong): LocalFilesNode = {

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.substrait
 
 import io.glutenproject.substrait.ddlplan.InsertOutputNode
-import io.glutenproject.substrait.rel.{LocalFilesNode, ReadSplit}
+import io.glutenproject.substrait.rel.{LocalFilesNode, SplitInfo}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import java.lang.{Integer => JInt, Long => JLong}
@@ -80,8 +80,8 @@ class SubstraitContext extends Serializable {
   // A map stores the relationship between aggregation operator id and its param.
   private val aggregationParamsMap = new JHashMap[JLong, AggregationParams]()
 
-  private var readSplitsIndex: JInt = 0
-  private var readSplits: Seq[ReadSplit] = _
+  private var splitInfosIndex: JInt = 0
+  private var splitInfos: Seq[SplitInfo] = _
   private var iteratorIndex: JLong = 0L
   private var fileFormat: JList[ReadFileFormat] = new JArrayList[ReadFileFormat]()
   private var insertOutputNode: InsertOutputNode = _
@@ -95,28 +95,28 @@ class SubstraitContext extends Serializable {
     iteratorNodes.put(index, localFilesNode)
   }
 
-  def initReadSplitsIndex(readSplitsIndex: JInt): Unit = {
-    this.readSplitsIndex = readSplitsIndex
+  def initSplitInfosIndex(splitInfosIndex: JInt): Unit = {
+    this.splitInfosIndex = splitInfosIndex
   }
 
-  def getReadSplits: Seq[ReadSplit] = readSplits
+  def getSplitInfos: Seq[SplitInfo] = splitInfos
 
   // FIXME Hongze 22/11/28
   // This makes calls to ReadRelNode#toProtobuf non-idempotent which doesn't seem to be
   // optimal in regard to the method name "toProtobuf".
-  def getCurrentReadSplit: ReadSplit = {
-    if (getReadSplits != null && getReadSplits.size > readSplitsIndex) {
-      val res = getReadSplits(readSplitsIndex)
-      readSplitsIndex += 1
+  def getCurrentSplitInfo: SplitInfo = {
+    if (getSplitInfos != null && getSplitInfos.size > splitInfosIndex) {
+      val res = getSplitInfos(splitInfosIndex)
+      splitInfosIndex += 1
       res
     } else {
       throw new IllegalStateException(
-        s"LocalFilesNodes index $readSplitsIndex exceeds the size of the LocalFilesNodes.")
+        s"LocalFilesNodes index $splitInfosIndex exceeds the size of the LocalFilesNodes.")
     }
   }
 
-  def setReadSplits(readSplits: Seq[ReadSplit]): Unit = {
-    this.readSplits = readSplits
+  def setSplitInfos(SplitInfos: Seq[SplitInfo]): Unit = {
+    this.splitInfos = SplitInfos
   }
 
   def getInputIteratorNode(index: JLong): LocalFilesNode = {

--- a/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
@@ -60,7 +60,9 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       ).toArray
     )
 
-    val locations = SoftAffinityUtil.getFilePartitionLocations(partition)
+    val locations = SoftAffinityUtil.getFilePartitionLocations(
+      partition.files.map(_.filePath.toString),
+      partition.preferredLocations())
 
     val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
     assertResult(Set("host-1", "host-2", "host-3")) {
@@ -89,7 +91,9 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       ).toArray
     )
 
-    val locations = SoftAffinityUtil.getFilePartitionLocations(partition)
+    val locations = SoftAffinityUtil.getFilePartitionLocations(
+      partition.files.map(_.filePath.toString),
+      partition.preferredLocations())
 
     val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
 
@@ -119,7 +123,9 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       ).toArray
     )
 
-    val locations = SoftAffinityUtil.getFilePartitionLocations(partition)
+    val locations = SoftAffinityUtil.getFilePartitionLocations(
+      partition.files.map(_.filePath.toString),
+      partition.preferredLocations())
 
     val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
 
@@ -161,7 +167,9 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       ).toArray
     )
 
-    val locations = SoftAffinityUtil.getFilePartitionLocations(partition)
+    val locations = SoftAffinityUtil.getFilePartitionLocations(
+      partition.files.map(_.filePath.toString),
+      partition.preferredLocations())
 
     val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Lake format has its own custom partition type, with a processing logic that is different from the existing `FilePartition` and `GlutenMergeTreePartition`. In the unified design, the Lake format will have its own scan transformer. In order to ensure that the injection of the Lake format does not affect gluten-core, the process of generating `LocalFilesNode` from handling partitions needs to be moved to the scan transformer, allowing the Lake format's scan transformer to customize the processing logic of the partitions.

Introduce ReadSplit interface for ExtensionTableNode and LocalFileNode, so that we can get rid of using java.io.Serializable.

## How was this patch tested?

Exists CI.

