### PR TITLE
[GLUTEN-4097][INFRA] Add .DS_Store into gitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/target/**
 *.class
 *.iml
+.DS_Store
 
 # logs
 *.log


### PR DESCRIPTION
## What changes were proposed in this pull request?

As the .DS_Store files (DS stands for Desktop Services) are automatically generated in macOS.

Following the practice of other open source communities(etc. Apache Spark), this should be added to the gitIgnore file

Close: #4097

## How was this patch tested?

Local Test

