### PR TITLE
[GLUTEN-3958] Use getDeclaredConstructor().newInstance() in ScanTransformerFactory

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
@@ -71,6 +71,7 @@ object ScanTransformerFactory {
       case _ if dataSourceV2TransformerExists(scan.getClass.getName) =>
         val cls = lookupDataSourceV2Transformer(scan.getClass.getName)
         cls
+          .getDeclaredConstructor()
           .newInstance()
           .asInstanceOf[DataSourceV2TransformerRegister]
           .createDataSourceV2Transformer(batchScanExec, newPartitionFilters)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #3958 

## How was this patch tested?

Exists CI.

