### PR TITLE
[GLUTEN-3796][VL][FOLLOW_UP] Correct test name match and move black list to exclude in `VeloxTestSettings`

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -272,6 +272,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFrameComplexTypeSuite]
   enableSuite[GlutenApproximatePercentileQuerySuite]
   enableSuite[GlutenDataFrameRangeSuite]
+    .exclude("SPARK-20430 Initialize Range parameters in a driver side")
+    .excludeByPrefix("Cancelling stage in a query with Range")
   enableSuite[GlutenTakeOrderedAndProjectSuite]
   enableSuite[GlutenSubquerySuite]
     .excludeByPrefix(

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameRangeSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameRangeSuite.scala
@@ -16,11 +16,4 @@
  */
 package org.apache.spark.sql
 
-class GlutenDataFrameRangeSuite extends DataFrameRangeSuite with GlutenSQLTestsTrait {
-
-  override def testNameBlackList: Seq[String] = Seq(
-    "Cancelling stage in a query with Range",
-    "SPARK-20430 Initialize Range parameters in a driver side"
-  )
-
-}
+class GlutenDataFrameRangeSuite extends DataFrameRangeSuite with GlutenSQLTestsTrait {}

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -989,8 +989,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // substring issue
     .exclude("pivot with column definition in groupby")
   enableSuite[GlutenDataFrameRangeSuite]
-    .exclude("Cancelling stage in a query with Range.")
     .exclude("SPARK-20430 Initialize Range parameters in a driver side")
+    .excludeByPrefix("Cancelling stage in a query with Range")
   enableSuite[GlutenDataFrameSelfJoinSuite]
   enableSuite[GlutenDataFrameSessionWindowingSuite]
   enableSuite[GlutenDataFrameSetOperationsSuite]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -989,6 +989,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // substring issue
     .exclude("pivot with column definition in groupby")
   enableSuite[GlutenDataFrameRangeSuite]
+    .exclude("Cancelling stage in a query with Range.")
+    .exclude("SPARK-20430 Initialize Range parameters in a driver side")
   enableSuite[GlutenDataFrameSelfJoinSuite]
   enableSuite[GlutenDataFrameSessionWindowingSuite]
   enableSuite[GlutenDataFrameSetOperationsSuite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameRangeSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameRangeSuite.scala
@@ -16,11 +16,4 @@
  */
 package org.apache.spark.sql
 
-class GlutenDataFrameRangeSuite extends DataFrameRangeSuite with GlutenSQLTestsTrait {
-
-  override def testNameBlackList: Seq[String] = Seq(
-    "Cancelling stage in a query with Range",
-    "SPARK-20430 Initialize Range parameters in a driver side"
-  )
-
-}
+class GlutenDataFrameRangeSuite extends DataFrameRangeSuite with GlutenSQLTestsTrait {}

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1021,6 +1021,8 @@ class VeloxTestSettings extends BackendTestSettings {
     // substring issue
     .exclude("pivot with column definition in groupby")
   enableSuite[GlutenDataFrameRangeSuite]
+    .exclude("SPARK-20430 Initialize Range parameters in a driver side")
+    .excludeByPrefix("Cancelling stage in a query with Range")
   enableSuite[GlutenDataFrameSelfJoinSuite]
   enableSuite[GlutenDataFrameSessionWindowingSuite]
   enableSuite[GlutenDataFrameSetOperationsSuite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameRangeSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameRangeSuite.scala
@@ -16,11 +16,4 @@
  */
 package org.apache.spark.sql
 
-class GlutenDataFrameRangeSuite extends DataFrameRangeSuite with GlutenSQLTestsTrait {
-
-  override def testNameBlackList: Seq[String] = Seq(
-    "Cancelling stage in a query with Range",
-    "SPARK-20430 Initialize Range parameters in a driver side"
-  )
-
-}
+class GlutenDataFrameRangeSuite extends DataFrameRangeSuite with GlutenSQLTestsTrait {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Match all test startWith `Cancelling stage in a query with Range`
2. As we mentioned, ban those flaky tests on VL, we should exclude those tests in `VeloxTestSettings`

Fixes: #3796

## How was this patch tested?
CI 