### PR TITLE
[VL] Fix StringToMap test failure

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -404,6 +404,15 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           substraitExprName,
           replaceWithExpressionTransformer(expr.children.head, attributeSeq),
           expr)
+      case _: StringToMap =>
+        if (SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
+            != SQLConf.MapKeyDedupPolicy.EXCEPTION.toString) {
+          throw new UnsupportedOperationException("Only EXCEPTION policy is supported!")
+        }
+        GenericExpressionTransformer(
+            substraitExprName,
+            expr.children.map(replaceWithExpressionTransformer(_, attributeSeq)),
+            expr)
       case b: BinaryArithmetic if DecimalArithmeticUtil.isDecimalArithmetic(b) =>
         // PrecisionLoss=true: velox support / ch not support
         // PrecisionLoss=false: velox not support / ch support

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -252,8 +252,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("corr, covar_pop, stddev_pop functions in specific window")
   enableSuite[GlutenDataFrameSelfJoinSuite]
   enableSuite[GlutenComplexTypeSuite]
-    // FIXME: feilong
-    .exclude("StringToMap")
   enableSuite[GlutenDateFunctionsSuite]
     // The below two are replaced by two modified versions.
     .exclude("unix_timestamp")

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -952,8 +952,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDSV2CharVarcharTestSuite]
   enableSuite[GlutenColumnExpressionSuite]
   enableSuite[GlutenComplexTypeSuite]
-    // FIXME: feilong
-    .exclude("StringToMap")
   enableSuite[GlutenConfigBehaviorSuite]
     // Will be fixed by cleaning up ColumnarShuffleExchangeExec.
     .exclude("SPARK-22160 spark.sql.execution.rangeExchange.sampleSizePerPartition")

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -983,8 +983,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDSV2CharVarcharTestSuite]
   enableSuite[GlutenColumnExpressionSuite]
   enableSuite[GlutenComplexTypeSuite]
-    // FIXME: feilong
-    .exclude("StringToMap")
   enableSuite[GlutenConfigBehaviorSuite]
     // Will be fixed by cleaning up ColumnarShuffleExchangeExec.
     .exclude("SPARK-22160 spark.sql.execution.rangeExchange.sampleSizePerPartition")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Gluten + Velox backend only supports the default SQLConf.MapKeyDedupPolicy.EXCEPTION policy. This PR adds the check to make it fall back on unsupported config.

## How was this patch tested?

Existing Spark UT covers it.