### PR TITLE
[VL] Enable split preloading by default

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1042,7 +1042,7 @@ object GlutenConfig {
       .internal()
       .doc("The IO threads for cache promoting")
       .intConf
-      .createWithDefault(1)
+      .createWithDefault(1) // TODO: Use task slot number instead
 
   val COLUMNAR_VELOX_SSD_ODIRECT_ENABLED =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.ssdODirect")
@@ -1056,7 +1056,7 @@ object GlutenConfig {
       .internal()
       .doc("The IO threads for connector split preloading")
       .intConf
-      .createWithDefault(0)
+      .createWithDefault(1) // TODO: Use task slot number instead
 
   val COLUMNAR_VELOX_SPLIT_PRELOAD_PER_DRIVER =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver")


### PR DESCRIPTION
We had applied a general [fix](https://github.com/oap-project/gluten/commit/00880547a67cbd7078423e4281a4ad5a1a0306c0) for crashes caused by Velox's async execution utilities. We can then safely enable split preloading feature by default.

