### PR TITLE
[VL] Remove linking installed simdjson when building gluten cpp test

### DIFF
--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ function(add_velox_test TEST_EXEC)
   add_executable(${TEST_EXEC} ${SOURCES})
   message(STATUS "!!!!!${VELOX_BUILD_PATH}/_deps/duckdb-src/include/")
   target_include_directories(${TEST_EXEC} PRIVATE ${CMAKE_SOURCE_DIR}/velox ${CMAKE_SOURCE_DIR}/src ${VELOX_BUILD_PATH}/_deps/duckdb-src/src/include)
-  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main google::glog benchmark::benchmark simdjson)
+  target_link_libraries(${TEST_EXEC} velox GTest::gtest GTest::gtest_main google::glog benchmark::benchmark)
   gtest_discover_tests(${TEST_EXEC} DISCOVERY_MODE PRE_TEST)
 endfunction()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Local test shows it is unnecessary to link installed simdjson.

## How was this patch tested?

Existing test.

