### PR TITLE
[VL] Fix VeloxTPCHV1BhjSuite and VeloxTPCHV2Suite useV1SourceList

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
@@ -220,7 +220,7 @@ class VeloxTPCHV1Suite extends VeloxTPCHSuite {
 class VeloxTPCHV1BhjSuite extends VeloxTPCHSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set("spark.sql.sources.useV1SourceList", "")
+      .set("spark.sql.sources.useV1SourceList", "parquet")
       .set("spark.sql.autoBroadcastJoinThreshold", "30M")
   }
 }
@@ -228,7 +228,7 @@ class VeloxTPCHV1BhjSuite extends VeloxTPCHSuite {
 class VeloxTPCHV2Suite extends VeloxTPCHSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set("spark.sql.sources.useV1SourceList", "parquet")
+      .set("spark.sql.sources.useV1SourceList", "")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

V1 should set spark.sql.sources.useV1SourceList="parquet"
V2 should set spark.sql.sources.useV1SourceList=""

## How was this patch tested?

Exists CI.

