### PR TITLE
[CORE] Add preProjection and postProjection in WindowExecTransformer

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -101,7 +101,7 @@ case class WindowExecTransformer(
     BackendsApiManager.getTransformerApiInstance.packPBMessage(message)
   }
 
-  private def needsPreProject: Boolean = (partitionSpec ++ orderSpec.map(_.child)).exists {
+  private def needsProject: Boolean = (partitionSpec ++ orderSpec.map(_.child)).exists {
     case _: Attribute => false
     case _ => true
   }
@@ -172,7 +172,7 @@ case class WindowExecTransformer(
     }
   }
 
-  private def getWindowRelWithPreProjection(
+  private def getWindowRelWithProjection(
       context: SubstraitContext,
       originalInputAttributes: Seq[Attribute],
       operatorId: Long,
@@ -230,7 +230,7 @@ case class WindowExecTransformer(
         operatorId,
         emitStartIndex)
     }
-    getWindowRelAfterProject(
+    createWindowRelAfterProjection(
       context,
       originalInputAttributes,
       preExprNodes,
@@ -240,7 +240,7 @@ case class WindowExecTransformer(
       validation)
   }
 
-  private def getWindowRelAfterProject(
+  private def createWindowRelAfterProjection(
       context: SubstraitContext,
       originalInputAttributes: Seq[Attribute],
       preExprNodes: JList[ExpressionNode],
@@ -315,7 +315,7 @@ case class WindowExecTransformer(
         context,
         operatorId)
     }
-    getPostProjection(
+    createPostProjection(
       context,
       originalInputAttributes,
       preExprNodes,
@@ -325,7 +325,7 @@ case class WindowExecTransformer(
       validation)
   }
 
-  private def getPostProjection(
+  private def createPostProjection(
       context: SubstraitContext,
       originalInputAttributes: Seq[Attribute],
       preExprNodes: JList[ExpressionNode],
@@ -381,7 +381,7 @@ case class WindowExecTransformer(
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
 
     val relNode = if (needsPreProject) {
-      getWindowRelWithPreProjection(
+      getWindowRelWithProjection(
         substraitContext,
         child.output,
         operatorId,
@@ -408,8 +408,8 @@ case class WindowExecTransformer(
       return childCtx
     }
 
-    val currRel = if (needsPreProject) {
-      getWindowRelWithPreProjection(
+    val currRel = if (needsProject) {
+      getWindowRelWithProjection(
         context,
         child.output,
         operatorId,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -380,7 +380,7 @@ case class WindowExecTransformer(
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
 
-    val relNode = if (needsPreProject) {
+    val relNode = if (needsProject) {
       getWindowRelWithProjection(
         substraitContext,
         child.output,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WindowExecTransformer.scala
@@ -21,9 +21,9 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression._
 import io.glutenproject.extension.ValidationResult
 import io.glutenproject.metrics.MetricsUpdater
-import io.glutenproject.substrait.`type`.TypeBuilder
+import io.glutenproject.substrait.`type`.{TypeBuilder, TypeNode}
 import io.glutenproject.substrait.SubstraitContext
-import io.glutenproject.substrait.expression.WindowFunctionNode
+import io.glutenproject.substrait.expression.{ExpressionBuilder, ExpressionNode, WindowFunctionNode}
 import io.glutenproject.substrait.extensions.ExtensionBuilder
 import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 
@@ -35,9 +35,10 @@ import org.apache.spark.sql.execution.window.WindowExecBase
 import com.google.protobuf.{Any, StringValue}
 import io.substrait.proto.SortField
 
-import java.util.{ArrayList => JArrayList}
+import java.util.{ArrayList => JArrayList, List => JList}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
 case class WindowExecTransformer(
     windowExpression: Seq[NamedExpression],
@@ -100,11 +101,13 @@ case class WindowExecTransformer(
     BackendsApiManager.getTransformerApiInstance.packPBMessage(message)
   }
 
-  def getRelNode(
+  private def needsPreProject: Boolean = (partitionSpec ++ orderSpec.map(_.child)).exists {
+    case _: Attribute => false
+    case _ => true
+  }
+
+  def getWindowRelWithoutProjection(
       context: SubstraitContext,
-      windowExpression: Seq[NamedExpression],
-      partitionSpec: Seq[Expression],
-      sortOrder: Seq[SortOrder],
       originalInputAttributes: Seq[Attribute],
       operatorId: Long,
       input: RelNode,
@@ -129,31 +132,18 @@ case class WindowExecTransformer(
 
     // Sort By Expressions
     val sortFieldList =
-      sortOrder.map {
+      orderSpec.map {
         order =>
           val builder = SortField.newBuilder()
           val exprNode = ExpressionConverter
             .replaceWithExpressionTransformer(order.child, attributeSeq = child.output)
             .doTransform(args)
           builder.setExpr(exprNode.toProtobuf)
-
-          (order.direction.sql, order.nullOrdering.sql) match {
-            case ("ASC", "NULLS FIRST") =>
-              builder.setDirectionValue(1);
-            case ("ASC", "NULLS LAST") =>
-              builder.setDirectionValue(2);
-            case ("DESC", "NULLS FIRST") =>
-              builder.setDirectionValue(3);
-            case ("DESC", "NULLS LAST") =>
-              builder.setDirectionValue(4);
-            case _ =>
-              builder.setDirectionValue(0);
-          }
+          builder.setDirectionValue(getSortDirectionValue(order))
           builder.build()
       }.asJava
     if (!validation) {
-      val extensionNode =
-        ExtensionBuilder.makeAdvancedExtension(genWindowParameters(), null)
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(genWindowParameters(), null)
       RelBuilder.makeWindowRel(
         input,
         windowExpressions,
@@ -182,6 +172,206 @@ case class WindowExecTransformer(
     }
   }
 
+  private def getWindowRelWithPreProjection(
+      context: SubstraitContext,
+      originalInputAttributes: Seq[Attribute],
+      operatorId: Long,
+      input: RelNode,
+      validation: Boolean): RelNode = {
+    val args = context.registeredFunction
+
+    val preExpressions = new ArrayBuffer[Expression]()
+    val selections = new ArrayBuffer[Int]()
+
+    // Window requires all output attributes from child.
+    preExpressions ++= originalInputAttributes
+    selections ++= originalInputAttributes.indices
+
+    def appendIfNotFound(expression: Expression): Unit = {
+      val foundExpr = preExpressions.find(e => e.semanticEquals(expression))
+      if (foundExpr.isDefined) {
+        // If found, no need to add it to preExpressions again.
+        // The selecting index will be found.
+        selections += preExpressions.indexOf(foundExpr.get)
+      } else {
+        // If not found, add this expression into preExpressions.
+        // A new selecting index will be created.
+        preExpressions += expression.clone()
+        selections += (preExpressions.size - 1)
+      }
+    }
+
+    partitionSpec.foreach(appendIfNotFound)
+    orderSpec.foreach(order => appendIfNotFound(order.child))
+
+    // Create the expression nodes needed by Project node.
+    val preExprNodes = preExpressions
+      .map(
+        ExpressionConverter
+          .replaceWithExpressionTransformer(_, originalInputAttributes)
+          .doTransform(args))
+      .asJava
+    val emitStartIndex = originalInputAttributes.size
+    val inputRel = if (!validation) {
+      RelBuilder.makeProjectRel(input, preExprNodes, context, operatorId, emitStartIndex)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for a validation.
+      val inputTypeNodeList = originalInputAttributes
+        .map(attr => ConverterUtils.getTypeNode(attr.dataType, attr.nullable))
+        .asJava
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        BackendsApiManager.getTransformerApiInstance.packPBMessage(
+          TypeBuilder.makeStruct(false, inputTypeNodeList).toProtobuf))
+      RelBuilder.makeProjectRel(
+        input,
+        preExprNodes,
+        extensionNode,
+        context,
+        operatorId,
+        emitStartIndex)
+    }
+    getWindowRelAfterProject(
+      context,
+      originalInputAttributes,
+      preExprNodes,
+      selections,
+      inputRel,
+      operatorId,
+      validation)
+  }
+
+  private def getWindowRelAfterProject(
+      context: SubstraitContext,
+      originalInputAttributes: Seq[Attribute],
+      preExprNodes: JList[ExpressionNode],
+      selections: Seq[Int],
+      inputRel: RelNode,
+      operatorId: Long,
+      validation: Boolean): RelNode = {
+    val args = context.registeredFunction
+
+    // WindowFunction Expressions
+    val windowExpressions = new JArrayList[WindowFunctionNode]()
+    BackendsApiManager.getSparkPlanExecApiInstance.genWindowFunctionsNode(
+      windowExpression,
+      windowExpressions,
+      originalInputAttributes,
+      args
+    )
+
+    var colIdx = originalInputAttributes.size
+    val partitionList = new JArrayList[ExpressionNode]()
+    val partitionAttributes = new ArrayBuffer[AttributeReference]()
+    partitionSpec.foreach {
+      partition =>
+        val partitionExpr = ExpressionBuilder.makeSelection(selections(colIdx))
+        partitionList.add(partitionExpr)
+        partitionAttributes += AttributeReference(s"col_$colIdx", partition.dataType)()
+        colIdx += 1
+    }
+
+    val sortAttributes = new ArrayBuffer[AttributeReference]()
+    val sortFieldList = orderSpec.map {
+      order =>
+        sortAttributes += AttributeReference(s"col_$colIdx", order.child.dataType)()
+        val builder = SortField.newBuilder()
+        val exprNode = ExpressionBuilder.makeSelection(selections(colIdx))
+        colIdx += 1
+        builder.setExpr(exprNode.toProtobuf)
+        builder.setDirectionValue(getSortDirectionValue(order))
+        builder.build()
+    }.asJava
+
+    val inputTypeNodeList = new java.util.ArrayList[TypeNode]()
+    originalInputAttributes.foreach(
+      attr => inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable)))
+    partitionAttributes.foreach(
+      attr => inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable)))
+    sortAttributes.foreach(
+      attr => inputTypeNodeList.add(ConverterUtils.getTypeNode(attr.dataType, attr.nullable)))
+
+    val windowRel = if (!validation) {
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(genWindowParameters(), null)
+      RelBuilder.makeWindowRel(
+        inputRel,
+        windowExpressions,
+        partitionList,
+        sortFieldList,
+        extensionNode,
+        context,
+        operatorId)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for validation.
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        BackendsApiManager.getTransformerApiInstance.packPBMessage(
+          TypeBuilder.makeStruct(false, inputTypeNodeList).toProtobuf))
+
+      RelBuilder.makeWindowRel(
+        inputRel,
+        windowExpressions,
+        partitionList,
+        sortFieldList,
+        extensionNode,
+        context,
+        operatorId)
+    }
+    getPostProjection(
+      context,
+      originalInputAttributes,
+      preExprNodes,
+      inputTypeNodeList,
+      windowRel,
+      operatorId,
+      validation)
+  }
+
+  private def getPostProjection(
+      context: SubstraitContext,
+      originalInputAttributes: Seq[Attribute],
+      preExprNodes: JList[ExpressionNode],
+      inputTypeNodeList: JList[TypeNode],
+      inputRel: RelNode,
+      operatorId: Long,
+      validation: Boolean): RelNode = {
+    val postExprNodes = new JArrayList[ExpressionNode]()
+    postExprNodes.addAll(preExprNodes.subList(0, originalInputAttributes.size))
+    var windowStartIdx = preExprNodes.size()
+    windowExpression.foreach {
+      _ =>
+        postExprNodes.add(ExpressionBuilder.makeSelection(windowStartIdx))
+        windowStartIdx += 1
+    }
+    if (!validation) {
+      RelBuilder.makeProjectRel(
+        inputRel,
+        postExprNodes,
+        context,
+        operatorId,
+        preExprNodes.size() + windowExpression.size)
+    } else {
+      // Use a extension node to send the input types through Substrait plan for a validation.
+      val extensionNode = ExtensionBuilder.makeAdvancedExtension(
+        BackendsApiManager.getTransformerApiInstance.packPBMessage(
+          TypeBuilder.makeStruct(false, inputTypeNodeList).toProtobuf))
+      RelBuilder.makeProjectRel(
+        inputRel,
+        postExprNodes,
+        extensionNode,
+        context,
+        operatorId,
+        preExprNodes.size() + windowExpression.size)
+    }
+  }
+
+  private def getSortDirectionValue(order: SortOrder): Int =
+    (order.direction.sql, order.nullOrdering.sql) match {
+      case ("ASC", "NULLS FIRST") => 1
+      case ("ASC", "NULLS LAST") => 2
+      case ("DESC", "NULLS FIRST") => 3
+      case ("DESC", "NULLS LAST") => 4
+      case _ => 0
+    }
+
   override protected def doValidateInternal(): ValidationResult = {
     if (!BackendsApiManager.getSettings.supportWindowExec(windowExpression)) {
       return ValidationResult
@@ -190,15 +380,21 @@ case class WindowExecTransformer(
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
 
-    val relNode = getRelNode(
-      substraitContext,
-      windowExpression,
-      partitionSpec,
-      orderSpec,
-      child.output,
-      operatorId,
-      null,
-      validation = true)
+    val relNode = if (needsPreProject) {
+      getWindowRelWithPreProjection(
+        substraitContext,
+        child.output,
+        operatorId,
+        null,
+        validation = true)
+    } else {
+      getWindowRelWithoutProjection(
+        substraitContext,
+        child.output,
+        operatorId,
+        null,
+        validation = true)
+    }
 
     doNativeValidation(substraitContext, relNode)
   }
@@ -212,15 +408,21 @@ case class WindowExecTransformer(
       return childCtx
     }
 
-    val currRel = getRelNode(
-      context,
-      windowExpression,
-      partitionSpec,
-      orderSpec,
-      child.output,
-      operatorId,
-      childCtx.root,
-      validation = false)
+    val currRel = if (needsPreProject) {
+      getWindowRelWithPreProjection(
+        context,
+        child.output,
+        operatorId,
+        childCtx.root,
+        validation = false)
+    } else {
+      getWindowRelWithoutProjection(
+        context,
+        child.output,
+        operatorId,
+        childCtx.root,
+        validation = false)
+    }
     assert(currRel != null, "Window Rel should be valid")
     TransformContext(childCtx.outputAttributes, output, currRel)
   }

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -16,6 +16,71 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.GlutenSQLTestsTrait
+import io.glutenproject.execution.WindowExecTransformer
 
-class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {}
+import org.apache.spark.sql.GlutenSQLTestsTrait
+import org.apache.spark.sql.Row
+
+class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {
+
+  import testImplicits._
+
+  val customerData: Seq[(Int, Int)] = Seq[(Int, Int)](
+    (4553, 11),
+    (4953, 10),
+    (35403, 5),
+    (35803, 12),
+    (60865, 5),
+    (61065, 13),
+    (127412, 13),
+    (148303, 10),
+    (9954, 5),
+    (95337, 12)
+  )
+
+  test("Literal in window partition by and sort") {
+    withTable("customer") {
+      customerData
+        .toDF("c_custkey", "c_nationkey")
+        .write
+        .format("parquet")
+        .saveAsTable("customer")
+      val query =
+        """
+          |SELECT
+          |  c_custkey,
+          |  row_number() OVER (
+          |    PARTITION BY c_nationkey,
+          |    "a"
+          |    ORDER BY
+          |      c_custkey,
+          |      "a"
+          |  ) AS row_num
+          |FROM
+          |   customer
+          |ORDER BY 1, 2;
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, 1),
+          Row(4953, 1),
+          Row(9954, 1),
+          Row(35403, 2),
+          Row(35803, 1),
+          Row(60865, 3),
+          Row(61065, 1),
+          Row(95337, 2),
+          Row(127412, 2),
+          Row(148303, 2))
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+}

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -20,35 +20,44 @@ import io.glutenproject.execution.WindowExecTransformer
 
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.types._
 
 class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {
 
-  import testImplicits._
+  private def decimal(v: BigDecimal): Decimal = Decimal(v, 7, 2)
 
-  val customerData: Seq[(Int, Int)] = Seq[(Int, Int)](
-    (4553, 11),
-    (4953, 10),
-    (35403, 5),
-    (35803, 12),
-    (60865, 5),
-    (61065, 13),
-    (127412, 13),
-    (148303, 10),
-    (9954, 5),
-    (95337, 12)
+  val customerSchema = StructType(
+    List(
+      StructField("c_custkey", IntegerType),
+      StructField("c_nationkey", IntegerType),
+      StructField("c_acctbal", DecimalType(7, 2))
+    )
+  )
+
+  val customerData = Seq(
+    Row(4553, 11, decimal(6388.41)),
+    Row(4953, 10, decimal(6037.28)),
+    Row(35403, 5, decimal(6034.70)),
+    Row(35803, 12, decimal(5284.87)),
+    Row(60865, 5, decimal(-227.83)),
+    Row(61065, 13, decimal(7284.77)),
+    Row(127412, 13, decimal(4621.41)),
+    Row(148303, 10, decimal(4302.30)),
+    Row(9954, 5, decimal(7587.25)),
+    Row(95337, 12, decimal(915.61))
   )
 
   test("Literal in window partition by and sort") {
     withTable("customer") {
-      customerData
-        .toDF("c_custkey", "c_nationkey")
-        .write
-        .format("parquet")
-        .saveAsTable("customer")
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
       val query =
         """
           |SELECT
           |  c_custkey,
+          |  c_acctbal,
           |  row_number() OVER (
           |    PARTITION BY c_nationkey,
           |    "a"
@@ -64,20 +73,63 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
       checkAnswer(
         df,
         Seq(
-          Row(4553, 1),
-          Row(4953, 1),
-          Row(9954, 1),
-          Row(35403, 2),
-          Row(35803, 1),
-          Row(60865, 3),
-          Row(61065, 1),
-          Row(95337, 2),
-          Row(127412, 2),
-          Row(148303, 2))
+          Row(4553, BigDecimal(6388.41), 1),
+          Row(4953, BigDecimal(6037.28), 1),
+          Row(9954, BigDecimal(7587.25), 1),
+          Row(35403, BigDecimal(6034.70), 2),
+          Row(35803, BigDecimal(5284.87), 1),
+          Row(60865, BigDecimal(-227.83), 3),
+          Row(61065, BigDecimal(7284.77), 1),
+          Row(95337, BigDecimal(915.61), 2),
+          Row(127412, BigDecimal(4621.41), 2),
+          Row(148303, BigDecimal(4302.30), 2)
+        )
       )
       assert(
         getExecutedPlan(df).exists {
           case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+
+  test("Expression in WindowExpression that will fallback") {
+    withTable("customer") {
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
+      val query =
+        """
+          |SELECT
+          |  c_custkey,
+          |  avg(c_acctbal) OVER (
+          |    PARTITION BY c_nationkey
+          |    ORDER BY c_custkey
+          |  )
+          |FROM
+          |   customer
+          |ORDER BY 1, 2;
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, BigDecimal(6388.410000)),
+          Row(4953, BigDecimal(6037.280000)),
+          Row(9954, BigDecimal(7587.250000)),
+          Row(35403, BigDecimal(6810.975000)),
+          Row(35803, BigDecimal(5284.870000)),
+          Row(60865, BigDecimal(4464.706667)),
+          Row(61065, BigDecimal(7284.770000)),
+          Row(95337, BigDecimal(3100.240000)),
+          Row(127412, BigDecimal(5953.090000)),
+          Row(148303, BigDecimal(5169.790000))
+        )
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowExec => true
           case _ => false
         }
       )

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -16,6 +16,71 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.GlutenSQLTestsTrait
+import io.glutenproject.execution.WindowExecTransformer
 
-class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {}
+import org.apache.spark.sql.GlutenSQLTestsTrait
+import org.apache.spark.sql.Row
+
+class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {
+
+  import testImplicits._
+
+  val customerData: Seq[(Int, Int)] = Seq[(Int, Int)](
+    (4553, 11),
+    (4953, 10),
+    (35403, 5),
+    (35803, 12),
+    (60865, 5),
+    (61065, 13),
+    (127412, 13),
+    (148303, 10),
+    (9954, 5),
+    (95337, 12)
+  )
+
+  test("Literal in window partition by and sort") {
+    withTable("customer") {
+      customerData
+        .toDF("c_custkey", "c_nationkey")
+        .write
+        .format("parquet")
+        .saveAsTable("customer")
+      val query =
+        """
+          |SELECT
+          |  c_custkey,
+          |  row_number() OVER (
+          |    PARTITION BY c_nationkey,
+          |    "a"
+          |    ORDER BY
+          |      c_custkey,
+          |      "a"
+          |  ) AS row_num
+          |FROM
+          |   customer
+          |ORDER BY 1, 2;
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, 1),
+          Row(4953, 1),
+          Row(9954, 1),
+          Row(35403, 2),
+          Row(35803, 1),
+          Row(60865, 3),
+          Row(61065, 1),
+          Row(95337, 2),
+          Row(127412, 2),
+          Row(148303, 2))
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+}

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -20,35 +20,44 @@ import io.glutenproject.execution.WindowExecTransformer
 
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.types._
 
 class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {
 
-  import testImplicits._
+  private def decimal(v: BigDecimal): Decimal = Decimal(v, 7, 2)
 
-  val customerData: Seq[(Int, Int)] = Seq[(Int, Int)](
-    (4553, 11),
-    (4953, 10),
-    (35403, 5),
-    (35803, 12),
-    (60865, 5),
-    (61065, 13),
-    (127412, 13),
-    (148303, 10),
-    (9954, 5),
-    (95337, 12)
+  val customerSchema = StructType(
+    List(
+      StructField("c_custkey", IntegerType),
+      StructField("c_nationkey", IntegerType),
+      StructField("c_acctbal", DecimalType(7, 2))
+    )
+  )
+
+  val customerData = Seq(
+    Row(4553, 11, decimal(6388.41)),
+    Row(4953, 10, decimal(6037.28)),
+    Row(35403, 5, decimal(6034.70)),
+    Row(35803, 12, decimal(5284.87)),
+    Row(60865, 5, decimal(-227.83)),
+    Row(61065, 13, decimal(7284.77)),
+    Row(127412, 13, decimal(4621.41)),
+    Row(148303, 10, decimal(4302.30)),
+    Row(9954, 5, decimal(7587.25)),
+    Row(95337, 12, decimal(915.61))
   )
 
   test("Literal in window partition by and sort") {
     withTable("customer") {
-      customerData
-        .toDF("c_custkey", "c_nationkey")
-        .write
-        .format("parquet")
-        .saveAsTable("customer")
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
       val query =
         """
           |SELECT
           |  c_custkey,
+          |  c_acctbal,
           |  row_number() OVER (
           |    PARTITION BY c_nationkey,
           |    "a"
@@ -64,20 +73,63 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
       checkAnswer(
         df,
         Seq(
-          Row(4553, 1),
-          Row(4953, 1),
-          Row(9954, 1),
-          Row(35403, 2),
-          Row(35803, 1),
-          Row(60865, 3),
-          Row(61065, 1),
-          Row(95337, 2),
-          Row(127412, 2),
-          Row(148303, 2))
+          Row(4553, BigDecimal(6388.41), 1),
+          Row(4953, BigDecimal(6037.28), 1),
+          Row(9954, BigDecimal(7587.25), 1),
+          Row(35403, BigDecimal(6034.70), 2),
+          Row(35803, BigDecimal(5284.87), 1),
+          Row(60865, BigDecimal(-227.83), 3),
+          Row(61065, BigDecimal(7284.77), 1),
+          Row(95337, BigDecimal(915.61), 2),
+          Row(127412, BigDecimal(4621.41), 2),
+          Row(148303, BigDecimal(4302.30), 2)
+        )
       )
       assert(
         getExecutedPlan(df).exists {
           case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+
+  test("Expression in WindowExpression that will fallback") {
+    withTable("customer") {
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
+      val query =
+        """
+          |SELECT
+          |  c_custkey,
+          |  avg(c_acctbal) OVER (
+          |    PARTITION BY c_nationkey
+          |    ORDER BY c_custkey
+          |  )
+          |FROM
+          |   customer
+          |ORDER BY 1, 2;
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, BigDecimal(6388.410000)),
+          Row(4953, BigDecimal(6037.280000)),
+          Row(9954, BigDecimal(7587.250000)),
+          Row(35403, BigDecimal(6810.975000)),
+          Row(35803, BigDecimal(5284.870000)),
+          Row(60865, BigDecimal(4464.706667)),
+          Row(61065, BigDecimal(7284.770000)),
+          Row(95337, BigDecimal(3100.240000)),
+          Row(127412, BigDecimal(5953.090000)),
+          Row(148303, BigDecimal(5169.790000))
+        )
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowExec => true
           case _ => false
         }
       )

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -16,6 +16,71 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.spark.sql.GlutenSQLTestsTrait
+import io.glutenproject.execution.WindowExecTransformer
 
-class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {}
+import org.apache.spark.sql.GlutenSQLTestsTrait
+import org.apache.spark.sql.Row
+
+class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {
+
+  import testImplicits._
+
+  val customerData: Seq[(Int, Int)] = Seq[(Int, Int)](
+    (4553, 11),
+    (4953, 10),
+    (35403, 5),
+    (35803, 12),
+    (60865, 5),
+    (61065, 13),
+    (127412, 13),
+    (148303, 10),
+    (9954, 5),
+    (95337, 12)
+  )
+
+  test("Literal in window partition by and sort") {
+    withTable("customer") {
+      customerData
+        .toDF("c_custkey", "c_nationkey")
+        .write
+        .format("parquet")
+        .saveAsTable("customer")
+      val query =
+        """
+          |SELECT
+          |  c_custkey,
+          |  row_number() OVER (
+          |    PARTITION BY c_nationkey,
+          |    "a"
+          |    ORDER BY
+          |      c_custkey,
+          |      "a"
+          |  ) AS row_num
+          |FROM
+          |   customer
+          |ORDER BY 1, 2;
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, 1),
+          Row(4953, 1),
+          Row(9954, 1),
+          Row(35403, 2),
+          Row(35803, 1),
+          Row(60865, 3),
+          Row(61065, 1),
+          Row(95337, 2),
+          Row(127412, 2),
+          Row(148303, 2))
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+}

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -20,35 +20,44 @@ import io.glutenproject.execution.WindowExecTransformer
 
 import org.apache.spark.sql.GlutenSQLTestsTrait
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.types._
 
 class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQLTestsTrait {
 
-  import testImplicits._
+  private def decimal(v: BigDecimal): Decimal = Decimal(v, 7, 2)
 
-  val customerData: Seq[(Int, Int)] = Seq[(Int, Int)](
-    (4553, 11),
-    (4953, 10),
-    (35403, 5),
-    (35803, 12),
-    (60865, 5),
-    (61065, 13),
-    (127412, 13),
-    (148303, 10),
-    (9954, 5),
-    (95337, 12)
+  val customerSchema = StructType(
+    List(
+      StructField("c_custkey", IntegerType),
+      StructField("c_nationkey", IntegerType),
+      StructField("c_acctbal", DecimalType(7, 2))
+    )
+  )
+
+  val customerData = Seq(
+    Row(4553, 11, decimal(6388.41)),
+    Row(4953, 10, decimal(6037.28)),
+    Row(35403, 5, decimal(6034.70)),
+    Row(35803, 12, decimal(5284.87)),
+    Row(60865, 5, decimal(-227.83)),
+    Row(61065, 13, decimal(7284.77)),
+    Row(127412, 13, decimal(4621.41)),
+    Row(148303, 10, decimal(4302.30)),
+    Row(9954, 5, decimal(7587.25)),
+    Row(95337, 12, decimal(915.61))
   )
 
   test("Literal in window partition by and sort") {
     withTable("customer") {
-      customerData
-        .toDF("c_custkey", "c_nationkey")
-        .write
-        .format("parquet")
-        .saveAsTable("customer")
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
       val query =
         """
           |SELECT
           |  c_custkey,
+          |  c_acctbal,
           |  row_number() OVER (
           |    PARTITION BY c_nationkey,
           |    "a"
@@ -64,20 +73,63 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
       checkAnswer(
         df,
         Seq(
-          Row(4553, 1),
-          Row(4953, 1),
-          Row(9954, 1),
-          Row(35403, 2),
-          Row(35803, 1),
-          Row(60865, 3),
-          Row(61065, 1),
-          Row(95337, 2),
-          Row(127412, 2),
-          Row(148303, 2))
+          Row(4553, BigDecimal(6388.41), 1),
+          Row(4953, BigDecimal(6037.28), 1),
+          Row(9954, BigDecimal(7587.25), 1),
+          Row(35403, BigDecimal(6034.70), 2),
+          Row(35803, BigDecimal(5284.87), 1),
+          Row(60865, BigDecimal(-227.83), 3),
+          Row(61065, BigDecimal(7284.77), 1),
+          Row(95337, BigDecimal(915.61), 2),
+          Row(127412, BigDecimal(4621.41), 2),
+          Row(148303, BigDecimal(4302.30), 2)
+        )
       )
       assert(
         getExecutedPlan(df).exists {
           case _: WindowExecTransformer => true
+          case _ => false
+        }
+      )
+    }
+  }
+
+  test("Expression in WindowExpression that will fallback") {
+    withTable("customer") {
+      val rdd = spark.sparkContext.parallelize(customerData)
+      val customerDF = spark.createDataFrame(rdd, customerSchema)
+      customerDF.createOrReplaceTempView("customer")
+      val query =
+        """
+          |SELECT
+          |  c_custkey,
+          |  avg(c_acctbal) OVER (
+          |    PARTITION BY c_nationkey
+          |    ORDER BY c_custkey
+          |  )
+          |FROM
+          |   customer
+          |ORDER BY 1, 2;
+          |""".stripMargin
+      val df = sql(query)
+      checkAnswer(
+        df,
+        Seq(
+          Row(4553, BigDecimal(6388.410000)),
+          Row(4953, BigDecimal(6037.280000)),
+          Row(9954, BigDecimal(7587.250000)),
+          Row(35403, BigDecimal(6810.975000)),
+          Row(35803, BigDecimal(5284.870000)),
+          Row(60865, BigDecimal(4464.706667)),
+          Row(61065, BigDecimal(7284.770000)),
+          Row(95337, BigDecimal(3100.240000)),
+          Row(127412, BigDecimal(5953.090000)),
+          Row(148303, BigDecimal(5169.790000))
+        )
+      )
+      assert(
+        getExecutedPlan(df).exists {
+          case _: WindowExec => true
           case _ => false
         }
       )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Window and agg are similar, and in Velox, they also do not support input that contains expressions. The input must be an attribute. Therefore, if there are non-attribute columns in the input for window, we need to add a preProjection to execute them. And similar to the approach in `SortExecTransformer`, the output of the window, which is `child.output ++ windowExpr`, requires a postProjection to remove any extra columns from child.output in the final output (where child refers to the added preProjection).

```sql
SELECT
  c_custkey,
  row_number() OVER (
    PARTITION BY c_nationkey,
    "a"
    ORDER BY
      c_custkey,
      "a"
  ) AS row_num
FROM
   customer
ORDER BY 1, 2;
```
Before this PR, the window in above query will fallback due to the reason "native validation failed due to: Only field is supported in window functions".

When converting window to a substrait plan, there are three parts that need to be handled: partitionExprs, sortExprs, and windowExprs. Expressions may exist in any of these three parts, and they all need to be verified. However, in the current PR, only partitionExprs and sortExprs are considered. I plan to refactor the existing logic of preProjection and postProjection in Gluten to be corrected based on Rules in the future. Therefore, in the future, support for windowExprs will be added.

## How was this patch tested?

Add a new test case GlutenSQLWindowFunctionSuite."Literal in window partition by and sort" for Velox and ClickHouse.

