### PR TITLE
[CORE] Add InputIteratorTransformer to decouple ReadRel and iterator index

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -38,6 +38,21 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
     MetricsUtil.updateNativeMetrics(child, relMap, joinParamsMap, aggParamsMap)
   }
 
+  override def genInputIteratorTransformerMetrics(
+      sparkContext: SparkContext): Map[String, SQLMetric] = {
+    Map(
+      "iterReadTime" -> SQLMetrics.createTimingMetric(
+        sparkContext,
+        "time of reading from iterator"),
+      "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors")
+    )
+  }
+
+  override def genInputIteratorTransformerMetricsUpdater(
+      metrics: Map[String, SQLMetric]): MetricsUpdater = {
+    InputIteratorMetricsUpdater(metrics)
+  }
+
   override def genBatchScanTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
     Map(
       "inputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
@@ -163,8 +178,6 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
         SQLMetrics.createTimingMetric(sparkContext, "time of aggregating"),
       "postProjectTime" ->
         SQLMetrics.createTimingMetric(sparkContext, "time of postProjection"),
-      "iterReadTime" ->
-        SQLMetrics.createTimingMetric(sparkContext, "time of reading from iterator"),
       "totalTime" -> SQLMetrics.createTimingMetric(sparkContext, "total time")
     )
 
@@ -312,12 +325,8 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
       "extraTime" -> SQLMetrics.createTimingMetric(sparkContext, "extra operators time"),
       "inputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for data"),
       "outputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for output"),
-      "streamIterReadTime" ->
-        SQLMetrics.createTimingMetric(sparkContext, "time of stream side read"),
       "streamPreProjectionTime" ->
         SQLMetrics.createTimingMetric(sparkContext, "time of stream side preProjection"),
-      "buildIterReadTime" ->
-        SQLMetrics.createTimingMetric(sparkContext, "time of build side read"),
       "buildPreProjectionTime" ->
         SQLMetrics.createTimingMetric(sparkContext, "time of build side preProjection"),
       "postProjectTime" ->

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -284,7 +284,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
         }
 
         def wrapChild(child: SparkPlan): WholeStageTransformer = {
-          val childWithAdapter = ColumnarCollapseTransformStages.wrapAdapter(child)
+          val childWithAdapter = ColumnarCollapseTransformStages.wrapInputIteratorTransformer(child)
           WholeStageTransformer(
             ProjectExecTransformer(child.output ++ appendedProjections, childWithAdapter))(
             ColumnarCollapseTransformStages.transformStageCounter.incrementAndGet()

--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -284,7 +284,9 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
         }
 
         def wrapChild(child: SparkPlan): WholeStageTransformer = {
-          WholeStageTransformer(ProjectExecTransformer(child.output ++ appendedProjections, child))(
+          val childWithAdapter = ColumnarCollapseTransformStages.wrapAdapter(child)
+          WholeStageTransformer(
+            ProjectExecTransformer(child.output ++ appendedProjections, childWithAdapter))(
             ColumnarCollapseTransformStages.transformStageCounter.incrementAndGet()
           )
         }

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
@@ -34,15 +34,6 @@ class HashAggregateMetricsUpdater(val metrics: Map[String, SQLMetric])
           var currentIdx = operatorMetrics.metricsList.size() - 1
           var totalTime = 0L
 
-          // read rel
-          if (aggregationParams.isReadRel) {
-            metrics("iterReadTime") +=
-              (operatorMetrics.metricsList.get(currentIdx).time / 1000L).toLong
-            metrics("outputVectors") += operatorMetrics.metricsList.get(currentIdx).outputVectors
-            totalTime += operatorMetrics.metricsList.get(currentIdx).time
-            currentIdx -= 1
-          }
-
           // pre projection
           if (aggregationParams.preProjectionNeeded) {
             metrics("preProjectTime") +=

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HashJoinMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HashJoinMetricsUpdater.scala
@@ -40,15 +40,6 @@ class HashJoinMetricsUpdater(val metrics: Map[String, SQLMetric])
             currentIdx -= 1
           }
 
-          // build side read rel
-          if (joinParams.isBuildReadRel) {
-            val buildSideRealRel = operatorMetrics.metricsList.get(currentIdx)
-            metrics("buildIterReadTime") += (buildSideRealRel.time / 1000L).toLong
-            metrics("outputVectors") += buildSideRealRel.outputVectors
-            totalTime += buildSideRealRel.time
-            currentIdx -= 1
-          }
-
           // stream side pre projection
           if (joinParams.streamPreProjectionNeeded) {
             metrics("streamPreProjectionTime") +=
@@ -58,25 +49,15 @@ class HashJoinMetricsUpdater(val metrics: Map[String, SQLMetric])
             currentIdx -= 1
           }
 
-          // stream side read rel
-          if (joinParams.isStreamedReadRel) {
-            metrics("streamIterReadTime") +=
-              (operatorMetrics.metricsList.get(currentIdx).time / 1000L).toLong
-            metrics("outputVectors") += operatorMetrics.metricsList.get(currentIdx).outputVectors
-            totalTime += operatorMetrics.metricsList.get(currentIdx).time
-
-            // update fillingRightJoinSideTime
-            MetricsUtil
-              .getAllProcessorList(operatorMetrics.metricsList.get(currentIdx))
-              .foreach(
-                processor => {
-                  if (processor.name.equalsIgnoreCase("FillingRightJoinSide")) {
-                    metrics("fillingRightJoinSideTime") += (processor.time / 1000L).toLong
-                  }
-                })
-
-            currentIdx -= 1
-          }
+          // update fillingRightJoinSideTime
+          MetricsUtil
+            .getAllProcessorList(operatorMetrics.metricsList.get(currentIdx))
+            .foreach(
+              processor => {
+                if (processor.name.equalsIgnoreCase("FillingRightJoinSide")) {
+                  metrics("fillingRightJoinSideTime") += (processor.time / 1000L).toLong
+                }
+              })
 
           // joining
           val joinMetricsData = operatorMetrics.metricsList.get(currentIdx)

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/InputIteratorMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/InputIteratorMetricsUpdater.scala
@@ -14,18 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.substrait.rel;
+package io.glutenproject.metrics
 
-import io.substrait.proto.Rel;
+import org.apache.spark.sql.execution.metric.SQLMetric
 
-import java.io.Serializable;
-
-/** Contains helper functions for constructing substrait relations. */
-public interface RelNode extends Serializable {
-  /**
-   * Converts a Rel into a protobuf.
-   *
-   * @return A rel protobuf
-   */
-  Rel toProtobuf();
+case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+  override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
+    if (opMetrics != null) {
+      val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
+      if (!operatorMetrics.metricsList.isEmpty) {
+        val metricsData = operatorMetrics.metricsList.get(0)
+        metrics("iterReadTime") += (metricsData.time / 1000L).toLong
+        metrics("outputVectors") += metricsData.outputVectors
+      }
+    }
+  }
 }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHBucketSuite.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.execution
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf}
-import org.apache.spark.sql.execution.ColumnarInputAdapter
+import org.apache.spark.sql.execution.InputIteratorTransformer
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 
 import org.apache.commons.io.FileUtils
@@ -246,12 +246,12 @@ class GlutenClickHouseTPCHBucketSuite
           plans(3)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
         assert(
           plans(3)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         // Check the bucket join
         assert(
@@ -269,13 +269,13 @@ class GlutenClickHouseTPCHBucketSuite
           plans(9)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
         if (sparkVersion.equals("3.2")) {
           assert(
             plans(9)
               .asInstanceOf[HashJoinLikeExecTransformer]
               .right
-              .isInstanceOf[ColumnarInputAdapter])
+              .isInstanceOf[InputIteratorTransformer])
         } else {
           assert(
             plans(9)
@@ -306,7 +306,7 @@ class GlutenClickHouseTPCHBucketSuite
             plans(1)
               .asInstanceOf[HashJoinLikeExecTransformer]
               .left
-              .isInstanceOf[ColumnarInputAdapter])
+              .isInstanceOf[InputIteratorTransformer])
         } else {
           assert(
             plans(1)
@@ -318,7 +318,7 @@ class GlutenClickHouseTPCHBucketSuite
           plans(1)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         if (sparkVersion.equals("3.2")) {
           assert(!(plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
@@ -447,7 +447,7 @@ class GlutenClickHouseTPCHBucketSuite
             plans(1)
               .asInstanceOf[HashJoinLikeExecTransformer]
               .left
-              .isInstanceOf[ColumnarInputAdapter])
+              .isInstanceOf[InputIteratorTransformer])
         } else {
           assert(
             plans(1)
@@ -459,18 +459,18 @@ class GlutenClickHouseTPCHBucketSuite
           plans(1)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         assert(
           plans(2)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
         assert(
           plans(2)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         assert(
           plans(3)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.execution
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf}
-import org.apache.spark.sql.execution.ColumnarInputAdapter
+import org.apache.spark.sql.execution.InputIteratorTransformer
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 
 import org.apache.commons.io.FileUtils
@@ -240,12 +240,12 @@ class GlutenClickHouseTPCHParquetBucketSuite
           plans(3)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
         assert(
           plans(3)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         // Check the bucket join
         assert(
@@ -263,13 +263,13 @@ class GlutenClickHouseTPCHParquetBucketSuite
           plans(9)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
         if (sparkVersion.equals("3.2")) {
           assert(
             plans(9)
               .asInstanceOf[HashJoinLikeExecTransformer]
               .right
-              .isInstanceOf[ColumnarInputAdapter])
+              .isInstanceOf[InputIteratorTransformer])
         } else {
           assert(
             plans(9)
@@ -303,7 +303,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
             plans(1)
               .asInstanceOf[HashJoinLikeExecTransformer]
               .left
-              .isInstanceOf[ColumnarInputAdapter])
+              .isInstanceOf[InputIteratorTransformer])
         } else {
           assert(
             plans(1)
@@ -316,7 +316,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
           plans(1)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         if (sparkVersion.equals("3.2")) {
           assert(!(plans(2).asInstanceOf[FileSourceScanExecTransformer].bucketedScan))
@@ -460,7 +460,7 @@ class GlutenClickHouseTPCHParquetBucketSuite
             plans(1)
               .asInstanceOf[HashJoinLikeExecTransformer]
               .left
-              .isInstanceOf[ColumnarInputAdapter])
+              .isInstanceOf[InputIteratorTransformer])
         } else {
           assert(
             plans(1)
@@ -472,18 +472,18 @@ class GlutenClickHouseTPCHParquetBucketSuite
           plans(1)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         assert(
           plans(2)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .left
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
         assert(
           plans(2)
             .asInstanceOf[HashJoinLikeExecTransformer]
             .right
-            .isInstanceOf[ColumnarInputAdapter])
+            .isInstanceOf[InputIteratorTransformer])
 
         assert(
           plans(3)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
@@ -22,6 +22,7 @@ import io.glutenproject.vectorized.GeneralInIterator
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.InputIteratorTransformer
 
 import scala.collection.JavaConverters._
 
@@ -89,7 +90,9 @@ class GlutenClickHouseTPCDSMetricsSuite extends GlutenClickHouseTPCDSAbstractSui
       metricsJsonFilePath + "/tpcds-q47-wholestage-9-metrics.json"
     ) {
       () =>
-        val allGlutenPlans = wholeStageTransformer.collect { case g: GlutenPlan => g }
+        val allGlutenPlans = wholeStageTransformer.collect {
+          case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
+        }
 
         assert(allGlutenPlans.size == 29)
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -247,7 +247,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         assert(allGlutenPlans.size == 58)
 
         val shjPlan = allGlutenPlans(8)
-        assert(shjPlan.metrics("totalTime").value == 7)
+        assert(shjPlan.metrics("totalTime").value == 6)
         assert(shjPlan.metrics("inputWaitTime").value == 5)
         assert(shjPlan.metrics("outputWaitTime").value == 0)
         assert(shjPlan.metrics("outputRows").value == 44)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -22,6 +22,7 @@ import io.glutenproject.vectorized.GeneralInIterator
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.InputIteratorTransformer
 
 import scala.collection.JavaConverters._
 
@@ -202,7 +203,9 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
       metricsJsonFilePath + "/tpch-q2-wholestage-2-metrics.json"
     ) {
       () =>
-        val allGlutenPlans = wholeStageTransformer1.collect { case g: GlutenPlan => g }
+        val allGlutenPlans = wholeStageTransformer1.collect {
+          case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
+        }
 
         val scanPlan = allGlutenPlans(10)
         assert(scanPlan.metrics("scanTime").value == 2)
@@ -237,7 +240,9 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
       metricsJsonFilePath + "/tpch-q2-wholestage-11-metrics.json"
     ) {
       () =>
-        val allGlutenPlans = wholeStageTransformer2.collect { case g: GlutenPlan => g }
+        val allGlutenPlans = wholeStageTransformer2.collect {
+          case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
+        }
 
         assert(allGlutenPlans.size == 58)
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
@@ -41,7 +41,7 @@ class MetricsApiImpl extends MetricsApi with Logging {
       sparkContext: SparkContext): Map[String, SQLMetric] = {
     Map(
       "cpuCount" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-      "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime of batch scan"),
+      "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime of input iterator"),
       "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors")
     )
   }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
@@ -37,6 +37,20 @@ class MetricsApiImpl extends MetricsApi with Logging {
     MetricsUtil.updateNativeMetrics(child, relMap, joinParamsMap, aggParamsMap)
   }
 
+  override def genInputIteratorTransformerMetrics(
+      sparkContext: SparkContext): Map[String, SQLMetric] = {
+    Map(
+      "cpuCount" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
+      "wallNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "totaltime of batch scan"),
+      "outputVectors" -> SQLMetrics.createMetric(sparkContext, "number of output vectors")
+    )
+  }
+
+  override def genInputIteratorTransformerMetricsUpdater(
+      metrics: Map[String, SQLMetric]): MetricsUpdater = {
+    InputIteratorMetricsUpdater(metrics)
+  }
+
   override def genBatchScanTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
     Map(
       "inputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
@@ -435,23 +449,12 @@ class MetricsApiImpl extends MetricsApi with Logging {
       "hashProbeDynamicFiltersProduced" -> SQLMetrics.createMetric(
         sparkContext,
         "number of hash probe dynamic filters produced"),
-      "streamCpuCount" -> SQLMetrics.createMetric(sparkContext, "stream input cpu wall time count"),
-      "streamWallNanos" -> SQLMetrics.createNanoTimingMetric(
-        sparkContext,
-        "totaltime of stream input"),
-      "streamVeloxToArrow" -> SQLMetrics.createNanoTimingMetric(
-        sparkContext,
-        "totaltime of velox2arrow converter"),
       "streamPreProjectionCpuCount" -> SQLMetrics.createMetric(
         sparkContext,
         "stream preProject cpu wall time count"),
       "streamPreProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
         sparkContext,
         "totaltime of stream preProjection"),
-      "buildCpuCount" -> SQLMetrics.createMetric(sparkContext, "build input cpu wall time count"),
-      "buildWallNanos" -> SQLMetrics.createNanoTimingMetric(
-        sparkContext,
-        "totaltime to build input"),
       "buildPreProjectionCpuCount" -> SQLMetrics.createMetric(
         sparkContext,
         "preProject cpu wall time count"),

--- a/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/FilterExecTransformer.scala
@@ -18,14 +18,9 @@ package io.glutenproject.execution
 
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.SubstraitContext
-import io.glutenproject.substrait.rel.RelBuilder
 
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.{And, Expression}
 import org.apache.spark.sql.execution.SparkPlan
-
-import java.util
-
-import scala.collection.JavaConverters._
 
 case class FilterExecTransformer(condition: Expression, child: SparkPlan)
   extends FilterExecTransformerBase(condition, child) {
@@ -47,13 +42,8 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {
+    val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
     val leftCondition = getLeftCondition
-    val childCtx = child match {
-      case c: TransformSupport =>
-        c.doTransform(context)
-      case _ =>
-        null
-    }
 
     val operatorId = context.nextOperatorId(this.nodeName)
     if (leftCondition == null) {
@@ -62,34 +52,15 @@ case class FilterExecTransformer(condition: Expression, child: SparkPlan)
       return childCtx
     }
 
-    val currRel = if (childCtx != null) {
-      getRelNode(
-        context,
-        leftCondition,
-        child.output,
-        operatorId,
-        childCtx.root,
-        validation = false)
-    } else {
-      // This means the input is just an iterator, so an ReadRel will be created as child.
-      // Prepare the input schema.
-      val attrList = new util.ArrayList[Attribute](child.output.asJava)
-      getRelNode(
-        context,
-        leftCondition,
-        child.output,
-        operatorId,
-        RelBuilder.makeReadRel(attrList, context, operatorId),
-        validation = false)
-    }
+    val currRel = getRelNode(
+      context,
+      leftCondition,
+      child.output,
+      operatorId,
+      childCtx.root,
+      validation = false)
     assert(currRel != null, "Filter rel should be valid.")
-    val inputAttributes = if (childCtx != null) {
-      // Use the outputAttributes of child context as inputAttributes.
-      childCtx.outputAttributes
-    } else {
-      child.output
-    }
-    TransformContext(inputAttributes, output, currRel)
+    TransformContext(childCtx.outputAttributes, output, currRel)
   }
 
   private def getLeftCondition: Expression = {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxHashJoinSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxHashJoinSuite.scala
@@ -19,7 +19,7 @@ package io.glutenproject.execution
 import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.execution.ColumnarInputAdapter
+import org.apache.spark.sql.execution.{ColumnarInputAdapter, InputIteratorTransformer}
 
 import java.io.File
 
@@ -73,7 +73,7 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
         assert(joins.length == 2)
 
         // Children of Join should be seperated into different `TransformContext`s.
-        assert(joins.forall(_.children.forall(_.isInstanceOf[ColumnarInputAdapter])))
+        assert(joins.forall(_.children.forall(_.isInstanceOf[InputIteratorTransformer])))
 
         // WholeStageTransformer should be inserted for joins and its children separately.
         val wholeStages = plan.collect { case wst: WholeStageTransformer => wst }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxHashJoinSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxHashJoinSuite.scala
@@ -19,7 +19,7 @@ package io.glutenproject.execution
 import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.execution.{ColumnarInputAdapter, InputIteratorTransformer}
+import org.apache.spark.sql.execution.InputIteratorTransformer
 
 import java.io.File
 
@@ -82,7 +82,7 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
         // Join should be in `TransformContext`
         val countSHJ = wholeStages.map {
           _.collectFirst {
-            case _: ColumnarInputAdapter => 0
+            case _: InputIteratorTransformer => 0
             case _: ShuffledHashJoinExecTransformer => 1
           }.getOrElse(0)
         }.sum
@@ -118,7 +118,7 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
       // Join should be in `TransformContext`
       val countSHJ = wholeStages.map {
         _.collectFirst {
-          case _: ColumnarInputAdapter => 0
+          case _: InputIteratorTransformer => 0
           case _: ShuffledHashJoinExecTransformer => 1
         }.getOrElse(0)
       }.sum

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/InputIteratorRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/InputIteratorRelNode.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.substrait.rel;
+
+import io.glutenproject.expression.ConverterUtils;
+import io.glutenproject.substrait.type.TypeNode;
+
+import io.substrait.proto.*;
+
+import java.util.List;
+
+/**
+ * The relation for input iterator, e.g., the input is ColumnarShuffleExchange or RowToColumnarExec.
+ * It uses `ReadRel` as the substrait rel type.
+ */
+public class InputIteratorRelNode implements RelNode {
+
+  private final List<TypeNode> types;
+  private final List<String> names;
+  private final Long iteratorIndex;
+
+  public InputIteratorRelNode(List<TypeNode> types, List<String> names, Long iteratorIndex) {
+    this.types = types;
+    this.names = names;
+    this.iteratorIndex = iteratorIndex;
+  }
+
+  @Override
+  public Rel toProtobuf() {
+    Type.Struct.Builder structBuilder = Type.Struct.newBuilder();
+    for (TypeNode typeNode : types) {
+      structBuilder.addTypes(typeNode.toProtobuf());
+    }
+
+    NamedStruct.Builder nStructBuilder = NamedStruct.newBuilder();
+    nStructBuilder.setStruct(structBuilder.build());
+    for (String name : names) {
+      nStructBuilder.addNames(name);
+    }
+
+    ReadRel.Builder readBuilder = ReadRel.newBuilder();
+    readBuilder.setBaseSchema(nStructBuilder.build());
+
+    LocalFilesNode iteratorIndexNode =
+        LocalFilesBuilder.makeLocalFiles(ConverterUtils.ITERATOR_PREFIX() + iteratorIndex);
+    readBuilder.setLocalFiles(iteratorIndexNode.toProtobuf());
+
+    Rel.Builder builder = Rel.newBuilder();
+    builder.setRead(readBuilder.build());
+    return builder.build();
+  }
+}

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -40,7 +40,6 @@ public class ReadRelNode implements RelNode, Serializable {
   private final List<ColumnTypeNode> columnTypeNodes = new ArrayList<>();
   private final SubstraitContext context;
   private final ExpressionNode filterNode;
-  private final Long iteratorIndex;
   private StructType dataSchema;
   private Map<String, String> properties;
 
@@ -49,26 +48,11 @@ public class ReadRelNode implements RelNode, Serializable {
       List<String> names,
       SubstraitContext context,
       ExpressionNode filterNode,
-      Long iteratorIndex) {
-    this.types.addAll(types);
-    this.names.addAll(names);
-    this.context = context;
-    this.filterNode = filterNode;
-    this.iteratorIndex = iteratorIndex;
-  }
-
-  ReadRelNode(
-      List<TypeNode> types,
-      List<String> names,
-      SubstraitContext context,
-      ExpressionNode filterNode,
-      Long iteratorIndex,
       List<ColumnTypeNode> columnTypeNodes) {
     this.types.addAll(types);
     this.names.addAll(names);
     this.context = context;
     this.filterNode = filterNode;
-    this.iteratorIndex = iteratorIndex;
     this.columnTypeNodes.addAll(columnTypeNodes);
   }
 
@@ -125,14 +109,7 @@ public class ReadRelNode implements RelNode, Serializable {
     if (filterNode != null) {
       readBuilder.setFilter(filterNode.toProtobuf());
     }
-    if (this.iteratorIndex != null) {
-      LocalFilesNode filesNode = context.getInputIteratorNode(iteratorIndex);
-      if (dataSchema != null) {
-        filesNode.setFileSchema(dataSchema);
-        filesNode.setFileReadProperties(properties);
-      }
-      readBuilder.setLocalFiles(filesNode.toProtobuf());
-    } else if (context.getSplitInfos() != null && !context.getSplitInfos().isEmpty()) {
+    if (context.getSplitInfos() != null && !context.getSplitInfos().isEmpty()) {
       SplitInfo currentSplitInfo = context.getCurrentSplitInfo();
       if (currentSplitInfo instanceof LocalFilesNode) {
         LocalFilesNode filesNode = (LocalFilesNode) currentSplitInfo;

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -127,6 +127,7 @@ public class RelBuilder {
     return new InputIteratorRelNode(typeList, nameList, iteratorIndex);
   }
 
+  // only used in CHHashAggregateExecTransformer for CH backend
   public static RelNode makeReadRelForInputIteratorWithoutRegister(
       List<TypeNode> typeList, List<String> nameList, SubstraitContext context) {
     Long iteratorIndex = context.currentIteratorIndex();

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -129,7 +129,7 @@ public class RelBuilder {
 
   public static RelNode makeReadRelForInputIteratorWithoutRegister(
       List<TypeNode> typeList, List<String> nameList, SubstraitContext context) {
-    Long iteratorIndex = context.nextIteratorIndex();
+    Long iteratorIndex = context.currentIteratorIndex();
     return new InputIteratorRelNode(typeList, nameList, iteratorIndex);
   }
 

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -99,8 +99,7 @@ public class RelBuilder {
       ExpressionNode filter,
       SubstraitContext context,
       Long operatorId) {
-    context.registerRelToOperator(operatorId);
-    return new ReadRelNode(types, names, context, filter, null);
+    return makeReadRel(types, names, null, filter, context, operatorId);
   }
 
   public static RelNode makeReadRel(
@@ -111,38 +110,21 @@ public class RelBuilder {
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
-    return new ReadRelNode(types, names, context, filter, null, columnTypeNodes);
+    return new ReadRelNode(types, names, context, filter, columnTypeNodes);
   }
 
-  public static RelNode makeReadRel(
-      List<TypeNode> types,
-      List<String> names,
-      ExpressionNode filter,
-      Long iteratorIndex,
-      SubstraitContext context,
-      Long operatorId) {
-    context.registerRelToOperator(operatorId);
-    return new ReadRelNode(types, names, context, filter, iteratorIndex);
-  }
-
-  public static RelNode makeReadRel(
+  public static RelNode makeReadRelForInputIterator(
       List<Attribute> attributes, SubstraitContext context, Long operatorId) {
-    if (operatorId >= 0) {
-      // If the operator id is negative, will not register the rel to operator.
-      // Currently, only for the special handling in join.
-      context.registerRelToOperator(operatorId);
-    }
-
     List<TypeNode> typeList = ConverterUtils.collectAttributeTypeNodes(attributes);
     List<String> nameList = ConverterUtils.collectAttributeNamesWithExprId(attributes);
+    return makeReadRelForInputIterator(typeList, nameList, context, operatorId);
+  }
 
-    // The iterator index will be added in the path of LocalFiles.
+  public static RelNode makeReadRelForInputIterator(
+      List<TypeNode> typeList, List<String> nameList, SubstraitContext context, Long operatorId) {
+    context.registerRelToOperator(operatorId);
     Long iteratorIndex = context.nextIteratorIndex();
-    context.setIteratorNode(
-        iteratorIndex,
-        LocalFilesBuilder.makeLocalFiles(
-            ConverterUtils.ITERATOR_PREFIX().concat(iteratorIndex.toString())));
-    return new ReadRelNode(typeList, nameList, context, null, iteratorIndex);
+    return new InputIteratorRelNode(typeList, nameList, iteratorIndex);
   }
 
   public static RelNode makeJoinRel(

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -127,6 +127,12 @@ public class RelBuilder {
     return new InputIteratorRelNode(typeList, nameList, iteratorIndex);
   }
 
+  public static RelNode makeReadRelForInputIteratorWithoutRegister(
+      List<TypeNode> typeList, List<String> nameList, SubstraitContext context) {
+    Long iteratorIndex = context.nextIteratorIndex();
+    return new InputIteratorRelNode(typeList, nameList, iteratorIndex);
+  }
+
   public static RelNode makeJoinRel(
       RelNode left,
       RelNode right,

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
@@ -33,6 +33,10 @@ trait MetricsApi extends Serializable {
       "pipelineTime" -> SQLMetrics
         .createTimingMetric(sparkContext, WholeStageCodegenExec.PIPELINE_DURATION_METRIC))
 
+  def genInputIteratorTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
+
+  def genInputIteratorTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
+
   def metricsUpdatingFunction(
       child: SparkPlan,
       relMap: JMap[JLong, JList[JLong]],

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GenerateExecTransformer.scala
@@ -95,11 +95,7 @@ case class GenerateExecTransformer(
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {
-    val childCtx = child match {
-      case c: TransformSupport => c.doTransform(context)
-      case _ => null
-    }
-
+    val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
     val args = context.registeredFunction
     val operatorId = context.nextOperatorId(this.nodeName)
     val generatorExpr =
@@ -116,12 +112,7 @@ case class GenerateExecTransformer(
       }
     }
 
-    val inputRel = if (childCtx != null) {
-      childCtx.root
-    } else {
-      val readRel = RelBuilder.makeReadRel(child.output.asJava, context, operatorId)
-      readRel
-    }
+    val inputRel = childCtx.root
     val projRel =
       if (BackendsApiManager.getSettings.insertPostProjectForGenerate()) {
         // need to insert one projection node for velox backend

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -21,7 +21,6 @@ import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.substrait.{JoinParams, SubstraitContext}
-import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
@@ -32,8 +31,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import com.google.protobuf.StringValue
 import io.substrait.proto.JoinRel
-
-import scala.collection.JavaConverters._
 
 /** Performs a sort merge join of two child relations. */
 case class SortMergeJoinExecTransformer(
@@ -249,41 +246,18 @@ case class SortMergeJoinExecTransformer(
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {
-    def transformAndGetOutput(plan: SparkPlan): (RelNode, Seq[Attribute], Boolean) = {
-      plan match {
-        case p: TransformSupport =>
-          val transformContext = p.doTransform(context)
-          (transformContext.root, transformContext.outputAttributes, false)
-        case _ =>
-          val readRel = RelBuilder.makeReadRel(
-            plan.output.asJava,
-            context,
-            -1
-          ) /* A special handling in Join to delay the rel registration. */
-          (readRel, plan.output, true)
-      }
-    }
+    val streamedPlanContext = streamedPlan.asInstanceOf[TransformSupport].doTransform(context)
+    val (inputStreamedRelNode, inputStreamedOutput) =
+      (streamedPlanContext.root, streamedPlanContext.outputAttributes)
 
-    val joinParams = new JoinParams
-    val (inputStreamedRelNode, inputStreamedOutput, isStreamedReadRel) =
-      transformAndGetOutput(streamedPlan)
-    joinParams.isStreamedReadRel = isStreamedReadRel
-
-    val (inputBuildRelNode, inputBuildOutput, isBuildReadRel) =
-      transformAndGetOutput(bufferedPlan)
-    joinParams.isBuildReadRel = isBuildReadRel
+    val bufferedPlanContext = bufferedPlan.asInstanceOf[TransformSupport].doTransform(context)
+    val (inputBuildRelNode, inputBuildOutput) =
+      (bufferedPlanContext.root, bufferedPlanContext.outputAttributes)
 
     // Get the operator id of this Join.
     val operatorId = context.nextOperatorId(this.nodeName)
 
-    // Register the ReadRel to correct operator Id.
-    if (joinParams.isStreamedReadRel) {
-      context.registerRelToOperator(operatorId)
-    }
-    if (joinParams.isBuildReadRel) {
-      context.registerRelToOperator(operatorId)
-    }
-
+    val joinParams = new JoinParams
     if (JoinUtils.preProjectionNeeded(leftKeys)) {
       joinParams.streamPreProjectionNeeded = true
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -87,7 +87,8 @@ case class TakeOrderedAndProjectExecTransformer(
         case other =>
           // if the child it is not WholeStageTransformer, add the adapter first
           // so that, later we can wrap WholeStageTransformer.
-          val localSortPlan = withLocalSort(ColumnarCollapseTransformStages.wrapAdapter(other))
+          val localSortPlan = withLocalSort(
+            ColumnarCollapseTransformStages.wrapInputIteratorTransformer(other))
           LimitTransformer(localSortPlan, 0, limit)
       }
       val transformStageCounter: AtomicInteger =
@@ -104,7 +105,7 @@ case class TakeOrderedAndProjectExecTransformer(
           SortExecTransformer(
             sortOrder,
             false,
-            ColumnarCollapseTransformStages.wrapAdapter(transformedShuffleExec))
+            ColumnarCollapseTransformStages.wrapInputIteratorTransformer(transformedShuffleExec))
         LimitTransformer(localSortPlan, 0, limit)
       }
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/TakeOrderedAndProjectExecTransformer.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{ColumnarCollapseTransformStages, ColumnarInputAdapter, ColumnarShuffleExchangeExec, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{ColumnarCollapseTransformStages, ColumnarShuffleExchangeExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -85,7 +85,9 @@ case class TakeOrderedAndProjectExecTransformer(
           val localSortPlan = withLocalSort(wholeStage.child)
           LimitTransformer(localSortPlan, 0, limit)
         case other =>
-          val localSortPlan = withLocalSort(other)
+          // if the child it is not WholeStageTransformer, add the adapter first
+          // so that, later we can wrap WholeStageTransformer.
+          val localSortPlan = withLocalSort(ColumnarCollapseTransformStages.wrapAdapter(other))
           LimitTransformer(localSortPlan, 0, limit)
       }
       val transformStageCounter: AtomicInteger =
@@ -99,7 +101,10 @@ case class TakeOrderedAndProjectExecTransformer(
         val transformedShuffleExec =
           ColumnarShuffleExchangeExec(shuffleExec, limitStagePlan, shuffleExec.child.output)
         val localSortPlan =
-          SortExecTransformer(sortOrder, false, new ColumnarInputAdapter(transformedShuffleExec))
+          SortExecTransformer(
+            sortOrder,
+            false,
+            ColumnarCollapseTransformStages.wrapAdapter(transformedShuffleExec))
         LimitTransformer(localSortPlan, 0, limit)
       }
 
@@ -112,7 +117,7 @@ case class TakeOrderedAndProjectExecTransformer(
       val finalPlan =
         WholeStageTransformer(projectPlan)(transformStageCounter.incrementAndGet())
 
-      finalPlan.doExecuteColumnar()
+      finalPlan.executeColumnar()
     }
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -207,13 +207,7 @@ case class WindowExecTransformer(
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {
-    val childCtx = child match {
-      case c: TransformSupport =>
-        c.doTransform(context)
-      case _ =>
-        null
-    }
-
+    val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
     val operatorId = context.nextOperatorId(this.nodeName)
     if (windowExpression == null || windowExpression.isEmpty) {
       // The computing for this project is not needed.
@@ -221,36 +215,17 @@ case class WindowExecTransformer(
       return childCtx
     }
 
-    val (currRel, inputAttributes) = if (childCtx != null) {
-      (
-        getRelNode(
-          context,
-          windowExpression,
-          partitionSpec,
-          orderSpec,
-          child.output,
-          operatorId,
-          childCtx.root,
-          validation = false),
-        childCtx.outputAttributes)
-    } else {
-      // This means the input is just an iterator, so an ReadRel will be created as child.
-      // Prepare the input schema.
-      val readRel = RelBuilder.makeReadRel(child.output.asJava, context, operatorId)
-      (
-        getRelNode(
-          context,
-          windowExpression,
-          partitionSpec,
-          orderSpec,
-          child.output,
-          operatorId,
-          readRel,
-          validation = false),
-        child.output)
-    }
+    val currRel = getRelNode(
+      context,
+      windowExpression,
+      partitionSpec,
+      orderSpec,
+      child.output,
+      operatorId,
+      childCtx.root,
+      validation = false)
     assert(currRel != null, "Window Rel should be valid")
-    TransformContext(inputAttributes, output, currRel)
+    TransformContext(childCtx.outputAttributes, output, currRel)
   }
 
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -687,7 +687,8 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               val limitPlan = LimitTransformer(plan.child, 0, plan.limit)
               tagged = limitPlan.doValidate()
             } else {
-              val sortPlan = SortExecTransformer(plan.sortOrder, false, plan.child)
+              val inputTransformer = ColumnarCollapseTransformStages.wrapAdapter(plan.child)
+              val sortPlan = SortExecTransformer(plan.sortOrder, false, inputTransformer)
               val limitPlan = LimitTransformer(sortPlan, 0, plan.limit)
               tagged = limitPlan.doValidate()
             }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -687,6 +687,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               val limitPlan = LimitTransformer(plan.child, 0, plan.limit)
               tagged = limitPlan.doValidate()
             } else {
+              // Here we are validating sort + limit which is a kind of whole stage transformer,
+              // because we would call sort.doTransform in limit.
+              // So, we should add adapter to make it work.
               val inputTransformer = ColumnarCollapseTransformStages.wrapAdapter(plan.child)
               val sortPlan = SortExecTransformer(plan.sortOrder, false, inputTransformer)
               val limitPlan = LimitTransformer(sortPlan, 0, plan.limit)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -690,7 +690,8 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               // Here we are validating sort + limit which is a kind of whole stage transformer,
               // because we would call sort.doTransform in limit.
               // So, we should add adapter to make it work.
-              val inputTransformer = ColumnarCollapseTransformStages.wrapAdapter(plan.child)
+              val inputTransformer =
+                ColumnarCollapseTransformStages.wrapInputIteratorTransformer(plan.child)
               val sortPlan = SortExecTransformer(plan.sortOrder, false, inputTransformer)
               val limitPlan = LimitTransformer(sortPlan, 0, plan.limit)
               tagged = limitPlan.doValidate()

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -124,6 +124,11 @@ class SubstraitContext extends Serializable {
     id
   }
 
+  def currentIteratorIndex: JLong = {
+    assert(iteratorIndex > 0)
+    this.iteratorIndex - 1
+  }
+
   /**
    * Register a rel to certain operator id.
    * @param operatorId

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -17,22 +17,16 @@
 package io.glutenproject.substrait
 
 import io.glutenproject.substrait.ddlplan.InsertOutputNode
-import io.glutenproject.substrait.rel.{LocalFilesNode, SplitInfo}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
+import io.glutenproject.substrait.rel.SplitInfo
 
 import java.lang.{Integer => JInt, Long => JLong}
 import java.security.InvalidParameterException
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
 case class JoinParams() {
-  // Whether the input of streamed side is a ReadRel represented iterator.
-  var isStreamedReadRel = false
-
   // Whether preProjection is needed in streamed side.
   var streamPreProjectionNeeded = false
-
-  // Whether the input of build side is a ReadRel represented iterator.
-  var isBuildReadRel = false
 
   // Whether preProjection is needed in build side.
   var buildPreProjectionNeeded = false
@@ -48,9 +42,6 @@ case class JoinParams() {
 }
 
 case class AggregationParams() {
-  // Whether the input is a ReadRel represented iterator.
-  var isReadRel = false
-
   // Whether preProjection is needed.
   var preProjectionNeeded = false
 
@@ -64,9 +55,6 @@ case class AggregationParams() {
 class SubstraitContext extends Serializable {
   // A map stores the relationship between function name and function id.
   private val functionMap = new JHashMap[String, JLong]()
-
-  // A map stores the relationship between id and local file node.
-  private val iteratorNodes = new JHashMap[JLong, LocalFilesNode]()
 
   // A map stores the relationship between Spark operator id and its respective Substrait Rel ids.
   private val operatorToRelsMap: JMap[JLong, JList[JLong]] = new JHashMap[JLong, JList[JLong]]()
@@ -87,13 +75,6 @@ class SubstraitContext extends Serializable {
   private var insertOutputNode: InsertOutputNode = _
   private var operatorId: JLong = 0L
   private var relId: JLong = 0L
-
-  def setIteratorNode(index: JLong, localFilesNode: LocalFilesNode): Unit = {
-    if (iteratorNodes.containsKey(index)) {
-      throw new IllegalStateException(s"Iterator index $index has been used.")
-    }
-    iteratorNodes.put(index, localFilesNode)
-  }
 
   def initSplitInfosIndex(splitInfosIndex: JInt): Unit = {
     this.splitInfosIndex = splitInfosIndex
@@ -117,10 +98,6 @@ class SubstraitContext extends Serializable {
 
   def setSplitInfos(SplitInfos: Seq[SplitInfo]): Unit = {
     this.splitInfos = SplitInfos
-  }
-
-  def getInputIteratorNode(index: JLong): LocalFilesNode = {
-    iteratorNodes.get(index)
   }
 
   def getInsertOutputNode: InsertOutputNode = insertOutputNode
@@ -162,18 +139,6 @@ class SubstraitContext extends Serializable {
       operatorToRelsMap.put(operatorId, rels)
     }
     relId += 1
-  }
-
-  /** Register a specified rel to certain operator id. */
-  def registerRelToOperator(operatorId: JLong, specifiedRedId: JLong): Unit = {
-    if (operatorToRelsMap.containsKey(operatorId)) {
-      val rels = operatorToRelsMap.get(operatorId)
-      rels.add(specifiedRedId)
-    } else {
-      val rels = new JArrayList[JLong]()
-      rels.add(specifiedRedId)
-      operatorToRelsMap.put(operatorId, rels)
-    }
   }
 
   /** Add the relId and register to operator later */

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -84,6 +84,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
         case _: WholeStageCodegenExec =>
         case _: WholeStageTransformer =>
         case _: InputAdapter =>
+        case _: InputIteratorTransformer =>
         case _: ColumnarToRowTransition =>
         case _: RowToColumnarTransition =>
         case p: QueryStageExec => collect(p.plan)

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -106,6 +106,7 @@ object GlutenImplicits {
           case _: WholeStageCodegenExec =>
           case _: WholeStageTransformer =>
           case _: InputAdapter =>
+          case _: InputIteratorTransformer =>
           case _: ColumnarToRowTransition =>
           case _: RowToColumnarTransition =>
           case p: AdaptiveSparkPlanExec if isFinalAdaptivePlan(p) =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
@@ -51,7 +51,7 @@ trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
     def injectAdapter(p: SparkPlan): SparkPlan = p match {
       case p: ProjectExecTransformer => p.mapChildren(injectAdapter)
       case s: SortExecTransformer => s.mapChildren(injectAdapter)
-      case _ => ColumnarCollapseTransformStages.wrapAdapter(p)
+      case _ => ColumnarCollapseTransformStages.wrapInputIteratorTransformer(p)
     }
 
     // why materializeInput = true? this is for CH backend.

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
@@ -16,16 +16,15 @@
  */
 package org.apache.spark.sql.execution.datasources
 
-import io.glutenproject.execution.TransformSupport
-import io.glutenproject.execution.WholeStageTransformer
+import io.glutenproject.execution.{ProjectExecTransformer, SortExecTransformer, TransformSupport, WholeStageTransformer}
 import io.glutenproject.execution.datasource.GlutenFormatWriterInjects
 import io.glutenproject.extension.TransformPreOverrides
 import io.glutenproject.extension.columnar.AddTransformHintRule
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.{ColumnarCollapseTransformStages, SparkPlan}
 import org.apache.spark.sql.execution.ColumnarCollapseTransformStages.transformStageCounter
-import org.apache.spark.sql.execution.SparkPlan
 
 trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
 
@@ -49,6 +48,12 @@ trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
           "consider disabling native writer to workaround this issue.")
     }
 
+    def injectAdapter(p: SparkPlan): SparkPlan = p match {
+      case p: ProjectExecTransformer => p.mapChildren(injectAdapter)
+      case s: SortExecTransformer => s.mapChildren(injectAdapter)
+      case _ => ColumnarCollapseTransformStages.wrapAdapter(p)
+    }
+
     // why materializeInput = true? this is for CH backend.
     // in this wst, a Sort will be executed by the underlying native engine.
     // In CH, a SortingTransform cannot handle Const Columns,
@@ -56,7 +61,8 @@ trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
     // and use const_columns_to_remove to skip const columns.
     // Unfortunately, in our case this wst's input is SourceFromJavaIter
     // and cannot provide const-ness.
-    val wst = WholeStageTransformer(transformed, materializeInput = true)(
+    val transformedWithAdapter = injectAdapter(transformed)
+    val wst = WholeStageTransformer(transformedWithAdapter, materializeInput = true)(
       transformStageCounter.incrementAndGet())
     FakeRowAdaptor(wst).execute()
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonExecTransformer.scala
@@ -87,11 +87,7 @@ case class EvalPythonExecTransformer(
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {
-    val childCtx = child match {
-      case c: TransformSupport => c.doTransform(context)
-      case _ => null
-    }
-
+    val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
     val args = context.registeredFunction
     val operatorId = context.nextOperatorId(this.nodeName)
     val expressionNodes = new JArrayList[ExpressionNode]
@@ -103,17 +99,8 @@ case class EvalPythonExecTransformer(
           ExpressionConverter.replaceWithExpressionTransformer(udf, child.output).doTransform(args))
       })
 
-    val relNode = if (childCtx != null) {
+    val relNode =
       getRelNode(childCtx.root, expressionNodes, context, operatorId, child.output, false)
-    } else {
-      val attrList = new JArrayList[Attribute]()
-      for (attr <- child.output) {
-        attrList.add(attr)
-      }
-      val readRel = RelBuilder.makeReadRel(attrList, context, operatorId)
-      getRelNode(readRel, expressionNodes, context, operatorId, child.output, false)
-    }
-
     TransformContext(child.output, output, relNode)
   }
 

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
@@ -89,9 +89,5 @@ class HashAggregateMetricsUpdaterImpl(val metrics: Map[String, SQLMetric])
       preProjectionWallNanos += aggregationMetrics.get(idx).wallNanos
       idx += 1
     }
-
-    if (aggParams.isReadRel) {
-      idx += 1
-    }
   }
 }

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/HashJoinMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/HashJoinMetricsUpdater.scala
@@ -65,15 +65,8 @@ class HashJoinMetricsUpdaterImpl(val metrics: Map[String, SQLMetric])
   val hashProbeDynamicFiltersProduced: SQLMetric =
     metrics("hashProbeDynamicFiltersProduced")
 
-  val streamCpuCount: SQLMetric = metrics("streamCpuCount")
-  val streamWallNanos: SQLMetric = metrics("streamWallNanos")
-  val streamVeloxToArrow: SQLMetric = metrics("streamVeloxToArrow")
-
   val streamPreProjectionCpuCount: SQLMetric = metrics("streamPreProjectionCpuCount")
   val streamPreProjectionWallNanos: SQLMetric = metrics("streamPreProjectionWallNanos")
-
-  val buildCpuCount: SQLMetric = metrics("buildCpuCount")
-  val buildWallNanos: SQLMetric = metrics("buildWallNanos")
 
   val buildPreProjectionCpuCount: SQLMetric = metrics("buildPreProjectionCpuCount")
   val buildPreProjectionWallNanos: SQLMetric = metrics("buildPreProjectionWallNanos")
@@ -140,23 +133,9 @@ class HashJoinMetricsUpdaterImpl(val metrics: Map[String, SQLMetric])
       idx += 1
     }
 
-    if (joinParams.isBuildReadRel) {
-      buildCpuCount += joinMetrics.get(idx).cpuCount
-      buildWallNanos += joinMetrics.get(idx).wallNanos
-      idx += 1
-    }
-
     if (joinParams.streamPreProjectionNeeded) {
       streamPreProjectionCpuCount += joinMetrics.get(idx).cpuCount
       streamPreProjectionWallNanos += joinMetrics.get(idx).wallNanos
-      idx += 1
-    }
-
-    if (joinParams.isStreamedReadRel) {
-      val streamMetrics = joinMetrics.get(idx)
-      streamCpuCount += streamMetrics.cpuCount
-      streamWallNanos += streamMetrics.wallNanos
-      streamVeloxToArrow += singleMetrics.veloxToArrow
       idx += 1
     }
   }

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/InputIteratorMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/InputIteratorMetricsUpdater.scala
@@ -14,18 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.glutenproject.substrait.rel;
+package io.glutenproject.metrics
+import org.apache.spark.sql.execution.metric.SQLMetric
 
-import io.substrait.proto.Rel;
-
-import java.io.Serializable;
-
-/** Contains helper functions for constructing substrait relations. */
-public interface RelNode extends Serializable {
-  /**
-   * Converts a Rel into a protobuf.
-   *
-   * @return A rel protobuf
-   */
-  Rel toProtobuf();
+case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+  override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
+    if (opMetrics != null) {
+      val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
+      metrics("cpuCount") += operatorMetrics.cpuCount
+      metrics("wallNanos") += operatorMetrics.wallNanos
+      metrics("outputVectors") += operatorMetrics.outputVectors
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds a new transformer `InputIteratorTransformer` to connect SparkPlan and TransformSupport. It replace the original `ColumnarInputAdapter` to provide the substrait plan ReadRel for the child columnar iterator, so that the TransformSupport always has input. It would be transformed to ValueStreamNode at native Velox side.

The reason is that:
1. decopule with scan transofrmer, the scan transofrmer does not need iterator index
2. make the whole stage transform framework more clear, all the TransformSupport does not need to check if the child is a TransformSupport and build a ReadRel by theirself
3. make the metrics framework more clear, the metrics should belong to the input iterator rather than the operators
4. it aligns with native side, e.g., velox backend will transform it to ValueStreamNode

## How was this patch tested?

Pass CI and manually test

<img width="1489" alt="image" src="https://github.com/oap-project/gluten/assets/12025282/8b674b14-2826-4fd0-aeaf-a3ef6a722884">


