### PR TITLE
[GLUTEN-3991][CH] Fix the incorrect display name for the mergetree file format

### DIFF
--- a/backends-clickhouse/src/main/delta-20/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
+++ b/backends-clickhouse/src/main/delta-20/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
@@ -22,6 +22,10 @@ import org.apache.spark.sql.delta.actions.Metadata
 class DeltaMergeTreeFileFormat(metadata: Metadata)
   extends DeltaParquetFileFormat(metadata.columnMappingMode, metadata.schema) {
 
+  override def shortName(): String = "mergetree"
+
+  override def toString(): String = "MergeTree"
+
   override def equals(other: Any): Boolean = {
     other match {
       case ff: DeltaMergeTreeFileFormat =>

--- a/backends-clickhouse/src/main/delta-22/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
+++ b/backends-clickhouse/src/main/delta-22/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
@@ -21,6 +21,10 @@ import org.apache.spark.sql.delta.actions.Metadata
 
 class DeltaMergeTreeFileFormat(metadata: Metadata) extends DeltaParquetFileFormat(metadata) {
 
+  override def shortName(): String = "mergetree"
+
+  override def toString(): String = "MergeTree"
+
   override def equals(other: Any): Boolean = {
     other match {
       case ff: DeltaMergeTreeFileFormat =>

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHSuite.scala
@@ -48,6 +48,8 @@ class GlutenClickHouseTPCHSuite extends GlutenClickHouseTPCHAbstractSuite {
         }
         assert(scanExec.size == 1)
 
+        assert(scanExec(0).nodeName.startsWith("Scan mergetree"))
+
         val sortExec = df.queryExecution.executedPlan.collect {
           case sortExec: SortExecTransformer => sortExec
         }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/FileSourceScanExecTransformer.scala
@@ -131,7 +131,7 @@ class FileSourceScanExecTransformer(
   override val nodeNamePrefix: String = "NativeFile"
 
   override val nodeName: String = {
-    s"NativeScan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
+    s"Scan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
   }
 
   override def doTransform(context: SubstraitContext): TransformContext = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The mergetree file format must show the message in the plan tree: `NativeFileScan mergetree xxxx`.

Close #3991.

(Fixes: #3991)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

