### PR TITLE
[VL] handle literal null

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxDataTypeValidationSuite.scala
@@ -56,6 +56,16 @@ class VeloxDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
       .set("spark.sql.sources.useV1SourceList", "avro")
   }
 
+  test("Null literal") {
+    runQueryAndCompare("select named_struct('int', int, 'null', null) from type1 limit 10") {
+      df =>
+        {
+          val executedPlan = getExecutedPlan(df)
+          assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
+        }
+    }
+  }
+
   test("Bool type") {
     runQueryAndCompare("select bool from type1 limit 1") { _ => }
 

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -83,6 +83,8 @@ TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType, bool 
       auto scale = substraitType.decimal().scale();
       return DECIMAL(precision, scale);
     }
+    case ::substrait::Type::KindCase::kNothing:
+      return UNKNOWN();
     default:
       VELOX_NYI("Parsing for Substrait type not supported: {}", substraitType.DebugString());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle literal null in `SubstriatParser`. This is found for test in https://github.com/facebookincubator/velox/pull/7560

E1115 23:16:39.690089 19385 Exceptions.h:69] Line: /var/git/gluten/cpp/velox/substrait/SubstraitParser.cc:87, Function:parseType, Expression:  Parsing for Substrait type not supported: nothing {
}
, Source: RUNTIME, ErrorCode: NOT_IMPLEMENTED

## How was this patch tested?

UT
