### PR TITLE
[VL] Enable using static link for QAT

### DIFF
--- a/cpp/CMake/BuildQATZstd.cmake
+++ b/cpp/CMake/BuildQATZstd.cmake
@@ -17,6 +17,12 @@
 
 include(ExternalProject)
 
+if("${MAKE}" STREQUAL "")
+  if(NOT MSVC)
+    find_program(MAKE make)
+  endif()
+endif()
+
 macro(build_qatzstd)
   # Find ZSTD
   include(FindZstd)
@@ -41,7 +47,7 @@ macro(build_qatzstd)
       GIT_TAG ${QATZSTD_SOURCE_BRANCH}
       SOURCE_DIR ${QATZSTD_SOURCE_DIR}
       CONFIGURE_COMMAND ""
-      BUILD_COMMAND $(MAKE) ${QATZSTD_MAKE_ARGS}
+      BUILD_COMMAND ${MAKE} ${QATZSTD_MAKE_ARGS}
       INSTALL_COMMAND ""
       BUILD_BYPRODUCTS ${QATZSTD_STATIC_LIB_TARGETS}
       BUILD_IN_SOURCE 1)
@@ -57,8 +63,10 @@ macro(build_qatzstd)
 
   set(QATZSTD_LINK_LIBRARIES
       "${ZSTD_LIBRARY}"
+      "${QAT_LIBRARY}"
       "${USDM_DRV_LIBRARY}"
-      "${QAT_S_LIBRARY}")
+      "${ADF_LIBRARY}"
+      "${OSAL_LIBRARY}")
 
   set_target_properties(qatzstd::qatzstd
       PROPERTIES IMPORTED_LOCATION
@@ -71,11 +79,15 @@ macro(build_qatzstd)
   add_dependencies(qatzstd::qatzstd qatzstd_ep)
 endmacro()
 
-find_library(USDM_DRV_LIBRARY REQUIRED NAMES usdm_drv_s PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
-find_library(QAT_S_LIBRARY REQUIRED NAMES qat_s PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(QAT_LIBRARY REQUIRED NAMES qat PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(USDM_DRV_LIBRARY REQUIRED NAMES usdm_drv PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(ADF_LIBRARY REQUIRED NAMES adf PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(OSAL_LIBRARY REQUIRED NAMES osal PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
 
+message(STATUS "Found qat: ${QAT_LIBRARY}")
 message(STATUS "Found usdm_drv: ${USDM_DRV_LIBRARY}")
-message(STATUS "Found qat_s: ${QAT_S_LIBRARY}")
+message(STATUS "Found adf: ${ADF_LIBRARY}")
+message(STATUS "Found osal: ${OSAL_LIBRARY}")
 
 build_qatzstd()
 

--- a/cpp/CMake/BuildQATzip.cmake
+++ b/cpp/CMake/BuildQATzip.cmake
@@ -17,6 +17,12 @@
 
 include(ExternalProject)
 
+if("${MAKE}" STREQUAL "")
+  if(NOT MSVC)
+    find_program(MAKE make)
+  endif()
+endif()
+
 macro(build_qatzip)
   message(STATUS "Building QATzip from source")
   set(QATZIP_BUILD_VERSION "v1.1.1")
@@ -43,7 +49,7 @@ macro(build_qatzip)
       URL_HASH "SHA256=${QATZIP_BUILD_SHA256_CHECKSUM}"
       SOURCE_DIR ${QATZIP_SOURCE_DIR}
       CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env QZ_ROOT=${QATZIP_SOURCE_DIR} ./configure ${QATZIP_CONFIGURE_ARGS}
-      BUILD_COMMAND $(MAKE) all
+      BUILD_COMMAND ${MAKE} all
       BUILD_BYPRODUCTS ${QATZIP_STATIC_LIB_TARGETS}
       BUILD_IN_SOURCE 1)
 
@@ -60,8 +66,10 @@ macro(build_qatzip)
       "${ZLIB_LIBRARY}"
       "${LZ4_LIBRARY}"
       "${UDEV_LIBRARY}"
+      "${QAT_LIBRARY}"
       "${USDM_DRV_LIBRARY}"
-      "${QAT_S_LIBRARY}"
+      "${ADF_LIBRARY}"
+      "${OSAL_LIBRARY}"
       Threads::Threads)
 
   add_library(qatzip::qatzip STATIC IMPORTED)
@@ -82,14 +90,16 @@ find_package(Threads REQUIRED)
 find_library(ZLIB_LIBRARY REQUIRED NAMES z)
 find_library(LZ4_LIBRARY REQUIRED NAMES lz4)
 find_library(UDEV_LIBRARY REQUIRED NAMES udev)
-find_library(USDM_DRV_LIBRARY REQUIRED NAMES usdm_drv_s PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
-find_library(QAT_S_LIBRARY REQUIRED NAMES qat_s PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(USDM_DRV_LIBRARY REQUIRED NAMES usdm_drv PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(QAT_LIBRARY REQUIRED NAMES qat PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(OSAL_LIBRARY REQUIRED NAMES osal PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
+find_library(ADF_LIBRARY REQUIRED NAMES adf PATHS "$ENV{ICP_ROOT}/build" NO_DEFAULT_PATH)
 
 message(STATUS "Found zlib: ${ZLIB_LIBRARY}")
 message(STATUS "Found lz4: ${LZ4_LIBRARY}")
 message(STATUS "Found udev: ${UDEV_LIBRARY}")
 message(STATUS "Found usdm_drv: ${USDM_DRV_LIBRARY}")
-message(STATUS "Found qat_s: ${QAT_S_LIBRARY}")
+message(STATUS "Found qat: ${QAT_LIBRARY}")
 
 build_qatzip()
 

--- a/cpp/CMake/FindZstd.cmake
+++ b/cpp/CMake/FindZstd.cmake
@@ -22,7 +22,7 @@
 # ZSTD_FOUND: whether zstd has been found
 
 if (NOT "$ENV{ZSTD_HOME}" STREQUAL "")
-  file(TO_CMAKE_PATH "$ENV${ZSTD_HOME}" _zstd_path)
+  file(TO_CMAKE_PATH "$ENV{ZSTD_HOME}" _zstd_path)
   message(STATUS "ZSTD_HOME: ${_zstd_path}")
 else()
   set(_zstd_path "/usr/local")

--- a/cpp/CMake/FindZstd.cmake
+++ b/cpp/CMake/FindZstd.cmake
@@ -22,7 +22,7 @@
 # ZSTD_FOUND: whether zstd has been found
 
 if (NOT "$ENV{ZSTD_HOME}" STREQUAL "")
-  file(TO_CMAKE_PATH "${ZSTD_HOME}" _zstd_path)
+  file(TO_CMAKE_PATH "$ENV${ZSTD_HOME}" _zstd_path)
   message(STATUS "ZSTD_HOME: ${_zstd_path}")
 else()
   set(_zstd_path "/usr/local")

--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -88,6 +88,15 @@
       "dependencies": [
         "memkind"
       ]
+    },
+    "qat": {
+      "description": "QAT",
+      "dependencies": [
+        {
+	  "name": "zstd",
+	  "version>=": "1.5.4"
+        }
+      ]
     }
   },
   "overrides": [


### PR DESCRIPTION
For reference, the steps below show how to install Gluten with QAT on an Ubuntu 22.04 Docker image. I will put these commands into a Dockerfile later.

1. Install basic dependencies
`apt install zip tar wget curl git gcc g++ pkg-config autoconf automake libtool flex bison openjdk-8-jdk maven make autoconf-archive cmake vim sudo`
2. Install dependencies for QAT driver
`apt-get install -y zlib1g-dev libudev-dev yasm libboost-all-dev linux-headers-$(uname -r)`
3. Build QAT driver and setup `ICP_ROOT`
4. Add "qat" to vcpkg default-features
```
diff --git a/dev/vcpkg/vcpkg.json b/dev/vcpkg/vcpkg.json
index 91cb430f..13ba43c5 100644
--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "builtin-baseline": "a7b6122f6b6504d16d96117336a0562693579933",
   "dependencies": ["jemalloc"],
-  "default-features": ["velox", "velox-s3", "velox-gcs", "velox-hdfs"],
+  "default-features": ["velox", "velox-s3", "velox-gcs", "velox-hdfs", "qat"],
   "features": {
     "velox": {
       "description": "Velox backend",

```
5. Build
```
source ./dev/vcpkg/env.sh
export CPATH=/root/gluten/dev/vcpkg/vcpkg_installed/x64-linux-avx/include
export LIBRARY_PATH=/root/gluten/dev/vcpkg/vcpkg_installed/x64-linux-avx/lib
./dev/builddeps-veloxbe.sh --enable_hdfs=ON --enable_qat=ON
```