### PR TITLE
[GLUTEN-3528][VL] Construct unique & non-overlapping partition/sort keys for window operator

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -270,6 +270,20 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
               " (partition by l_suppkey order by l_orderkey) from lineitem ") {
             assertWindowOffloaded
           }
+
+          // Test same partition/ordering keys.
+          runQueryAndCompare(
+            "select avg(l_partkey) over" +
+              " (partition by l_suppkey order by l_suppkey) from lineitem ") {
+            assertWindowOffloaded
+          }
+
+          // Test overlapping partition/ordering keys.
+          runQueryAndCompare(
+            "select avg(l_partkey) over" +
+              " (partition by l_suppkey order by l_suppkey, l_orderkey) from lineitem ") {
+            assertWindowOffloaded
+          }
         }
     }
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -647,17 +647,28 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
   // Construct partitionKeys
   std::vector<core::FieldAccessTypedExprPtr> partitionKeys;
+  std::unordered_set<string> keyNames;
   const auto& partitions = windowRel.partition_expressions();
   partitionKeys.reserve(partitions.size());
   for (const auto& partition : partitions) {
     auto expression = exprConverter_->toVeloxExpr(partition, inputType);
-    auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
-    VELOX_CHECK(expr_field != nullptr, " the partition key in Window Operator only support field")
-
-    partitionKeys.emplace_back(std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression));
+    core::FieldAccessTypedExprPtr veloxPartitionKey =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression);
+    VELOX_USER_CHECK_NOT_NULL(veloxPartitionKey, "Window Operator only supports field partition key.");
+    // Constructs unique parition keys.
+    if (keyNames.insert(veloxPartitionKey->name)->second) {
+      partitionKeys.emplace_back(veloxPartitionKey);
+    }
   }
-
-  auto [sortingKeys, sortingOrders] = processSortField(windowRel.sorts(), inputType);
+  std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<core::SortOrder> sortingOrders;
+  for (auto& iter : processSortField(windowRel.sorts(), inputType)) {
+    // Constructs unique sort keys and excludes keys overlapped with partition keys.
+    if (keyNames.insert(iter->first->name)->second) {
+      sortingKeys.emplace_back(iter->first);
+      sortingOrders.emplace_back(iter->second);
+    }
+  }
 
   if (windowRel.has_advanced_extension() &&
       SubstraitParser::configSetInOptimization(windowRel.advanced_extension(), "isStreaming=")) {
@@ -705,7 +716,7 @@ SubstraitToVeloxPlanConverter::processSortField(
     if (sort.has_expr()) {
       auto expression = exprConverter_->toVeloxExpr(sort.expr(), inputType);
       auto fieldExpr = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expression);
-      VELOX_CHECK_NOT_NULL(fieldExpr, " the sorting key in Sort Operator only support field");
+      VELOX_USER_CHECK_NOT_NULL(fieldExpr, "Sort Operator only supports field sorting key");
       sortingKeys.emplace_back(fieldExpr);
     }
   }


### PR DESCRIPTION
To meet Velox's requirement, this PR proposes constructing unique & non-overlapping partition/sort keys for window operator.

Fix #3528.

## How was this patch tested?

Added test cases.

