### PR TITLE
[GLUTEN-3666][VL] Refine connector IO executor initialization

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -89,7 +89,7 @@ const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.IOT
 const std::string kVeloxIOThreadsDefault = "0";
 
 const std::string kVeloxSplitPreloadPerDriver = "spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver";
-const std::string kVeloxSplitPreloadPerDriverDefault = "2";
+const std::string kVeloxSplitPreloadPerDriverDefault = "0";
 
 // udf
 const std::string kVeloxUdfLibraryPaths = "spark.gluten.sql.columnar.backend.velox.udfLibraryPaths";
@@ -347,13 +347,10 @@ void VeloxBackend::initIOExecutor(const std::unordered_map<std::string, std::str
   int32_t splitPreloadPerDriver =
       std::stoi(getConfigValue(conf, kVeloxSplitPreloadPerDriver, kVeloxSplitPreloadPerDriverDefault));
   if (ioThreads > 0) {
-    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads);
+    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads, ioThreads);
     FLAGS_split_preload_per_driver = splitPreloadPerDriver;
-  }
-
-  if (splitPreloadPerDriver > 0 && ioThreads > 0) {
-    LOG(INFO) << "STARTUP: Using split preloading, Split preload per driver: " << splitPreloadPerDriver
-              << ", IO threads: " << ioThreads;
+    LOG(INFO) << "STARTUP: Initalize connector IO thread executor with " << ioThreads
+              << " threads, Split preload per driver: " << splitPreloadPerDriver;
   }
 }
 

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1018,7 +1018,7 @@ object GlutenConfig {
   val COLUMNAR_VELOX_CONNECTOR_IO_THREADS =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.IOThreads")
       .internal()
-      .doc("The IO threads for connector split preloading")
+      .doc("The IO threads of connector to preload split or prefetching")
       .intConf
       .createWithDefault(0)
 
@@ -1027,7 +1027,7 @@ object GlutenConfig {
       .internal()
       .doc("The split preload per task")
       .intConf
-      .createWithDefault(2)
+      .createWithDefault(0)
 
   val COLUMNAR_VELOX_GLOG_VERBOSE_LEVEL =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.glogVerboseLevel")


### PR DESCRIPTION
Change default value of spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver to 0, make startup message more clear.

(Fixes: \#3666)
