### PR TITLE
[GLUTEN-4100][VL] Should not simply apply `collect_set` to `array_distinct`

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -296,7 +296,6 @@ std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunc
     {"bit_or_merge", "bitwise_or_agg_merge"},
     {"bit_and", "bitwise_and_agg"},
     {"bit_and_merge", "bitwise_and_agg_merge"},
-    {"collect_set", "array_distinct"},
     {"murmur3hash", "hash_with_seed"},
     {"modulus", "mod"}, /*Presto functions.*/
     {"date_format", "format_datetime"}};


### PR DESCRIPTION
## What changes were proposed in this pull request?

`collect_set` is a agg func in Spark, `array_distinct` is a array func not agg func.

So we can't simply use array_distinct instead of collect_set.

Close: #4100 

## How was this patch tested?

CI
