### PR TITLE
[VL] rebase velox to 20231114

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -31,10 +31,10 @@ using namespace facebook::velox;
 namespace gluten {
 
 namespace {
-std::unique_ptr<ByteStream> toByteStream(uint8_t* data, int32_t size) {
-  auto byteStream = std::make_unique<ByteStream>();
-  ByteRange byteRange{data, size, 0};
-  byteStream->resetInput({byteRange});
+std::unique_ptr<ByteInputStream> toByteStream(uint8_t* data, int32_t size) {
+  std::vector<ByteRange> byteRanges;
+  byteRanges.push_back(ByteRange{data, size, 0});
+  auto byteStream = std::make_unique<ByteInputStream>(byteRanges);
   return byteStream;
 }
 } // namespace

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -161,10 +161,10 @@ VectorPtr readFlatVector<TypeKind::VARBINARY>(
   return readFlatVectorStringView(buffers, bufferIdx, length, type, pool);
 }
 
-std::unique_ptr<ByteStream> toByteStream(uint8_t* data, int32_t size) {
-  auto byteStream = std::make_unique<ByteStream>();
-  ByteRange byteRange{data, size, 0};
-  byteStream->resetInput({byteRange});
+std::unique_ptr<ByteInputStream> toByteStream(uint8_t* data, int32_t size) {
+  std::vector<ByteRange> byteRanges;
+  byteRanges.push_back(ByteRange{data, size, 0});
+  auto byteStream = std::make_unique<ByteInputStream>(byteRanges);
   return byteStream;
 }
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=20231114
+VELOX_BRANCH=2023-11-14
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=update
+VELOX_BRANCH=20231114
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
rebase velox to 20231114
ByteStream is replaced by ByteInputStream. Velox PR: https://github.com/facebookincubator/velox/pull/7541

