### PR TITLE
[GLUTEN-4170][VL] Decouple partitions from plan to avoid driver stalled

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -95,7 +95,9 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
    *
    * @return
    */
-  override def genPartitions(wsCtx: WholeStageTransformContext, splitInfos: Seq[Seq[SplitInfo]]): Seq[BaseGlutenPartition] = {
+  override def genPartitions(
+      wsCtx: WholeStageTransformContext,
+      splitInfos: Seq[Seq[SplitInfo]]): Seq[BaseGlutenPartition] = {
     splitInfos.zipWithIndex.map {
       case (splitInfos, index) =>
         wsCtx.substraitContext.initSplitInfosIndex(0)
@@ -265,7 +267,7 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
           GlutenPartition(
             index,
             substraitPlan.toByteArray,
-            splitInfo.preferredLocations().asScala.toArray)
+            locations = splitInfo.preferredLocations().asScala.toArray)
       }
     }(t => logInfo(s"Generating the Substrait plan took: $t ms."))
 

--- a/backends-clickhouse/src/test/scala/org/apache/spark/affinity/MixedAffinitySuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/affinity/MixedAffinitySuite.scala
@@ -49,7 +49,7 @@ class MixedAffinitySuite extends QueryTest with SharedSparkSession {
     }
     val partition = GlutenMergeTreePartition(0, "", "", "", "fakePath", 0, 0)
     val locations = affinity.getNativeMergeTreePartitionLocations(partition)
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
     assertResult(Set("forced_host_host-0")) {
       nativePartition.preferredLocations().toSet
     }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -202,8 +202,10 @@ class IteratorApiImpl extends IteratorApi with Logging {
     val nativeResultIterator =
       transKernel.createKernelWithBatchIterator(
         rootNode.toProtobuf.toByteArray,
+        // Final iterator does not contain scan split, so pass empty split info to native here.
         new Array[Array[Byte]](0),
-        columnarNativeIterator)
+        columnarNativeIterator
+      )
 
     Iterators
       .wrap(nativeResultIterator.asScala)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -21,7 +21,7 @@ import io.glutenproject.backendsapi.IteratorApi
 import io.glutenproject.execution._
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
-import io.glutenproject.substrait.rel.{LocalFilesBuilder, SplitInfo}
+import io.glutenproject.substrait.rel.{LocalFilesBuilder, LocalFilesNode, SplitInfo}
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.utils.Iterators
 import io.glutenproject.vectorized._
@@ -47,16 +47,12 @@ import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.time.ZoneOffset
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, Map => JMap}
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
 class IteratorApiImpl extends IteratorApi with Logging {
 
-  /**
-   * Generate native row partition.
-   *
-   * @return
-   */
   override def genSplitInfo(
       partition: InputPartition,
       partitionSchema: StructType,
@@ -77,6 +73,24 @@ class IteratorApiImpl extends IteratorApi with Logging {
           preferredLocations.toList.asJava)
       case _ =>
         throw new UnsupportedOperationException(s"Unsupported input partition.")
+    }
+  }
+
+  /** Generate native row partition. */
+  override def genPartitions(
+      wsCtx: WholeStageTransformContext,
+      splitInfos: Seq[Seq[SplitInfo]]): Seq[BaseGlutenPartition] = {
+    // Only serialize plan once, save lots time when plan is complex.
+    val planByteArray = wsCtx.root.toProtobuf.toByteArray
+
+    splitInfos.zipWithIndex.map {
+      case (splitInfos, index) =>
+        GlutenPartition(
+          index,
+          planByteArray,
+          splitInfos.map(_.asInstanceOf[LocalFilesNode].toProtobuf.toByteArray).toArray,
+          splitInfos.flatMap(_.preferredLocations().asScala).toArray
+        )
     }
   }
 
@@ -121,11 +135,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
     transKernel.injectWriteFilesTempPath(path)
   }
 
-  /**
-   * Generate Iterator[ColumnarBatch] for first stage.
-   *
-   * @return
-   */
+  /** Generate Iterator[ColumnarBatch] for first stage. */
   override def genFirstStageIterator(
       inputPartition: BaseGlutenPartition,
       context: TaskContext,
@@ -133,13 +143,26 @@ class IteratorApiImpl extends IteratorApi with Logging {
       updateInputMetrics: (InputMetricsWrapper) => Unit,
       updateNativeMetrics: IMetrics => Unit,
       inputIterators: Seq[Iterator[ColumnarBatch]] = Seq()): Iterator[ColumnarBatch] = {
+    assert(
+      inputPartition.isInstanceOf[GlutenPartition],
+      "Velox backend only accept GlutenPartition.")
+
+    val beforeBuild = System.nanoTime()
     val columnarNativeIterators =
       new JArrayList[GeneralInIterator](inputIterators.map {
         iter => new ColumnarBatchInIterator(iter.asJava)
       }.asJava)
     val transKernel = NativePlanEvaluator.create()
+
+    val splitInfoByteArray = inputPartition
+      .asInstanceOf[GlutenPartition]
+      .splitInfosByteArray
     val resIter: GeneralOutIterator =
-      transKernel.createKernelWithBatchIterator(inputPartition.plan, columnarNativeIterators)
+      transKernel.createKernelWithBatchIterator(
+        inputPartition.plan,
+        splitInfoByteArray,
+        columnarNativeIterators)
+    pipelineTime += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - beforeBuild)
 
     Iterators
       .wrap(resIter.asScala)
@@ -157,11 +180,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
 
   // scalastyle:off argcount
 
-  /**
-   * Generate Iterator[ColumnarBatch] for final stage.
-   *
-   * @return
-   */
+  /** Generate Iterator[ColumnarBatch] for final stage. */
   override def genFinalStageIterator(
       context: TaskContext,
       inputIterators: Seq[Iterator[ColumnarBatch]],
@@ -183,6 +202,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
     val nativeResultIterator =
       transKernel.createKernelWithBatchIterator(
         rootNode.toProtobuf.toByteArray,
+        new Array[Array[Byte]](0),
         columnarNativeIterator)
 
     Iterators

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -72,6 +72,8 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
 
   virtual void injectWriteFilesTempPath(const std::string& path) = 0;
 
+  virtual void parseSplitInfo(const uint8_t* data, int32_t size) = 0;
+
   // Just for benchmark
   ::substrait::Plan& getPlan() {
     return substraitPlan_;
@@ -140,6 +142,7 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
  protected:
   std::unique_ptr<ObjectStore> objStore_ = ObjectStore::create();
   ::substrait::Plan substraitPlan_;
+  std::vector<::substrait::ReadRel_LocalFiles> localFiles_;
   std::optional<std::string> writeFilesTempPath_;
   SparkTaskInfo taskInfo_;
   // Session conf map

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -382,9 +382,6 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
 
   auto spillDirStr = jStringToCString(env, spillDir);
 
-  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArr, nullptr));
-  auto planSize = env->GetArrayLength(planArr);
-
   if (jsize splitInfoArraySize = env->GetArrayLength(splitInfosArr); splitInfoArraySize != 0) {
     for (auto i = 0; i < splitInfoArraySize; i++) {
       jbyteArray splitInfoArray = reinterpret_cast<jbyteArray>(env->GetObjectArrayElement(splitInfosArr, i));
@@ -393,6 +390,9 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
       ctx->parseSplitInfo(splitInfoData, splitInfoSize);
     }
   }
+
+  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArr, nullptr));
+  auto planSize = env->GetArrayLength(planArr);
   ctx->parsePlan(planData, planSize, {stageId, partitionId, taskId});
 
   auto& conf = ctx->getConfMap();

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -368,6 +368,7 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
     jobject wrapper,
     jlong memoryManagerHandle,
     jbyteArray planArr,
+    jobjectArray splitInfosArr,
     jobjectArray iterArr,
     jint stageId,
     jint partitionId,
@@ -384,7 +385,16 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
   auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArr, nullptr));
   auto planSize = env->GetArrayLength(planArr);
 
+  if (jsize splitInfoArraySize = env->GetArrayLength(splitInfosArr); splitInfoArraySize != 0) {
+    for (auto i = 0; i < splitInfoArraySize; i++) {
+      jbyteArray splitInfoArray = reinterpret_cast<jbyteArray>(env->GetObjectArrayElement(splitInfosArr, i));
+      jsize splitInfoSize = env->GetArrayLength(splitInfoArray);
+      auto splitInfoData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(splitInfoArray, nullptr));
+      ctx->parseSplitInfo(splitInfoData, splitInfoSize);
+    }
+  }
   ctx->parsePlan(planData, planSize, {stageId, partitionId, taskId});
+
   auto& conf = ctx->getConfMap();
 
   // Handle the Java iters

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -382,13 +382,11 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
 
   auto spillDirStr = jStringToCString(env, spillDir);
 
-  if (jsize splitInfoArraySize = env->GetArrayLength(splitInfosArr); splitInfoArraySize != 0) {
-    for (auto i = 0; i < splitInfoArraySize; i++) {
-      jbyteArray splitInfoArray = reinterpret_cast<jbyteArray>(env->GetObjectArrayElement(splitInfosArr, i));
-      jsize splitInfoSize = env->GetArrayLength(splitInfoArray);
-      auto splitInfoData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(splitInfoArray, nullptr));
-      ctx->parseSplitInfo(splitInfoData, splitInfoSize);
-    }
+  for (jsize i = 0, splitInfoArraySize = env->GetArrayLength(splitInfosArr); i < splitInfoArraySize; i++) {
+    jbyteArray splitInfoArray = static_cast<jbyteArray>(env->GetObjectArrayElement(splitInfosArr, i));
+    jsize splitInfoSize = env->GetArrayLength(splitInfoArray);
+    auto splitInfoData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(splitInfoArray, nullptr));
+    ctx->parseSplitInfo(splitInfoData, splitInfoSize);
   }
 
   auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArr, nullptr));

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -109,7 +109,7 @@ void populateWriterMetrics(
 } // namespace
 
 auto BM_Generic = [](::benchmark::State& state,
-                     const std::string& substraitJsonFile,
+                     const std::string& planFile,
                      const std::string& splitFile,
                      const std::vector<std::string>& inputFiles,
                      const std::unordered_map<std::string, std::string>& conf,
@@ -123,9 +123,7 @@ auto BM_Generic = [](::benchmark::State& state,
   memory::MemoryManager::testingSetInstance({});
   auto memoryManager = getDefaultMemoryManager();
   auto runtime = Runtime::create(kVeloxRuntimeKind, conf);
-  const auto& filePath = substraitJsonFile;
-  auto plan = getPlanFromFile("Plan", filePath);
-  const auto& splitPath = splitFile;
+  auto plan = getPlanFromFile("Plan", planFile);
   auto split = getPlanFromFile("ReadRel.LocalFiles", splitPath);
   auto startTime = std::chrono::steady_clock::now();
   int64_t collectBatchTime = 0;

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -124,7 +124,7 @@ auto BM_Generic = [](::benchmark::State& state,
   auto memoryManager = getDefaultMemoryManager();
   auto runtime = Runtime::create(kVeloxRuntimeKind, conf);
   auto plan = getPlanFromFile("Plan", planFile);
-  auto split = getPlanFromFile("ReadRel.LocalFiles", splitPath);
+  auto split = getPlanFromFile("ReadRel.LocalFiles", splitFile);
   auto startTime = std::chrono::steady_clock::now();
   int64_t collectBatchTime = 0;
   WriterMetrics writerMetrics{};

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -269,19 +269,20 @@ int main(int argc, char** argv) {
     std::exit(EXIT_FAILURE);
   }
 
-#define GENERIC_BENCHMARK(NAME, READER_TYPE)                                                                      \
-  do {                                                                                                            \
-    auto* bm = ::benchmark::RegisterBenchmark(NAME, BM_Generic, substraitJsonFile, inputFiles, conf, READER_TYPE) \
-                   ->MeasureProcessCPUTime()                                                                      \
-                   ->UseRealTime();                                                                               \
-    if (FLAGS_threads > 0) {                                                                                      \
-      bm->Threads(FLAGS_threads);                                                                                 \
-    } else {                                                                                                      \
-      bm->ThreadRange(1, std::thread::hardware_concurrency());                                                    \
-    }                                                                                                             \
-    if (FLAGS_iterations > 0) {                                                                                   \
-      bm->Iterations(FLAGS_iterations);                                                                           \
-    }                                                                                                             \
+#define GENERIC_BENCHMARK(NAME, READER_TYPE)                                                                          \
+  do {                                                                                                                \
+    auto* bm =                                                                                                        \
+        ::benchmark::RegisterBenchmark(NAME, BM_Generic, substraitJsonFile, splitFile, inputFiles, conf, READER_TYPE) \
+            ->MeasureProcessCPUTime()                                                                                 \
+            ->UseRealTime();                                                                                          \
+    if (FLAGS_threads > 0) {                                                                                          \
+      bm->Threads(FLAGS_threads);                                                                                     \
+    } else {                                                                                                          \
+      bm->ThreadRange(1, std::thread::hardware_concurrency());                                                        \
+    }                                                                                                                 \
+    if (FLAGS_iterations > 0) {                                                                                       \
+      bm->Iterations(FLAGS_iterations);                                                                               \
+    }                                                                                                                 \
   } while (0)
 
   DLOG(INFO) << "FLAGS_threads:" << FLAGS_threads;

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -251,7 +251,8 @@ int main(int argc, char** argv) {
     if (argc < 2) {
       LOG(INFO)
           << "No input args. Usage: " << std::endl
-          << "./generic_benchmark /absolute-path/to/substrait_json_file /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
+          << "./generic_benchmark /absolute-path/to/substrait_json_file /absolute-path/to/split_json_file(optional)"
+          << " /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
       LOG(INFO) << "Running example...";
       inputFiles.resize(2);
       substraitJsonFile = getGeneratedFilePath("example.json");

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.cc
@@ -47,14 +47,14 @@ void initVeloxBackend() {
   initVeloxBackend(bmConfMap);
 }
 
-std::string getPlanFromFile(const std::string& filePath) {
+std::string getPlanFromFile(const std::string& type, const std::string& filePath) {
   // Read json file and resume the binary data.
   std::ifstream msgJson(filePath);
   std::stringstream buffer;
   buffer << msgJson.rdbuf();
   std::string msgData = buffer.str();
 
-  return gluten::substraitFromJsonToPb("Plan", msgData);
+  return gluten::substraitFromJsonToPb(type, msgData);
 }
 
 velox::dwio::common::FileFormat getFileFormat(const std::string& fileFormat) {

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.h
@@ -72,7 +72,7 @@ inline std::string getGeneratedFilePath(const std::string& fileName) {
 }
 
 /// Read binary data from a json file.
-std::string getPlanFromFile(const std::string& filePath);
+std::string getPlanFromFile(const std::string& type, const std::string& filePath);
 
 /// Get the file paths, starts, lengths from a directory.
 /// Use fileFormat to specify the format to read, eg., orc, parquet.

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -18,7 +18,6 @@
 #include "VeloxPlanConverter.h"
 #include <filesystem>
 
-#include "arrow/c/bridge.h"
 #include "compute/ResultIterator.h"
 #include "config/GlutenConfig.h"
 #include "operators/plannodes/RowVectorStream.h"
@@ -34,183 +33,80 @@ VeloxPlanConverter::VeloxPlanConverter(
     const std::unordered_map<std::string, std::string>& confMap,
     const std::optional<std::string> writeFilesTempPath,
     bool validationMode)
-    : inputIters_(inputIters),
-      validationMode_(validationMode),
+    : validationMode_(validationMode),
       substraitVeloxPlanConverter_(veloxPool, confMap, writeFilesTempPath, validationMode),
-      pool_(veloxPool) {}
-
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::WriteRel& writeRel) {
-  if (writeRel.has_input()) {
-    setInputPlanNode(writeRel.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
+      pool_(veloxPool) {
+  substraitVeloxPlanConverter_.setInputIterators(inputIters);
 }
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::FetchRel& fetchRel) {
-  if (fetchRel.has_input()) {
-    setInputPlanNode(fetchRel.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::ExpandRel& sexpand) {
-  if (sexpand.has_input()) {
-    setInputPlanNode(sexpand.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::GenerateRel& sGenerate) {
-  if (sGenerate.has_input()) {
-    setInputPlanNode(sGenerate.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
+namespace {
+std::shared_ptr<SplitInfo> parseScanSplitInfo(
+    const google::protobuf::RepeatedPtrField<substrait::ReadRel_LocalFiles_FileOrFiles>& fileList) {
+  using SubstraitFileFormatCase = ::substrait::ReadRel_LocalFiles_FileOrFiles::FileFormatCase;
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::SortRel& ssort) {
-  if (ssort.has_input()) {
-    setInputPlanNode(ssort.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
+  auto splitInfo = std::make_shared<SplitInfo>();
+  splitInfo->paths.reserve(fileList.size());
+  splitInfo->starts.reserve(fileList.size());
+  splitInfo->lengths.reserve(fileList.size());
+  splitInfo->partitionColumns.reserve(fileList.size());
+  for (const auto& file : fileList) {
+    // Expect all Partitions share the same index.
+    splitInfo->partitionIndex = file.partition_index();
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::WindowRel& swindow) {
-  if (swindow.has_input()) {
-    setInputPlanNode(swindow.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
-
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::AggregateRel& sagg) {
-  if (sagg.has_input()) {
-    setInputPlanNode(sagg.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
-
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::ProjectRel& sproject) {
-  if (sproject.has_input()) {
-    setInputPlanNode(sproject.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
-
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::FilterRel& sfilter) {
-  if (sfilter.has_input()) {
-    setInputPlanNode(sfilter.input());
-  } else {
-    throw std::runtime_error("Child expected");
-  }
-}
-
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::JoinRel& sjoin) {
-  if (sjoin.has_left()) {
-    setInputPlanNode(sjoin.left());
-  } else {
-    throw std::runtime_error("Left child expected");
-  }
-
-  if (sjoin.has_right()) {
-    setInputPlanNode(sjoin.right());
-  } else {
-    throw std::runtime_error("Right child expected");
-  }
-}
-
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::ReadRel& sread) {
-  int32_t iterIdx = substraitVeloxPlanConverter_.getStreamIndex(sread);
-  if (iterIdx == -1) {
-    return;
-  }
-
-  // Get the input schema of this iterator.
-  uint64_t colNum = 0;
-  std::vector<velox::TypePtr> veloxTypeList;
-  if (sread.has_base_schema()) {
-    const auto& baseSchema = sread.base_schema();
-    // Input names is not used. Instead, new input/output names will be created
-    // because the ValueStreamNode in Velox does not support name change.
-    colNum = baseSchema.names().size();
-    veloxTypeList = SubstraitParser::parseNamedStruct(baseSchema);
-  }
-
-  std::vector<std::string> outNames;
-  outNames.reserve(colNum);
-  for (int idx = 0; idx < colNum; idx++) {
-    auto colName = SubstraitParser::makeNodeName(planNodeId_, idx);
-    outNames.emplace_back(colName);
-  }
-
-  std::shared_ptr<ResultIterator> iterator;
-  if (!validationMode_) {
-    if (inputIters_.size() == 0) {
-      throw std::runtime_error("Invalid input iterator.");
+    std::unordered_map<std::string, std::string> partitionColumnMap;
+    for (const auto& partitionColumn : file.partition_columns()) {
+      partitionColumnMap[partitionColumn.key()] = partitionColumn.value();
     }
-    iterator = inputIters_[iterIdx];
-  }
+    splitInfo->partitionColumns.emplace_back(partitionColumnMap);
 
-  auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
-  auto vectorStream = std::make_shared<RowVectorStream>(pool_, std::move(iterator), outputType);
-  auto valuesNode = std::make_shared<ValueStreamNode>(nextPlanNodeId(), outputType, std::move(vectorStream));
-  substraitVeloxPlanConverter_.insertInputNode(iterIdx, valuesNode, planNodeId_);
+    splitInfo->paths.emplace_back(file.uri_file());
+    splitInfo->starts.emplace_back(file.start());
+    splitInfo->lengths.emplace_back(file.length());
+    switch (file.file_format_case()) {
+      case SubstraitFileFormatCase::kOrc:
+        splitInfo->format = dwio::common::FileFormat::ORC;
+        break;
+      case SubstraitFileFormatCase::kDwrf:
+        splitInfo->format = dwio::common::FileFormat::DWRF;
+        break;
+      case SubstraitFileFormatCase::kParquet:
+        splitInfo->format = dwio::common::FileFormat::PARQUET;
+        break;
+      case SubstraitFileFormatCase::kText:
+        splitInfo->format = dwio::common::FileFormat::TEXT;
+        break;
+      default:
+        splitInfo->format = dwio::common::FileFormat::UNKNOWN;
+        break;
+    }
+  }
+  return splitInfo;
 }
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::Rel& srel) {
-  if (srel.has_aggregate()) {
-    setInputPlanNode(srel.aggregate());
-  } else if (srel.has_project()) {
-    setInputPlanNode(srel.project());
-  } else if (srel.has_filter()) {
-    setInputPlanNode(srel.filter());
-  } else if (srel.has_read()) {
-    setInputPlanNode(srel.read());
-  } else if (srel.has_join()) {
-    setInputPlanNode(srel.join());
-  } else if (srel.has_sort()) {
-    setInputPlanNode(srel.sort());
-  } else if (srel.has_expand()) {
-    setInputPlanNode(srel.expand());
-  } else if (srel.has_fetch()) {
-    setInputPlanNode(srel.fetch());
-  } else if (srel.has_window()) {
-    setInputPlanNode(srel.window());
-  } else if (srel.has_generate()) {
-    setInputPlanNode(srel.generate());
-  } else if (srel.has_write()) {
-    setInputPlanNode(srel.write());
-  } else {
-    throw std::runtime_error("Rel is not supported: " + srel.DebugString());
-  }
-}
+void parseLocalFileNodes(
+    SubstraitToVeloxPlanConverter* planConverter,
+    std::vector<::substrait::ReadRel_LocalFiles>& localFiles) {
+  std::vector<std::shared_ptr<SplitInfo>> splitInfos;
+  for (int32_t i = 0; i < localFiles.size(); i++) {
+    const auto& localFile = localFiles[i];
+    const auto& fileList = localFile.items();
 
-void VeloxPlanConverter::setInputPlanNode(const ::substrait::RelRoot& sroot) {
-  // Output names can be got from RelRoot, but are not used currently.
-  if (sroot.has_input()) {
-    setInputPlanNode(sroot.input());
-  } else {
-    throw std::runtime_error("Input is expected in RelRoot.");
+    splitInfos.push_back(std::move(parseScanSplitInfo(fileList)));
   }
+
+  planConverter->setSplitInfos(std::move(splitInfos));
 }
+} // namespace
 
 std::shared_ptr<const facebook::velox::core::PlanNode> VeloxPlanConverter::toVeloxPlan(
-    ::substrait::Plan& substraitPlan) {
-  // In fact, only one RelRoot is expected here.
-  for (auto& srel : substraitPlan.relations()) {
-    if (srel.has_root()) {
-      setInputPlanNode(srel.root());
-    }
-    if (srel.has_rel()) {
-      setInputPlanNode(srel.rel());
-    }
+    ::substrait::Plan& substraitPlan,
+    std::vector<::substrait::ReadRel_LocalFiles> localFiles) {
+  if (!validationMode_) {
+    parseLocalFileNodes(&substraitVeloxPlanConverter_, localFiles);
   }
+
   auto veloxPlan = substraitVeloxPlanConverter_.toVeloxPlan(substraitPlan);
   DLOG(INFO) << "Plan Node: " << std::endl << veloxPlan->toString(true, true);
   return veloxPlan;

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -96,6 +96,7 @@ void parseLocalFileNodes(
     SubstraitToVeloxPlanConverter* planConverter,
     std::vector<::substrait::ReadRel_LocalFiles>& localFiles) {
   std::vector<std::shared_ptr<SplitInfo>> splitInfos;
+  splitInfos.reserve(localFiles.size());
   for (int32_t i = 0; i < localFiles.size(); i++) {
     const auto& localFile = localFiles[i];
     const auto& fileList = localFile.items();

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -37,7 +37,7 @@ class VeloxPlanConverter {
       bool validationMode = false);
 
   std::shared_ptr<const facebook::velox::core::PlanNode> toVeloxPlan(
-      ::substrait::Plan& substraitPlan,
+      const ::substrait::Plan& substraitPlan,
       std::vector<::substrait::ReadRel_LocalFiles> localFiles);
 
   const std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfos() {

--- a/cpp/velox/compute/VeloxPlanConverter.h
+++ b/cpp/velox/compute/VeloxPlanConverter.h
@@ -36,44 +36,18 @@ class VeloxPlanConverter {
       const std::optional<std::string> writeFilesTempPath = std::nullopt,
       bool validationMode = false);
 
-  std::shared_ptr<const facebook::velox::core::PlanNode> toVeloxPlan(::substrait::Plan& substraitPlan);
+  std::shared_ptr<const facebook::velox::core::PlanNode> toVeloxPlan(
+      ::substrait::Plan& substraitPlan,
+      std::vector<::substrait::ReadRel_LocalFiles> localFiles);
 
   const std::unordered_map<facebook::velox::core::PlanNodeId, std::shared_ptr<SplitInfo>>& splitInfos() {
     return substraitVeloxPlanConverter_.splitInfos();
   }
 
  private:
-  void setInputPlanNode(const ::substrait::WriteRel& writeRel);
-
-  void setInputPlanNode(const ::substrait::FetchRel& fetchRel);
-
-  void setInputPlanNode(const ::substrait::ExpandRel& sExpand);
-
-  void setInputPlanNode(const ::substrait::GenerateRel& sGenerate);
-
-  void setInputPlanNode(const ::substrait::SortRel& sSort);
-
-  void setInputPlanNode(const ::substrait::WindowRel& s);
-
-  void setInputPlanNode(const ::substrait::AggregateRel& sagg);
-
-  void setInputPlanNode(const ::substrait::ProjectRel& sproject);
-
-  void setInputPlanNode(const ::substrait::FilterRel& sfilter);
-
-  void setInputPlanNode(const ::substrait::JoinRel& sJoin);
-
-  void setInputPlanNode(const ::substrait::ReadRel& sread);
-
-  void setInputPlanNode(const ::substrait::Rel& srel);
-
-  void setInputPlanNode(const ::substrait::RelRoot& sroot);
-
   std::string nextPlanNodeId();
 
   int planNodeId_ = 0;
-
-  std::vector<std::shared_ptr<ResultIterator>> inputIters_;
 
   bool validationMode_;
 

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -37,6 +37,8 @@ class VeloxRuntime final : public Runtime {
 
   void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo) override;
 
+  void parseSplitInfo(const uint8_t* data, int32_t size) override;
+
   static std::shared_ptr<facebook::velox::memory::MemoryPool> getAggregateVeloxPool(MemoryManager* memoryManager) {
     return toVeloxMemoryManager(memoryManager)->getAggregateMemoryPool();
   }

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <velox/common/memory/MemoryPool.h>
 #include "compute/ResultIterator.h"
 #include "memory/VeloxColumnarBatch.h"
 #include "velox/exec/Driver.h"
@@ -30,7 +29,7 @@ class RowVectorStream {
       facebook::velox::memory::MemoryPool* pool,
       std::shared_ptr<ResultIterator> iterator,
       const facebook::velox::RowTypePtr& outputType)
-      : iterator_(iterator), outputType_(outputType), pool_(pool) {}
+      : iterator_(std::move(iterator)), outputType_(outputType), pool_(pool) {}
 
   bool hasNext() {
     return iterator_->hasNext();

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -16,10 +16,8 @@
  */
 
 #include "SubstraitToVeloxPlan.h"
-
 #include "TypeUtils.h"
 #include "VariantToVectorConverter.h"
-#include "operators/plannodes/RowVectorStream.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/type/Type.h"
@@ -987,13 +985,12 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::constructValueStreamNode(
   }
 
   auto outputType = ROW(std::move(outNames), std::move(veloxTypeList));
-  auto vectorStream = std::make_shared<RowVectorStream>(pool_, std::move(inputIters_[streamIdx]), outputType);
-  auto valuesNode = std::make_shared<ValueStreamNode>(nextPlanNodeId(), outputType, std::move(vectorStream));
+  auto node = valueStreamNodeFactory_(nextPlanNodeId(), pool_, std::move(inputIters_[streamIdx]), outputType);
 
   auto splitInfo = std::make_shared<SplitInfo>();
   splitInfo->isStream = true;
-  splitInfoMap_[valuesNode->id()] = splitInfo;
-  return valuesNode;
+  splitInfoMap_[node->id()] = splitInfo;
+  return node;
 }
 
 core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::ReadRel& readRel) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -145,8 +145,7 @@ class SubstraitToVeloxPlanConverter {
   }
 
   void setValueStreamNodeFactory(
-      std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, int32_t, RowTypePtr)>
-          factory) {
+      std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, int32_t, RowTypePtr)> factory) {
     valueStreamNodeFactory_ = std::move(factory);
   }
 
@@ -546,8 +545,7 @@ class SubstraitToVeloxPlanConverter {
   /// The map storing the split stats for each PlanNode.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>> splitInfoMap_;
 
-  std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, int32_t, RowTypePtr)>
-      valueStreamNodeFactory_;
+  std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, int32_t, RowTypePtr)> valueStreamNodeFactory_;
 
   /// The map storing the pre-built plan nodes which can be accessed through
   /// index. This map is only used when the computation of a Substrait plan

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -144,12 +144,8 @@ class SubstraitToVeloxPlanConverter {
     splitInfos_ = splitInfos;
   }
 
-  void setInputIterators(const std::vector<std::shared_ptr<ResultIterator>>& inputIters) {
-    inputIters_ = inputIters;
-  }
-
   void setValueStreamNodeFactory(
-      std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, std::shared_ptr<ResultIterator>, RowTypePtr)>
+      std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, int32_t, RowTypePtr)>
           factory) {
     valueStreamNodeFactory_ = std::move(factory);
   }
@@ -550,7 +546,7 @@ class SubstraitToVeloxPlanConverter {
   /// The map storing the split stats for each PlanNode.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>> splitInfoMap_;
 
-  std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, std::shared_ptr<ResultIterator>, RowTypePtr)>
+  std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, int32_t, RowTypePtr)>
       valueStreamNodeFactory_;
 
   /// The map storing the pre-built plan nodes which can be accessed through
@@ -560,8 +556,6 @@ class SubstraitToVeloxPlanConverter {
 
   int32_t splitInfoIdx_{0};
   std::vector<std::shared_ptr<SplitInfo>> splitInfos_;
-
-  std::vector<std::shared_ptr<ResultIterator>> inputIters_;
 
   /// The Expression converter used to convert Substrait representations into
   /// Velox expressions.

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -19,13 +19,12 @@
 
 #include "SubstraitToVeloxExpr.h"
 #include "TypeUtils.h"
-#include "compute/ResultIterator.h"
-#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/PlanNode.h"
 #include "velox/dwio/common/Options.h"
 
 namespace gluten {
+class ResultIterator;
 
 // Holds names of Spark OffsetWindowFunctions.
 static const std::unordered_set<std::string> kOffsetWindowFunctions = {"nth_value"};
@@ -148,6 +147,12 @@ class SubstraitToVeloxPlanConverter {
 
   void setInputIterators(const std::vector<std::shared_ptr<ResultIterator>>& inputIters) {
     inputIters_ = inputIters;
+  }
+
+  void setValueStreamNodeFactory(
+      std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, std::shared_ptr<ResultIterator>, RowTypePtr)>
+          factory) {
+    valueStreamNodeFactory_ = std::move(factory);
   }
 
   /// Used to check if ReadRel specifies an input of stream.
@@ -545,6 +550,9 @@ class SubstraitToVeloxPlanConverter {
 
   /// The map storing the split stats for each PlanNode.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>> splitInfoMap_;
+
+  std::function<core::PlanNodePtr(std::string, memory::MemoryPool*, std::shared_ptr<ResultIterator>, RowTypePtr)>
+      valueStreamNodeFactory_;
 
   /// The map storing the pre-built plan nodes which can be accessed through
   /// index. This map is only used when the computation of a Substrait plan

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -141,7 +141,6 @@ class SubstraitToVeloxPlanConverter {
   }
 
   void setSplitInfos(std::vector<std::shared_ptr<SplitInfo>> splitInfos) {
-    splitInfoIdx_ = 0;
     splitInfos_ = splitInfos;
   }
 

--- a/cpp/velox/tests/RuntimeTest.cc
+++ b/cpp/velox/tests/RuntimeTest.cc
@@ -27,6 +27,8 @@ class DummyRuntime final : public Runtime {
 
   void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo) override {}
 
+  void parseSplitInfo(const uint8_t* data, int32_t size) override {}
+
   std::shared_ptr<ResultIterator> createResultIterator(
       MemoryManager* memoryManager,
       const std::string& spillDir,

--- a/cpp/velox/tests/data/filter_upper.json
+++ b/cpp/velox/tests/data/filter_upper.json
@@ -96,14 +96,6 @@
                                           }
                                       ]
                                   }
-                              },
-                              "localFiles": {
-                                  "items": [{
-                                          "uriFile": "file:///tmp/file.parquet",
-                                          "length": "1486",
-                                          "parquet": {}
-                                      }
-                                  ]
                               }
                           }
                       },

--- a/cpp/velox/tests/data/filter_upper_split.json
+++ b/cpp/velox/tests/data/filter_upper_split.json
@@ -1,0 +1,8 @@
+{
+    "items": [{
+        "uriFile": "file:///tmp/file.parquet",
+        "length": "1486",
+        "parquet": {}
+    }
+    ]
+}

--- a/cpp/velox/tests/data/if_then.json
+++ b/cpp/velox/tests/data/if_then.json
@@ -367,14 +367,6 @@
                                           }
                                       ]
                                   }
-                              },
-                              "localFiles": {
-                                  "items": [{
-                                          "uriFile": "file:///tmp/tmp_file",
-                                          "length": "31979",
-                                          "parquet": {}
-                                      }
-                                  ]
                               }
                           }
                       },

--- a/cpp/velox/tests/data/if_then_split.json
+++ b/cpp/velox/tests/data/if_then_split.json
@@ -1,0 +1,8 @@
+{
+    "items": [{
+        "uriFile": "file:///tmp/tmp_file",
+        "length": "31979",
+        "parquet": {}
+    }
+    ]
+}

--- a/cpp/velox/tests/data/q6_first_stage.json
+++ b/cpp/velox/tests/data/q6_first_stage.json
@@ -484,17 +484,6 @@
                                                             }
                                                         }
                                                     }
-                                                },
-                                                "local_files": {
-                                                    "items": [
-                                                        {
-                                                            "partition_index": "0",
-                                                            "start": "0",
-                                                            "length": "3719",
-                                                            "uri_file": "/mock_lineitem.dwrf",
-                                                            "dwrf": {}
-                                                        }
-                                                    ]
                                                 }
                                             }
                                         },

--- a/cpp/velox/tests/data/q6_first_stage_split.json
+++ b/cpp/velox/tests/data/q6_first_stage_split.json
@@ -1,0 +1,11 @@
+{
+    "items": [
+        {
+            "partition_index": "0",
+            "start": "0",
+            "length": "3719",
+            "uri_file": "/mock_lineitem.dwrf",
+            "dwrf": {}
+        }
+    ]
+}

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/LocalFilesNode.java
@@ -108,7 +108,7 @@ public class LocalFilesNode implements SplitInfo {
   public ReadRel.LocalFiles toProtobuf() {
     ReadRel.LocalFiles.Builder localFilesBuilder = ReadRel.LocalFiles.newBuilder();
     // The input is iterator, and the path is in the format of: Iterator:index.
-    if (iterAsInput && paths.size() > 0) {
+    if (iterAsInput && !paths.isEmpty()) {
       ReadRel.LocalFiles.FileOrFiles.Builder fileBuilder =
           ReadRel.LocalFiles.FileOrFiles.newBuilder();
       fileBuilder.setUriFile(paths.get(0));

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -93,6 +93,7 @@ public class RelBuilder {
     return new AggregateRelNode(input, groupings, aggregateFunctionNodes, filters, extensionNode);
   }
 
+  // CH
   public static RelNode makeReadRel(
       List<TypeNode> types,
       List<String> names,
@@ -102,6 +103,7 @@ public class RelBuilder {
     return makeReadRel(types, names, null, filter, context, operatorId);
   }
 
+  // VL
   public static RelNode makeReadRel(
       List<TypeNode> types,
       List<String> names,

--- a/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-core/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -159,16 +159,16 @@ message ReadRel {
         DwrfReadOptions dwrf = 13;
         TextReadOptions text = 14;
         JsonReadOptions json = 15;
-     }
+      }
 
-     message partitionColumn {
+      message partitionColumn {
         string key = 1;
         string value = 2;
-     }
-     repeated partitionColumn partition_columns = 16;
+      }
+      repeated partitionColumn partition_columns = 16;
 
-     /// File schema
-     NamedStruct schema = 17;
+      /// File schema
+      NamedStruct schema = 17;
     }
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
@@ -34,15 +34,15 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 trait IteratorApi {
 
-  /**
-   * Generate native row partition.
-   *
-   * @return
-   */
   def genSplitInfo(
       partition: InputPartition,
       partitionSchema: StructType,
       fileFormat: ReadFileFormat): SplitInfo
+
+  /** Generate native row partition. */
+  def genPartitions(
+      wsCtx: WholeStageTransformContext,
+      splitInfos: Seq[Seq[SplitInfo]]): Seq[BaseGlutenPartition]
 
   /**
    * Inject the task attempt temporary path for native write files, this method should be called
@@ -53,8 +53,6 @@ trait IteratorApi {
   /**
    * Generate Iterator[ColumnarBatch] for first stage. ("first" means it does not depend on other
    * SCAN inputs)
-   *
-   * @return
    */
   def genFirstStageIterator(
       inputPartition: BaseGlutenPartition,
@@ -68,8 +66,6 @@ trait IteratorApi {
   /**
    * Generate Iterator[ColumnarBatch] for final stage. ("Final" means it depends on other SCAN
    * inputs, maybe it was a mistake to use the word "final")
-   *
-   * @return
    */
   // scalastyle:off argcount
   def genFinalStageIterator(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/GlutenWholeStageColumnarRDD.scala
@@ -38,6 +38,7 @@ trait BaseGlutenPartition extends Partition with InputPartition {
 case class GlutenPartition(
     index: Int,
     plan: Array[Byte],
+    splitInfosByteArray: Array[Array[Byte]] = Array.empty[Array[Byte]],
     locations: Array[String] = Array.empty[String])
   extends BaseGlutenPartition {
 
@@ -111,9 +112,11 @@ class GlutenWholeStageColumnarRDD(
   }
 
   override protected def getPartitions: Array[Partition] = {
-    Array.tabulate[Partition](inputPartitions.size) {
-      i => FirstZippedPartitionsPartition(i, inputPartitions(i), rdds.getPartitions(i))
-    }
+    inputPartitions.zipWithIndex
+      .map {
+        case (partition, i) => FirstZippedPartitionsPartition(i, partition, rdds.getPartitions(i))
+      }
+      .toArray[Partition]
   }
 
   override protected def clearDependencies(): Unit = {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -419,9 +419,6 @@ class ColumnarInputRDDsWrapper(columnarInputRDDs: Seq[RDD[ColumnarBatch]]) exten
   }
 
   def getPartitions(index: Int): Seq[Partition] = {
-    if (columnarInputRDDs.isEmpty) {
-      return Seq.empty
-    }
     columnarInputRDDs.filterNot(_.isInstanceOf[BroadcastBuildSideRDD]).map(_.partitions(index))
   }
 

--- a/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
@@ -64,7 +64,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       partition.files.map(_.filePath.toString),
       partition.preferredLocations())
 
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
     assertResult(Set("host-1", "host-2", "host-3")) {
       nativePartition.preferredLocations().toSet
     }
@@ -95,7 +95,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       partition.files.map(_.filePath.toString),
       partition.preferredLocations())
 
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
     assertResult(Set("host-1", "host-4", "host-5")) {
       nativePartition.preferredLocations().toSet
@@ -127,7 +127,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       partition.files.map(_.filePath.toString),
       partition.preferredLocations())
 
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
     assertResult(Set("executor_host-2_2", "executor_host-1_0")) {
       nativePartition.preferredLocations().toSet
@@ -150,7 +150,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       partition.files.map(_.filePath.toString),
       partition.preferredLocations())
 
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
     assertResult(Set("executor_host-1_1")) {
       nativePartition.preferredLocations().toSet
@@ -182,7 +182,7 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
       partition.files.map(_.filePath.toString),
       partition.preferredLocations())
 
-    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+    val nativePartition = GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
     assertResult(Set("host-1", "host-5", "host-6")) {
       nativePartition.preferredLocations().toSet

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/NativePlanEvaluator.java
@@ -66,7 +66,8 @@ public class NativePlanEvaluator {
   // Used by WholeStageTransform to create the native computing pipeline and
   // return a columnar result iterator.
   public GeneralOutIterator createKernelWithBatchIterator(
-      byte[] wsPlan, List<GeneralInIterator> iterList) throws RuntimeException, IOException {
+      byte[] wsPlan, byte[][] splitInfo, List<GeneralInIterator> iterList)
+      throws RuntimeException, IOException {
     final AtomicReference<ColumnarBatchOutIterator> outIterator = new AtomicReference<>();
     final NativeMemoryManager nmm =
         NativeMemoryManagers.create(
@@ -102,6 +103,7 @@ public class NativePlanEvaluator {
         jniWrapper.nativeCreateKernelWithIterator(
             memoryManagerHandle,
             wsPlan,
+            splitInfo,
             iterList.toArray(new GeneralInIterator[0]),
             TaskContext.get().stageId(),
             TaskContext.getPartitionId(),

--- a/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
+++ b/gluten-data/src/main/java/io/glutenproject/vectorized/PlanEvaluatorJniWrapper.java
@@ -67,6 +67,7 @@ public class PlanEvaluatorJniWrapper implements RuntimeAware {
   public native long nativeCreateKernelWithIterator(
       long memoryManagerHandle,
       byte[] wsPlan,
+      byte[][] splitInfo,
       GeneralInIterator[] batchItr,
       int stageId,
       int partitionId,


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two parts will lead driver stalled when scan contains lots of partitions,
1. plan serialization happens in every GlutenPartition construction.
2. GlutenWholeStageColumnarRDD#getPartitions

| |  | 22374 partitions | 44611 partitions |
|--------|--------|--------|--------|
| before | #1 | 880ms | 1352ms |
| | #2 | 3662ms | 17186ms |
| after | #1 | 21ms | 106ms |
|  | #2 | 6ms | 25ms | 

This patch decouple scan splitInfo(LocalFileNodes) from ReadRel to avoid serialize substrait plan for each partition in Driver, when the plan is complex or the number of partitions is particularly large, the cost of this serialization cannot be ignored.

Stream splitInfo(inputIterator) still kept in ReadRel for now.

(Fixes: \#4170)

## How was this patch tested?
