### PR TITLE
[VL] Error "Mutable config cannot return unprotected reference to values" when reading from S3

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -375,8 +375,10 @@ void VeloxBackend::initConnector(const facebook::velox::Config* conf) {
   if (ioThreads > 0) {
     ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads);
   }
-  velox::connector::registerConnector(
-      std::make_shared<velox::connector::hive::HiveConnector>(kHiveConnectorId, mutableConf, ioExecutor_.get()));
+  velox::connector::registerConnector(std::make_shared<velox::connector::hive::HiveConnector>(
+      kHiveConnectorId,
+      std::make_shared<facebook::velox::core::MemConfig>(mutableConf->valuesCopy()),
+      ioExecutor_.get()));
 }
 
 void VeloxBackend::initUdf(const facebook::velox::Config* conf) {


### PR DESCRIPTION
```
23/12/17 20:54:26 WARN TaskSetManager: Lost task 0.1 in stage 32.0 (TID 11949) (sr270 executor 10): io.glutenproject.exception.GlutenException: java.lang.RuntimeException: Exception: VeloxUserError
Error Source: USER
Error Code: UNSUPPORTED
Reason: Mutable config cannot return unprotected reference to values.
Retriable: False
Context: Split [Hive: s3a://tpcds/t_tpcds_part_1_stringdate/store/part-00000-3502e042-fa34-42ed-bf8e-cb5f60cfebf0-c000.snappy.parquet 0 - 9653] Task Gluten_Stage_32_TID_11949
Top-Level Context: Same as context.
Function: values
File: ../.././velox/core/Config.h
Line: 114
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxUserError, char const*>(facebook::velox::detail::VeloxCheckFailArgs const&, char const*)
# 2  0x0000000000000000
# 3  facebook::velox::filesystems::S3FileSystem::Impl::Impl(facebook::velox::Config const*)
# 4  facebook::velox::filesystems::S3FileSystem::S3FileSystem(std::shared_ptr<facebook::velox::Config const>)
# 5  void folly::basic_once_flag<folly::SharedMutexImpl<false, void, std::atomic, folly::SharedMutexPolicyDefault>, std::atomic>::call_once_slow<facebook::velox::filesystems::fileSystemGenerator()::{lambda(std::shared_ptr<facebook::velox::Config const>, std::basic_string_view<char, std::char_traits<char> >)#1}::operator()(std::shared_ptr<facebook::velox::Config const>, std::basic_string_view<char, std::char_traits<char> >) const::{lambda()#1}>(facebook::velox::filesystems::fileSystemGenerator()::{lambda(std::shared_ptr<facebook::velox::Config const>, std::basic_string_view<char, std::char_traits<char> >)#1}::operator()(std::shared_ptr<facebook::velox::Config const>, std::basic_string_view<char, std::char_traits<char> >) const::{lambda()#1}&&) [clone .constprop.0]
# 6  std::_Function_handler<std::shared_ptr<facebook::velox::filesystems::FileSystem> (std::shared_ptr<facebook::velox::Config const>, std::basic_string_view<char, std::char_traits<char> >), facebook::velox::filesystems::fileSystemGenerator()::{lambda(std::shared_ptr<facebook::velox::Config const>, std::basic_string_view<char, std::char_traits<char> >)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<facebook::velox::Config const>&&, std::basic_string_view<char, std::char_traits<char> >&&)
# 7  facebook::velox::filesystems::getFileSystem(std::basic_string_view<char, std::char_traits<char> >, std::shared_ptr<facebook::velox::Config const>)
# 8  facebook::velox::FileHandleGenerator::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 9  facebook::velox::CachedFactory<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<facebook::velox::FileHandle>, facebook::velox::FileHandleGenerator>::generate(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 10 facebook::velox::connector::hive::HiveDataSource::addSplit(std::shared_ptr<facebook::velox::connector::ConnectorSplit>)
# 11 facebook::velox::exec::TableScan::getOutput()
# 12 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 13 facebook::velox::exec::Driver::next(std::shared_ptr<facebook::velox::exec::BlockingState>&)
# 14 facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
# 15 gluten::WholeStageResultIterator::next()
# 16 Java_io_glutenproject_vectorized_ColumnarBatchOutIterator_nativeHasNext
# 17 0x00007fd6283ad6c7
```
This might be related to https://github.com/facebookincubator/velox/pull/8083