### PR TITLE
[GLUTEN-4000][CORE] Apply Basic Common Subexpression Elimination for Spark Logical Plan

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -49,6 +49,7 @@ import org.apache.spark.sql.execution.joins.{BuildSideRelation, ClickHouseBuildS
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.utils.CHExecUtil
 import org.apache.spark.sql.extension.ClickHouseAnalysis
+import org.apache.spark.sql.extension.CommonSubexpressionEliminateRule
 import org.apache.spark.sql.extension.RewriteDateTimestampComparisonRule
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -342,6 +343,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
     val analyzers = List(spark => new ClickHouseAnalysis(spark, spark.sessionState.conf))
     if (GlutenConfig.getConf.enableDateTimestampComparison) {
       analyzers :+ (spark => new RewriteDateTimestampComparisonRule(spark, spark.sessionState.conf))
+      analyzers :+ (spark => new CommonSubexpressionEliminateRule(spark, spark.sessionState.conf))
     } else {
       analyzers
     }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDecimalSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDecimalSuite.scala
@@ -53,6 +53,8 @@ class GlutenClickHouseDecimalSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
       .set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
+      .set("spark.sql.planChangeLog.level", "error")
+      .set("spark.gluten.sql.commonSubexpressionEliminate", "true")
   }
 
   override def beforeAll(): Unit = {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDecimalSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseDecimalSuite.scala
@@ -53,8 +53,6 @@ class GlutenClickHouseDecimalSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
       .set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
-      .set("spark.sql.planChangeLog.level", "error")
-      .set("spark.gluten.sql.commonSubexpressionEliminate", "true")
   }
 
   override def beforeAll(): Unit = {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSParquetColumnarShuffleSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCDSParquetColumnarShuffleSuite.scala
@@ -39,6 +39,7 @@ class GlutenClickHouseTPCDSParquetColumnarShuffleSuite extends GlutenClickHouseT
       //      .set("spark.sql.files.maxPartitionBytes", "134217728")
       //      .set("spark.sql.files.openCostInBytes", "134217728")
       .set("spark.memory.offHeap.size", "4g")
+    // .set("spark.sql.planChangeLog.level", "error")
   }
 
   executeTPCDSTest(false)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -48,6 +48,8 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
       .set("spark.gluten.supported.scala.udfs", "my_add")
+    // .set("spark.sql.planChangeLog.level", "error")
+    // .set("spark.gluten.sql.commonSubexpressionEliminate", "true")
   }
 
   override protected val createNullableTables = true

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -49,7 +49,6 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
       .set("spark.gluten.supported.scala.udfs", "my_add")
     // .set("spark.sql.planChangeLog.level", "error")
-    // .set("spark.gluten.sql.commonSubexpressionEliminate", "true")
   }
 
   override protected val createNullableTables = true

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -82,7 +82,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       .set("spark.sql.shuffle.partitions", "5")
       .set("spark.sql.autoBroadcastJoinThreshold", "10MB")
       .set("spark.gluten.sql.columnar.backend.ch.use.v2", "false")
-        }
+  }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -224,7 +224,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     spark.catalog.createTable("url_table", urlFilePath, fileFormat)
   }
 
-    test("Test get_json_object 1") {
+  test("Test get_json_object 1") {
     runQueryAndCompare("SELECT get_json_object(string_field1, '$.a') from json_test") {
       checkOperatorMatch[ProjectExecTransformer]
     }
@@ -535,7 +535,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       )(checkOperatorMatch[ProjectExecTransformer])
     }
   }
-   
+
   test("test common subexpression eliminate") {
     def checkOperatorCount[T <: TransformSupport](count: Int)(df: DataFrame)(implicit
         tag: ClassTag[T]): Unit = {
@@ -552,10 +552,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     withSQLConf(("spark.gluten.sql.commonSubexpressionEliminate", "true")) {
       // CSE in project
       runQueryAndCompare("select hash(id), hash(id)+1, hash(id)-1 from range(10)") {
-        df =>
-          {
-            checkOperatorCount[ProjectExecTransformer](2)(df)
-          }
+        df => checkOperatorCount[ProjectExecTransformer](2)(df)
       }
 
       // CSE in filter(not work yet)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -531,7 +531,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
   test("test common subexpression eliminate") {
     withSQLConf(("spark.gluten.sql.commonSubexpressionEliminate", "true")) {
       // CSE in project
-      runQueryAndCompare("select hex(id), lower(hex(id)), upper(hex(id)) from range(10)") { _ => }
+      runQueryAndCompare("select hash(id), hash(id)+1, hash(id)-1 from range(10)") { _ => }
 
       // CSE in filter(not work yet)
       runQueryAndCompare(
@@ -545,13 +545,13 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
 
       // CSE in aggregate
       runQueryAndCompare(
-        "select id % 2, max(hex(id)), min(hex(id)) " +
+        "select id % 2, max(hash(id)), min(hash(id)) " +
           "from range(10) group by id % 2") { _ => }
 
       // CSE in sort
       runQueryAndCompare(
-        "select id from range(00) " +
-          "order by hex(id%10), lower(hex(id%10))") { _ => }
+        "select id from range(10) " +
+          "order by hash(id%10), hash(hash(id%10))") { _ => }
     }
   }
 }

--- a/cpp-ch/local-engine/Parser/TypeParser.cpp
+++ b/cpp-ch/local-engine/Parser/TypeParser.cpp
@@ -254,8 +254,9 @@ DB::Block TypeParser::buildBlockFromNamedStruct(const substrait::NamedStruct & s
 
         // This is a partial aggregate data column.
         // It's type is special, must be a struct type contains all arguments types.
+        // Notice: there are some coincidence cases in which the type is not a struct type, e.g. name is "_1#913 + _2#914#928". We need to handle it.
         Poco::StringTokenizer name_parts(name, "#");
-        if (name_parts.count() >= 4)
+        if (name_parts.count() >= 4 && !name.contains(' '))
         {
             auto nested_data_type = DB::removeNullable(ch_type);
             const auto * tuple_type = typeid_cast<const DB::DataTypeTuple *>(nested_data_type.get());

--- a/cpp-ch/local-engine/Rewriter/ExpressionRewriter.h
+++ b/cpp-ch/local-engine/Rewriter/ExpressionRewriter.h
@@ -216,7 +216,7 @@ private:
                     arg0->CopyFrom(scalar_function_pb.arguments(0));
                     auto * arg1 = decoded_json_function.add_arguments();
                     arg1->mutable_value()->mutable_literal()->set_string(required_fields_str);
-                    
+
                     substrait::Expression new_get_json_object_arg0;
                     new_get_json_object_arg0.mutable_scalar_function()->CopyFrom(decoded_json_function);
                     *scalar_function_pb.mutable_arguments()->Mutable(0)->mutable_value() = new_get_json_object_arg0;

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -30,14 +30,12 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
   with Logging {
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    // scalastyle:off println
-    // println(s"apply cse for plan:$plan")
-    // scalastyle:on println
-    if (plan.resolved) {
+    val newPlan = if (plan.resolved) {
       visitPlan(plan)
     } else {
       plan
     }
+    newPlan
   }
 
   private case class AliasAndAttribute(alias: Alias, attribute: Attribute)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -23,9 +23,13 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
 
+import scala.collection.mutable
+
 class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
   extends Rule[LogicalPlan]
   with Logging {
+
+  case class AliasAndAttribute(alias: Alias, attribute: Attribute)
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     if (plan.resolved) {
@@ -42,8 +46,20 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
       other.withNewChildren(children)
   }
 
+  private def replaceWithSubExprEliminationExprs(
+      expr: Expression,
+      subExprEliminationExprs: mutable.HashMap[ExpressionEquals, AliasAndAttribute]): Expression = {
+    val exprEquals = subExprEliminationExprs.get(ExpressionEquals(expr))
+    if (exprEquals.isDefined) {
+      exprEquals.get.attribute
+    } else {
+      expr.mapChildren(replaceWithSubExprEliminationExprs(_, subExprEliminationExprs))
+    }
+  }
+
   private def visitProject(project: Project): Project = {
-    val input = project.child
+    // scalastyle:off println
+
     val equivalentExpressions: EquivalentExpressions = new EquivalentExpressions
     project.projectList.foreach(equivalentExpressions.addExprTree(_))
 
@@ -54,27 +70,28 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
     }
 
     // Put the common expressions into a hash map
-    var subExprEliminationExprs = Set.empty[ExpressionEquals]
+    val subExprEliminationExprs = mutable.HashMap.empty[ExpressionEquals, AliasAndAttribute]
     commonExprs.foreach {
       expr =>
-        val exprEquals = new ExpressionEquals(expr)
-        subExprEliminationExprs += exprEquals
+        val exprEquals = ExpressionEquals(expr)
+        val alias = Alias(expr, expr.toString)()
+        val attribute = alias.toAttribute
+        subExprEliminationExprs.put(exprEquals, AliasAndAttribute(alias, attribute))
     }
+    println(s"subExprEliminationExprs: $subExprEliminationExprs")
+
+    // Generate a pre-project operator
+    val input = project.child
+    var preProjectList = subExprEliminationExprs.values.map(_.alias).toSeq ++ input.output
+    val preProject = Project(preProjectList, input)
+    println(s"preproject: $preProject")
 
     // Replace the common expressions with the first expression that produces it.
-    var newProjectList = project.projectList.map(_.transformDown {
-      case expr: Expression =>
-        val exprEquals = subExprEliminationExprs.find(_.equals(ExpressionEquals(expr)))
-        if (exprEquals.isDefined) {
-          Alias(exprEquals.get.e, expr.toString())()
-        } else {
-          expr
-        }
-      case other => other
-    }).map(_.asInstanceOf[NamedExpression])
-
-    newProjectList ++= subExprEliminationExprs.map(_.e.asInstanceOf[NamedExpression]).toSeq
-
-    Project(newProjectList, input)
+    var newProjectList = project.projectList
+      .map(replaceWithSubExprEliminationExprs(_, subExprEliminationExprs))
+      .map(_.asInstanceOf[NamedExpression])
+    println(s"projectList: $newProjectList")
+    Project(newProjectList, preProject)
+    // scalastyle:on println
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -46,7 +46,7 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
     var newPlan = plan match {
       case project: Project => visitProject(project)
       // TODO: CSE in Filter doesn't work for unknown reason, need to fix it later
-      case filter: Filter => visitFilter(filter)
+      // case filter: Filter => visitFilter(filter)
       case window: Window => visitWindow(window)
       case aggregate: Aggregate => visitAggregate(aggregate)
       case sort: Sort => visitSort(sort)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -83,6 +83,8 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
     if (
       (expr.isInstanceOf[Unevaluable] && !expr.isInstanceOf[AttributeReference])
       || expr.isInstanceOf[AggregateFunction]
+      || (expr.isInstanceOf[AttributeReference]
+        && expr.asInstanceOf[AttributeReference].name == VirtualColumn.groupingIdName)
     ) {
       logTrace(s"Check common expression failed $expr class ${expr.getClass.toString}")
       return false
@@ -161,6 +163,9 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
   }
 
   private def visitAggregate(aggregate: Aggregate): Aggregate = {
+    logTrace(
+      s"aggregate groupingExpressions: ${aggregate.groupingExpressions} " +
+        s"aggregateExpressions: ${aggregate.aggregateExpressions}")
     val groupingSize = aggregate.groupingExpressions.size
     val aggregateSize = aggregate.aggregateExpressions.size
 

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.extension
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.internal.SQLConf
+
+class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
+  extends Rule[LogicalPlan]
+  with Logging {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (plan.resolved) {
+      visitPlan(plan)
+    } else {
+      plan
+    }
+  }
+
+  private def visitPlan(plan: LogicalPlan): LogicalPlan = plan match {
+    case project: Project => visitProject(project)
+    case other =>
+      val children = other.children.map(visitPlan)
+      other.withNewChildren(children)
+  }
+
+  private def visitProject(project: Project): Project = {
+    val input = project.child
+    val equivalentExpressions: EquivalentExpressions = new EquivalentExpressions
+    project.projectList.foreach(equivalentExpressions.addExprTree(_))
+
+    // Get all the expressions that appear at least twice
+    val commonExprs = equivalentExpressions.getCommonSubexpressions
+    if (commonExprs.isEmpty) {
+      return project
+    }
+
+    // Put the common expressions into a hash map
+    var subExprEliminationExprs = Set.empty[ExpressionEquals]
+    commonExprs.foreach {
+      expr =>
+        val exprEquals = new ExpressionEquals(expr)
+        subExprEliminationExprs += exprEquals
+    }
+
+    // Replace the common expressions with the first expression that produces it.
+    var newProjectList = project.projectList.map(_.transformDown {
+      case expr: Expression =>
+        val exprEquals = subExprEliminationExprs.find(_.equals(ExpressionEquals(expr)))
+        if (exprEquals.isDefined) {
+          Alias(exprEquals.get.e, expr.toString())()
+        } else {
+          expr
+        }
+      case other => other
+    }).map(_.asInstanceOf[NamedExpression])
+
+    newProjectList ++= subExprEliminationExprs.map(_.e.asInstanceOf[NamedExpression]).toSeq
+
+    Project(newProjectList, input)
+  }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -81,7 +81,7 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
 
   private def rewrite(inputCtx: RewriteContext): RewriteContext = {
     // scalastyle:off println
-    println(s"start rewrite with input exprs:${inputCtx.exprs} input child:${inputCtx.child}")
+    // println(s"start rewrite with input exprs:${inputCtx.exprs} input child:${inputCtx.child}")
     val equivalentExpressions = new EquivalentExpressions
     inputCtx.exprs.foreach(equivalentExpressions.addExprTree(_))
 
@@ -97,30 +97,30 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
           !expr.isInstanceOf[Unevaluable] && !expr.foldable
           && !expr.isInstanceOf[Attribute] && !expr.isInstanceOf[AggregateFunction]
         ) {
-          println(s"common expr $expr class ${expr.getClass.toString}")
+          // println(s"common expr $expr class ${expr.getClass.toString}")
           val exprEquals = ExpressionEquals(expr)
           val alias = Alias(expr, expr.toString)()
           val attribute = alias.toAttribute
           commonExprMap.put(exprEquals, AliasAndAttribute(alias, attribute))
         }
     }
-    println(s"commonExprMap: $commonExprMap")
+    // println(s"commonExprMap: $commonExprMap")
 
     if (commonExprMap.isEmpty) {
-      println(s"commonExprMap is empty all exprs: ${equivalentExpressions.debugString(true)}")
+      // println(s"commonExprMap is empty all exprs: ${equivalentExpressions.debugString(true)}")
       return RewriteContext(inputCtx.exprs, newChild)
     }
 
     // Generate pre-project as new child
     var preProjectList = newChild.output ++ commonExprMap.values.map(_.alias)
     val preProject = Project(preProjectList, newChild)
-    println(s"newChild: $preProject")
+    // println(s"newChild: $preProject")
 
     // Replace the common expressions with the first expression that produces it.
     try {
       var newExprs = inputCtx.exprs
         .map(replaceCommonExprWithAttribute(_, commonExprMap))
-      println(s"newExprs: $newExprs")
+      // println(s"newExprs: $newExprs")
       RewriteContext(newExprs, preProject)
     } catch {
       case e: Exception =>

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -29,8 +29,11 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
   extends Rule[LogicalPlan]
   with Logging {
 
+  private var lastPlan: LogicalPlan = null
+
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    val newPlan = if (plan.resolved) {
+    val newPlan = if (plan.resolved && !plan.fastEquals(lastPlan)) {
+      lastPlan = plan
       visitPlan(plan)
     } else {
       plan

--- a/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/CommonSubexpressionEliminateRule.scala
@@ -45,6 +45,7 @@ class CommonSubexpressionEliminateRule(session: SparkSession, conf: SQLConf)
   private def visitPlan(plan: LogicalPlan): LogicalPlan = {
     var newPlan = plan match {
       case project: Project => visitProject(project)
+      // TODO: CSE in Filter doesn't work for unknown reason, need to fix it later
       case filter: Filter => visitFilter(filter)
       case window: Window => visitWindow(window)
       case aggregate: Aggregate => visitAggregate(aggregate)

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -86,7 +86,11 @@ class GlutenConfig(conf: SQLConf) extends Logging {
 
   def columnarTableCacheEnabled: Boolean = conf.getConf(COLUMNAR_TABLE_CACHE_ENABLED)
 
-  def enableDateTimestampComparison: Boolean = conf.getConf(ENABLE_DATE_TIMESTAMP_COMPARISON)
+  def enableRewriteDateTimestampComparison: Boolean =
+    conf.getConf(ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON)
+
+  def enableCommonSubexpressionEliminate: Boolean =
+    conf.getConf(ENABLE_COMMON_SUBEXPRESSION_ELIMINATE)
 
   // whether to use ColumnarShuffleManager
   def isUseColumnarShuffleManager: Boolean =
@@ -1388,7 +1392,7 @@ object GlutenConfig {
       .intConf
       .createOptional
 
-  val ENABLE_DATE_TIMESTAMP_COMPARISON =
+  val ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON =
     buildConf("spark.gluten.sql.rewrite.dateTimestampComparison")
       .internal()
       .doc("Rewrite the comparision between date and timestamp to timestamp comparison."
@@ -1400,6 +1404,15 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.columnar.project.collapse")
       .internal()
       .doc("Combines two columnar project operators into one and perform alias substitution")
+      .booleanConf
+      .createWithDefault(true)
+
+  val ENABLE_COMMON_SUBEXPRESSION_ELIMINATE =
+    buildConf("spark.gluten.sql.commonSubexpressionEliminate")
+      .internal()
+      .doc(
+        "Eliminate common subexpressions in logical plan to avoid multiple evaluation of the same"
+          + "expression, may improve performance")
       .booleanConf
       .createWithDefault(true)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Fixes: \#4000) 

Background: in spark, CSE(common subexpression eliminate) is implemented based on codegen instead of logical plan, which makes it impossible for gluten to utilize spark built-in CSE optimization, whether the backend is CH or Velox. So we need to implement CSE based on spark logical plan. 

Implementation: for logical operators like project/sort/aggregate/window, if it contains common subexpressions, firstly a pre-project operator is generated as current operator's child to evaluate the common subexpressions. Then expressions in current operator need to be rewritten to replace common subexprs to attributes refering to pre-project operator's output.   

Notice that not every common subexpressions should be extract into pre-project operator.
- Common subexpressions which contains recursively `Unevaluable` children which are not `AttributeReference`, like `SortOrder` or `WindowSpecDefinition`
- Common subexpressions which contains recursively `AttributeReference` children with name `spark_grouping_id`.
- Common subexpressions which are foldable. 
- Common subexpressions from filter operator because rule `PushDownPredicates` and current CSE have conflicts which will make  RuleExecutor fall into an infinite loop until iterations reaches `maxIterations`. 