### PR TITLE
[VL] Fix aggregation dumpped as json string

### DIFF
--- a/docs/developers/MicroBenchmarks.md
+++ b/docs/developers/MicroBenchmarks.md
@@ -101,9 +101,14 @@ cd /path_to_gluten/
 ./dev/buildbundle-veloxbe.sh --build_tests=ON --build_benchmarks=ON --build_type=RelWithDebInfo
 
 ```
-Run the query by spark-shell.  Get the Substrait plan from executor's stdout.
+Run the query by spark-shell. Be sure to add below configurations to get the Substrait plan from executor's stdout.
 
-Example:
+```
+--conf spark.gluten.sql.debug=true
+--conf spark.gluten.sql.columnar.backend.velox.glogSeverityLevel=0
+```
+
+Example output:
 ```shell
 ################################################## received substrait::Plan:
 Task stageId: 2, partitionId: 855, taskId: 857; {"extensions":[{"extensionFunction":{"name":"sum:req_i32"}}],"relations":[{"root":{"input":{"fetch":{"common":{"direct":{}},"input":{"project":{"common":{"direct":{}},"input":{"aggregate":{"common":{"direct":{}},"input":{"read":{"common":{"direct":{}},"baseSchema":{"names":["i_product_name#15","i_brand#16","spark_grouping_id#14","sum#22"],"struct":{"types":[{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"i64":{"nullability":"NULLABILITY_REQUIRED"}},{"i64":{"nullability":"NULLABILITY_NULLABLE"}}]}},"localFiles":{"items":[{"uriFile":"iterator:0"}]}}},"groupings":[{"groupingExpressions":[{"selection":{"directReference":{"structField":{}}}},{"selection":{"directReference":{"structField":{"field":1}}}},{"selection":{"directReference":{"structField":{"field":2}}}}]}],"measures":[{"measure":{"phase":"AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT","outputType":{"i64":{"nullability":"NULLABILITY_NULLABLE"}},"arguments":[{"value":{"selection":{"directReference":{"structField":{"field":3}}}}}]}}]}},"expressions":[{"selection":{"directReference":{"structField":{"field":3}}}}]}},"count":"100"}},"names":["qoh#10"]}}]}

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -574,7 +574,8 @@ abstract class HashAggregateExecBaseTransformer(
       "0"
     }
     val optimization =
-      Any.pack(StringValue.newBuilder.setValue(s"isStreaming=$isStreaming\n").build)
+      BackendsApiManager.getTransformerApiInstance.getPackMessage(
+        StringValue.newBuilder.setValue(s"isStreaming=$isStreaming\n").build)
     ExtensionBuilder.makeAdvancedExtension(optimization, enhancement)
   }
 


### PR DESCRIPTION
Fix below error when try to dump the json plan:

```
132 W20231207 01:54:01.932435 4101830 VeloxRuntime.cc:46] Error converting Substrait plan to JSON: BinaryToJsonStream returned INTERNAL:Invalid type URL, type URLs must be of the form '/<typename>', got: type.googleapis.com/google.protobuf.StringValue
```