### PR TITLE
[GLUTEN-3668][CH] Performance regresses seriously after PR 3169 merge when executing convert string to date

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -2102,7 +2102,8 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     }
   }
 
-  test("GLUTEN-3135: Bug fix to_date") {
+  // ISSUE-3668, revert first
+  ignore("GLUTEN-3135: Bug fix to_date") {
     val create_table_sql =
       """
         | create table test_tbl_3135(id bigint, data string) using parquet


### PR DESCRIPTION
## What changes were proposed in this pull request?

PR #3169 add some functions to convert string to date, which leads to performance regression serious. Will be reverted first and raise another pr to fix the issue later.

Test case, 2000W records:
before PR #3169 : 3s
after PR #3169: 3.6m

Related PR: #3169, #3563;


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

