### PR TITLE
[GLUTEN-3942][CORE]fix: Change columnar overrides to accept ShuffleExchangeLike

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -162,7 +162,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
    * result columns from the projection.
    */
   private def addProjectionForShuffleExchange(
-      plan: ShuffleExchangeExec): (Int, Partitioning, SparkPlan) = {
+      plan: ShuffleExchangeLike): (Int, Partitioning, SparkPlan) = {
     def selectExpressions(
         exprs: Seq[Expression],
         attributes: Seq[Attribute]): (Seq[NamedExpression], Seq[Int]) = {
@@ -378,7 +378,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
         TakeOrderedAndProjectExecTransformer(plan.limit, plan.sortOrder, plan.projectList, child)
-      case plan: ShuffleExchangeExec =>
+      case plan: ShuffleExchangeLike =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
         if (

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -168,7 +168,7 @@ case class ColumnarShuffleExchangeExec(
 object ColumnarShuffleExchangeExec extends Logging {
 
   def apply(
-      plan: ShuffleExchangeExec,
+      plan: ShuffleExchangeLike,
       child: SparkPlan,
       shuffleOutputAttributes: Seq[Attribute]): ColumnarShuffleExchangeExec = {
     ColumnarShuffleExchangeExec(


### PR DESCRIPTION
## What changes were proposed in this pull request?

TransformPreOverrides.replaceWithTransformerPlan only tranform ShuffleExchangeExec, which is a case class, meaning I can't extend it.

This PR changes it to support ShuffleExchangeLike.

Partially fix the #3942

## How was this patch tested?

Existing tests