### PR TITLE
[GLUTEN-3799][CORE] Fix records read metric for columnar shuffle

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.CoalesceExec.EmptyPartition
 import org.apache.spark.sql.execution.exchange._
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLShuffleWriteMetricsReporter}
+import org.apache.spark.sql.metric.SQLColumnarShuffleReadMetricsReporter
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.concurrent.Future
@@ -47,7 +48,7 @@ case class ColumnarShuffleExchangeExec(
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
 
   private[sql] lazy val readMetrics =
-    SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
+    SQLColumnarShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics =

--- a/gluten-core/src/main/scala/org/apache/spark/sql/metric/SQLColumnarShuffleMetricsReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/metric/SQLColumnarShuffleMetricsReporter.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.metric
+
+import org.apache.spark.SparkContext
+import org.apache.spark.executor.TempShuffleReadMetrics
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics, SQLShuffleReadMetricsReporter}
+
+class SQLColumnarShuffleReadMetricsReporter(
+    tempMetrics: TempShuffleReadMetrics,
+    metrics: Map[String, SQLMetric])
+  extends SQLShuffleReadMetricsReporter(tempMetrics, metrics) {
+
+  private[this] val _batchesRead =
+    metrics(SQLColumnarShuffleReadMetricsReporter.BATCHES_READ)
+
+  private[this] val _recordsRead =
+    metrics(SQLShuffleReadMetricsReporter.RECORDS_READ)
+
+  override def incRecordsRead(v: Long): Unit = {
+    _batchesRead.add(v)
+    // tempMetrics.incRecordsRead(v)
+  }
+
+  def incBatchesRecordsRead(v: Long): Unit = {
+    _recordsRead.add(v)
+    tempMetrics.incRecordsRead(v)
+  }
+
+}
+
+object SQLColumnarShuffleReadMetricsReporter {
+  val BATCHES_READ = "batchesRead"
+
+  def createShuffleReadMetrics(sc: SparkContext): Map[String, SQLMetric] = {
+    SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sc) ++ Map(
+      BATCHES_READ -> SQLMetrics.createMetric(sc, "batches read")
+    )
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

As discussed in https://github.com/oap-project/gluten/issues/3799#issuecomment-1822832054, the current shuffle records metirc shows read batches.

This PR fixes `records read` metric for columnar shuffle and adds a new `batches read` metric.

Fixes: #3799

## How was this patch tested?

After this pr (tpcds q1.sql):

![image](https://github.com/oap-project/gluten/assets/17894939/17f93472-7d4c-469c-b583-7571d63f6453)
![image](https://github.com/oap-project/gluten/assets/17894939/20fabdf2-62c2-476a-b0dc-e9305ae85856)
![image](https://github.com/oap-project/gluten/assets/17894939/d619e2cd-3e67-423e-93f0-ff9f64b87504)


