### PR TITLE
[VL] Daily Update Velox Version (2023-12-26) 

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2023_12_25
+VELOX_BRANCH=231226
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
No updates yet from Velox upstream.

Just to test targeting to OAP Velox's tag rather than branch in `get_velox.sh`.

https://github.com/oap-project/velox/tree/231226