### PR TITLE
[UI] Collapse the collapse table arrow of gluten build information

### DIFF
--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
@@ -88,7 +88,6 @@ private[ui] class GlutenAllExecutionsPage(parent: GlutenSQLTab) extends WebUIPag
             {infos}
           </div>
         </div>
-        <br/>
       </div>
 
     UIUtils.headerSparkPage(request, "Gluten SQL / DataFrame", summary ++ content, parent)

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
@@ -80,11 +80,11 @@ private[ui] class GlutenAllExecutionsPage(parent: GlutenSQLTab) extends WebUIPag
           <span class="collapse-sql-properties collapse-table"
                 onClick="collapseTable('collapse-sql-properties', 'sql-properties')">
             <h4>
-              <span class="collapse-table-arrow arrow-open"></span>
+              <span class="collapse-table-arrow arrow-closed"></span>
               <a>Gluten Build Information</a>
             </h4>
           </span>
-          <div class="sql-properties collapsible-table">
+          <div class="sql-properties collapsible-table collapsed">
             {infos}
           </div>
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Gluten Build Information` is not very important, we can collapse it by default.

## How was this patch tested?

before:

![image](https://github.com/oap-project/gluten/assets/17894939/04f32051-5145-4995-9d7c-5e8bcb1ff544)

after:

![image](https://github.com/oap-project/gluten/assets/17894939/2dc209d1-4f32-48a4-ae28-6d2eee6df6a2)



