### PR TITLE
[GLUTEN-3806][VL] Fix build issues of libhdfs3 for Arm64 on Ubuntu

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -80,6 +80,7 @@ function apply_compilation_fixes {
   current_dir=$1
   velox_home=$2
   sudo cp ${current_dir}/modify_velox.patch ${velox_home}/
+  sudo cp ${current_dir}/modify_libhdfs3.patch ${velox_home}/
   sudo cp ${current_dir}/modify_arrow.patch ${velox_home}/third_party/
   cd ${velox_home}
   git apply modify_velox.patch

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -84,7 +84,7 @@ function process_setup_ubuntu {
   sed -i '/libre2-dev/d' scripts/setup-ubuntu.sh
   sed -i '/libgmock-dev/d' scripts/setup-ubuntu.sh # resolved by ep/build-velox/build/velox_ep/CMake/resolve_dependency_modules/gtest.cmake
   if [ $ENABLE_HDFS == "ON" ]; then
-    sed -i '/^function install_fmt.*/i function install_libhdfs3 {\n  github_checkout oap-project/libhdfs3 master \n cmake_install\n}\n' scripts/setup-ubuntu.sh
+    sed -i '/^function install_fmt.*/i function install_libhdfs3 {\n  github_checkout oap-project/libhdfs3 master \n git apply ../modify_libhdfs3.patch\n  cmake_install\n}\n' scripts/setup-ubuntu.sh
     sed -i '/^  run_and_time install_fmt/a \ \ run_and_time install_libhdfs3' scripts/setup-ubuntu.sh
     sed -i '/ccache /a\  yasm \\' scripts/setup-ubuntu.sh
   fi

--- a/ep/build-velox/src/modify_libhdfs3.patch
+++ b/ep/build-velox/src/modify_libhdfs3.patch
@@ -1,0 +1,35 @@
+diff --git a/CMake/Options.cmake b/CMake/Options.cmake
+index 14762eb..161190d 100644
+--- a/CMake/Options.cmake
++++ b/CMake/Options.cmake
+@@ -1,6 +1,18 @@
+ OPTION(ENABLE_COVERAGE "enable code coverage" OFF)
+ OPTION(ENABLE_DEBUG "enable debug build" OFF)
+-OPTION(ENABLE_SSE "enable SSE4.2 buildin function" ON)
++
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
++  OPTION(ENABLE_SSE "enable SSE4.2 buildin function" ON)
++else()
++  OPTION(ENABLE_SSE "enable SSE4.2 buildin function" OFF)
++endif()
++
++if (CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(AARCH64)|(ARM64)|(arm64)")
++	OPTION(ENABLE_NEON "enable NEON buildin function" ON)
++else()
++	OPTION(ENABLE_NEON "enable NEON buildin function" OFF)
++endif()
++
+ OPTION(ENABLE_FRAME_POINTER "enable frame pointer on 64bit system with flag -fno-omit-frame-pointer, on 32bit system, it is always enabled" ON)
+ OPTION(ENABLE_LIBCPP "using libc++ instead of libstdc++, only valid for clang compiler" OFF)
+ OPTION(ENABLE_BOOST "using boost instead of native compiler c++0x support" OFF)
+@@ -34,6 +46,10 @@ IF(ENABLE_SSE STREQUAL ON)
+     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+ ENDIF(ENABLE_SSE STREQUAL ON) 
+ 
++IF(ENABLE_NEON STREQUAL ON)
++    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
++ENDIF(ENABLE_NEON STREQUAL ON)
++
+ IF(NOT TEST_HDFS_PREFIX)
+ SET(TEST_HDFS_PREFIX "./" CACHE STRING "default directory prefix used for test." FORCE)
+ ENDIF(NOT TEST_HDFS_PREFIX)


### PR DESCRIPTION
## What changes were proposed in this pull request?
`SSE4.2` is always enabled in  Project `oap-project/libhdfs3` [Options.cmake](https://github.com/oap-project/libhdfs3/blob/master/CMake/Options.cmake#L3).
When building Gluten-Velox with enabling HDFS(`--enable_hdfs=ON`)  on **Arm64** Ubuntu, build issues occurred:
```
c++: error: unrecognized command-line option ‘-msse4.2’
ninja: build stopped: subcommand failed.
```


## How was this patch tested?
Build Gluten-Velox with `--enable_hdfs=ON`
`./dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_hdfs=ON`

`libhdfs.so` could be properly installed:
```
ls -al /usr/local/lib/*hdfs*
-rw-r--r-- 1 root root 136438610 Nov 22 10:14 /usr/local/lib/libhdfs3.a
lrwxrwxrwx 1 root root        13 Nov 22 10:06 /usr/local/lib/libhdfs3.so -> libhdfs3.so.1
lrwxrwxrwx 1 root root        18 Nov 22 10:06 /usr/local/lib/libhdfs3.so.1 -> libhdfs3.so.2.2.30
-rw-r--r-- 1 root root  51596560 Nov 22 10:14 /usr/local/lib/libhdfs3.so.2.2.30
```