### PR TITLE
[VL] Avoid shrinking the binary buffer which triggers spill

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -90,6 +90,16 @@ namespace gluten {
 enum SplitState { kInit, kPreAlloc, kSplit, kStop };
 enum EvictState { kEvictable, kUnevictable };
 
+struct BinaryArrayResizeState {
+  bool inResize;
+  uint32_t partitionId;
+  uint32_t binaryIdx;
+
+  BinaryArrayResizeState() : inResize(false) {}
+  BinaryArrayResizeState(uint32_t partitionId, uint32_t binaryIdx)
+      : inResize(false), partitionId(partitionId), binaryIdx(binaryIdx) {}
+};
+
 class VeloxShuffleWriter final : public ShuffleWriter {
   enum {
     kValidityBufferIndex = 0,
@@ -322,6 +332,8 @@ class VeloxShuffleWriter final : public ShuffleWriter {
   SplitState splitState_{kInit};
 
   EvictState evictState_{kEvictable};
+
+  BinaryArrayResizeState binaryArrayResizeState_{};
 
   bool supportAvx512_ = false;
 

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -110,15 +110,15 @@ class VeloxShuffleWriter final : public ShuffleWriter {
 
  public:
   struct BinaryBuf {
-    BinaryBuf(uint8_t* value, uint8_t* offset, uint64_t valueCapacityIn, uint64_t valueOffsetIn)
-        : valuePtr(value), offsetPtr(offset), valueCapacity(valueCapacityIn), valueOffset(valueOffsetIn) {}
+    BinaryBuf(uint8_t* value, uint8_t* length, uint64_t valueCapacityIn, uint64_t valueOffsetIn)
+        : valuePtr(value), lengthPtr(length), valueCapacity(valueCapacityIn), valueOffset(valueOffsetIn) {}
 
-    BinaryBuf(uint8_t* value, uint8_t* offset, uint64_t valueCapacity) : BinaryBuf(value, offset, valueCapacity, 0) {}
+    BinaryBuf(uint8_t* value, uint8_t* length, uint64_t valueCapacity) : BinaryBuf(value, length, valueCapacity, 0) {}
 
     BinaryBuf() : BinaryBuf(nullptr, nullptr, 0) {}
 
     uint8_t* valuePtr;
-    uint8_t* offsetPtr;
+    uint8_t* lengthPtr;
     uint64_t valueCapacity;
     uint64_t valueOffset;
   };

--- a/cpp/velox/utils/tests/MemoryPoolUtils.cc
+++ b/cpp/velox/utils/tests/MemoryPoolUtils.cc
@@ -133,15 +133,19 @@ arrow::Status SelfEvictedMemoryPool::evict(int64_t size) {
     int64_t actual;
     RETURN_NOT_OK(evictable_->evictFixedSize(size, &actual));
     if (size > capacity_ - pool_->bytes_allocated()) {
-      return arrow::Status::OutOfMemory(
-          "Failed to allocate after evict. Capacity: ",
-          capacity_,
-          ", Requested: ",
-          size,
-          ", Evicted: ",
-          actual,
-          ", Allocated: ",
-          pool_->bytes_allocated());
+      if (failIfOOM_) {
+        return arrow::Status::OutOfMemory(
+            "Failed to allocate after evict. Capacity: ",
+            capacity_,
+            ", Requested: ",
+            size,
+            ", Evicted: ",
+            actual,
+            ", Allocated: ",
+            pool_->bytes_allocated());
+      } else {
+        capacity_ = size + pool_->bytes_allocated();
+      }
     }
     bytesEvicted_ += actual;
   }

--- a/cpp/velox/utils/tests/MemoryPoolUtils.h
+++ b/cpp/velox/utils/tests/MemoryPoolUtils.h
@@ -59,7 +59,7 @@ class LimitedMemoryPool final : public arrow::MemoryPool {
  */
 class SelfEvictedMemoryPool : public arrow::MemoryPool {
  public:
-  explicit SelfEvictedMemoryPool(arrow::MemoryPool* pool) : pool_(pool) {}
+  explicit SelfEvictedMemoryPool(arrow::MemoryPool* pool, bool failIfOOM = true) : pool_(pool), failIfOOM_(failIfOOM) {}
 
   bool checkEvict(int64_t newCapacity, std::function<void()> block);
 
@@ -89,6 +89,8 @@ class SelfEvictedMemoryPool : public arrow::MemoryPool {
   arrow::Status evict(int64_t size);
 
   arrow::MemoryPool* pool_;
+  bool failIfOOM_;
+
   Evictable* evictable_;
   int64_t capacity_{std::numeric_limits<int64_t>::max()};
 


### PR DESCRIPTION
If spill is triggered by resizing binary partition buffer, should avoid shrinking itself during reclaiming memory from shrinking partition buffers. Because shrinking the buffer can possibly invalid the original underlying `ptr`.