### PR TITLE
[VL] Increase async wait time to 30s when stopping tasks

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -58,6 +58,8 @@ DECLARE_bool(velox_exception_user_stacktrace_enabled);
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 DECLARE_bool(velox_memory_use_hugepages);
 
+DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
+
 using namespace facebook;
 
 namespace {
@@ -97,8 +99,12 @@ const std::string kVeloxSsdCacheIOThreads = "spark.gluten.sql.columnar.backend.v
 const uint32_t kVeloxSsdCacheIOThreadsDefault = 1;
 const std::string kVeloxSsdODirectEnabled = "spark.gluten.sql.columnar.backend.velox.ssdODirect";
 
+// async
 const std::string kVeloxIOThreads = "spark.gluten.sql.columnar.backend.velox.IOThreads";
 const uint32_t kVeloxIOThreadsDefault = 0;
+const std::string kVeloxAsyncTimeoutOnTaskStopping =
+    "spark.gluten.sql.columnar.backend.velox.asyncTimeoutOnTaskStopping";
+const int32_t kVeloxAsyncTimeoutOnTaskStoppingDefault = 30000; // 30s
 
 // udf
 const std::string kVeloxUdfLibraryPaths = "spark.gluten.sql.columnar.backend.velox.udfLibraryPaths";
@@ -158,6 +164,10 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
 
   // Set velox_memory_use_hugepages.
   FLAGS_velox_memory_use_hugepages = veloxcfg->get<bool>(kMemoryUseHugePages, kMemoryUseHugePagesDefault);
+
+  // Async timeout.
+  FLAGS_gluten_velox_aysnc_timeout_on_task_stopping =
+      veloxcfg->get<int32_t>(kVeloxAsyncTimeoutOnTaskStopping, kVeloxAsyncTimeoutOnTaskStoppingDefault);
 
   // Set backtrace_allocation
   gluten::backtrace_allocation = veloxcfg->get<bool>(kBacktraceAllocation, false);

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -59,6 +59,7 @@ DECLARE_int32(velox_memory_num_shared_leaf_pools);
 DECLARE_bool(velox_memory_use_hugepages);
 
 DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
+DEFINE_int32(gluten_velox_aysnc_timeout_on_task_stopping, 30000, "Aysnc timout when task is being stopped");
 
 using namespace facebook;
 

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -286,7 +286,6 @@ bool VeloxMemoryManager::tryDestructSafe() {
 
 VeloxMemoryManager::~VeloxMemoryManager() {
   static const uint32_t kWaitTimeoutMs = FLAGS_gluten_velox_aysnc_timeout_on_task_stopping; // 30s by default
-  GLUTEN_CHECK(kWaitTimeoutMs > 0, "Aysnc timeout must be greater than 0");
   uint32_t accumulatedWaitMs = 0UL;
   for (int32_t tryCount = 0; accumulatedWaitMs < kWaitTimeoutMs; tryCount++) {
     if (tryDestructSafe()) {

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -283,18 +283,20 @@ bool VeloxMemoryManager::tryDestructSafe() {
 }
 
 VeloxMemoryManager::~VeloxMemoryManager() {
-  // Wait (50 + 100 + 200 + 400 + 800)ms = 1550ms to let possible async tasks (e.g. preload split) complete.
-  for (int32_t tryCount = 0; tryCount < 5; tryCount++) {
+  static const uint32_t kWaitTimeoutMs = 30000UL; // 30s
+  uint32_t accumulatedWaitMs = 0UL;
+  for (int32_t tryCount = 0; accumulatedWaitMs < kWaitTimeoutMs; tryCount++) {
     if (tryDestructSafe()) {
       if (tryCount > 0) {
         LOG(INFO) << "All the outstanding memory resources successfully released. ";
       }
       break;
     }
-    uint32_t waitMs = 50 * static_cast<uint32_t>(pow(2, tryCount));
+    uint32_t waitMs = 50 * static_cast<uint32_t>(pow(1.5, tryCount)); // 50ms, 75ms, 112.5ms ...
     LOG(INFO) << "There are still outstanding Velox memory allocations. Waiting for " << waitMs
               << " ms to let possible async tasks done... ";
     usleep(waitMs * 1000);
+    accumulatedWaitMs += waitMs;
   }
 }
 

--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -23,6 +23,8 @@
 #include "memory/ArrowMemoryPool.h"
 #include "utils/exception.h"
 
+DECLARE_int32(gluten_velox_aysnc_timeout_on_task_stopping);
+
 namespace gluten {
 
 using namespace facebook;
@@ -283,7 +285,8 @@ bool VeloxMemoryManager::tryDestructSafe() {
 }
 
 VeloxMemoryManager::~VeloxMemoryManager() {
-  static const uint32_t kWaitTimeoutMs = 30000UL; // 30s
+  static const uint32_t kWaitTimeoutMs = FLAGS_gluten_velox_aysnc_timeout_on_task_stopping; // 30s by default
+  GLUTEN_CHECK(kWaitTimeoutMs > 0, "Aysnc timeout must be greater than 0");
   uint32_t accumulatedWaitMs = 0UL;
   for (int32_t tryCount = 0; accumulatedWaitMs < kWaitTimeoutMs; tryCount++) {
     if (tryDestructSafe()) {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import java.util
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 
@@ -1079,6 +1080,16 @@ object GlutenConfig {
       .doc("The IO threads for connector split preloading")
       .intConf
       .createWithDefault(0)
+
+  val COLUMNAR_VELOX_ASYNC_TIMEOUT =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.asyncTimeoutOnTaskStopping")
+      .internal()
+      .doc(
+        "Timeout for asynchronous execution when task is being stopped in Velox backend. " +
+          "It's recommended to set to a number larger than network connection timeout that the " +
+          "possible aysnc tasks are relying on.")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(30000)
 
   val COLUMNAR_VELOX_SPLIT_PRELOAD_PER_DRIVER =
     buildStaticConf("spark.gluten.sql.columnar.backend.velox.SplitPreloadPerDriver")


### PR DESCRIPTION
This will fix some core dump issues in the case of turning on split preloading, and to query for remote data source like S3 or remote HDFS cluster.