### PR TITLE
[CH] Use if function if condition size is 1

### DIFF
--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1993,10 +1993,10 @@ ASTPtr ASTParser::parseArgumentToAST(const Names & names, const substrait::Expre
             {
                 const auto & ifs = if_then.ifs(i);
                 auto if_node = parseArgumentToAST(names, ifs.if_());
-                args.emplace_back(std::move(if_node));
+                args.emplace_back(if_node);
 
                 auto then_node = parseArgumentToAST(names, ifs.then());
-                args.emplace_back(std::move(then_node));
+                args.emplace_back(then_node);
             }
 
             auto else_node = parseArgumentToAST(names, if_then.else_());

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1700,10 +1700,14 @@ const ActionsDAG::Node * SerializedPlanParser::parseExpression(ActionsDAGPtr act
 
         case substrait::Expression::RexTypeCase::kIfThen: {
             const auto & if_then = rel.if_then();
-            auto function_multi_if = DB::FunctionFactory::instance().get("multiIf", context);
+            DB::FunctionOverloadResolverPtr function_ptr = nullptr;
+            auto condition_nums = if_then.ifs_size();
+            if (condition_nums == 1)
+                function_ptr = DB::FunctionFactory::instance().get("if", context);
+            else
+                function_ptr = DB::FunctionFactory::instance().get("multiIf", context);
             DB::ActionsDAG::NodeRawConstPtrs args;
 
-            auto condition_nums = if_then.ifs_size();
             for (int i = 0; i < condition_nums; ++i)
             {
                 const auto & ifs = if_then.ifs(i);
@@ -1717,8 +1721,12 @@ const ActionsDAG::Node * SerializedPlanParser::parseExpression(ActionsDAGPtr act
             const auto * else_node = parseExpression(actions_dag, if_then.else_());
             args.emplace_back(else_node);
             std::string args_name = join(args, ',');
-            auto result_name = "multiIf(" + args_name + ")";
-            const auto * function_node = &actions_dag->addFunction(function_multi_if, args, result_name);
+            std::string result_name;
+            if (condition_nums == 1)
+                result_name = "if(" + args_name + ")";
+            else
+                result_name = "multiIf(" + args_name + ")";
+            const auto * function_node = &actions_dag->addFunction(function_ptr, args, result_name);
             actions_dag->addOrReplaceInOutputs(*function_node);
             return function_node;
         }
@@ -1976,11 +1984,15 @@ ASTPtr ASTParser::parseArgumentToAST(const Names & names, const substrait::Expre
         }
         case substrait::Expression::RexTypeCase::kIfThen: {
             const auto & if_then = rel.if_then();
-            const auto * ch_function_name = "multiIf";
+            auto condition_nums = if_then.ifs_size();
+            std::string ch_function_name;
+            if (condition_nums == 1)
+                ch_function_name = "if";
+            else
+                ch_function_name = "multiIf";
             auto function_multi_if = DB::FunctionFactory::instance().get(ch_function_name, context);
             ASTs args;
 
-            auto condition_nums = if_then.ifs_size();
             for (int i = 0; i < condition_nums; ++i)
             {
                 const auto & ifs = if_then.ifs(i);

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1993,13 +1993,14 @@ ASTPtr ASTParser::parseArgumentToAST(const Names & names, const substrait::Expre
             {
                 const auto & ifs = if_then.ifs(i);
                 auto if_node = parseArgumentToAST(names, ifs.if_());
-                args.emplace_back(if_node);
+                args.emplace_back(std::move(if_node));
 
                 auto then_node = parseArgumentToAST(names, ifs.then());
-                args.emplace_back(then_node);
+                args.emplace_back(std::move(then_node));
             }
 
             auto else_node = parseArgumentToAST(names, if_then.else_());
+            args.emplace_back(std::move(else_node));
             return makeASTFunction(ch_function_name, args);
         }
         case substrait::Expression::RexTypeCase::kScalarFunction: {

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1985,11 +1985,7 @@ ASTPtr ASTParser::parseArgumentToAST(const Names & names, const substrait::Expre
         case substrait::Expression::RexTypeCase::kIfThen: {
             const auto & if_then = rel.if_then();
             auto condition_nums = if_then.ifs_size();
-            std::string ch_function_name;
-            if (condition_nums == 1)
-                ch_function_name = "if";
-            else
-                ch_function_name = "multiIf";
+            std::string ch_function_name = condition_nums == 1 ? "if" : "multiIf";
             auto function_multi_if = DB::FunctionFactory::instance().get(ch_function_name, context);
             ASTs args;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#4041)
If performance is better than mulitiIf, so we use if function if we have only on condition.
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
CI
Function `if` has better performance than `mulitiIf` when there is only one condition, especially after PR:
https://github.com/ClickHouse/ClickHouse/pull/57885

On SQL 7954_0
Before:
<img width="1251" alt="image" src="https://github.com/oap-project/gluten/assets/985418/02c5f605-40da-4afb-8e73-5afebffb2363">

After PR https://github.com/ClickHouse/ClickHouse/pull/57745
<img width="1208" alt="image" src="https://github.com/oap-project/gluten/assets/985418/d045ebce-0246-4c7a-9123-30276937d5ba">

Still if is faster than multiIf:
<img width="1113" alt="image" src="https://github.com/oap-project/gluten/assets/985418/91e381b7-d376-446a-b878-16ab88dfcbfb">

