### PR TITLE
[VL] Refine fallback msg in scan type validation

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi.clickhouse
 import io.glutenproject.{CH_BRANCH, CH_COMMIT, GlutenConfig, GlutenPlugin}
 import io.glutenproject.backendsapi._
 import io.glutenproject.expression.WindowFunctionsBuilder
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat._
 
@@ -129,7 +130,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       format: ReadFileFormat,
       fields: Array[StructField],
       partTable: Boolean,
-      paths: Seq[String]): Boolean = {
+      paths: Seq[String]): ValidationResult = {
 
     def validateFilePath: Boolean = {
       // Fallback to vanilla spark when the input path
@@ -158,12 +159,22 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
       !unsupportedDataTypes.isEmpty
     }
     format match {
-      case ParquetReadFormat => validateFilePath
-      case OrcReadFormat => true
-      case MergeTreeReadFormat => true
-      case TextReadFormat => !hasComplexType
-      case JsonReadFormat => true
-      case _ => false
+      case ParquetReadFormat =>
+        if (validateFilePath) {
+          ValidationResult.ok
+        } else {
+          ValidationResult.notOk("Validate file path failed.")
+        }
+      case OrcReadFormat => ValidationResult.ok
+      case MergeTreeReadFormat => ValidationResult.ok
+      case TextReadFormat =>
+        if (!hasComplexType) {
+          ValidationResult.ok
+        } else {
+          ValidationResult.notOk("Has complex type.")
+        }
+      case JsonReadFormat => ValidationResult.ok
+      case _ => ValidationResult.notOk(s"Unsupported file format $format")
     }
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -98,7 +98,16 @@ object BackendSettings extends BackendSettingsApi {
       case DwrfReadFormat => ValidationResult.ok
       case OrcReadFormat =>
         val typeValidator: PartialFunction[DataType, String] = {
-          case _: TimestampType => "TimestampType"
+          case _: ByteType => "ByteType not support"
+          case arrayType: ArrayType if arrayType.elementType.isInstanceOf[StructType] =>
+            "StructType as element in ArrayType"
+          case arrayType: ArrayType if arrayType.elementType.isInstanceOf[ArrayType] =>
+            "ArrayType as element in ArrayType"
+          case mapType: MapType if mapType.keyType.isInstanceOf[StructType] =>
+            "StructType as Key in MapType"
+          case mapType: MapType if mapType.valueType.isInstanceOf[ArrayType] =>
+            "ArrayType as Value in MapType"
+          case _: TimestampType => "TimestampType not support"
         }
         validateTypes(typeValidator)
       case _ => ValidationResult.notOk(s"Unsupported file format for $format.")

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -19,6 +19,7 @@ package io.glutenproject.backendsapi.velox
 import io.glutenproject.{GlutenConfig, GlutenPlugin, VELOX_BRANCH, VELOX_REVISION, VELOX_REVISION_TIME}
 import io.glutenproject.backendsapi._
 import io.glutenproject.expression.WindowFunctionsBuilder
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
 
@@ -64,49 +65,43 @@ object BackendSettings extends BackendSettingsApi {
       format: ReadFileFormat,
       fields: Array[StructField],
       partTable: Boolean,
-      paths: Seq[String]): Boolean = {
+      paths: Seq[String]): ValidationResult = {
     // Validate if all types are supported.
-    def validateTypes: Boolean = {
+    def validateTypes(validatorFunc: PartialFunction[DataType, String]): ValidationResult = {
       // Collect unsupported types.
-      val unsupportedDataTypes = fields.map(_.dataType).collect {
-        case _: ByteType => "ByteType"
-        // Parquet scan of nested array with struct/array as element type is not supported in Velox.
-        case arrayType: ArrayType if arrayType.elementType.isInstanceOf[StructType] =>
-          "StructType as element type in ArrayType"
-        case arrayType: ArrayType if arrayType.elementType.isInstanceOf[ArrayType] =>
-          "ArrayType as element type in ArrayType"
-        // Parquet scan of nested map with struct as key type,
-        // or array type as value type is not supported in Velox.
-        case mapType: MapType if mapType.keyType.isInstanceOf[StructType] =>
-          "StructType as Key type in MapType"
-        case mapType: MapType if mapType.valueType.isInstanceOf[ArrayType] =>
-          "ArrayType as Value type in MapType"
+      val unsupportedDataTypeReason = fields.map(_.dataType).collect(validatorFunc)
+      if (unsupportedDataTypeReason.isEmpty) {
+        ValidationResult.ok
+      } else {
+        ValidationResult.notOk(
+          s"Found unsupported data type in $format: ${unsupportedDataTypeReason.mkString(", ")}.")
       }
-      for (unsupportedDataType <- unsupportedDataTypes) {
-        // scalastyle:off println
-        println(
-          s"Validation failed for ${this.getClass.toString}" +
-            s" due to: data type $unsupportedDataType. in file schema. ")
-        // scalastyle:on println
-      }
-      unsupportedDataTypes.isEmpty
     }
 
     format match {
-      case ParquetReadFormat => validateTypes
-      case DwrfReadFormat => true
-      case OrcReadFormat =>
-        val unsupportedDataTypes =
-          fields.map(_.dataType).collect { case _: TimestampType => "TimestampType" }
-        for (unsupportedDataType <- unsupportedDataTypes) {
-          // scalastyle:off println
-          println(
-            s"Validation failed for ${this.getClass.toString}" +
-              s" due to: data type $unsupportedDataType. in file schema. ")
-          // scalastyle:on println
+      case ParquetReadFormat =>
+        val typeValidator: PartialFunction[DataType, String] = {
+          case _: ByteType => "ByteType not support"
+          // Parquet scan of nested array with struct/array as element type is unsupported in Velox.
+          case arrayType: ArrayType if arrayType.elementType.isInstanceOf[StructType] =>
+            "StructType as element in ArrayType"
+          case arrayType: ArrayType if arrayType.elementType.isInstanceOf[ArrayType] =>
+            "ArrayType as element in ArrayType"
+          // Parquet scan of nested map with struct as key type,
+          // or array type as value type is not supported in Velox.
+          case mapType: MapType if mapType.keyType.isInstanceOf[StructType] =>
+            "StructType as Key in MapType"
+          case mapType: MapType if mapType.valueType.isInstanceOf[ArrayType] =>
+            "ArrayType as Value in MapType"
         }
-        unsupportedDataTypes.isEmpty && validateTypes
-      case _ => false
+        validateTypes(typeValidator)
+      case DwrfReadFormat => ValidationResult.ok
+      case OrcReadFormat =>
+        val typeValidator: PartialFunction[DataType, String] = {
+          case _: TimestampType => "TimestampType"
+        }
+        validateTypes(typeValidator)
+      case _ => ValidationResult.notOk(s"Unsupported file format for $format.")
     }
   }
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
@@ -17,6 +17,7 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.GlutenConfig
+import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.SparkConf
@@ -33,7 +34,7 @@ trait BackendSettingsApi {
       format: ReadFileFormat,
       fields: Array[StructField],
       partTable: Boolean,
-      paths: Seq[String]): Boolean = false
+      paths: Seq[String]): ValidationResult = ValidationResult.ok
   def supportExpandExec(): Boolean = false
   def supportSortExec(): Boolean = false
   def supportSortMergeJoinExec(): Boolean = true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -83,17 +83,16 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
 
   override protected def doValidateInternal(): ValidationResult = {
     val fileFormat = ConverterUtils.getFileFormat(this)
-    if (
-      !BackendsApiManager.getSettings
-        .supportFileFormatRead(
-          fileFormat,
-          schema.fields,
-          getPartitionSchema.nonEmpty,
-          getInputFilePaths)
-    ) {
-      return ValidationResult.notOk(
-        s"Not supported file format or complex type for scan: $fileFormat")
+    val validationResult = BackendsApiManager.getSettings
+      .supportFileFormatRead(
+        fileFormat,
+        schema.fields,
+        getPartitionSchema.nonEmpty,
+        getInputFilePaths)
+    if (!validationResult.isValid) {
+      return validationResult
     }
+
     val substraitContext = new SubstraitContext
     val relNode = doTransform(substraitContext).root
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before
```
(6) Scan parquet xxx: Not supported file format or complex type for scan: ParquetReadFormat
```

After
```
(1) Scan parquet xxx: Found unsupported data type in ParquetReadFormat: StructType as element in ArrayType.
```