### PR TITLE
[GLUTEN-3705][FOLLOW][CH] Set the correct agg schema names after mapping one agg function to the other name

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -327,8 +327,19 @@ case class CHHashAggregateExecTransformer(
       ConverterUtils.genColumnNameWithExprId(resultAttr)
     } else {
       val aggExpr = aggExpressions(columnIndex - groupingExprs.length)
+      val aggregateFunc = aggExpr.aggregateFunction
       var aggFunctionName =
-        AggregateFunctionsBuilder.getSubstraitFunctionName(aggExpr.aggregateFunction).get
+        if (
+          ExpressionMappings.expressionExtensionTransformer.extensionExpressionsMapping.contains(
+            aggregateFunc.getClass)
+        ) {
+          ExpressionMappings.expressionExtensionTransformer
+            .buildCustomAggregateFunction(aggregateFunc)
+            ._1
+            .get
+        } else {
+          AggregateFunctionsBuilder.getSubstraitFunctionName(aggregateFunc).get
+        }
       ConverterUtils.genColumnNameWithExprId(resultAttr) + "#Partial#" + aggFunctionName
     }
   }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/extension/CustomAggExpressionTransformer.scala
@@ -46,17 +46,17 @@ case class CustomAggExpressionTransformer() extends ExpressionExtensionTrait {
     aggregateFunc match {
       case CustomSum(_, _) =>
         mode match {
-          case Partial =>
+          // custom logic: can not support 'Partial'
+          /* case Partial =>
             val aggBufferAttr = aggregateFunc.inputAggBufferAttributes
             val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr.head)
             aggregateAttr += attr
             reIndex += 1
-            reIndex
-          // custom logic: can not support 'Final'
-          /* case Final =>
+            reIndex */
+          case Final =>
             aggregateAttr += aggregateAttributeList(reIndex)
             reIndex += 1
-            reIndex */
+            reIndex
           case other =>
             throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
         }
@@ -74,10 +74,12 @@ case class CustomAggExpressionTransformer() extends ExpressionExtensionTrait {
           Some("custom_sum_double")
         }
       case _ =>
-        throw new UnsupportedOperationException(
-          s"Aggregate function ${aggregateFunc.getClass} is not supported.")
+        extensionExpressionsMapping.get(aggregateFunc.getClass)
     }
-
+    if (substraitAggFuncName.isEmpty) {
+      throw new UnsupportedOperationException(
+        s"Aggregate function ${aggregateFunc.getClass} is not supported.")
+    }
     (substraitAggFuncName, aggregateFunc.children.map(child => child.dataType))
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

With CH backend, in the final stage, the agg schema names must be the `agg_function#exprId#Partial#custom_sum`, after mapping the agg function to the other name, it does not modify according to the new one.

(Fixes: \#3705)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

