### PR TITLE
[GLUTEN-4182][VL] Disallow resetting HDFS client credential to fix performance issue / to avoid race condition

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -312,6 +312,10 @@ set(VELOX_SRCS
     utils/Common.cc
     )
 
+if (ENABLE_HDFS)
+  list(APPEND VELOX_SRCS utils/HdfsUtils.cc)
+endif ()
+
 if(BUILD_TESTS OR BUILD_BENCHMARKS)
   list(APPEND VELOX_SRCS utils/tests/MemoryPoolUtils.cc)
 endif()

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -100,7 +100,7 @@ WholeStageResultIterator::WholeStageResultIterator(
       taskInfo_(taskInfo),
       memoryManager_(memoryManager) {
 #ifdef ENABLE_HDFS
-  gluten::updateHdfsTokens(veloxCfg_);
+  gluten::updateHdfsTokens(veloxCfg_.get());
 #endif
   spillStrategy_ = veloxCfg_->get<std::string>(kSpillStrategy, kSpillStrategyDefaultValue);
   getOrderedNodeIds(veloxPlan_, orderedNodeIds_);

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -26,10 +26,6 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h"
 
-#ifdef ENABLE_HDFS
-#include <mutex>
-#endif
-
 namespace gluten {
 
 class WholeStageResultIterator : public ColumnarBatchIterator {
@@ -76,12 +72,6 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
  private:
   /// Get the Spark confs to Velox query context.
   std::unordered_map<std::string, std::string> getQueryContextConf();
-
-#ifdef ENABLE_HDFS
-  /// Set latest tokens to global HiveConnector
-  inline static std::mutex mutex;
-  void updateHdfsTokens();
-#endif
 
   /// Get all the children plan node ids with postorder traversal.
   void getOrderedNodeIds(

--- a/cpp/velox/utils/HdfsUtils.cc
+++ b/cpp/velox/utils/HdfsUtils.cc
@@ -52,9 +52,9 @@ void updateHdfsTokens(const facebook::velox::Config* veloxCfg) {
   Credential newCredential{newUserName.value(), newAllTokens.value()};
 
   if (!activeCredential.has_value()) {
-    hdfsSetDefautUserName(activeCredential->userName.c_str());
+    hdfsSetDefautUserName(newCredential.userName.c_str());
     std::vector<folly::StringPiece> tokens;
-    folly::split('\0', activeCredential->allTokens, tokens);
+    folly::split('\0', newCredential.allTokens, tokens);
     for (auto& token : tokens)
       hdfsSetTokenForDefaultUser(token.data());
     activeCredential.emplace(newCredential);

--- a/cpp/velox/utils/HdfsUtils.cc
+++ b/cpp/velox/utils/HdfsUtils.cc
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HdfsUtils.h"
+#include "config/GlutenConfig.h"
+#include "utils/exception.h"
+
+namespace gluten {
+
+namespace {
+struct Credential {
+  const std::string userName;
+  const std::string allTokens;
+
+  bool operator==(const Credential& rhs) const {
+    return userName == rhs.userName && allTokens == rhs.allTokens;
+  }
+  bool operator!=(const Credential& rhs) const {
+    return !(rhs == *this);
+  }
+};
+} // namespace
+
+void updateHdfsTokens(const facebook::velox::Config* veloxCfg) {
+  static std::mutex mtx;
+  std::lock_guard lock{mtx};
+
+  static std::optional<Credential> credential{std::nullopt};
+
+  const auto& newUserName = veloxCfg->get<std::string>(gluten::kUGIUserName);
+  const auto& newAllTokens = veloxCfg->get<std::string>(gluten::kUGITokens);
+
+  if (!newUserName.hasValue() || !newAllTokens.hasValue()) {
+    return;
+  }
+
+  Credential newCredential{newUserName.value(), newAllTokens.value()};
+
+  if (!credential.has_value()) {
+    credential.emplace(newCredential);
+    return;
+  }
+
+  // credential already set
+  GLUTEN_CHECK(
+      credential.value() == newCredential, "Gluten currently doesn't allow resetting HDFS credential in session");
+}
+} // namespace gluten

--- a/cpp/velox/utils/HdfsUtils.cc
+++ b/cpp/velox/utils/HdfsUtils.cc
@@ -61,7 +61,7 @@ void updateHdfsTokens(const facebook::velox::Config* veloxCfg) {
     return;
   }
 
-  // activeCredential already set
+  // active credential already set
   GLUTEN_CHECK(
       activeCredential.value() == newCredential,
       "Gluten currently doesn't allow resetting HDFS activeCredential in session");

--- a/cpp/velox/utils/HdfsUtils.h
+++ b/cpp/velox/utils/HdfsUtils.h
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <velox/core/Config.h>
+#include <memory>
+namespace gluten {
+void updateHdfsTokens(const std::shared_ptr<const facebook::velox::Config>& veloxCfg);
+}

--- a/cpp/velox/utils/HdfsUtils.h
+++ b/cpp/velox/utils/HdfsUtils.h
@@ -18,5 +18,5 @@
 #include <velox/core/Config.h>
 #include <memory>
 namespace gluten {
-void updateHdfsTokens(const std::shared_ptr<const facebook::velox::Config>& veloxCfg);
+void updateHdfsTokens(const facebook::velox::Config* veloxCfg);
 }


### PR DESCRIPTION
`updateHdfsTokens` may lead to race condition since `spark.gluten.ugi.tokens` / `spark.gluten.ugi.username` are both resettable in Spark session while Velox `hdfsSetDefautUserName` and `hdfsSetTokenForDefaultUser` are global static API.

The patch adds a check to prevent user from resetting the two options in the same session.

Also, we will call Velox's relevant APIs mentioned above only once in the same session after the patch. This will fix the severe performance issue #4182.

Related to https://github.com/oap-project/gluten/pull/1706