### PR TITLE
[GLUTEN-3705][CORE] Support mapping one custom aggregate function to more than one backend functions

### DIFF
--- a/cpp-ch/local-engine/Parser/example_udf/customSum.cpp
+++ b/cpp-ch/local-engine/Parser/example_udf/customSum.cpp
@@ -24,4 +24,5 @@ namespace local_engine
 {
 // Only for ut to test custom aggregate function
 REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(CustomSum, custom_sum, sum)
+REGISTER_COMMON_AGGREGATE_FUNCTION_PARSER(CustomSumDouble, custom_sum_double, sum)
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ExpressionExtensionTrait.scala
@@ -21,6 +21,7 @@ import io.glutenproject.expression.{ExpressionTransformer, Sig}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, AggregateMode}
+import org.apache.spark.sql.types.DataType
 
 import scala.collection.mutable.ListBuffer
 
@@ -49,6 +50,13 @@ trait ExpressionExtensionTrait {
       aggregateAttributeList: Seq[Attribute],
       aggregateAttr: ListBuffer[Attribute],
       resIndex: Int): Int = {
+    throw new UnsupportedOperationException(
+      s"Aggregate function ${aggregateFunc.getClass} is not supported.")
+  }
+
+  /** Get the custom agg function substrait name and the input types of the child */
+  def buildCustomAggregateFunction(
+      aggregateFunc: AggregateFunction): (Option[String], Seq[DataType]) = {
     throw new UnsupportedOperationException(
       s"Aggregate function ${aggregateFunc.getClass} is not supported.")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support mapping one custom aggregate function to more than one backend functions, like first/last function, they will be mapped to two backend function names according to the ignoreNulls parameter.

Close #3705 .

(Fixes: #3705)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

