### PR TITLE
[GLUTEN-4160][CORE] Fix ClassCastException occurred when fallback broadcast join and broadcast exchange

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -535,8 +535,11 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       ColumnarBroadcastExchangeExec(exchange.mode, newChild)
     }
 
-    if (GlutenConfig.getConf.enableScanOnly) {
-      // Disable ColumnarSubqueryBroadcast for scan-only execution.
+    if (
+      GlutenConfig.getConf.enableScanOnly || !GlutenConfig.getConf.enableColumnarBroadcastExchange
+    ) {
+      // Disable ColumnarSubqueryBroadcast for scan-only execution
+      // or ColumnarBroadcastExchange was disabled.
       partitionFilters
     } else {
       val newPartitionFilters = partitionFilters.map {


### PR DESCRIPTION
## What changes were proposed in this pull request?

An exception occurred when I disabled broadcasthashjoin，I expect it to work fine after I fallback broadcasthashjoin and broadcastExchange. here's how to make it happen, run tpcds q31 with the following configuration

--conf spark.gluten.sql.columnar.broadcastJoin=false
--conf spark.gluten.sql.columnar.broadcastExchange=false

```bash
Caused by: java.lang.ClassCastException: org.apache.spark.sql.execution.joins.LongHashedRelation cannot be cast to org.apache.spark.sql.execution.joins.BuildSideRelation
        at org.apache.spark.sql.execution.ColumnarSubqueryBroadcastExec.$anonfun$relationFuture$3(ColumnarSubqueryBroadcastExec.scala:89)
        at io.glutenproject.utils.Arm$.withResource(Arm.scala:25)
        at io.glutenproject.metrics.GlutenTimeMetric$.millis(GlutenTimeMetric.scala:37)
        at org.apache.spark.sql.execution.ColumnarSubqueryBroadcastExec.$anonfun$relationFuture$2(ColumnarSubqueryBroadcastExec.scala:77)
        at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withExecutionId$1(SQLExecution.scala:145)
        at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:169)
        at org.apache.spark.sql.execution.SQLExecution$.withExecutionId(SQLExecution.scala:143)
        at org.apache.spark.sql.execution.ColumnarSubqueryBroadcastExec.$anonfun$relationFuture$1(ColumnarSubqueryBroadcastExec.scala:75)
        at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
        at scala.util.Success.$anonfun$map$1(Try.scala:255)
        at scala.util.Success.map(Try.scala:213)
        at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
        at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
        at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

(Fixes: \#4160)

## How was this patch tested?

Run tpcds q31 with the following configurations
--conf spark.gluten.sql.columnar.broadcastJoin=false
--conf spark.gluten.sql.columnar.broadcastExchange=false

