### PR TITLE
[DNM]remove vectorgraphics2d from xchart

### DIFF
--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -163,6 +163,12 @@
       <artifactId>xchart</artifactId>
       <version>3.6.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>de.erichseifert.vectorgraphics2d</groupId>
+          <artifactId>VectorGraphics2D</artifactId>		      
+	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.glutenproject</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove vectorgraphcis2d dependency from xchart since GPL license issue

## How was this patch tested?

Tested in my local server, but need to test pass in Github Action


