### PR TITLE
[VL] Fix: add validate check for Generate

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -18,7 +18,7 @@ package io.glutenproject.execution
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.execution.RDDScanExec
+import org.apache.spark.sql.execution.{GenerateExec, RDDScanExec}
 import org.apache.spark.sql.functions.{avg, col}
 import org.apache.spark.sql.types.{DecimalType, StringType, StructField, StructType}
 
@@ -563,9 +563,10 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
 
       // Testing unsupported case
       runQueryAndCompare("SELECT explode(from_json(cast(c1 as string),'ARRAY<STRING>')) from t;") {
-        df => {
-          getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
-        }
+        df =>
+          {
+            getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
+          }
       }
 
       // Testing unsupported case in case when
@@ -574,9 +575,10 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           |SELECT explode(case when size(from_json(cast(c1 as string),'ARRAY<STRING>')) > 0
           |then array(c1) else array(c2) end) from t;
           |""".stripMargin) {
-        df => {
-          getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
-        }
+        df =>
+          {
+            getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
+          }
       }
     }
   }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -552,7 +552,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  test("Add the missing Generate validation check") {
+  test("Validation should fail if unsupported expression is used for Generate.") {
     withTable("t") {
       spark
         .range(10)

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -565,7 +565,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("SELECT explode(from_json(cast(c1 as string),'ARRAY<STRING>')) from t;") {
         df =>
           {
-            getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
+            getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[GenerateExec]).isDefined)
           }
       }
 
@@ -577,7 +577,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
           |""".stripMargin) {
         df =>
           {
-            getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
+            getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[GenerateExec]).isDefined)
           }
       }
     }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -569,7 +569,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       runQueryAndCompare("SELECT explode(intToArray(c1)) from t;") {
         df =>
           {
-            getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
+            getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[GenerateExec]).isDefined)
           }
       }
 
@@ -580,7 +580,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
                            |""".stripMargin) {
         df =>
           {
-            getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))
+            getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[GenerateExec]).isDefined)
           }
       }
     }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -574,11 +574,10 @@ class TestOperator extends VeloxWholeStageTransformerSuite {
       }
 
       // Testing unsupported case in case when
-      runQueryAndCompare(
-        """
-          |SELECT explode(case when size(intToArray(c1)) > 0
-          |then array(c1) else array(c2) end) from t;
-          |""".stripMargin) {
+      runQueryAndCompare("""
+                           |SELECT explode(case when size(intToArray(c1)) > 0
+                           |then array(c1) else array(c2) end) from t;
+                           |""".stripMargin) {
         df =>
           {
             getExecutedPlan(df).exists(plan => plan.exists(_.isInstanceOf[GenerateExec]))

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -335,8 +335,7 @@ bool SubstraitToVeloxPlanValidator::validateIfThen(
     const ::substrait::Expression_IfThen& ifThen,
     const RowTypePtr& inputType) {
   for (const auto& ifThen : ifThen.ifs()) {
-    return validateExpression(ifThen.if_(), inputType) &&
-      validateExpression(ifThen.then(), inputType);
+    return validateExpression(ifThen.if_(), inputType) && validateExpression(ifThen.then(), inputType);
   }
 }
 
@@ -404,7 +403,6 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
 
   return true;
 }
-
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& generateRel) {
   if (generateRel.has_input() && !validate(generateRel.input())) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -41,6 +41,7 @@ static const std::unordered_set<std::string> kBlackList = {
     "split_part",
     "factorial",
     "concat_ws",
+    "from_json",
     "rand",
     "json_array_length",
     "from_unixtime",
@@ -330,6 +331,15 @@ bool SubstraitToVeloxPlanValidator::validateCast(
   return true;
 }
 
+bool SubstraitToVeloxPlanValidator::validateIfThen(
+    const ::substrait::Expression_IfThen& ifThen,
+    const RowTypePtr& inputType) {
+  for (const auto& ifThen : ifThen.ifs()) {
+    return validateExpression(ifThen.if_(), inputType) &&
+      validateExpression(ifThen.then(), inputType);
+  }
+}
+
 bool SubstraitToVeloxPlanValidator::validateExpression(
     const ::substrait::Expression& expression,
     const RowTypePtr& inputType) {
@@ -341,6 +351,8 @@ bool SubstraitToVeloxPlanValidator::validateExpression(
       return validateLiteral(expression.literal(), inputType);
     case ::substrait::Expression::RexTypeCase::kCast:
       return validateCast(expression.cast(), inputType);
+    case ::substrait::Expression::RexTypeCase::kIfThen:
+      return validateIfThen(expression.if_then(), inputType);
     default:
       return true;
   }
@@ -393,8 +405,45 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
   return true;
 }
 
+
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& generateRel) {
-  // TODO(yuan): add check
+  if (generateRel.has_input() && !validate(generateRel.input())) {
+    logValidateMsg("native validation failed due to: input validation fails in GenerateRel.");
+    return false;
+  }
+
+  // Get and validate the input types from extension.
+  if (!generateRel.has_advanced_extension()) {
+    logValidateMsg("native validation failed due to: Input types are expected in GenerateRel.");
+    return false;
+  }
+  const auto& extension = generateRel.advanced_extension();
+  std::vector<TypePtr> types;
+  if (!validateInputTypes(extension, types)) {
+    logValidateMsg("native validation failed due to: Validation failed for input types in GenerateRel.");
+    return false;
+  }
+
+  int32_t inputPlanNodeId = 0;
+  // Create the fake input names to be used in row type.
+  std::vector<std::string> names;
+  names.reserve(types.size());
+  for (uint32_t colIdx = 0; colIdx < types.size(); colIdx++) {
+    names.emplace_back(SubstraitParser::makeNodeName(inputPlanNodeId, colIdx));
+  }
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
+    logValidateMsg("native validation failed due to: input validation fails in GenerateRel.");
+    return false;
+  }
+
+  try {
+    planConverter_.toVeloxPlan(generateRel);
+  } catch (const VeloxException& err) {
+    logValidateMsg("native validation failed due to: in GenerateRel, " + err.message());
+    return false;
+  }
   return true;
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -436,13 +436,6 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
     logValidateMsg("native validation failed due to: input validation fails in GenerateRel.");
     return false;
   }
-
-  try {
-    planConverter_.toVeloxPlan(generateRel);
-  } catch (const VeloxException& err) {
-    logValidateMsg("native validation failed due to: in GenerateRel, " + err.message());
-    return false;
-  }
   return true;
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -337,6 +337,7 @@ bool SubstraitToVeloxPlanValidator::validateIfThen(
   for (const auto& ifThen : ifThen.ifs()) {
     return validateExpression(ifThen.if_(), inputType) && validateExpression(ifThen.then(), inputType);
   }
+  return true;
 }
 
 bool SubstraitToVeloxPlanValidator::validateExpression(

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -121,6 +121,9 @@ class SubstraitToVeloxPlanValidator {
   /// Validate Substrait literal.
   bool validateLiteral(const ::substrait::Expression_Literal& literal, const RowTypePtr& inputType);
 
+  /// Validate Substrait if-then expression.
+  bool validateIfThen(const ::substrait::Expression_IfThen& ifThen, const RowTypePtr& inputType);
+
   /// Add necessary log for fallback
   void logValidateMsg(const std::string& log) {
     validateLog_.emplace_back(log);

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -123,9 +123,7 @@ case class GenerateExecTransformer(
       readRel
     }
     val projRel =
-      if (
-        BackendsApiManager.getSettings.insertPostProjectForGenerate() && needsProjection(generator)
-      ) {
+      if (BackendsApiManager.getSettings.insertPostProjectForGenerate()) {
         // need to insert one projection node for velox backend
         val projectExpressions = new JArrayList[ExpressionNode]()
         val childOutputNodes = child.output.indices
@@ -158,10 +156,6 @@ case class GenerateExecTransformer(
       validation = false)
 
     TransformContext(child.output, output, relNode)
-  }
-
-  def needsProjection(generator: Generator): Boolean = {
-    !generator.asInstanceOf[Explode].child.isInstanceOf[AttributeReference]
   }
 
   def getRelNode(


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Fix the validate check for Generate operator while parsing substrait to velox;
2. Fix the missing validate check for ifthen, such as `select explode(case a is null then array('test') else array(a) end) from test_string`;
3. Fix the validate failed while passing a `Alias` to Generate, such as `select all, a from (select split(a, '2') as al, a from test_string) lateral view explode(al) as all;`;
4. [mirror] add `from_json` to black_list since it is not support now;

## How was this patch tested?
unit and manul tests

