### PR TITLE
[WIP][VL] fix RoundRobinPartitioner by setting seed pre partition

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -783,6 +783,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
     jdouble reallocThreshold,
     jlong firstBatchHandle,
     jlong taskAttemptId,
+    jint partitionKeySeed,
     jint pushBufferMaxSize,
     jobject partitionPusher,
     jstring partitionWriterTypeJstr) {
@@ -825,6 +826,7 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ShuffleWriterJniWrapper
   }
 
   shuffleWriterOptions.task_attempt_id = (int64_t)taskAttemptId;
+  shuffleWriterOptions.partition_key_seed = partitionKeySeed;
   shuffleWriterOptions.compression_threshold = bufferCompressThreshold;
 
   auto partitionWriterTypeC = env->GetStringUTFChars(partitionWriterTypeJstr, JNI_FALSE);

--- a/cpp/core/shuffle/Options.h
+++ b/cpp/core/shuffle/Options.h
@@ -58,6 +58,7 @@ struct ShuffleWriterOptions {
 
   int64_t thread_id = -1;
   int64_t task_attempt_id = -1;
+  int32_t partition_key_seed = 0;
 
   arrow::ipc::IpcWriteOptions ipc_write_options = arrow::ipc::IpcWriteOptions::Defaults();
 

--- a/cpp/core/shuffle/Partitioner.cc
+++ b/cpp/core/shuffle/Partitioner.cc
@@ -23,12 +23,15 @@
 
 namespace gluten {
 
-arrow::Result<std::shared_ptr<Partitioner>> Partitioner::make(Partitioning partitioning, int32_t numPartitions) {
+arrow::Result<std::shared_ptr<Partitioner>> Partitioner::make(
+    Partitioning partitioning,
+    int32_t numPartitions,
+    int32_t partitionKeySeed) {
   switch (partitioning) {
     case Partitioning::kHash:
       return std::make_shared<HashPartitioner>(numPartitions);
     case Partitioning::kRoundRobin:
-      return std::make_shared<RoundRobinPartitioner>(numPartitions);
+      return std::make_shared<RoundRobinPartitioner>(numPartitions, partitionKeySeed);
     case Partitioning::kSingle:
       return std::make_shared<SinglePartitioner>();
     case Partitioning::kRange:

--- a/cpp/core/shuffle/Partitioner.h
+++ b/cpp/core/shuffle/Partitioner.h
@@ -26,7 +26,10 @@ namespace gluten {
 
 class Partitioner {
  public:
-  static arrow::Result<std::shared_ptr<Partitioner>> make(Partitioning partitioning, int32_t numPartitions);
+  static arrow::Result<std::shared_ptr<Partitioner>> make(
+      Partitioning partitioning,
+      int32_t numPartitions,
+      int32_t partitionKeySeed);
 
   // Whether the first column is partition key.
   bool hasPid() const {

--- a/cpp/core/shuffle/RoundRobinPartitioner.cc
+++ b/cpp/core/shuffle/RoundRobinPartitioner.cc
@@ -27,21 +27,9 @@ arrow::Status gluten::RoundRobinPartitioner::compute(
   std::fill(std::begin(partition2RowCount), std::end(partition2RowCount), 0);
   row2Partition.resize(numRows);
 
-  int32_t pidSelection = pidSelection_;
-  for (int32_t i = 0; i < numRows;) {
-    int32_t low = i;
-    int32_t up = std::min((int64_t)(i + (numPartitions_ - pidSelection)), numRows);
-    for (; low != up;) {
-      row2Partition[low++] = pidSelection++;
-    }
-
-    pidSelection_ = pidSelection;
-    pidSelection = 0;
-    i = up;
-  }
-
-  if (pidSelection_ >= numPartitions_) {
-    pidSelection_ -= numPartitions_;
+  for (int32_t i = 0; i < numRows; ++i) {
+    pidSelection_ = (pidSelection_ + 1) % numPartitions_;
+    row2Partition[i] = pidSelection_;
   }
 
   for (auto& pid : row2Partition) {

--- a/cpp/core/shuffle/RoundRobinPartitioner.h
+++ b/cpp/core/shuffle/RoundRobinPartitioner.h
@@ -23,7 +23,8 @@ namespace gluten {
 
 class RoundRobinPartitioner final : public Partitioner {
  public:
-  RoundRobinPartitioner(int32_t numPartitions) : Partitioner(numPartitions, false) {}
+  RoundRobinPartitioner(int32_t numPartitions, int32_t partitionKeySeed) 
+      : Partitioner(numPartitions, false), pidSelection_(partitionKeySeed) {}
 
   arrow::Status compute(
       const int32_t* pidArr,

--- a/cpp/core/tests/RoundRobinPartitionerTest.cc
+++ b/cpp/core/tests/RoundRobinPartitionerTest.cc
@@ -62,18 +62,18 @@ class RoundRobinPartitionerTest : public ::testing::Test {
 };
 
 TEST_F(RoundRobinPartitionerTest, TestInit) {
-  int numPart = 0;
-  prepareData(numPart);
+  int numPart = 2;
+  prepareData(numPart, 1);
   ASSERT_NE(partitioner_, nullptr);
   int32_t pidSelection = getPidSelection();
-  ASSERT_EQ(pidSelection, 0);
+  ASSERT_EQ(pidSelection, 1);
 }
 
 TEST_F(RoundRobinPartitionerTest, TestComoputeNormal) {
   // numRows equal numPart
   {
     int numPart = 10;
-    prepareData(numPart);
+    prepareData(numPart, 0);
     int numRows = 10;
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 0);
@@ -85,7 +85,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeNormal) {
   // numRows less than numPart
   {
     int numPart = 10;
-    prepareData(numPart);
+    prepareData(numPart, 0);
     int numRows = 8;
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 8);
@@ -99,7 +99,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeNormal) {
   // numRows greater than numPart
   {
     int numPart = 10;
-    prepareData(numPart);
+    prepareData(numPart, 0);
     int numRows = 12;
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 2);
@@ -113,7 +113,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeNormal) {
   // numRows greater than 2*numPart
   {
     int numPart = 10;
-    prepareData(numPart);
+    prepareData(numPart, 0);
     int numRows = 22;
     ASSERT_TRUE(partitioner_->compute(nullptr, numRows, row2Partition_, partition2RowCount_).ok());
     ASSERT_EQ(getPidSelection(), 2);
@@ -127,7 +127,7 @@ TEST_F(RoundRobinPartitionerTest, TestComoputeNormal) {
 
 TEST_F(RoundRobinPartitionerTest, TestComoputeContinuous) {
   int numPart = 10;
-  prepareData(numPart);
+  prepareData(numPart, 0);
 
   {
     int numRows = 8;

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -411,7 +411,9 @@ arrow::Status VeloxShuffleWriter::init() {
   VELOX_CHECK_NOT_NULL(options_.memory_pool);
 
   ARROW_ASSIGN_OR_RAISE(partitionWriter_, partitionWriterCreator_->make(this));
-  ARROW_ASSIGN_OR_RAISE(partitioner_, Partitioner::make(options_.partitioning, numPartitions_));
+  ARROW_ASSIGN_OR_RAISE(
+      partitioner_,
+      Partitioner::make(options_.partitioning, numPartitions_, options_.partition_key_seed));
 
   // pre-allocated buffer size for each partition, unit is row count
   // when partitioner is SinglePart, partial variables don`t need init

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/ShuffleWriterJniWrapper.java
@@ -64,7 +64,8 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
       boolean writeEOS,
       double reallocThreshold,
       long handle,
-      long taskAttemptId) {
+      long taskAttemptId,
+      int partitionKeySeed) {
     return nativeMake(
         part.getShortName(),
         part.getNumPartitions(),
@@ -81,6 +82,7 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
         reallocThreshold,
         handle,
         taskAttemptId,
+        partitionKeySeed,
         0,
         null,
         "local");
@@ -105,6 +107,7 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
       long memoryManagerHandle,
       long handle,
       long taskAttemptId,
+      int partitionKeySeed,
       String partitionWriterType,
       double reallocThreshold) {
     return nativeMake(
@@ -123,6 +126,7 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
         reallocThreshold,
         handle,
         taskAttemptId,
+        partitionKeySeed,
         pushBufferMaxSize,
         pusher,
         partitionWriterType);
@@ -144,6 +148,7 @@ public class ShuffleWriterJniWrapper implements RuntimeAware {
       double reallocThreshold,
       long handle,
       long taskAttemptId,
+      int partitionKeySeed,
       int pushBufferMaxSize,
       Object pusher,
       String partitionWriterType);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`spark.range(100).withColumn("pCol", 'id % 2).repartition(10).write.format("parquet").mode("overwrite").save("/tmp/veloxtest7")`

This query should generate 10 files under directory /tmp/veloxtest7, but in my local shell, only 6 files are genereated (16 cores, so 16 partition by default, and average 6 rows each partition).

RoundRobinPartitioner always start with 0 as selected partition id for all partitions this is not expected. Make this change to align with spark behavior: to set seed as `xshift(partitionId)`.

## How was this patch tested?

TBD.

