### PR TITLE
[GLUTEN-3711][VL] Fix `printConf` to Support Velox Config 

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -108,10 +108,10 @@ const std::string kVeloxShuffleReaderPrintFlag = "spark.gluten.velox.shuffleRead
 
 namespace gluten {
 
-void VeloxBackend::printConf(const std::unordered_map<std::string, std::string>& conf) {
+void VeloxBackend::printConf(const facebook::velox::Config& conf) {
   std::ostringstream oss;
   oss << "STARTUP: VeloxBackend conf = {\n";
-  for (auto& [k, v] : conf) {
+  for (auto& [k, v] : conf.values()) {
     oss << " {" << k << ", " << v << "}\n";
   }
   oss << "}\n";

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -63,7 +63,7 @@ class VeloxBackend {
 
   void initJolFilesystem(const facebook::velox::Config* conf);
 
-  void printConf(const std::unordered_map<std::string, std::string>& conf);
+  void printConf(const facebook::velox::Config& conf);
 
   std::string getCacheFilePrefix() {
     return "cache." + boost::lexical_cast<std::string>(boost::uuids::random_generator()()) + ".";


### PR DESCRIPTION
Closes https://github.com/oap-project/gluten/issues/3711
## What changes were proposed in this pull request?
Compilation fails with:
```
VeloxBackend.cc:204:13: error: cannot convert ‘const facebook::velox::Config*’ to ‘const std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&’
  204 |   printConf(veloxcfg);
      |             ^~~~~~~~
      |             |
      |             const facebook::velox::Config*
```

Fix by modifying the method to take a `facebook::velox::Config` instead.
