### PR TITLE
[GLUTEN-3635][VL] Clean up docs related to `build-arrow` paths 

### DIFF
--- a/.github/workflows/velox_tpch_merge.yml
+++ b/.github/workflows/velox_tpch_merge.yml
@@ -31,7 +31,6 @@ on:
       - 'shims/**'
       - 'tools/gluten-it/**'
       - 'tools/gluten-te/**'
-      - 'ep/build-arrow/**'
       - 'ep/build-velox/**'
       - 'cpp/*'
       - 'cpp/CMake/**'

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -41,7 +41,7 @@ To debug C++, you have to generate the example files, the example files consist 
 
 You can generate the example files by the following steps:
 
-1. build Velox
+1. build Velox and Gluten CPP
 ```
 gluten_home/dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --build_type=Debug
 ```

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -41,32 +41,14 @@ To debug C++, you have to generate the example files, the example files consist 
 
 You can generate the example files by the following steps:
 
-1. get and build Arrow
+1. build Velox
 ```
-cd gluten_home/ep/build-arrow/src
-./get_arrow.sh
-./build_arrow.sh
-```
-
-2. get and build Velox
-```
-cd gluten_home/ep/build-velox/src
-./get_velox.sh
-./build_velox.sh --build_type=Debug
-```
-
-3. compile the CPP
-```
-cd gluten_home/cpp
-mkdir build
-cd build
-cmake -DBUILD_VELOX_BACKEND=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Debug ..
-make -j
+gluten_home/dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --build_type=Debug
 ```
 - Compiling with `--build_type=Debug` is good for debugging.
 - The executable file `generic_benchmark` will be generated under the directory of `gluten_home/cpp/build/velox/benchmarks/`.
 
-4. build Gluten and generate the example files
+2. build Gluten and generate the example files
 ```
 cd gluten_home
 mvn clean package -Pspark-3.2 -Pbackends-velox -Prss
@@ -87,7 +69,7 @@ gluten_home/backends-velox/generated-native-benchmark/
     └── _SUCCESS
 ```
 
-5. now, run benchmarks with GDB
+3. now, run benchmarks with GDB
 ```
 cd gluten_home/cpp/build/velox/benchmarks/
 gdb generic_benchmark
@@ -99,15 +81,15 @@ gdb generic_benchmark
 - Actually, you can debug `generic_benchmark` with any gdb commands as debugging normal C++ program, because the `generic_benchmark` is a pure C++
   executable file in fact.
 
-6. `gdb-tui` is a valuable feature and is worth trying. You can get more help from the online docs.
+4. `gdb-tui` is a valuable feature and is worth trying. You can get more help from the online docs.
 [gdb-tui](https://sourceware.org/gdb/onlinedocs/gdb/TUI.html)
 
-7. you can start `generic_benchmark` with specific JSON plan and input files
+5. you can start `generic_benchmark` with specific JSON plan and input files
 - If you omit them, the `example.json, example_lineitem + example_orders` under the directory of `gluten_home/backends-velox/generated-native-benchmark`
   will be used as default.
 - You can also edit the file `example.json` to custom the Substrait plan or specify the inputs files placed in the other directory.
 
-8. get more detail information about benchmarks from [MicroBenchmarks](./MicroBenchmarks.md)
+6. get more detail information about benchmarks from [MicroBenchmarks](./MicroBenchmarks.md)
 
 ## 2 How to debug Java/Scala
 wait to add

--- a/docs/developers/NewToGluten.md
+++ b/docs/developers/NewToGluten.md
@@ -58,12 +58,8 @@ You can just refer to [build-gluten-with-velox-backend](../get-started/Velox.md#
 If you need to debug cpp code, please compile the backend code and gluten cpp code with debug mode.
 
 ```bash
-## compile velox
-./build_velox.sh --build_type=Debug
-## compile arrow with tests required library
-./build_arrow.sh
-## compile gluten cpp with benchmark and tests to debug
-cmake -DBUILD_VELOX_BACKEND=ON -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Debug ..
+## compile velox backend with benchmark and tests to debug
+gluten_home/dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --build_type=Debug
 ```
 
 If you need to debug the tests in <gluten>/gluten-ut, You need to compile java code with `-P spark-ut`.


### PR DESCRIPTION
## What changes were proposed in this pull request?
As in https://github.com/oap-project/gluten/issues/3635, gluten currently relies on arrow in Velox. This means the build-arrow stuff has been removed.

Most of the necessary docs changes were covered in https://github.com/oap-project/gluten/pull/3573/files but a couple small details were missed. 

## How was this patch tested?
Docs have been updated here to remove reference to the build-arrow paths.

