### PR TITLE
[VL] gluten-te: In dockerfiles, use symbolic link for /opt/velox

### DIFF
--- a/tools/gluten-te/centos/dockerfile-build
+++ b/tools/gluten-te/centos/dockerfile-build
@@ -96,6 +96,6 @@ RUN EXTRA_MAVEN_OPTIONS=$(cat ~/.gluten-mvn-options) \
     && cd /opt/gluten \
     && bash -c "$DEPS_INSTALL_SCRIPT" \
     && bash -c "mvn clean install $GLUTEN_MAVEN_OPTIONS $EXTRA_MAVEN_OPTIONS" \
-    && bash -c "ln -s ep/build-velox/build/velox_ep /opt/velox"
+    && bash -c "ln -sf ep/build-velox/build/velox_ep /opt/velox"
 
 # EOF

--- a/tools/gluten-te/centos/dockerfile-build
+++ b/tools/gluten-te/centos/dockerfile-build
@@ -96,6 +96,6 @@ RUN EXTRA_MAVEN_OPTIONS=$(cat ~/.gluten-mvn-options) \
     && cd /opt/gluten \
     && bash -c "$DEPS_INSTALL_SCRIPT" \
     && bash -c "mvn clean install $GLUTEN_MAVEN_OPTIONS $EXTRA_MAVEN_OPTIONS" \
-    && bash -c "mv ep/build-velox/build/velox_ep /opt/velox"
+    && bash -c "ln -s ep/build-velox/build/velox_ep /opt/velox"
 
 # EOF

--- a/tools/gluten-te/ubuntu/dockerfile-build
+++ b/tools/gluten-te/ubuntu/dockerfile-build
@@ -96,6 +96,6 @@ RUN EXTRA_MAVEN_OPTIONS=$(cat ~/.gluten-mvn-options) \
     && cd /opt/gluten \
     && bash -c "$DEPS_INSTALL_SCRIPT" \
     && bash -c "mvn clean install $GLUTEN_MAVEN_OPTIONS $EXTRA_MAVEN_OPTIONS" \
-    && bash -c "ln -s ep/build-velox/build/velox_ep /opt/velox"
+    && bash -c "ln -sf ep/build-velox/build/velox_ep /opt/velox"
 
 # EOF

--- a/tools/gluten-te/ubuntu/dockerfile-build
+++ b/tools/gluten-te/ubuntu/dockerfile-build
@@ -96,6 +96,6 @@ RUN EXTRA_MAVEN_OPTIONS=$(cat ~/.gluten-mvn-options) \
     && cd /opt/gluten \
     && bash -c "$DEPS_INSTALL_SCRIPT" \
     && bash -c "mvn clean install $GLUTEN_MAVEN_OPTIONS $EXTRA_MAVEN_OPTIONS" \
-    && bash -c "mv ep/build-velox/build/velox_ep /opt/velox"
+    && bash -c "ln -s ep/build-velox/build/velox_ep /opt/velox"
 
 # EOF


### PR DESCRIPTION
In case of debugging in the docker. libvelox.so will find symbol sources in `/opt/gluten/ep/build-velox/build/velox_ep` so we'd preserve the directory.