### PR TITLE
[CH-3667] Use `max_block_size` controller read mergetree block size

### DIFF
--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -367,7 +367,7 @@ DB::QueryPlanPtr SerializedPlanParser::parseMergeTreeTable(const substrait::Read
         query_context.storage_snapshot,
         *query_info,
         context,
-        4096 * 2,
+        context->getSettingsRef().max_block_size,
         1);
     QueryPlanPtr query = std::make_unique<QueryPlan>();
     steps.emplace_back(read_step.get());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `spark.gluten.sql.columnar.backend.ch.runtime_settings.max_block_size` controller read mergetree bolck size. Defalut is `DEFAULT_BLOCK_SIZE`=65409

(Fixes: \#3667)

## How was this patch tested?

Test by UT.