### PR TITLE
[VL] Fix corrupted metrics data in the filter transformer

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -257,6 +257,13 @@ void WholeStageResultIterator::collectMetrics() {
     if (planStats.find(nodeId) == planStats.end()) {
       // Special handing for Filter over Project case. Filter metrics are
       // omitted.
+      metrics_->get(Metrics::kOutputRows)[metricIndex] = 0;
+      metrics_->get(Metrics::kOutputVectors)[metricIndex] = 0;
+      metrics_->get(Metrics::kOutputBytes)[metricIndex] = 0;
+      metrics_->get(Metrics::kCpuCount)[metricIndex] = 0;
+      metrics_->get(Metrics::kWallNanos)[metricIndex] = 0;
+      metrics_->get(Metrics::kPeakMemoryBytes)[metricIndex] = 0;
+      metrics_->get(Metrics::kNumMemoryAllocations)[metricIndex] = 0;
       metricIndex += 1;
       continue;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Although the metrics of the omitted filter are useless, it still needs to be initialized as 0. Otherwise, incorrect metrics information will be displayed in the UI.

## How was this patch tested?

N/A

