### PR TITLE
[GLUTEN-3908][CH] Improve shuffle split for clickhouse backend by remove ColumnNullable's `memcmp` 

### DIFF
--- a/cpp-ch/local-engine/Shuffle/ShuffleSplitter.cpp
+++ b/cpp-ch/local-engine/Shuffle/ShuffleSplitter.cpp
@@ -30,6 +30,7 @@
 #include <Poco/StringTokenizer.h>
 #include <Common/Stopwatch.h>
 #include <Common/DebugUtils.h>
+#include <Common/typeid_cast.h>
 
 namespace local_engine
 {
@@ -305,8 +306,18 @@ void ColumnsBuffer::appendSelective(
     }
     if (!accumulated_columns[column_idx]->onlyNull())
     {
-        accumulated_columns[column_idx]->insertRangeSelective(
-            *source.getByPosition(column_idx).column->convertToFullColumnIfConst(), selector, from, length);
+        auto * nullable_column = checkAndGetColumn<DB::ColumnNullable>(*source.getByPosition(column_idx).column);
+        if (nullable_column)
+        {
+            accumulated_columns[column_idx]->insertRangeSelective(
+                *source.getByPosition(column_idx).column->convertToFullColumnIfConst(), selector, from, length);
+        }
+        else
+        {
+            auto * dst_column = typeid_cast<DB::ColumnNullable *>(accumulated_columns[column_idx].get());
+            dst_column->getNestedColumn().insertRangeSelective(nullable_column->getNestedColumn(), selector, from, length);
+            dst_column->getNullMapColumn().insertRangeSelective(nullable_column->getNullMapColumn(), selector, from, length);
+        }
     }
     else
     {

--- a/cpp-ch/local-engine/Shuffle/ShuffleSplitter.cpp
+++ b/cpp-ch/local-engine/Shuffle/ShuffleSplitter.cpp
@@ -307,7 +307,7 @@ void ColumnsBuffer::appendSelective(
     if (!accumulated_columns[column_idx]->onlyNull())
     {
         auto * nullable_column = checkAndGetColumn<DB::ColumnNullable>(*source.getByPosition(column_idx).column);
-        if (nullable_column)
+        if (!nullable_column)
         {
             accumulated_columns[column_idx]->insertRangeSelective(
                 *source.getByPosition(column_idx).column->convertToFullColumnIfConst(), selector, from, length);


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#3908)

## How was this patch tested?

d_10267_0 部分测试数据

使用该PR 优化前，打印shufflewrite 各阶段耗时：
```
xxx CHShuffleSplitterJniWrapper_top end, using time(ms): 702 , compute_pid_time: 673108959, write time: 598128235, spill time: 4335076848, compress_time: 2657002019, bytes_writen:209895520, bytes_spilled: 61
1560616, serialize_time: 4335074129, partition_len: 1000, split_time:7045147620
```

使用该PR 优化后，打印shuffle write 各阶段耗时
```
xxx CHShuffleSplitterJniWrapper_top end, using time(ms): 656 , compute_pid_time: 693334189, write time: 593510681, spill time: 4424348215, compress_time: 2726385185, bytes_writen:214243801, bytes_spilled: 62
4202520, serialize_time: 4424346782, partition_len: 1000, split_time:2549022952
```

可见split 耗时从 优化前的7s 降低到了2.55s左右，有2倍左右的减少

同时shuffle write 阶段的总体执行时间也从 12.5min 减少到 8.8min