### PR TITLE
[GLUTEN-3625][FOLLOWUP] Always use the hardcode module name

### DIFF
--- a/gluten-ut/pom.xml
+++ b/gluten-ut/pom.xml
@@ -26,7 +26,6 @@
 
   <modules>
     <module>common</module>
-    <module>${spark.test.module}</module>
   </modules>
 
   <artifactId>gluten-ut</artifactId>
@@ -180,4 +179,25 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spark-3.2</id>
+      <modules>
+        <module>spark32</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>spark-3.3</id>
+      <modules>
+        <module>spark33</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>spark-3.4</id>
+      <modules>
+        <module>spark34</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <spark.major.version>3</spark.major.version>
     <sparkbundle.version>3.2</sparkbundle.version>
     <spark.shim.module>spark32</spark.shim.module>
-    <spark.test.module>spark32</spark.test.module>
     <spark.version>3.2.2</spark.version>
     <sparkshim.artifactId>spark-sql-columnar-shims-${spark.shim.module}</sparkshim.artifactId>
     <celeborn.version>0.3.0-incubating</celeborn.version>
@@ -109,7 +108,6 @@
       <properties>
         <sparkbundle.version>3.2</sparkbundle.version>
         <spark.shim.module>spark32</spark.shim.module>
-        <spark.test.module>spark32</spark.test.module>
         <spark.version>3.2.2</spark.version>
         <delta.version>2.0.1</delta.version>
         <delta.binary.version>20</delta.binary.version>
@@ -120,7 +118,6 @@
       <properties>
         <sparkbundle.version>3.3</sparkbundle.version>
         <spark.shim.module>spark33</spark.shim.module>
-        <spark.test.module>spark33</spark.test.module>
         <spark.version>3.3.1</spark.version>
         <delta.version>2.2.0</delta.version>
         <delta.binary.version>22</delta.binary.version>
@@ -131,7 +128,6 @@
       <properties>
         <sparkbundle.version>3.4</sparkbundle.version>
         <spark.shim.module>spark34</spark.shim.module>
-        <spark.test.module>spark34</spark.test.module>
         <spark.version>3.4.1</spark.version>
         <delta.version>2.2.0</delta.version>
         <delta.binary.version>22</delta.binary.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,8 @@
     <scala.version>2.12.15</scala.version>
     <spark.major.version>3</spark.major.version>
     <sparkbundle.version>3.2</sparkbundle.version>
-    <spark.shim.module>spark32</spark.shim.module>
     <spark.version>3.2.2</spark.version>
-    <sparkshim.artifactId>spark-sql-columnar-shims-${spark.shim.module}</sparkshim.artifactId>
+    <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
     <celeborn.version>0.3.0-incubating</celeborn.version>
     <arrow.version>12.0.0</arrow.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
@@ -107,7 +106,7 @@
       </activation>
       <properties>
         <sparkbundle.version>3.2</sparkbundle.version>
-        <spark.shim.module>spark32</spark.shim.module>
+        <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
         <spark.version>3.2.2</spark.version>
         <delta.version>2.0.1</delta.version>
         <delta.binary.version>20</delta.binary.version>
@@ -117,7 +116,7 @@
       <id>spark-3.3</id>
       <properties>
         <sparkbundle.version>3.3</sparkbundle.version>
-        <spark.shim.module>spark33</spark.shim.module>
+        <sparkshim.artifactId>spark-sql-columnar-shims-spark33</sparkshim.artifactId>
         <spark.version>3.3.1</spark.version>
         <delta.version>2.2.0</delta.version>
         <delta.binary.version>22</delta.binary.version>
@@ -127,7 +126,7 @@
       <id>spark-3.4</id>
       <properties>
         <sparkbundle.version>3.4</sparkbundle.version>
-        <spark.shim.module>spark34</spark.shim.module>
+        <sparkshim.artifactId>spark-sql-columnar-shims-spark34</sparkshim.artifactId>
         <spark.version>3.4.1</spark.version>
         <delta.version>2.2.0</delta.version>
         <delta.binary.version>22</delta.binary.version>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -30,7 +30,6 @@
 
   <modules>
     <module>common</module>
-    <module>${spark.shim.module}</module>
   </modules>
 
   <dependencies>
@@ -69,4 +68,25 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spark-3.2</id>
+      <modules>
+        <module>spark32</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>spark-3.3</id>
+      <modules>
+        <module>spark33</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>spark-3.4</id>
+      <modules>
+        <module>spark34</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this pr the follow cmd can not change the project version for sub-module. It seems the maven plugin compatibility is not very good for using property value module name. So this pr reverts the change and go back to use the profile to specify the sub-module to avoid potential issue.

```
mvn versions:set -DgenerateBackupPoms=false \
  -DnewVersion="1.0.x" \
  -Pspark-3.2,spark-3.3,spark-3.4 -Pbackends-velox -Pspark-ut -Prss
```

## How was this patch tested?

manully test
