### PR TITLE
[VL] Support StreamingAggregate if child output ordering is satisfied

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/HashAggregateExecTransformer.scala
@@ -654,11 +654,14 @@ case class HashAggregateExecTransformer(
         }
         addFunctionNode(args, aggregateFunc, childrenNodes, aggExpr.mode, aggregateFunctionList)
       })
+
+    val extensionNode = getAdvancedExtension()
     RelBuilder.makeAggregateRel(
       projectRel,
       groupingList,
       aggregateFunctionList,
       aggFilterList,
+      extensionNode,
       context,
       operatorId)
   }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/StreamingAggregateBenchmark.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/benchmark/StreamingAggregateBenchmark.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.benchmark
+
+import io.glutenproject.GlutenConfig
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Benchmark to measure performance for streaming aggregate. To run this benchmark:
+ * {{{
+ *    bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ * }}}
+ */
+object StreamingAggregateBenchmark extends SqlBasedBenchmark {
+  private val numRows = {
+    spark.sparkContext.conf.getLong("spark.gluten.benchmark.rows", 8 * 1000 * 1000)
+  }
+
+  private val mode = {
+    spark.sparkContext.conf.getLong("spark.gluten.benchmark.remainder", 4 * 1000 * 1000)
+  }
+
+  private def doBenchmark(): Unit = {
+    val benchmark = new Benchmark("streaming aggregate", numRows, output = output)
+
+    val query =
+      """
+        |SELECT c1, count(*), sum(c2) FROM (
+        |SELECT t1.c1, t2.c2 FROM t t1 JOIN t t2 ON t1.c1 = t2.c1
+        |)
+        |GROUP BY c1
+        |""".stripMargin
+    benchmark.addCase(s"Enable streaming aggregate", 3) {
+      _ =>
+        withSQLConf(
+          GlutenConfig.COLUMNAR_PREFER_STREAMING_AGGREGATE.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+          GlutenConfig.COLUMNAR_FPRCE_SHUFFLED_HASH_JOIN_ENABLED.key -> "false"
+        ) {
+          spark.sql(query).noop()
+        }
+    }
+
+    benchmark.addCase(s"Disable streaming aggregate", 3) {
+      _ =>
+        withSQLConf(
+          GlutenConfig.COLUMNAR_PREFER_STREAMING_AGGREGATE.key -> "false",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+          GlutenConfig.COLUMNAR_FPRCE_SHUFFLED_HASH_JOIN_ENABLED.key -> "false"
+        ) {
+          spark.sql(query).noop()
+        }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    spark
+      .range(numRows)
+      .selectExpr(s"id % $mode as c1", "id as c2")
+      .write
+      .saveAsTable("t")
+
+    try {
+      doBenchmark()
+    } finally {
+      spark.sql("DROP TABLE t")
+    }
+  }
+}

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -365,6 +365,11 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
   bool ignoreNullKeys = false;
   std::vector<core::FieldAccessTypedExprPtr> preGroupingExprs;
+  if (aggRel.has_advanced_extension() &&
+      SubstraitParser::configSetInOptimization(aggRel.advanced_extension(), "isStreaming=")) {
+    preGroupingExprs.reserve(veloxGroupingExprs.size());
+    preGroupingExprs.insert(preGroupingExprs.begin(), veloxGroupingExprs.begin(), veloxGroupingExprs.end());
+  }
 
   // Get the output names of Aggregation.
   std::vector<std::string> aggOutNames;

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -976,7 +976,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
   if (aggRel.has_advanced_extension()) {
     std::vector<TypePtr> types;
     const auto& extension = aggRel.advanced_extension();
-    // Aggregate always has advanced extension for steaming aggregate optimization,
+    // Aggregate always has advanced extension for streaming aggregate optimization,
     // but only some of them have enhancement for validation.
     if (extension.has_enhancement() && !validateInputTypes(extension, types)) {
       logValidateMsg("native validation failed due to: Validation failed for input types in AggregateRel.");

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -976,7 +976,9 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
   if (aggRel.has_advanced_extension()) {
     std::vector<TypePtr> types;
     const auto& extension = aggRel.advanced_extension();
-    if (!validateInputTypes(extension, types)) {
+    // Aggregate always has advanced extension for steaming aggregate optimization,
+    // but only some of them have enhancement for validation.
+    if (extension.has_enhancement() && !validateInputTypes(extension, types)) {
       logValidateMsg("native validation failed due to: Validation failed for input types in AggregateRel.");
       return false;
     }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -86,17 +86,6 @@ public class RelBuilder {
       List<ExpressionNode> groupings,
       List<AggregateFunctionNode> aggregateFunctionNodes,
       List<ExpressionNode> filters,
-      SubstraitContext context,
-      Long operatorId) {
-    context.registerRelToOperator(operatorId);
-    return new AggregateRelNode(input, groupings, aggregateFunctionNodes, filters);
-  }
-
-  public static RelNode makeAggregateRel(
-      RelNode input,
-      List<ExpressionNode> groupings,
-      List<AggregateFunctionNode> aggregateFunctionNodes,
-      List<ExpressionNode> filters,
       AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -644,6 +644,17 @@ object GlutenConfig {
       .checkValues(Set("streaming", "sort"))
       .createWithDefault("streaming")
 
+  val COLUMNAR_PREFER_STREAMING_AGGREGATE =
+    buildConf("spark.gluten.sql.columnar.preferStreamingAggregate")
+      .internal()
+      .doc(
+        "Velox backend supports `StreamingAggregate`. `StreamingAggregate` uses the less " +
+          "memory as it does not need to hold all groups in memory, so it could avoid spill. " +
+          "When true and the child output ordering satisfies the grouping key then " +
+          "Gluten will choose `StreamingAggregate` as the native operator.")
+      .booleanConf
+      .createWithDefault(true)
+
   val COLUMNAR_FPRCE_SHUFFLED_HASH_JOIN_ENABLED =
     buildConf("spark.gluten.sql.columnar.forceShuffledHashJoin")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the child output ordering satisfies the grouping keys then the grouping keys are pregrouped, we can choose to use `StreamingAggregate`. Velox supports `StreamingAggregate` which requires the input is pregrouped, so `StreamingAggregate` could use less memory to do aggregate as it does not need to hold all groups in memory and it could avoid spill.

For example, the query can hit this optimization if the join is SMJ:
```
SELECT c1, count(*), sum(c2) FROM (
SELECT t1.c1, t2.c2 FROM t1 t1 JOIN t1 t2 ON t1.c1 = t2.c1
)
GROUP BY c1;
```

## How was this patch tested?

manually benchmark

```
OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Linux 5.10.0-21-amd64
Intel(R) Core(TM) i5-10500 CPU @ 3.10GHz
streaming aggregate:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Enable streaming aggregate                         8074           8101          24          1.0        1009.2       1.0X
Disable streaming aggregate                       12338          12352          20          0.6        1542.2       0.7X

```
