### PR TITLE
[VL] Add config to velox's file read, DNM until Velox PR merged

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -66,6 +66,17 @@ const std::string kBloomFilterExpectedNumItems = "spark.gluten.sql.columnar.back
 const std::string kBloomFilterNumBits = "spark.gluten.sql.columnar.backend.velox.bloomFilter.numBits";
 const std::string kBloomFilterMaxNumBits = "spark.gluten.sql.columnar.backend.velox.bloomFilter.maxNumBits";
 
+/* configs for file read in velox*/
+const std::string kDirectorySizeGuess = "spark.gluten.sql.columnar.backend.velox.directorySizeGuess";
+const std::string kFilePreloadThreshold = "spark.gluten.sql.columnar.backend.velox.filePreloadThreshold";
+const std::string kPrefetchRowGroups = "spark.gluten.sql.columnar.backend.velox.prefetchRowGroups";
+const std::string kLoadQuantum = "spark.gluten.sql.columnar.backend.velox.loadQuantum";
+const std::string kMaxCoalescedDistanceBytes = "spark.gluten.sql.columnar.backend.maxCoalescedDistanceBytes";
+const std::string kMaxCoalescedBytes = "spark.gluten.sql.columnar.backend.maxCoalescedBytes";
+
+
+
+
 // metrics
 const std::string kDynamicFiltersProduced = "dynamicFiltersProduced";
 const std::string kDynamicFiltersAccepted = "dynamicFiltersAccepted";
@@ -415,6 +426,20 @@ std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig()
   configs[velox::connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCase] =
       getConfigValue(confMap_, kCaseSensitive, "false") == "false" ? "true" : "false";
   configs[velox::connector::hive::HiveConfig::kArrowBridgeTimestampUnit] = "6";
+
+
+  configs[velox::connector::hive::HiveConfig::kMaxCoalescedBytes] = 
+      getConfigValue(confMap_, kMaxCoalescedBytes, "67108864"); // 64M
+  configs[velox::connector::hive::HiveConfig::kMaxCoalescedDistanceBytes] =
+      getConfigValue(confMap_, kMaxCoalescedDistanceBytes, "1048576"); // 1M
+  configs[velox::connector::hive::HiveConfig::kPrefetchRowGroups] =
+      getConfigValue(confMap_, kPrefetchRowGroups, "1");
+  configs[velox::connector::hive::HiveConfig::kLoadQuantum] =
+      getConfigValue(confMap_, kLoadQuantum, "268435456"); // 256M
+  configs[velox::connector::hive::HiveConfig::kDirectorySizeGuess] =
+      getConfigValue(confMap_, kDirectorySizeGuess, "32768"); // 32K
+  configs[velox::connector::hive::HiveConfig::kFilePreloadThreshold] =
+      getConfigValue(confMap_, kFilePreloadThreshold, "1048576"); // 1M
 
   return std::make_shared<velox::core::MemConfig>(configs);
 }


### PR DESCRIPTION
Velox PR7217(https://github.com/facebookincubator/velox/pull/7217) added directbufferinput, which leads to performance regression seriously. The root cause is that the default config in the PR is not optimal for remote storage. You may find more talk here: https://github.com/facebookincubator/velox/pull/7873

The PR added 3 config:
loadQuantum: 256M (make sure it's larger than row group size, parquet default is 128M)
maxCoalesceDistance: 1M ( in case the columns are not load contieneously, like select a, c from table_with_column_a_b_c. If b is mall column than 1M, then we can load it to make a large block
CoalesceBytes: 64M, break the row group fetches into small chunks

With these configuration, here is the final traceview: You can see the S3 read is totally in parallel with data processing.

![image](https://github.com/oap-project/gluten/assets/47296334/7a4f1459-b9a7-406c-a64b-6800dab977c8)

