### PR TITLE
[CI] increase operations per run for stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,3 +28,4 @@ jobs:
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
           days-before-pr-stale: 45
           days-before-pr-close: 10
+          operations-per-run: 300


### PR DESCRIPTION
## What changes were proposed in this pull request?

follow up #3634 
Increase the operations per run to 300 

The default value is 30, which seems too small for gluten project

## How was this patch tested?

no tests required

