### PR TITLE
[VL] [Minor] Fix compile error in debug mode

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -111,7 +111,7 @@ namespace gluten {
 void VeloxBackend::printConf(const facebook::velox::Config& conf) {
   std::ostringstream oss;
   oss << "STARTUP: VeloxBackend conf = {\n";
-  for (auto& [k, v] : conf.values()) {
+  for (auto& [k, v] : conf.valuesCopy()) {
     oss << " {" << k << ", " << v << "}\n";
   }
   oss << "}\n";

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -201,7 +201,7 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
   initIOExecutor(veloxcfg);
 
 #ifdef GLUTEN_PRINT_DEBUG
-  printConf(veloxcfg);
+  printConf(*veloxcfg);
 #endif
 
   auto hiveConnector =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following compile error in debug mode.

```
/mnt/DP_disk1/sparkuser/projects/gluten/cpp/velox/compute/VeloxBackend.cc: In member function ‘void gluten::VeloxBackend::init(const std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&)’:
/mnt/DP_disk1/sparkuser/projects/gluten/cpp/velox/compute/VeloxBackend.cc:204:13: error: cannot convert ‘const facebook::velox::Config*’ to ‘const facebook::velox::Config&’
  204 |   printConf(veloxcfg);
      |             ^~~~~~~~
      |             |
      |             const facebook::velox::Config*
/mnt/DP_disk1/sparkuser/projects/gluten/cpp/velox/compute/VeloxBackend.cc:111:61: note:   initializing argument 1 of ‘void gluten::VeloxBackend::printConf(const facebook::velox::Config&)’
  111 | void VeloxBackend::printConf(const facebook::velox::Config& conf) {
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
make[2]: *** [velox/CMakeFiles/velox.dir/build.make:63: velox/CMakeFiles/velox.dir/compute/VeloxBackend.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:192: velox/CMakeFiles/velox.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

```

## How was this patch tested?

local debug mode compile.

