### PR TITLE
[VL] Flush intermediate results when partial aggregation runs out of memory

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -172,6 +172,7 @@ VeloxMemoryManager::VeloxMemoryManager(
       velox::memory::MemoryAllocator::kMaxAlignment,
       velox::memory::kMaxMemory,
       velox::memory::kMaxMemory,
+      velox::memory::kDefaultGrowthQuantum,
       true, // memory usage tracking
       true, // leak check
       false, // debug

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -16,8 +16,8 @@
 
 set -exu
 
-VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=update
+VELOX_REPO=https://github.com/zhztheplayer/velox.git
+VELOX_BRANCH=wip-partial-flush
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
Velox dependency https://github.com/zhztheplayer/velox/commits/wip-partial-flush