### PR TITLE
 [GLUTEN-4218] fix: Fix Gluten CPP build breaks 

### DIFF
--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -48,7 +48,8 @@
         "protobuf",
         "benchmark",
         "jemalloc",
-        "icu"
+        "icu",
+        "thrift"
       ]
     },
     "velox-s3": {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes below two build issues:

1. While building gluten cpp with vcpkg, build is breaking with below error:

![image](https://github.com/oap-project/gluten/assets/47717334/f62f07b2-1153-47c1-b84c-4e0fb53fca42)

Adding "thrift" to dev/vcpkg/vcpkg.json dependencies resolves the issue.
 
(Fixes: \#4218)

## How was this patch tested?
Build passes after the fixes
