### PR TITLE
[VL] Add the metrics for WriteFilesExecTransformer

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -364,4 +364,15 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
 
   override def genGenerateTransformerMetricsUpdater(
       metrics: Map[String, SQLMetric]): MetricsUpdater = new GenerateMetricsUpdater(metrics)
+
+  def genWriteFilesTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] = {
+    throw new UnsupportedOperationException(
+      s"WriteFilesTransformer metrics update is not supported in CH backend")
+  }
+
+  def genWriteFilesTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater = {
+    throw new UnsupportedOperationException(
+      s"WriteFilesTransformer metrics update is not supported in CH backend")
+  }
+
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
@@ -335,6 +335,15 @@ class MetricsApiImpl extends MetricsApi with Logging {
   override def genLimitTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater =
     new LimitMetricsUpdater(metrics)
 
+  def genWriteFilesTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
+    Map(
+      "physicalWrittenBytes" -> SQLMetrics.createMetric(sparkContext, "number of written bytes"),
+      "numWrittenFiles" -> SQLMetrics.createMetric(sparkContext, "number of written files")
+    )
+
+  def genWriteFilesTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater =
+    new WriteFilesMetricsUpdater(metrics)
+
   override def genSortTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric] =
     Map(
       "outputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -252,7 +252,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   metricsBuilderClass = createGlobalClassReferenceOrError(env, "Lio/glutenproject/metrics/Metrics;");
 
   metricsBuilderConstructor = getMethodIdOrError(
-      env, metricsBuilderClass, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J)V");
+      env, metricsBuilderClass, "<init>", "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J)V");
 
   serializedColumnarBatchIteratorClass =
       createGlobalClassReferenceOrError(env, "Lio/glutenproject/vectorized/ColumnarBatchInIterator;");
@@ -502,7 +502,9 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchOutItera
       longArray[Metrics::kProcessedStrides],
       longArray[Metrics::kRemainingFilterTime],
       longArray[Metrics::kIoWaitTime],
-      longArray[Metrics::kPreloadSplits]);
+      longArray[Metrics::kPreloadSplits],
+      longArray[Metrics::kPhysicalWrittenBytes],
+      longArray[Metrics::kNumWrittenFiles]);
 
   JNI_METHOD_END(nullptr)
 }

--- a/cpp/core/utils/metrics.h
+++ b/cpp/core/utils/metrics.h
@@ -73,6 +73,10 @@ struct Metrics {
     kIoWaitTime,
     kPreloadSplits,
 
+    // Write metrics.
+    kPhysicalWrittenBytes,
+    kNumWrittenFiles,
+
     // The end of enum items.
     kEnd,
     kNum = kEnd - kBegin

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -307,7 +307,7 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->get(Metrics::kPreloadSplits)[metricIndex] =
           runtimeMetric("sum", entry.second->customStats, kPreloadSplits);
       metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =
-                  runtimeMetric("sum", entry.second->customStats, kNumWrittenFiles);
+          runtimeMetric("sum", entry.second->customStats, kNumWrittenFiles);
       metrics_->get(Metrics::kPhysicalWrittenBytes)[metricIndex] = second->physicalWrittenBytes;
 
       metricIndex += 1;

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -306,21 +306,8 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->get(Metrics::kIoWaitTime)[metricIndex] = runtimeMetric("sum", second->customStats, kIoWaitTime);
       metrics_->get(Metrics::kPreloadSplits)[metricIndex] =
           runtimeMetric("sum", entry.second->customStats, kPreloadSplits);
-
-      // Update the Write metrics.
-      if (entry.first == "TableWrite") {
-        for (int i = 0; i < task_->taskStats().pipelineStats.size(); ++i) {
-          auto operatorStats = task_->taskStats().pipelineStats.at(i).operatorStats;
-          for (int j = 0; j < operatorStats.size(); ++j) {
-            auto operatorStat = operatorStats.at(j);
-            if (operatorStat.operatorType == "TableWrite") {
-              metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =
-                  operatorStat.runtimeStats.at(kNumWrittenFiles).sum;
-              metrics_->get(Metrics::kPhysicalWrittenBytes)[metricIndex] = operatorStat.physicalWrittenBytes;
-            }
-          }
-        }
-      }
+      metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =
+                  runtimeMetric("sum", entry.second->customStats, kNumWrittenFiles);
 
       metricIndex += 1;
     }

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -308,16 +308,20 @@ void WholeStageResultIterator::collectMetrics() {
           runtimeMetric("sum", entry.second->customStats, kPreloadSplits);
 
       // Update the Write metrics.
-      for (int i = 0; i < task_->taskStats().pipelineStats.size(); ++i) {
-        auto operatorStats = task_->taskStats().pipelineStats.at(i).operatorStats;
-        for (int j = 0; j < operatorStats.size(); ++j) {
-          auto operatorStat = operatorStats.at(j);
-          if (operatorStat.operatorType == "TableWrite") {
-            metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] = operatorStat.runtimeStats.at(kNumWrittenFiles).sum;
-            metrics_->get(Metrics::kPhysicalWrittenBytes)[metricIndex] = operatorStat.physicalWrittenBytes;
+      if (entry.first == "TableWrite") {
+        for (int i = 0; i < task_->taskStats().pipelineStats.size(); ++i) {
+          auto operatorStats = task_->taskStats().pipelineStats.at(i).operatorStats;
+          for (int j = 0; j < operatorStats.size(); ++j) {
+            auto operatorStat = operatorStats.at(j);
+            if (operatorStat.operatorType == "TableWrite") {
+              metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =
+                  operatorStat.runtimeStats.at(kNumWrittenFiles).sum;
+              metrics_->get(Metrics::kPhysicalWrittenBytes)[metricIndex] = operatorStat.physicalWrittenBytes;
+            }
           }
         }
       }
+
       metricIndex += 1;
     }
   }

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -308,6 +308,7 @@ void WholeStageResultIterator::collectMetrics() {
           runtimeMetric("sum", entry.second->customStats, kPreloadSplits);
       metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =
                   runtimeMetric("sum", entry.second->customStats, kNumWrittenFiles);
+      metrics_->get(Metrics::kPhysicalWrittenBytes)[metricIndex] = second->physicalWrittenBytes;
 
       metricIndex += 1;
     }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/MetricsApi.scala
@@ -87,6 +87,10 @@ trait MetricsApi extends Serializable {
 
   def genLimitTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
 
+  def genWriteFilesTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
+
+  def genWriteFilesTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater
+
   def genSortTransformerMetrics(sparkContext: SparkContext): Map[String, SQLMetric]
 
   def genSortTransformerMetricsUpdater(metrics: Map[String, SQLMetric]): MetricsUpdater

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
@@ -19,7 +19,7 @@ package io.glutenproject.execution
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.extension.ValidationResult
-import io.glutenproject.metrics.{MetricsUpdater, NoopMetricsUpdater}
+import io.glutenproject.metrics.MetricsUpdater
 import io.glutenproject.substrait.`type`.{ColumnTypeNode, TypeBuilder}
 import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.extensions.ExtensionBuilder
@@ -49,7 +49,12 @@ case class WriteFilesExecTransformer(
     options: Map[String, String],
     staticPartitions: TablePartitionSpec)
   extends UnaryTransformSupport {
-  override def metricsUpdater(): MetricsUpdater = NoopMetricsUpdater
+  // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
+  @transient override lazy val metrics =
+    BackendsApiManager.getMetricsApiInstance.genWriteFilesTransformerMetrics(sparkContext)
+
+  override def metricsUpdater(): MetricsUpdater =
+    BackendsApiManager.getMetricsApiInstance.genWriteFilesTransformerMetricsUpdater(metrics)
 
   override def output: Seq[Attribute] = Seq.empty
 

--- a/gluten-data/src/main/java/io/glutenproject/metrics/Metrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/metrics/Metrics.java
@@ -47,6 +47,11 @@ public class Metrics implements IMetrics {
   public long[] remainingFilterTime;
   public long[] ioWaitTime;
   public long[] preloadSplits;
+
+  public long[] physicalWrittenBytes;
+
+  public long[] numWrittenFiles;
+
   public SingleMetric singleMetric = new SingleMetric();
 
   /** Create an instance for native metrics. */
@@ -79,7 +84,9 @@ public class Metrics implements IMetrics {
       long[] processedStrides,
       long[] remainingFilterTime,
       long[] ioWaitTime,
-      long[] preloadSplits) {
+      long[] preloadSplits,
+      long[] physicalWrittenBytes,
+      long[] numWrittenFiles) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -109,6 +116,8 @@ public class Metrics implements IMetrics {
     this.remainingFilterTime = remainingFilterTime;
     this.ioWaitTime = ioWaitTime;
     this.preloadSplits = preloadSplits;
+    this.physicalWrittenBytes = physicalWrittenBytes;
+    this.numWrittenFiles = numWrittenFiles;
   }
 
   public OperatorMetrics getOperatorMetrics(int index) {
@@ -144,7 +153,9 @@ public class Metrics implements IMetrics {
         processedStrides[index],
         remainingFilterTime[index],
         ioWaitTime[index],
-        preloadSplits[index]);
+        preloadSplits[index],
+        physicalWrittenBytes[index],
+        numWrittenFiles[index]);
   }
 
   public SingleMetric getSingleMetrics() {

--- a/gluten-data/src/main/java/io/glutenproject/metrics/OperatorMetrics.java
+++ b/gluten-data/src/main/java/io/glutenproject/metrics/OperatorMetrics.java
@@ -46,6 +46,10 @@ public class OperatorMetrics implements IOperatorMetrics {
   public long ioWaitTime;
   public long preloadSplits;
 
+  public long physicalWrittenBytes;
+
+  public long numWrittenFiles;
+
   /** Create an instance for operator metrics. */
   public OperatorMetrics(
       long inputRows,
@@ -75,7 +79,9 @@ public class OperatorMetrics implements IOperatorMetrics {
       long processedStrides,
       long remainingFilterTime,
       long ioWaitTime,
-      long preloadSplits) {
+      long preloadSplits,
+      long physicalWrittenBytes,
+      long numWrittenFiles) {
     this.inputRows = inputRows;
     this.inputVectors = inputVectors;
     this.inputBytes = inputBytes;
@@ -104,5 +110,7 @@ public class OperatorMetrics implements IOperatorMetrics {
     this.remainingFilterTime = remainingFilterTime;
     this.ioWaitTime = ioWaitTime;
     this.preloadSplits = preloadSplits;
+    this.physicalWrittenBytes = physicalWrittenBytes;
+    this.numWrittenFiles = numWrittenFiles;
   }
 }

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/MetricsUtil.scala
@@ -96,6 +96,8 @@ object MetricsUtil extends Logging {
     val outputVectors = operatorMetrics.get(0).outputVectors
     val outputBytes = operatorMetrics.get(0).outputBytes
 
+    val physicalWrittenBytes = operatorMetrics.get(0).physicalWrittenBytes
+
     var cpuCount: Long = 0
     var wallNanos: Long = 0
     var peakMemoryBytes: Long = 0
@@ -116,6 +118,7 @@ object MetricsUtil extends Logging {
     var remainingFilterTime: Long = 0
     var ioWaitTime: Long = 0
     var preloadSplits: Long = 0
+    var numWrittenFiles: Long = 0
 
     val metricsIterator = operatorMetrics.iterator()
     while (metricsIterator.hasNext) {
@@ -140,6 +143,7 @@ object MetricsUtil extends Logging {
       remainingFilterTime += metrics.remainingFilterTime
       ioWaitTime += metrics.ioWaitTime
       preloadSplits += metrics.preloadSplits
+      numWrittenFiles += metrics.numWrittenFiles
     }
 
     new OperatorMetrics(
@@ -170,7 +174,9 @@ object MetricsUtil extends Logging {
       processedStrides,
       remainingFilterTime,
       ioWaitTime,
-      preloadSplits
+      preloadSplits,
+      physicalWrittenBytes,
+      numWrittenFiles
     )
   }
 

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/WriteFilesMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/WriteFilesMetricsUpdater.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.metrics
+
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+class WriteFilesMetricsUpdater(val metrics: Map[String, SQLMetric]) extends MetricsUpdater {
+
+  override def updateNativeMetrics(opMetrics: IOperatorMetrics): Unit = {
+    if (opMetrics != null) {
+      val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
+      metrics("physicalWrittenBytes") += operatorMetrics.physicalWrittenBytes
+      metrics("numWrittenFiles") += operatorMetrics.numWrittenFiles
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the `physicalWrittenBytes `and `numWrittenFiles  `metrics for WriteFilesExecTransformer. 

![image](https://github.com/oap-project/gluten/assets/11972570/98bb13b4-37c1-43de-8381-e1a20e0f3fe4)


## How was this patch tested?

Adding Unit test and UI locally check.

