### PR TITLE
[CORE] set default spark.version to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <scala.version>2.12.15</scala.version>
     <spark.major.version>3</spark.major.version>
     <sparkbundle.version>3.2</sparkbundle.version>
-    <spark.version>3.2.2</spark.version>
+    <spark.version>3.4.1</spark.version>
     <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
     <celeborn.version>0.3.0-incubating</celeborn.version>
     <arrow.version>12.0.0</arrow.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set the default `spark.version` to 3.4.1 to fix the security issues reported by local code scan 
Note this will be overwrite in each profile


## How was this patch tested?

pass GHA
