### PR TITLE
[VL] Fix scan time metrics 

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
@@ -49,7 +49,7 @@ class MetricsApiImpl extends MetricsApi with Logging {
       "outputBytes" -> SQLMetrics.createSizeMetric(sparkContext, "number of output bytes"),
       "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime of batch scan"),
       "cpuCount" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-      "scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"),
+      "scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "scan time"),
       "peakMemoryBytes" -> SQLMetrics.createSizeMetric(sparkContext, "peak memory bytes"),
       "numMemoryAllocations" -> SQLMetrics.createMetric(
         sparkContext,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Before:
> scan time total (min, med, max (stageId: taskId))
0 ms (0 ms, 0 ms, 0 ms (stage 8.0: task 74))

After:

> scan time total (min, med, max (stageId: taskId))
13.1 s (117 ms, 192 ms, 289 ms (stage 8.0: task 44))

Depends on: https://github.com/oap-project/velox/pull/443.

## How was this patch tested?

under test

