### PR TITLE
[GLUTEN-4194][CORE] Clarify fallback reason when columnar filter is disabled

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -434,9 +434,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           val childIsScan = plan.child.isInstanceOf[FileSourceScanExec] ||
             plan.child.isInstanceOf[BatchScanExec]
           if (!enableColumnarFilter) {
-            TransformHints.tagNotTransformable(
-              plan,
-              "columnar Filter is not enabled in FilterExec")
+            TransformHints.tagNotTransformable(plan, "columnar Filter is not enabled in FilterExec")
           } else if (scanOnly && !childIsScan) {
             // When scanOnly is enabled, filter after scan will be offloaded.
             TransformHints.tagNotTransformable(

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -433,8 +433,12 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
         case plan: FilterExec =>
           val childIsScan = plan.child.isInstanceOf[FileSourceScanExec] ||
             plan.child.isInstanceOf[BatchScanExec]
-          // When scanOnly is enabled, filter after scan will be offloaded.
-          if ((!scanOnly && !enableColumnarFilter) || (scanOnly && !childIsScan)) {
+          if (!enableColumnarFilter) {
+            TransformHints.tagNotTransformable(
+              plan,
+              "columnar Filter is not enabled in FilterExec")
+          } else if (scanOnly && !childIsScan) {
+            // When scanOnly is enabled, filter after scan will be offloaded.
             TransformHints.tagNotTransformable(
               plan,
               "ScanOnly enabled and plan child is not Scan in FilterExec")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Clarify fallback reason when columnar filter is disabled.

(Fixes: #4194)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

