### PR TITLE
[GLUTEN-3654][VL]Fix the duplicated key exception in TopN

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/LimitTransformer.scala
@@ -56,7 +56,11 @@ case class LimitTransformer(child: SparkPlan, offset: Long, count: Long)
   override protected def doValidateInternal(): ValidationResult = {
     val context = new SubstraitContext
     val operatorId = context.nextOperatorId(this.nodeName)
-    val relNode = getRelNode(context, operatorId, offset, count, child.output, null, true)
+    val input = child match {
+      case c: TransformSupport => c.doTransform(context).root
+      case _ => null
+    }
+    val relNode = getRelNode(context, operatorId, offset, count, child.output, input, true)
 
     doNativeValidation(context, relNode)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The `TakeOrderedAndProjectExec `will be transformed into either a sort + limit or directly into a limit operation. If it is a sort + limit case, Velox will convert it into a `TopNNode`. Here, we need to do some validation on the `TopNNode`.

## How was this patch tested?

Pass Jenkins test