### PR TITLE
[GLUTEN-4116][VL] Support other object store server scheme in native write

### DIFF
--- a/cpp/velox/operators/writer/VeloxParquetDatasource.cc
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.cc
@@ -47,7 +47,7 @@ void VeloxParquetDatasource::init(const std::unordered_map<std::string, std::str
     auto path = filePath_.substr(5);
     auto localWriteFile = std::make_unique<LocalWriteFile>(path, true, false);
     sink_ = std::make_unique<WriteFileSink>(std::move(localWriteFile), path);
-  } else if (strncmp(filePath_.c_str(), "s3a:", 4) == 0) {
+  } else if (isSupportedS3SdkPath(filePath_)) {
 #ifdef ENABLE_S3
     auto fileSystem = getFileSystem(filePath_, nullptr);
     auto* s3FileSystem = dynamic_cast<filesystems::S3FileSystem*>(fileSystem.get());

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.h
@@ -71,7 +71,7 @@ class VeloxParquetDatasource final : public Datasource {
 
   bool isSupportedS3SdkPath(const std::string& filePath_) {
     // support scheme
-    const std::array<const char*, 4> supported_schemes = {"s3a:", "oss:", "cos:", "cosn:"};
+    const std::array<const char*, 5> supported_schemes = {"s3:", "s3a:", "oss:", "cos:", "cosn:"};
 
     for (const char* scheme : supported_schemes) {
       size_t scheme_length = std::strlen(scheme);

--- a/cpp/velox/operators/writer/VeloxParquetDatasource.h
+++ b/cpp/velox/operators/writer/VeloxParquetDatasource.h
@@ -69,6 +69,19 @@ class VeloxParquetDatasource final : public Datasource {
     return schema_;
   }
 
+  bool isSupportedS3SdkPath(const std::string& filePath_) {
+    // support scheme
+    const std::array<const char*, 4> supported_schemes = {"s3a:", "oss:", "cos:", "cosn:"};
+
+    for (const char* scheme : supported_schemes) {
+      size_t scheme_length = std::strlen(scheme);
+      if (filePath_.length() >= scheme_length && std::strncmp(filePath_.c_str(), scheme, scheme_length) == 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
  private:
   int64_t maxRowGroupBytes_ = 134217728; // 128MB
   int64_t maxRowGroupRows_ = 100000000; // 100M


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to support other object store server scheme in native write.

ref: https://facebookincubator.github.io/velox/develop/connectors.html#storage-adapters

(Fixes: \#4116)

## How was this patch tested?

manual tests

