### PR TITLE
[GLUTEN-3547][VL] [Minor] Remove the space in taskid name

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -465,7 +465,10 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten {}", taskInfo_.toString()), std::move(planFragment), 0, std::move(queryCtx));
+      fmt::format("Gluten_StageId_{}_TaskId_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
+      std::move(planFragment),
+      0,
+      std::move(queryCtx));
 
   if (!task_->supportsSingleThreadedExecution()) {
     throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());
@@ -518,7 +521,10 @@ WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten {}", taskInfo_.toString()), std::move(planFragment), 0, std::move(queryCtx));
+      fmt::format("Gluten_StageId_{}_TaskId_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
+      std::move(planFragment),
+      0,
+      std::move(queryCtx));
 
   if (!task_->supportsSingleThreadedExecution()) {
     throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -465,7 +465,7 @@ WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten_StageId_{}_TaskId_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
+      fmt::format("Gluten_Stage_{}_TID_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
       std::move(planFragment),
       0,
       std::move(queryCtx));
@@ -521,7 +521,7 @@ WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
 
   task_ = velox::exec::Task::create(
-      fmt::format("Gluten_StageId_{}_TaskId_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
+      fmt::format("Gluten_Stage_{}_TID_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
       std::move(planFragment),
       0,
       std::move(queryCtx));


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Velox TableWrite node generates the write file name based on the task ID name. However, in this case, Gluten passed the task ID name as `Gluten [Stage: 3 TID: 3]`, which contains a space in the file name. Spark cannot read files with spaces in their names. This pull request resolves the issue by removing the space in the task ID. And the taskid name will changed from `Gluten [Stage: 3 TID: 3]` to `Gluten_StageId_3_TaskId_3`.

## How was this patch tested?
no need

