### PR TITLE
[GLUTEN-3283][VL] Upgrade arrow version to 14.0.1 and add compile arrow java module.

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -31,6 +31,7 @@ VELOX_REPO=""
 VELOX_BRANCH=""
 VELOX_HOME=""
 VELOX_PARAMETER=""
+COMPILE_ARROW_JAVA=OFF
 
 for arg in "$@"
 do
@@ -121,6 +122,10 @@ do
         BUILD_VELOX_BENCHMARKS=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
+        --compile_arrow_java=*)
+        COMPILE_ARROW_JAVA=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
 	      *)
         OTHER_ARGUMENTS+=("$1")
         shift # Remove generic argument from processing
@@ -156,7 +161,8 @@ concat_velox_param
 cd $GLUTEN_DIR/ep/build-velox/src
 ./get_velox.sh --enable_hdfs=$ENABLE_HDFS --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --enable_abfs=$ENABLE_ABFS $VELOX_PARAMETER
 ./build_velox.sh --run_setup_script=$RUN_SETUP_SCRIPT --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_VELOX_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS
+                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_VELOX_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS \
+                 --compile_arrow_java=$COMPILE_ARROW_JAVA
 
 ## compile gluten cpp
 cd $GLUTEN_DIR/cpp

--- a/docs/developers/docker_centos7.md
+++ b/docs/developers/docker_centos7.md
@@ -47,5 +47,6 @@ git clone https://github.com/oap-project/gluten.git
 cd gluten
 
 # To access HDFS or S3, you need to add the parameters `--enable_hdfs=ON` and `--enable_s3=ON`
+# If you have the same error with issue-3283, you need to add the parameter `--compile_arrow_java=ON`
 ./dev/buildbundle-veloxbe.sh
 ```

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -56,6 +56,7 @@ cd /path/to/gluten
 ## After a complete build, if you need to re-build the project and only some gluten code is changed,
 ## you can use the following command to skip building velox and protobuf.
 # ./dev/buildbundle-veloxbe.sh --enable_ep_cache=ON --build_protobuf=OFF
+## If you have the same error with issue-3283, you need to add the parameter `--compile_arrow_java=ON`
 ```
 
 **For aarch64 build:**

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <spark.version>3.4.1</spark.version>
     <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
     <celeborn.version>0.3.0-incubating</celeborn.version>
-    <arrow.version>12.0.0</arrow.version>
+    <arrow.version>14.0.1</arrow.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
     <hadoop.version>2.7.4</hadoop.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -231,7 +231,7 @@
       </modules>
       <properties>
         <backend_type>velox</backend_type>
-        <arrow.version>12.0.0</arrow.version>
+        <arrow.version>14.0.1</arrow.version>
         <build_velox_backend>ON</build_velox_backend>
       </properties>
     </profile>


### PR DESCRIPTION
## What changes were proposed in this pull request?
To fix a bug where invalid Pointers appear when running on centos7, it was found to have occurred while loading libarrow_cdata_jni.so. The arrow java module needs to be recompiled in the local environment.

notice: `This configuration is OFF by default. The test is enabled temporarily to test the CI flow`

(Fixes: \#3283)

## How was this patch tested?
./dev/builddeps-veloxbe.sh --compile_arrow_java=ON

## Relevant logs

```bash
*** Error in `/usr/local/jdk1.8.0_381/bin/java': free(): invalid pointer: 0x00007f36cb5cec80 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x7d1fd)[0x7f38c29da1fd]
/lib64/libstdc++.so.6(_ZNSt6locale5_Impl16_M_install_facetEPKNS_2idEPKNS_5facetE+0x142)[0x7f36cb3370d2]
/lib64/libstdc++.so.6(_ZNSt6locale5_ImplC1Em+0x1e3)[0x7f36cb337523]
/lib64/libstdc++.so.6(+0x71495)[0x7f36cb338495]
/lib64/libpthread.so.0(pthread_once+0x50)[0x7f38c3147be0]
/lib64/libstdc++.so.6(+0x714e1)[0x7f36cb3384e1]
/lib64/libstdc++.so.6(_ZNSt6localeC2Ev+0x13)[0x7f36cb338523]
/lib64/libstdc++.so.6(_ZNSt8ios_base4InitC2Ev+0xbc)[0x7f36cb33537c]
/tmp/jnilib-645156599284574767.tmp(+0x2a90)[0x7f375d235a90]
/lib64/ld-linux-x86-64.so.2(+0xf4e3)[0x7f38c33664e3]
/lib64/ld-linux-x86-64.so.2(+0x13b04)[0x7f38c336ab04]
/lib64/ld-linux-x86-64.so.2(+0xf2f4)[0x7f38c33662f4]
/lib64/ld-linux-x86-64.so.2(+0x1321b)[0x7f38c336a21b]
/lib64/libdl.so.2(+0x102b)[0x7f38c2d1f02b]
/lib64/ld-linux-x86-64.so.2(+0xf2f4)[0x7f38c33662f4]
/lib64/libdl.so.2(+0x162d)[0x7f38c2d1f62d]
/lib64/libdl.so.2(dlopen+0x31)[0x7f38c2d1f0c1]
/usr/local/jdk1.8.0_381/jre/lib/amd64/server/libjvm.so(+0x9292b1)[0x7f38c22732b1]
/usr/local/jdk1.8.0_381/jre/lib/amd64/server/libjvm.so(JVM_LoadLibrary+0xa1)[0x7f38c205e0c1]
/usr/local/jdk1.8.0_381/jre/lib/amd64/libjava.so(Java_java_lang_ClassLoader_00024NativeLibrary_load+0x1ac)
...



