### PR TITLE
[VL] Fix incorrect url path caused by decoding on non-original encoded path in PartitionedFile

### DIFF
--- a/backends-velox/src/main/java/io/glutenproject/utils/GlutenURLDecoder.java
+++ b/backends-velox/src/main/java/io/glutenproject/utils/GlutenURLDecoder.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.utils;
+
+import java.io.*;
+import java.net.URLEncoder;
+
+public class GlutenURLDecoder {
+  // This Util is copied from
+  // https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/net/URLDecoder.java
+  // Just remove the special handle for '+'
+  /**
+   * Decodes a <code>application/x-www-form-urlencoded</code> string using a specific encoding
+   * scheme. The supplied encoding is used to determine what characters are represented by any
+   * consecutive sequences of the form "<code>%<i>xy</i></code>".
+   *
+   * <p><em><strong>Note:</strong> The <a href=
+   * "http://www.w3.org/TR/html40/appendix/notes.html#non-ascii-chars"> World Wide Web Consortium
+   * Recommendation</a> states that UTF-8 should be used. Not doing so may introduce
+   * incompatibilites.</em>
+   *
+   * @param s the <code>String</code> to decode
+   * @param enc The name of a supported <a href="../lang/package-summary.html#charenc">character
+   *     encoding</a>.
+   * @return the newly decoded <code>String</code>
+   * @exception UnsupportedEncodingException If character encoding needs to be consulted, but named
+   *     character encoding is not supported
+   * @see URLEncoder#encode(java.lang.String, java.lang.String)
+   * @since 1.4
+   */
+  public static String decode(String s, String enc) throws UnsupportedEncodingException {
+
+    boolean needToChange = false;
+    int numChars = s.length();
+    StringBuffer sb = new StringBuffer(numChars > 500 ? numChars / 2 : numChars);
+    int i = 0;
+
+    if (enc.length() == 0) {
+      throw new UnsupportedEncodingException("URLDecoder: empty string enc parameter");
+    }
+
+    char c;
+    byte[] bytes = null;
+    while (i < numChars) {
+      c = s.charAt(i);
+      switch (c) {
+        case '%':
+          /*
+           * Starting with this instance of %, process all
+           * consecutive substrings of the form %xy. Each
+           * substring %xy will yield a byte. Convert all
+           * consecutive  bytes obtained this way to whatever
+           * character(s) they represent in the provided
+           * encoding.
+           */
+
+          try {
+
+            // (numChars-i)/3 is an upper bound for the number
+            // of remaining bytes
+            if (bytes == null) {
+              bytes = new byte[(numChars - i) / 3];
+            }
+            int pos = 0;
+
+            while (((i + 2) < numChars) && (c == '%')) {
+              int v = Integer.parseInt(s.substring(i + 1, i + 3), 16);
+              if (v < 0) {
+                throw new IllegalArgumentException(
+                    "URLDecoder: Illegal "
+                        + "hex characters in escape (%) pattern - negative value");
+              }
+              bytes[pos++] = (byte) v;
+              i += 3;
+              if (i < numChars) {
+                c = s.charAt(i);
+              }
+            }
+
+            // A trailing, incomplete byte encoding such as
+            // "%x" will cause an exception to be thrown
+
+            if ((i < numChars) && (c == '%')) {
+              throw new IllegalArgumentException(
+                  "URLDecoder: Incomplete trailing escape (%) pattern");
+            }
+
+            sb.append(new String(bytes, 0, pos, enc));
+          } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                "URLDecoder: Illegal hex characters in escape (%) pattern - " + e.getMessage());
+          }
+          needToChange = true;
+          break;
+        default:
+          sb.append(c);
+          i++;
+          break;
+      }
+    }
+
+    return (needToChange ? sb.toString() : s);
+  }
+}

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -23,7 +23,7 @@ import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.{LocalFilesBuilder, SplitInfo}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.utils.Iterators
+import io.glutenproject.utils._
 import io.glutenproject.vectorized._
 
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
@@ -43,7 +43,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ExecutorManager
 
 import java.lang.{Long => JLong}
-import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.time.ZoneOffset
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, Map => JMap}
@@ -88,11 +87,10 @@ class IteratorApiImpl extends IteratorApi with Logging {
     files.foreach {
       file =>
         // The "file.filePath" in PartitionedFile is not the original encoded path, so the decoded
-        // path is incorrect in some cases and here fix the case of ' '
+        // path is incorrect in some cases and here fix the case of ' ' by using GlutenURLDecoder
         paths.add(
-          URLDecoder
-            .decode(file.filePath.toString, StandardCharsets.UTF_8.name())
-            .replace(' ', '+'))
+          GlutenURLDecoder
+            .decode(file.filePath.toString, StandardCharsets.UTF_8.name()))
         starts.add(JLong.valueOf(file.start))
         lengths.add(JLong.valueOf(file.length))
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -80,6 +80,47 @@ class IteratorApiImpl extends IteratorApi with Logging {
     }
   }
 
+  private def fromHex(x: Char): Char = {
+    var y = -1
+    if (x >= 'A' && x <= 'Z') y = x - 'A' + 10
+    else if (x >= 'a' && x <= 'z') y = x - 'a' + 10
+    else if (x >= '0' && x <= '9') y = x - '0'
+    else return x
+    y.toChar
+  }
+
+  private def UrlFix(str: String): String = {
+    val strTemp: StringBuffer = new StringBuffer
+    val length: Int = str.length
+    var i: Int = 0
+    while (i < length) {
+      if (str.charAt(i) == '+') {
+        strTemp.append(' ')
+      }
+      if (str.charAt(i) == ' ') {
+        strTemp.append('+')
+      } else {
+        if (str.charAt(i) == '%') {
+          assert((i + 2 < length))
+          val high: Char = fromHex(str.charAt({
+            i += 1;
+            i
+          }))
+          val low: Char = fromHex(str.charAt({
+            i += 1;
+            i
+          }))
+          strTemp.append(high * 16 + low)
+        } else {
+          strTemp.append(str.charAt(i))
+        }
+      }
+
+      i += 1
+    }
+    String.valueOf(strTemp)
+  }
+
   private def constructSplitInfo(schema: StructType, files: Array[PartitionedFile]) = {
     val paths = new JArrayList[String]()
     val starts = new JArrayList[JLong]
@@ -87,7 +128,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
     val partitionColumns = new JArrayList[JMap[String, String]]
     files.foreach {
       file =>
-        paths.add(URLDecoder.decode(file.filePath.toString, StandardCharsets.UTF_8.name()))
+        paths.add(UrlFix(URLDecoder.decode(file.filePath.toString, StandardCharsets.UTF_8.name())))
         starts.add(JLong.valueOf(file.start))
         lengths.add(JLong.valueOf(file.length))
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -777,9 +777,9 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
 
   test("Fix incorrect path by decode") {
     val c = "?.+<_>|/"
-    val path = rootPath + "/test+?.+<_>|"
-    val key1 = s"${c}key1$c$c"
-    val key2 = s"${c}key2$c$c"
+    val path = rootPath + "/test +?.+<_>|"
+    val key1 = s"${c}key1 $c$c"
+    val key2 = s"${c}key2 $c$c"
     val valueA = s"${c}some$c${c}value${c}A"
     val valueB = s"${c}some$c${c}value${c}B"
     val valueC = s"${c}some$c${c}value${c}C"

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -23,7 +23,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.execution.{GenerateExec, RDDScanExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.functions.{avg, col, udf}
+import org.apache.spark.sql.functions.{avg, col, lit, udf}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DecimalType, StringType, StructField, StructType}
 
@@ -772,6 +772,27 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
           checkOperatorMatch[SortMergeJoinExecTransformer]
         }
       }
+    }
+  }
+
+  test("Fix incorrect path by decode") {
+    val c = "?.+<_>|/"
+    val path = rootPath + "/test+?.+<_>|"
+    val key1 = s"${c}key1$c$c"
+    val key2 = s"${c}key2$c$c"
+    val valueA = s"${c}some$c${c}value${c}A"
+    val valueB = s"${c}some$c${c}value${c}B"
+    val valueC = s"${c}some$c${c}value${c}C"
+    val valueD = s"${c}some$c${c}value${c}D"
+
+    val df1 = spark.range(3).withColumn(key1, lit(valueA)).withColumn(key2, lit(valueB))
+    val df2 = spark.range(4, 7).withColumn(key1, lit(valueC)).withColumn(key2, lit(valueD))
+    val df = df1.union(df2)
+    df.write.partitionBy(key1, key2).format("parquet").mode("overwrite").save(path)
+
+    spark.read.format("parquet").load(path).createOrReplaceTempView("test")
+    runQueryAndCompare("select * from test") {
+      checkOperatorMatch[BatchScanExecTransformer]
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When constructing Spark `PartitionedFile`, the path used is the not the original encoded path so the decoded path in `IteratorApiImpl` is not correct in some cases. Current we observed the case for '+'.  It's encoded to `%2B` in `URLEncoder.encode` but it becomes `+` when passed into `PartitionedFile` and finally becomes ` ` after decode. This PR tries to fix this issue with UT added.

## How was this patch tested?

Test in customer S3 environment.

