### PR TITLE
[VL] Code refactoring of variable names related to TPCH in Velox UTs

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxColumnarCacheSuite.scala
@@ -57,8 +57,8 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
   }
 
   test("input columnar batch") {
-    TPCHTables.foreach {
-      case (table, _) =>
+    TPCHTables.map(_.name).foreach {
+      table =>
         runQueryAndCompare(s"SELECT * FROM $table", cache = true) {
           df => checkColumnarTableCache(df.queryExecution.executedPlan)
         }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -32,7 +32,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
   }
 
   protected def createDataTypeTable(): Unit = {
-    TPCHTables = Seq(
+    TPCHTableDataFrames = Seq(
       "type1",
       "type2"
     ).map {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -32,7 +32,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
   }
 
   protected def createDataTypeTable(): Unit = {
-    TPCHTables = Seq(
+    TPCHTableDataFrames = Seq(
       "type1",
       "type2"
     ).map {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCHSuite.scala
@@ -244,7 +244,7 @@ class VeloxTPCHV2BhjSuite extends VeloxTPCHSuite {
 
 class VeloxPartitionedTableTPCHSuite extends VeloxTPCHSuite {
   override protected def createTPCHNotNullTables(): Unit = {
-    TPCHTables = TPCHTable.map {
+    TPCHTableDataFrames = TPCHTables.map {
       table =>
         val tableDir = getClass.getResource(resourcePath).getFile
         val tablePath = new File(tableDir, table.name).getAbsolutePath
@@ -260,8 +260,8 @@ class VeloxPartitionedTableTPCHSuite extends VeloxTPCHSuite {
   }
 
   override protected def afterAll(): Unit = {
-    if (TPCHTables != null) {
-      TPCHTables.keys.foreach(v => spark.sql(s"DROP TABLE IF EXISTS $v"))
+    if (TPCHTableDataFrames != null) {
+      TPCHTableDataFrames.keys.foreach(table => spark.sql(s"DROP TABLE IF EXISTS $table"))
     }
     super.afterAll()
   }

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/VeloxParquetWriteSuite.scala
@@ -49,7 +49,7 @@ class VeloxParquetWriteSuite extends VeloxWholeStageTransformerSuite {
             case _ => codec
           }
 
-          TPCHTables.foreach {
+          TPCHTableDataFrames.foreach {
             case (_, df) =>
               withTempPath {
                 f =>

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -41,7 +41,7 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
   protected val fileFormat: String
   protected val logLevel: String = "WARN"
 
-  protected val TPCHTable = Seq(
+  protected val TPCHTables = Seq(
     Table("part", partitionColumns = "p_brand" :: Nil),
     Table("supplier", partitionColumns = Nil),
     Table("partsupp", partitionColumns = Nil),
@@ -52,7 +52,7 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
     Table("region", partitionColumns = Nil)
   )
 
-  protected var TPCHTables: Map[String, DataFrame] = _
+  protected var TPCHTableDataFrames: Map[String, DataFrame] = _
 
   private val isFallbackCheckDisabled0 = new AtomicBoolean(false)
 
@@ -67,14 +67,14 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
   }
 
   override protected def afterAll(): Unit = {
-    if (TPCHTables != null) {
-      TPCHTables.keys.foreach(v => spark.sessionState.catalog.dropTempView(v))
+    if (TPCHTableDataFrames != null) {
+      TPCHTableDataFrames.keys.foreach(v => spark.sessionState.catalog.dropTempView(v))
     }
     super.afterAll()
   }
 
   protected def createTPCHNotNullTables(): Unit = {
-    TPCHTables = TPCHTable
+    TPCHTableDataFrames = TPCHTables
       .map(_.name)
       .map {
         table =>

--- a/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxTPCHDeltaSuite.scala
+++ b/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxTPCHDeltaSuite.scala
@@ -41,7 +41,7 @@ class VeloxTPCHDeltaSuite extends VeloxTPCHSuite {
   }
 
   override protected def createTPCHNotNullTables(): Unit = {
-    TPCHTables = TPCHTable
+    TPCHTables
       .map(_.name)
       .map {
         table =>
@@ -51,5 +51,10 @@ class VeloxTPCHDeltaSuite extends VeloxTPCHSuite {
           (table, tableDF)
       }
       .toMap
+  }
+
+  override protected def afterAll(): Unit = {
+    TPCHTables.map(_.name).foreach(table => spark.sql(s"DROP TABLE IF EXISTS $table"))
+    super.afterAll()
   }
 }

--- a/gluten-iceberg/src/test/scala/io/glutenproject/execution/VeloxTPCHIcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/io/glutenproject/execution/VeloxTPCHIcebergSuite.scala
@@ -47,7 +47,7 @@ class VeloxTPCHIcebergSuite extends VeloxTPCHSuite {
   }
 
   override protected def createTPCHNotNullTables(): Unit = {
-    TPCHTables = TPCHTable
+    TPCHTables
       .map(_.name)
       .map {
         table =>
@@ -60,9 +60,7 @@ class VeloxTPCHIcebergSuite extends VeloxTPCHSuite {
   }
 
   override protected def afterAll(): Unit = {
-    if (TPCHTables != null) {
-      TPCHTables.keys.foreach(v => spark.sql(s"DROP TABLE IF EXISTS $v"))
-    }
+    TPCHTables.map(_.name).foreach(table => spark.sql(s"DROP TABLE IF EXISTS $table"))
     super.afterAll()
   }
 
@@ -96,7 +94,7 @@ class VeloxTPCHIcebergSuite extends VeloxTPCHSuite {
 
 class VeloxPartitionedTableTPCHIcebergSuite extends VeloxTPCHIcebergSuite {
   override protected def createTPCHNotNullTables(): Unit = {
-    TPCHTables = TPCHTable.map {
+    TPCHTables.map {
       table =>
         val tablePath = new File(resourcePath, table.name).getAbsolutePath
         val tableDF = spark.read.format(fileFormat).load(tablePath)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the `WholeStageTransformerSuite`, the variable names `TPCHTable` and `TPCHTables` are very confusing and need to be renamed. Additionally, if a class that inherits from `WholeStageTransformerSuite` overrides the `createTPCHNotNullTables` and `afterAll` methods, there is no need to construct `TPCHTableDataFrames` if they don't require using dataframe. Furthermore, an `afterAll` method has been added to `VeloxTPCHDeltaSuite` because the parent class's `afterAll` method cleans up views, whereas Delta creates tables.

## How was this patch tested?

Exists CI.

