### PR TITLE
[CORE] Introduce custom protobuf dependency with recursion limit enlarged

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -27,11 +27,6 @@
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${custom.protobuf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.glutenproject</groupId>
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -22,6 +22,16 @@
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${custom.protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.glutenproject</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${custom.protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.glutenproject</groupId>
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -41,12 +41,12 @@
     <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${custom.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${custom.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -38,6 +38,18 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+        <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${forked.protobuf.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${forked.protobuf.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>gluten-core</artifactId>

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -38,17 +38,15 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
-        <dependency>
-      <groupId>com.google.protobuf</groupId>
+    <dependency>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${forked.protobuf.version}</version>
-      <scope>provided</scope>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${forked.protobuf.version}</version>
-      <scope>provided</scope>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -45,11 +45,6 @@
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${custom.protobuf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.glutenproject</groupId>
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/gluten-celeborn/pom.xml
+++ b/gluten-celeborn/pom.xml
@@ -41,6 +41,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/gluten-celeborn/pom.xml
+++ b/gluten-celeborn/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -177,10 +177,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
-      <scope>provided</scope>
+      <version>${custom.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -173,13 +173,13 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${forked.protobuf.version}</version>
+      <version>${protobuf.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${forked.protobuf.version}</version>
+      <version>${protobuf.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -282,7 +282,7 @@
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${forked.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>src/main/resources/substrait/proto</protoSourceRoot>
               <clearOutputDirectory>true</clearOutputDirectory>
@@ -297,7 +297,7 @@
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${forked.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>src/main/resources/io/glutenproject/proto</protoSourceRoot>
               <clearOutputDirectory>false</clearOutputDirectory>

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -171,12 +171,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java-util</artifactId>
       <version>${protobuf.version}</version>
     </dependency>
@@ -280,7 +280,7 @@
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${forked.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>src/main/resources/substrait/proto</protoSourceRoot>
               <clearOutputDirectory>true</clearOutputDirectory>
@@ -295,7 +295,7 @@
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${forked.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>src/main/resources/io/glutenproject/proto</protoSourceRoot>
               <clearOutputDirectory>false</clearOutputDirectory>

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -171,14 +171,16 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${forked.protobuf.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
+      <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${forked.protobuf.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -54,12 +54,12 @@
     <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${custom.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${custom.protobuf.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -52,15 +52,14 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${forked.protobuf.version}</version>
-      <scope>provided</scope>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>${forked.protobuf.version}</version>
+      <version>${protobuf.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -57,9 +57,9 @@
       <version>${custom.protobuf.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.glutenproject</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${custom.protobuf.version}</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/gluten-data/pom.xml
+++ b/gluten-data/pom.xml
@@ -52,6 +52,18 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${forked.protobuf.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${forked.protobuf.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -30,22 +30,6 @@
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
-      <!--   <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions> -->
-    </dependency>
-    <dependency>
-      <groupId>io.glutenproject</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.glutenproject</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
 
     <!-- Do not remove the following. They are for enforcer plugin -->

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -53,45 +53,21 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 
@@ -295,7 +271,8 @@
                     <ignoreClass>org.apache.spark.sql.execution.datasources.WriterBucketSpec$</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand$</ignoreClass>
-
+                    <!--protobuf-->
+                    <ignoreClass>com.google.protobuf.*</ignoreClass>
                   </ignoreClasses>
                   <scopes>
                     <scope>compile</scope>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -30,6 +30,22 @@
       <artifactId>gluten-core</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
+      <!--   <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions> -->
+    </dependency>
+    <dependency>
+      <groupId>io.glutenproject</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.glutenproject</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
 
     <!-- Do not remove the following. They are for enforcer plugin -->
@@ -37,21 +53,45 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -255,7 +255,7 @@
                     <ignoreClass>org.apache.spark.sql.execution.datasources.WriterBucketSpec$</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand$</ignoreClass>
-                    <!--protobuf-->
+                    <!-- protobuf -->
                     <ignoreClass>com.google.protobuf.*</ignoreClass>
                   </ignoreClasses>
                   <scopes>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,10 @@
     <junit.version>4.13.1</junit.version>
 
     <substrait.version>0.5.0</substrait.version>
-    <forked.protobuf.version>3.23.4</forked.protobuf.version>
-    <protobuf.version>3.23.4-0</protobuf.version>
+    <!-- The original protobuf version -->
+    <protobuf.version>3.23.4</protobuf.version>
+    <!-- The custom protobuf version (based on 3.23.4) with recursion limit enlarged. -->
+    <custom.protobuf.version>3.23.4-0</custom.protobuf.version>
     <guava.version>32.0.1-jre</guava.version>
     <!--spotless-->
     <spotless.version>2.27.2</spotless.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,8 @@
     <junit.version>4.13.1</junit.version>
 
     <substrait.version>0.5.0</substrait.version>
-    <protobuf.version>3.23.4</protobuf.version>
+    <forked.protobuf.version>3.23.4</forked.protobuf.version>
+    <protobuf.version>3.23.4-0</protobuf.version>
     <!--spotless-->
     <spotless.version>2.27.2</spotless.version>
     <spotless.scalafmt.version>3.5.9</spotless.scalafmt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <substrait.version>0.5.0</substrait.version>
     <forked.protobuf.version>3.23.4</forked.protobuf.version>
     <protobuf.version>3.23.4-0</protobuf.version>
+    <guava.version>32.0.1-jre</guava.version>
     <!--spotless-->
     <spotless.version>2.27.2</spotless.version>
     <spotless.scalafmt.version>3.5.9</spotless.scalafmt.version>

--- a/substrait/substrait-spark/pom.xml
+++ b/substrait/substrait-spark/pom.xml
@@ -46,7 +46,7 @@
       <artifactId>core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
+      <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>
     </dependency>

--- a/substrait/substrait-spark/pom.xml
+++ b/substrait/substrait-spark/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>io.glutenproject</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
+      <version>${custom.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Protobuf has a hard-code limit (100) for recursion depth and runtime exception can occur when exceeding the limit. This PR proposes a custom protobuf dependency which has a much larger limit (100, 000, see source [here](https://github.com/oap-project/protobuf/tree/v3.23.4-0)). Thanks to @weiting-chen, the dependency jar has been published in maven repo (see [link](https://repo1.maven.org/maven2/io/glutenproject/protobuf-java/3.23.4-0/)).


Fixes: #1727, #2414. 

## How was this patch tested?

Existing tests.

