### PR TITLE
[GLUTEN-4071][VL] Fix the issue of failed installation of xsimd and gtest on the macOS system, leading to the compilation failure of Velox.

### DIFF
--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -138,7 +138,7 @@ function compile {
       if [ $OS == 'Linux' ]; then
         sudo cmake --install xsimd-build/
       elif [ $OS == 'Darwin' ]; then
-        cmake --install xsimd-build/
+        sudo cmake --install xsimd-build/
       fi
     fi
     if [ -d gtest-build ]; then
@@ -146,7 +146,7 @@ function compile {
       if [ $OS == 'Linux' ]; then
         sudo cmake --install gtest-build/
       elif [ $OS == 'Darwin' ]; then
-        cmake --install gtest-build/
+        sudo cmake --install gtest-build/
       fi
     fi
   fi


### PR DESCRIPTION
Resolving the issue of failed installation of xsimd and gtest on the macOS system, leading to the compilation failure of Velox.
## What changes were proposed in this pull request?

On macOS, add 'sudo' when installing xsimd and gtest
Fix: #4071

## How was this patch tested?
With the addition of local testing on the Apple silicon architecture in the macOS system, Velox can be successfully compiled
