### PR TITLE
[GLUTEN-4018][VL] set AWS C++ SDK Log Level in gluten to avoid recompile velox

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -116,6 +116,10 @@ const std::string kVeloxShuffleReaderPrintFlag = "spark.gluten.velox.shuffleRead
 const std::string kVeloxFileHandleCacheEnabled = "spark.gluten.sql.columnar.backend.velox.fileHandleCacheEnabled";
 const bool kVeloxFileHandleCacheEnabledDefault = false;
 
+// Log granularity of AWS C++ SDK
+const std::string kVeloxAwsSdkLogLevel = "spark.gluten.velox.awsSdkLogLevel";
+const std::string kVeloxAwsSdkLogLevelDefault = "FATAL";
+
 } // namespace
 
 namespace gluten {
@@ -263,6 +267,8 @@ void VeloxBackend::initConnector(const facebook::velox::Config* conf) {
   std::string iamRole = conf->get<std::string>("spark.hadoop.fs.s3a.iam.role", "");
   std::string iamRoleSessionName = conf->get<std::string>("spark.hadoop.fs.s3a.iam.role.session.name", "");
 
+  std::string awsSdkLogLevel = conf->get<std::string>(kVeloxAwsSdkLogLevel, kVeloxAwsSdkLogLevelDefault);
+
   const char* envAwsAccessKey = std::getenv("AWS_ACCESS_KEY_ID");
   if (envAwsAccessKey != nullptr) {
     awsAccessKey = std::string(envAwsAccessKey);
@@ -294,6 +300,7 @@ void VeloxBackend::initConnector(const facebook::velox::Config* conf) {
   }
   mutableConf->setValue("hive.s3.ssl.enabled", sslEnabled ? "true" : "false");
   mutableConf->setValue("hive.s3.path-style-access", pathStyleAccess ? "true" : "false");
+  mutableConf->setValue("hive.s3.log-level", awsSdkLogLevel);
 #endif
 
 #ifdef ENABLE_ABFS

--- a/docs/get-started/VeloxS3.md
+++ b/docs/get-started/VeloxS3.md
@@ -45,6 +45,17 @@ Note that `spark.hadoop.fs.s3a.iam.role.session.name` is optional.
 
 - [AWS temporary credential](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
 
+## Log granularity of AWS C++ SDK in velox
+
+You can change log granularity of AWS C++ SDK by setting the `spark.gluten.velox.awsSdkLogLevel` configuration. The Allowed values are:
+* OFF
+* FATAL
+* ERROR
+* WARN
+* INFO
+* DEBUG
+* TRACE
+
 # Local Caching support
 
 Velox supports a local cache when reading data from HDFS/S3. The feature is very useful if remote storage is slow, e.g., reading from a public S3 bucket and stronger performance is desired. With this feature, Velox can asynchronously cache the data on local disk when reading from remote storage, and the future reading requests on already cached blocks will be serviced from local cache files. To enable the local caching feature, below configurations are required:

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -302,6 +302,8 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableNativeWriter: Boolean = conf.getConf(NATIVE_WRITER_ENABLED)
 
   def enableColumnarProjectCollapse: Boolean = conf.getConf(ENABLE_COLUMNAR_PROJECT_COLLAPSE)
+
+  def awsSdkLogLevel: String = conf.getConf(AWS_SDK_LOG_LEVEL)
 }
 
 object GlutenConfig {
@@ -524,7 +526,8 @@ object GlutenConfig {
       ("spark.sql.orc.compression.codec", "snappy"),
       (
         COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.key,
-        COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.defaultValueString)
+        COLUMNAR_VELOX_FILE_HANDLE_CACHE_ENABLED.defaultValueString),
+      (AWS_SDK_LOG_LEVEL.key, AWS_SDK_LOG_LEVEL.defaultValueString)
     )
     keyWithDefault.forEach(e => nativeConfMap.put(e._1, conf.getOrElse(e._1, e._2)))
 
@@ -1413,4 +1416,11 @@ object GlutenConfig {
         "`WholeStageTransformerContext`.")
       .booleanConf
       .createWithDefault(false)
+
+  val AWS_SDK_LOG_LEVEL =
+    buildConf("spark.gluten.velox.awsSdkLogLevel")
+      .internal()
+      .doc("Log granularity of AWS C++ SDK in velox.")
+      .stringConf
+      .createWithDefault("FATAL")
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR add new configuration `spark.gluten.velox.awsSdkLogLevel` to set AWS C++ SDK Log Level in gluten.

(Fixes: \#4018)

## How was this patch tested?

manual tests

