### PR TITLE
[VL] enable test 'as map of case class - reorder fields by name'

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -346,8 +346,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite the following two tests in GlutenDatasetSuite.
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
-    // Map could not contain non-scalar type.
-    .exclude("as map of case class - reorder fields by name")
   enableSuite[GlutenJsonFunctionsSuite]
     // Velox does not support single quotes in get_json_object function.
     .exclude("function get_json_object - support single quotes")

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1043,8 +1043,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite the following two tests in GlutenDatasetSuite.
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
-    // Map could not contain non-scalar type.
-    .exclude("as map of case class - reorder fields by name")
     // exclude as velox has different behavior in these cases
     .exclude("SPARK-40407: repartition should not result in severe data skew")
     .exclude("SPARK-40660: Switch to XORShiftRandom to distribute elements")

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1076,8 +1076,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Rewrite the following two tests in GlutenDatasetSuite.
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
-    // Map could not contain non-scalar type.
-    .exclude("as map of case class - reorder fields by name")
     // exclude as velox has different behavior in these cases
     .exclude("SPARK-40407: repartition should not result in severe data skew")
     .exclude("SPARK-40660: Switch to XORShiftRandom to distribute elements")


### PR DESCRIPTION
## What changes were proposed in this pull request?

UT change. Complex type support for map functions is added in https://github.com/facebookincubator/velox/pull/7560.
```
-- Project[expressions: (n1_1:MAP<INTEGER,ROW<b:INTEGER,a:VARCHAR>>, map(1,row_constructor(try_cast "n0_0" as INTEGER,"a")))] -> n1_1:MAP<INTEGER,ROW<b:INTEGER,a:VARCHAR>>
  -- ValueStream[] -> n0_0:BIGINT

```
