### PR TITLE
[GLUTEN-3668][CH]Fix to_date function performance

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -2227,5 +2227,28 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     compareResultsAgainstVanillaSpark(select_sql, true, { _ => })
     spark.sql("drop table test_tbl_3521")
   }
+
+  test("GLUTEN-3135 revert: Bug fix to_date") {
+    val create_table_sql =
+      """
+        | create table test_tbl_3135(id bigint, data string) using parquet
+        |""".stripMargin
+    val insert_data_sql =
+      """
+        |insert into test_tbl_3135 values
+        |(1, '2023-09-02 23:59:59.299+11'),
+        |(2, '2023-09-02 23:59:59.299-11'),
+        |(3, '2023-09-02 00:00:01.333+11'),
+        |(4, '2023-09-02 00:00:01.333-11'),
+        |(5, '  2023-09-02 agdfegfew'),
+        |(6, 'afe2023-09-02 11:22:33'),
+        |(7, '1970-01-01 00:00:00')
+        |""".stripMargin
+    spark.sql(create_table_sql)
+    spark.sql(insert_data_sql)
+    val select_sql = "select id, to_date(data) from test_tbl_3135"
+    compareResultsAgainstVanillaSpark(select_sql, true, { _ => })
+    spark.sql("drop table test_tbl_3135")
+  }
 }
 // scalastyle:on line.size.limit

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -2102,8 +2102,7 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     }
   }
 
-  // ISSUE-3668, revert first
-  ignore("GLUTEN-3135: Bug fix to_date") {
+  test("GLUTEN-3135: Bug fix to_date") {
     val create_table_sql =
       """
         | create table test_tbl_3135(id bigint, data string) using parquet
@@ -2228,27 +2227,5 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     spark.sql("drop table test_tbl_3521")
   }
 
-  test("GLUTEN-3135 revert: Bug fix to_date") {
-    val create_table_sql =
-      """
-        | create table test_tbl_3135(id bigint, data string) using parquet
-        |""".stripMargin
-    val insert_data_sql =
-      """
-        |insert into test_tbl_3135 values
-        |(1, '2023-09-02 23:59:59.299+11'),
-        |(2, '2023-09-02 23:59:59.299-11'),
-        |(3, '2023-09-02 00:00:01.333+11'),
-        |(4, '2023-09-02 00:00:01.333-11'),
-        |(5, '  2023-09-02 agdfegfew'),
-        |(6, 'afe2023-09-02 11:22:33'),
-        |(7, '1970-01-01 00:00:00')
-        |""".stripMargin
-    spark.sql(create_table_sql)
-    spark.sql(insert_data_sql)
-    val select_sql = "select id, to_date(data) from test_tbl_3135"
-    compareResultsAgainstVanillaSpark(select_sql, true, { _ => })
-    spark.sql("drop table test_tbl_3135")
-  }
 }
 // scalastyle:on line.size.limit

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Common/LocalDate.h>
+#include <Core/Field.h>
+#include <DataTypes/DataTypeDate32.h>
+#include <Functions/FunctionsConversion.h>
+#include <Functions/FunctionFactory.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadHelpers.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+}
+
+namespace local_engine
+{
+class SparkFunctionConvertToDate : public DB::FunctionToDate32OrNull
+{
+public:
+    static constexpr auto name = "spark_to_date";
+    static DB::FunctionPtr create(DB::ContextPtr) { return std::make_shared<SparkFunctionConvertToDate>(); }
+    SparkFunctionConvertToDate() = default;
+    ~SparkFunctionConvertToDate() override = default;
+    DB::String getName() const override { return name; }
+
+    bool checkDateFormat(DB::ReadBuffer & buf) const
+    {
+        auto checkNumbericASCII = [&](DB::ReadBuffer & rb, size_t start, size_t length) -> bool
+        {
+            for (size_t i = start; i < start + length; ++i)
+            {
+                if (!isNumericASCII(*(rb.position() + i)))
+                    return false;
+            }
+            return true;
+        };
+        auto checkDelimiter = [&](DB::ReadBuffer & rb, size_t pos) -> bool
+        {
+            if (*(rb.position() + pos) != '-')
+                return false;
+            else
+                return true;
+        };
+        auto checkMonthDay = [&](DB::ReadBuffer &rb) -> bool
+        {
+            int month = (*(rb.position() + 5) - '0') * 10 + (*(rb.position() + 6) - '0');
+            if (month > 12 || month < 0)
+                return false;
+            int day = (*(rb.position() + 8) - '0') * 10 + (*(rb.position() + 9) - '0');
+            if (day < 0 || day > 31)
+                return false;
+            else if (day == 31 && (month == 2 || month == 4 || month == 6 || month == 9 || month == 11))
+                return false;
+            else if (day == 30 && month == 2)
+                return false;
+            else if (day == 29 && month == 2)
+            {
+                int year = (*(rb.position() + 0) - '0') * 1000 + 
+                    (*(rb.position() + 1) - '0') * 100 + 
+                    (*(rb.position() + 2) - '0') * 10 + 
+                    (*(rb.position() + 3) - '0');
+                if (year % 4 != 0)
+                    return false;
+                else
+                    return true;
+            }
+            else
+                return true;
+
+        };
+        if (!checkNumbericASCII(buf, 0, 4))
+            return false;
+        if (!checkDelimiter(buf, 4))
+            return false;
+        if (!checkNumbericASCII(buf, 5, 2))
+            return false;
+        if (!checkDelimiter(buf, 7))
+            return false;
+        if (!checkNumbericASCII(buf, 8, 2))
+            return false;
+        if (!checkMonthDay(buf))
+            return false;
+        return true;
+    }
+
+    DB::ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t) const override
+    {
+        auto result_column = result_type->createColumn();
+        if (arguments.size() != 1)
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 1.", name);
+        
+        const DB::ColumnWithTypeAndName arg1 = arguments[0];
+        const auto * src_col = checkAndGetColumn<DB::ColumnString>(arg1.column.get());
+        for (size_t i = 0; i < src_col->size(); ++i)
+        {
+            auto str = src_col->getDataAt(i);
+            if (str.size < 10)
+            {
+                result_column->insert(DB::Field());
+            }
+            else
+            {
+                DB::ReadBufferFromMemory buf(str.data, str.size);
+                while(!buf.eof() && *buf.position() == ' ')
+                {
+                    buf.position() ++;
+                }
+                if(buf.buffer().end() - buf.position() < 10)
+                {
+                    result_column->insert(DB::Field());
+                    continue;
+                }
+                if (!checkDateFormat(buf))
+                {
+                    result_column->insert(DB::Field());
+                    continue;
+                }
+                LocalDate date;
+                if (readDateTextImpl<bool>(date, buf))
+                    result_column->insert(date.getDayNum());
+                else
+                    result_column->insert(DB::Field());
+            }
+        }
+        return result_column;
+    }
+};
+
+REGISTER_FUNCTION(SparkToDate)
+{
+    factory.registerFunction<SparkFunctionConvertToDate>();
+}
+
+}

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -70,10 +70,10 @@ public:
         else
         {
             int month = (*(buf.position() + 5) - '0') * 10 + (*(buf.position() + 6) - '0');
-            if (month < 0 || month > 12)
+            if (month <= 0 || month > 12)
                 return false;
             int day = (*(buf.position() + 8) - '0') * 10 + (*(buf.position() + 9) - '0');
-            if (day < 0 || day > 31)
+            if (day <= 0 || day > 31)
                 return false;
             else if (day == 31 && (month == 2 || month == 4 || month == 6 || month == 9 || month == 11))
                 return false;

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -69,10 +69,10 @@ public:
             return false;
         else
         {
-            char month = (*(buf.position() + 5) - '0') * 10 + (*(buf.position() + 6) - '0');
+            int month = (*(buf.position() + 5) - '0') * 10 + (*(buf.position() + 6) - '0');
             if (month < 0 || month > 12)
                 return false;
-            char day = (*(buf.position() + 8) - '0') * 10 + (*(buf.position() + 9) - '0');
+            int day = (*(buf.position() + 8) - '0') * 10 + (*(buf.position() + 9) - '0');
             if (day < 0 || day > 31)
                 return false;
             else if (day == 31 && (month == 2 || month == 4 || month == 6 || month == 9 || month == 11))
@@ -81,7 +81,7 @@ public:
                 return false;
             else
             {
-                short year = (*(buf.position() + 0) - '0') * 1000 + 
+                int year = (*(buf.position() + 0) - '0') * 1000 + 
                     (*(buf.position() + 1) - '0') * 100 + 
                     (*(buf.position() + 2) - '0') * 10 + 
                     (*(buf.position() + 3) - '0');

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -61,7 +61,6 @@ public:
             else
                 return true;
         };
-        std::pair<bool, LocalDate> result;
         if (!checkNumbericASCII(buf, 0, 4) 
             || !checkDelimiter(buf, 4) 
             || !checkNumbericASCII(buf, 5, 2) 

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -17,7 +17,6 @@
 #include <Common/LocalDate.h>
 #include <Common/DateLUT.h>
 #include <Common/DateLUTImpl.h>
-#include <Core/Field.h>
 #include <DataTypes/DataTypeDate32.h>
 #include <Functions/FunctionsConversion.h>
 #include <Functions/FunctionFactory.h>
@@ -107,7 +106,7 @@ public:
         if (!result_type->isNullable())
             throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s return type must be nullable", name);
         
-        if (!std::dynamic_pointer_cast<const DB::DataTypeDate32>(removeNullable(result_type)))
+        if (!isDate32(removeNullable(result_type)))
             throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s return type must be data32.", name);
         
         using ColVecTo = DB::DataTypeDate32::ColumnType;

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1654,7 +1654,7 @@ const ActionsDAG::Node * SerializedPlanParser::parseExpression(ActionsDAGPtr act
                 /// FIXME. Now we treet '1900-01-01' as null value. Not realy good.
                 /// Updating `toDate32OrNull` to return null if the string is invalid is not acceptable by
                 /// ClickHouse (https://github.com/ClickHouse/ClickHouse/issues/47120).
-                String function_name = "toDate32OrNull";
+                String function_name = "spark_to_date";
                 const auto * date_node = toFunctionNode(actions_dag, function_name, args);
                 const auto * zero_date_col_node = add_column(std::make_shared<DataTypeString>(), "1900-01-01");
                 const auto * zero_date_node = toFunctionNode(actions_dag, function_name, {zero_date_col_node});


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#3668)

## How was this patch tested?

TEST BY UT

性能测试数据


3000W 行正常数据 
测试SQL: `select count(1) from $test_tbl where to_date($col) > '1990-01-01'`
PR改动前耗时： 2.983s， 2.686s,   2.804s
PR改动后耗时： 2.94s，2.861s，2.842s；

3000W行数据 (其中2500W行是NULL，500W是正常数据)
测试SQL:  `select count(1) from $test_tbl where to_date($col) > '1990-01-01'`
PR改动前耗时：0.621s， 0.614s,  0.677s
PR改动后耗时：0.631s，0.641s，0.692s；

3000W行数据 (其中2500W数据是不符合日期格式的随机字符串，500W行是正常数据) 
测试SQL: `select count(1) from $test_tbl where to_date($col) > '1990-01-01'`
PR改动前耗时：6.148s，6.018s，5.845s
PR改动后耗时：3.188s，3.055s，3.08s

对比发现，正常数据测试情况下性能接近，在某些异常场景下性能有所提升

