### PR TITLE
[GLUTEN-3906] [VL] fix: fix package.sh failed for x86

### DIFF
--- a/dev/package.sh
+++ b/dev/package.sh
@@ -10,7 +10,6 @@ VERSION=$(. /etc/os-release && echo ${VERSION_ID})
 ARCH=`uname -m`
 
 # compile gluten jar
-export CPU_TARGET="${ARCH}"
 $GLUTEN_DIR/dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON --enable_hdfs=ON
 mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
 mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests


### PR DESCRIPTION
package.sh export CPU_ARCH env from 'uname -m' ,  this will get `x86_64` for intel platform。 velox need CPU_ARCH for aarch64/aarch64/avx/sse,  this will cause velox build fmt dependency failed 。 Velox will automatically check CPU_ARCH environment if not specified

Fix: #3906 