### PR TITLE
[VL] Set the default value of the glog severity level to 1

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -63,7 +63,7 @@ const std::string kGlogVerboseLevel = "spark.gluten.sql.columnar.backend.velox.g
 const uint32_t kGlogVerboseLevelDefault = 0;
 
 const std::string kGlogSeverityLevel = "spark.gluten.sql.columnar.backend.velox.glogSeverityLevel";
-const uint32_t kGlogSeverityLevelDefault = 0;
+const uint32_t kGlogSeverityLevelDefault = 1;
 
 const std::string kEnableSystemExceptionStacktrace =
     "spark.gluten.sql.columnar.backend.velox.enableSystemExceptionStacktrace";

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1066,7 +1066,7 @@ object GlutenConfig {
       .internal()
       .doc("Set glog severity level in Velox backend, same as FLAGS_minloglevel.")
       .intConf
-      .createWithDefault(0)
+      .createWithDefault(1)
 
   val COLUMNAR_VELOX_SPILL_STRATEGY =
     buildConf("spark.gluten.sql.columnar.backend.velox.spillStrategy")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set the default value of the glog severity level to 1. This will help to remove some redundant glog information.
```
I1123 15:37:56.429041 103986 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_107 with state Finished after running for 438 ms.
I1123 15:37:56.449131 103990 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_123 after running for 472 ms.
I1123 15:37:56.449167 103990 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_123 with state Finished after running for 472 ms.
I1123 15:37:56.466111 103971 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_120 after running for 468 ms.
I1123 15:37:56.466140 103971 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_120 with state Finished after running for 468 ms.
I1123 15:37:56.471377 103999 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_126 after running for 466 ms.
I1123 15:37:56.471407 103999 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_126 with state Finished after running for 466 ms.
I1123 15:37:56.479224 103988 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_135 after running for 501 ms.
I1123 15:37:56.479252 103988 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_135 with state Finished after running for 501 ms.
I1123 15:37:56.480363 103978 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_117 after running for 504 ms.
I1123 15:37:56.480382 103978 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_117 with state Finished after running for 504 ms.
I1123 15:37:56.527155 104006 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_139 after running for 228 ms.
I1123 15:37:56.527185 104006 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_139 with state Finished after running for 228 ms.
I1123 15:37:56.606266 103996 Task.cpp:1030] All drivers (6) finished for task Gluten_Stage_32_TID_138 after running for 322 ms.
I1123 15:37:56.606317 103996 Task.cpp:1714] Terminating task Gluten_Stage_32_TID_138 with state Finished after running for 322 ms.
```
