### PR TITLE
[CORE] Fix ExpandExecTransformer miss input

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ExpandExecTransformer.scala
@@ -50,7 +50,10 @@ case class ExpandExecTransformer(
   @transient override lazy val metrics =
     BackendsApiManager.getMetricsApiInstance.genExpandTransformerMetrics(sparkContext)
 
-  val originalInputAttributes: Seq[Attribute] = child.output
+  @transient
+  override lazy val references: AttributeSet = {
+    AttributeSet.fromAttributeSets(projections.flatten.map(_.references))
+  }
 
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genExpandTransformerMetricsUpdater(metrics)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before this pr, the ExpandExecTransformer would miss input. It does not affect the result for now, but better to avoid potential issue in future.

<img width="415" alt="image" src="https://github.com/oap-project/gluten/assets/12025282/26e8d656-2675-4fbf-a42d-a2a1c32544ea">

## How was this patch tested?

Pass CI
