### PR TITLE
[VL] Decouple velox benchmarks/tests build from gluten cpp benchmarks/tests build

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -12,6 +12,7 @@ BUILD_TYPE=Release
 BUILD_TESTS=OFF
 BUILD_EXAMPLES=OFF
 BUILD_BENCHMARKS=OFF
+BUILD_VELOX_BENCHMARKS=OFF
 BUILD_JEMALLOC=OFF
 BUILD_PROTOBUF=ON
 ENABLE_QAT=OFF
@@ -47,6 +48,10 @@ do
         ;;
         --build_benchmarks=*)
         BUILD_BENCHMARKS=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --build_velox_benchmarks=*)
+        BUILD_VELOX_BENCHMARKS=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         --build_jemalloc=*)
@@ -141,12 +146,12 @@ if [ "$ENABLE_VCPKG" = "ON" ]; then
     eval "$envs"
 fi
 
-##install velox
+## build velox
 concat_velox_param
 cd $GLUTEN_DIR/ep/build-velox/src
 ./get_velox.sh --enable_hdfs=$ENABLE_HDFS --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --enable_abfs=$ENABLE_ABFS $VELOX_PARAMETER
 ./build_velox.sh --run_setup_script=$RUN_SETUP_SCRIPT --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_TESTS --build_benchmarks=$BUILD_BENCHMARKS
+                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS
 
 ## compile gluten cpp
 cd $GLUTEN_DIR/cpp

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -12,9 +12,10 @@ BUILD_TYPE=Release
 BUILD_TESTS=OFF
 BUILD_EXAMPLES=OFF
 BUILD_BENCHMARKS=OFF
-BUILD_VELOX_BENCHMARKS=OFF
 BUILD_JEMALLOC=OFF
 BUILD_PROTOBUF=ON
+BUILD_VELOX_TESTS=OFF
+BUILD_VELOX_BENCHMARKS=OFF
 ENABLE_QAT=OFF
 ENABLE_IAA=OFF
 ENABLE_HBM=OFF
@@ -48,10 +49,6 @@ do
         ;;
         --build_benchmarks=*)
         BUILD_BENCHMARKS=("${arg#*=}")
-        shift # Remove argument name from processing
-        ;;
-        --build_velox_benchmarks=*)
-        BUILD_VELOX_BENCHMARKS=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         --build_jemalloc=*)
@@ -105,17 +102,25 @@ do
         shift # Remove argument name from processing
         ;;
         --velox_repo=*)
-	VELOX_REPO=("${arg#*=}")
-	shift # Remove argument name from processing
-	;;
+        VELOX_REPO=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
         --velox_branch=*)
-	VELOX_BRANCH=("${arg#*=}")
-	shift # Remove argument name from processing
-	;;
+        VELOX_BRANCH=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
         --velox_home=*)
-	VELOX_HOME=("${arg#*=}")
-	shift # Remove argument name from processing
-	;;
+        VELOX_HOME=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --build_velox_tests=*)
+        BUILD_VELOX_TESTS=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --build_velox_benchmarks=*)
+        BUILD_VELOX_BENCHMARKS=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
 	      *)
         OTHER_ARGUMENTS+=("$1")
         shift # Remove generic argument from processing
@@ -151,7 +156,7 @@ concat_velox_param
 cd $GLUTEN_DIR/ep/build-velox/src
 ./get_velox.sh --enable_hdfs=$ENABLE_HDFS --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --enable_abfs=$ENABLE_ABFS $VELOX_PARAMETER
 ./build_velox.sh --run_setup_script=$RUN_SETUP_SCRIPT --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS
+                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_VELOX_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS
 
 ## compile gluten cpp
 cd $GLUTEN_DIR/cpp

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -68,7 +68,7 @@ for arg in "$@"; do
     ENABLE_TESTS=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
-  --build_benchmarks=*)
+  --build_velox_benchmarks=*)
     ENABLE_BENCHMARK=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
@@ -115,7 +115,7 @@ function compile {
     fi
   else
     echo "ENABLE_BENCHMARK is ON. Disabling Tests, GCS and ABFS connectors if enabled."
-    COMPILE_OPTION="$COMPILE_OPTION -DVELOX_BUILD_BENCHMARKS=ON"
+    COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_BENCHMARKS=ON"
   fi
 
   COMPILE_OPTION="$COMPILE_OPTION -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove `VELOX_BUILD_BENCHMARKS` as it was removed in upstream velox. Use `VELOX_ENABLE_BENCHMARKS` instead.
2. Decouple building gluten cpp benchmark & building velox benchmark. There is no dependency between them. Added a new option `--build_velox_benchmarks` to control whether to build velox benchmark.
3. Decouple building gluten cpp tests & building velox tests. Also, there is no dependency between them. Added a new build option `--build_velox_tests` to control whether to build velox tests.

## How was this patch tested?

Existing tests.

