### PR TITLE
[VL] Avoid early return when spark.gluten.sql.columnar.libpath is not blank

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ListenerApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ListenerApiImpl.scala
@@ -149,11 +149,11 @@ class ListenerApiImpl extends ListenerApi {
     val libPath = conf.get(GlutenConfig.GLUTEN_LIB_PATH, StringUtils.EMPTY)
     if (StringUtils.isNotBlank(libPath)) { // Path based load. Ignore all other loadees.
       JniLibLoader.loadFromPath(libPath, false)
-      return
+    } else {
+      val baseLibName = conf.get(GlutenConfig.GLUTEN_LIB_NAME, "gluten")
+      loader.mapAndLoad(baseLibName, false)
+      loader.mapAndLoad(VeloxBackend.BACKEND_NAME, false)
     }
-    val baseLibName = conf.get(GlutenConfig.GLUTEN_LIB_NAME, "gluten")
-    loader.mapAndLoad(baseLibName, false)
-    loader.mapAndLoad(VeloxBackend.BACKEND_NAME, false)
 
     initializeNative(conf.getAll.toMap)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ListenerApiImpl#initialize` should not return early when libPath is empty.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

