### PR TITLE
[VL] Explode support Literal array and map

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -706,5 +706,17 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
                          |""".stripMargin) {
       checkOperatorMatch[GenerateExecTransformer]
     }
+    runQueryAndCompare(
+      """
+        |SELECT explode(array(map(1, 'a', 2, 'b'), map(3, 'c', 4, 'd'), map(5, 'e', 6, 'f')));
+        |""".stripMargin) {
+      checkOperatorMatch[GenerateExecTransformer]
+    }
+    runQueryAndCompare(
+      """
+        |SELECT explode(map(1, array(1, 2), 2, array(3, 4)));
+        |""".stripMargin) {
+      checkOperatorMatch[GenerateExecTransformer]
+    }
   }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -712,10 +712,9 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
         |""".stripMargin) {
       checkOperatorMatch[GenerateExecTransformer]
     }
-    runQueryAndCompare(
-      """
-        |SELECT explode(map(1, array(1, 2), 2, array(3, 4)));
-        |""".stripMargin) {
+    runQueryAndCompare("""
+                         |SELECT explode(map(1, array(1, 2), 2, array(3, 4)));
+                         |""".stripMargin) {
       checkOperatorMatch[GenerateExecTransformer]
     }
   }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -694,4 +694,17 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       }
     }
   }
+
+  test("test explode function") {
+    runQueryAndCompare("""
+                         |SELECT explode(array(1, 2, 3));
+                         |""".stripMargin) {
+      checkOperatorMatch[GenerateExecTransformer]
+    }
+    runQueryAndCompare("""
+                         |SELECT explode(map(1, 'a', 2, 'b'));
+                         |""".stripMargin) {
+      checkOperatorMatch[GenerateExecTransformer]
+    }
+  }
 }

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -498,8 +498,6 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
   std::vector<core::FieldAccessTypedExprPtr> replicated;
   std::vector<core::FieldAccessTypedExprPtr> unnest;
-  // TODO(yuan): get from generator output
-  std::vector<std::string> unnestNames = {"C0"};
 
   const auto& generator = generateRel.generator();
   const auto& requiredChildOutput = generateRel.child_output();
@@ -532,6 +530,21 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     auto unnestFieldExpr = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(unnestExpr);
     VELOX_CHECK_NOT_NULL(unnestFieldExpr, " the key in unnest Operator only support field");
     unnest.emplace_back(unnestFieldExpr);
+  }
+
+  // TODO(yuan): get from generator output
+  std::vector<std::string> unnestNames;
+  int unnestIndex = 0;
+  for (const auto& variable : unnest) {
+    if (variable->type()->isArray()) {
+      unnestNames.emplace_back(fmt::format("C{}", unnestIndex++));
+    } else if (variable->type()->isMap()) {
+      unnestNames.emplace_back(fmt::format("C{}", unnestIndex++));
+      unnestNames.emplace_back(fmt::format("C{}", unnestIndex++));
+    } else {
+      VELOX_FAIL(
+          "Unexpected type of unnest variable. Expected ARRAY or MAP, but got {}.", variable->type()->toString());
+    }
   }
 
   auto node = std::make_shared<core::UnnestNode>(


### PR DESCRIPTION
## What changes were proposed in this pull request?

After my tests, I have found that the Velox backend does support the explode function for Literal inputs of both array and map types. We can lift the restrictions on validation.

## How was this patch tested?

Add a test case in `TestOperator`.

