### PR TITLE
[GLUTEN-2723][CH] Improve Broadcast Join performance -- Part 3

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -324,8 +324,9 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       throw new SparkException(
         s"Cannot broadcast the table that is larger than 8GB: ${rawSize >> 30} GB")
     }
-    numOutputRows += countsAndBytes.map(_._1).sum
-    ClickHouseBuildSideRelation(mode, newOutput, batches.flatten, newBuildKeys)
+    val rowCount = countsAndBytes.map(_._1).sum
+    numOutputRows += rowCount
+    ClickHouseBuildSideRelation(mode, newOutput, batches.flatten, rowCount, newBuildKeys)
   }
 
   /**

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/joins/ClickHouseBuildSideRelation.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/joins/ClickHouseBuildSideRelation.scala
@@ -34,6 +34,7 @@ case class ClickHouseBuildSideRelation(
     mode: BroadcastMode,
     output: Seq[Attribute],
     batches: Array[Byte],
+    numOfRows: Long,
     newBuildKeys: Seq[Expression] = Seq.empty)
   extends BuildSideRelation
   with Logging {
@@ -52,8 +53,12 @@ case class ClickHouseBuildSideRelation(
           s"BHJ value size: " +
             s"${broadCastContext.buildHashTableId} = ${batches.length}")
         // Build the hash table
-        hashTableData =
-          StorageJoinBuilder.build(batches, broadCastContext, newBuildKeys.asJava, output.asJava)
+        hashTableData = StorageJoinBuilder.build(
+          batches,
+          numOfRows,
+          broadCastContext,
+          newBuildKeys.asJava,
+          output.asJava)
         (hashTableData, this)
       } else {
         (StorageJoinBuilder.nativeCloneBuildHashTable(hashTableData), null)

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHHashBuildBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHHashBuildBenchmark.scala
@@ -46,7 +46,7 @@ object CHHashBuildBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark w
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    // /home/chang/test/tpch/parquet/s100/supplier 3 * 20 false
+    // /home/chang/test/tpch/parquet/s100/supplier * 200
     val (parquetDir, scanSchema, executedCnt) =
       if (mainArgs.isEmpty) {
         ("/data/tpch-data/parquet/lineitem", "l_orderkey,l_receiptdate", 5)
@@ -82,6 +82,7 @@ object CHHashBuildBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark w
               for (i <- 0 until iteration) {
                 val table = StorageJoinBuilder.build(
                   bytes,
+                  num,
                   relation,
                   new util.ArrayList[Expression](),
                   new util.ArrayList[Attribute]())

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHStorageJoinBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHStorageJoinBenchmark.scala
@@ -49,7 +49,7 @@ object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
   }
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
 
-    // /home/chang/test/tpch/parquet/s100/supplier 3 * 20 false
+    // /home/chang/test/tpch/parquet/s100/supplier * 200
     val (parquetDir, scanSchema, executedCnt) =
       if (mainArgs.isEmpty) {
         ("/data/tpch-data/parquet/lineitem", "l_orderkey,l_receiptdate", 5)
@@ -110,6 +110,7 @@ object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
       NoopBroadcastMode,
       child.output,
       allBytes,
+      count0,
       Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
   }
 
@@ -133,6 +134,7 @@ object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
       NoopBroadcastMode,
       child.output,
       allBytes,
+      count0,
       Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
   }
 
@@ -154,6 +156,7 @@ object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
       NoopBroadcastMode,
       child.output,
       allBytes,
+      count0,
       Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
   }
 
@@ -175,6 +178,7 @@ object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
       NoopBroadcastMode,
       child.output,
       allBytes,
+      count0,
       Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
   }
 
@@ -205,6 +209,7 @@ object CHStorageJoinBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
       NoopBroadcastMode,
       child.output,
       allBytes,
+      count0,
       Seq(BoundReference(0, child.output.head.dataType, child.output.head.nullable)))
   }
 

--- a/cpp-ch/local-engine/Join/BroadCastJoinBuilder.cpp
+++ b/cpp-ch/local-engine/Join/BroadCastJoinBuilder.cpp
@@ -32,7 +32,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
-    extern const int UNKNOWN_TYPE;
+extern const int UNKNOWN_TYPE;
 }
 }
 
@@ -40,102 +40,94 @@ namespace local_engine
 {
 namespace BroadCastJoinBuilder
 {
-    static jclass Java_CHBroadcastBuildSideCache = nullptr;
-    static jmethodID Java_get = nullptr;
-    jlong callJavaGet(const std::string & id)
-    {
-        GET_JNIENV(env)
-        jstring s = charTojstring(env, id.c_str());
-        auto result = safeCallStaticLongMethod(env, Java_CHBroadcastBuildSideCache, Java_get, s);
-        CLEAN_JNIENV
+static jclass Java_CHBroadcastBuildSideCache = nullptr;
+static jmethodID Java_get = nullptr;
+jlong callJavaGet(const std::string & id)
+{
+    GET_JNIENV(env)
+    const jstring s = charTojstring(env, id.c_str());
+    const auto result = safeCallStaticLongMethod(env, Java_CHBroadcastBuildSideCache, Java_get, s);
+    CLEAN_JNIENV
 
-        return result;
-    }
+    return result;
+}
 
-    void cleanBuildHashTable(const std::string & hash_table_id, jlong instance)
-    {
-        /// Thread status holds raw pointer on query context, thus it always must be destroyed
-        /// It always called by no thread_status. We need create first.
-        /// Otherwise global tracker will not free bhj memory.
-        DB::ThreadStatus thread_status;
-        SharedPointerWrapper<StorageJoinFromReadBuffer>::dispose(instance);
-        LOG_DEBUG(&Poco::Logger::get("BroadCastJoinBuilder"), "Broadcast hash table {} is cleaned", hash_table_id);
-    }
+void cleanBuildHashTable(const std::string & hash_table_id, jlong instance)
+{
+    /// Thread status holds raw pointer on query context, thus it always must be destroyed
+    /// It always called by no thread_status. We need create first.
+    /// Otherwise global tracker will not free bhj memory.
+    DB::ThreadStatus thread_status;
+    SharedPointerWrapper<StorageJoinFromReadBuffer>::dispose(instance);
+    LOG_DEBUG(&Poco::Logger::get("BroadCastJoinBuilder"), "Broadcast hash table {} is cleaned", hash_table_id);
+}
 
-    std::shared_ptr<StorageJoinFromReadBuffer> getJoin(const std::string & key)
-    {
-        jlong result = callJavaGet(key);
+std::shared_ptr<StorageJoinFromReadBuffer> getJoin(const std::string & key)
+{
+    const jlong result = callJavaGet(key);
 
-        if (unlikely(result == 0))
-        {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "broadcast table {} not found in cache.", key);
-        }
+    if (unlikely(result == 0))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "broadcast table {} not found in cache.", key);
 
-        auto wrapper = SharedPointerWrapper<StorageJoinFromReadBuffer>::sharedPtr(result);
-        if (unlikely(!wrapper))
-        {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "broadcast table {} not found, cache value is invalidated.", key);
-        }
+    auto wrapper = SharedPointerWrapper<StorageJoinFromReadBuffer>::sharedPtr(result);
+    if (unlikely(!wrapper))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "broadcast table {} not found, cache value is invalidated.", key);
 
-        return wrapper;
-    }
+    return wrapper;
+}
 
-    std::shared_ptr<StorageJoinFromReadBuffer> buildJoin(
-        const std::string & key,
-        jobject input,
-        const std::string & join_keys,
-        substrait::JoinRel_JoinType join_type,
-        const std::string & named_struct)
-    {
-        auto join_key_list = Poco::StringTokenizer(join_keys, ",");
-        Names key_names;
-        for (const auto & key_name : join_key_list)
-        {
-            key_names.emplace_back(key_name);
-        }
-        DB::JoinKind kind;
-        DB::JoinStrictness strictness;
+std::shared_ptr<StorageJoinFromReadBuffer> buildJoin(
+    const std::string & key,
+    DB::ReadBuffer & input,
+    jlong row_count,
+    const std::string & join_keys,
+    substrait::JoinRel_JoinType join_type,
+    const std::string & named_struct)
+{
+    auto join_key_list = Poco::StringTokenizer(join_keys, ",");
+    Names key_names;
+    for (const auto & key_name : join_key_list)
+        key_names.emplace_back(key_name);
+    DB::JoinKind kind;
+    DB::JoinStrictness strictness;
 
-        std::tie(kind, strictness) = getJoinKindAndStrictness(join_type);
+    std::tie(kind, strictness) = getJoinKindAndStrictness(join_type);
 
-        substrait::NamedStruct substrait_struct;
-        substrait_struct.ParseFromString(named_struct);
-        Block header = TypeParser::buildBlockFromNamedStruct(substrait_struct);
-        ColumnsDescription columns_description(header.getNamesAndTypesList());
+    substrait::NamedStruct substrait_struct;
+    substrait_struct.ParseFromString(named_struct);
+    Block header = TypeParser::buildBlockFromNamedStruct(substrait_struct);
+    ColumnsDescription columns_description(header.getNamesAndTypesList());
 
-        ReadBufferFromJavaInputStream in(input);
-        CompressedReadBuffer compressed_in(in);
-        configureCompressedReadBuffer(compressed_in);
+    return make_shared<StorageJoinFromReadBuffer>(
+        input,
+        row_count,
+        key_names,
+        true,
+        std::make_shared<DB::TableJoin>(SizeLimits(), true, kind, strictness, key_names),
+        columns_description,
+        ConstraintsDescription(),
+        key,
+        true);
+}
 
-        return make_shared<StorageJoinFromReadBuffer>(
-            compressed_in,
-            key_names,
-            true,
-            std::make_shared<DB::TableJoin>(SizeLimits(), true, kind, strictness, key_names),
-            columns_description,
-            ConstraintsDescription(),
-            key,
-            true);
-    }
-
-    void init(JNIEnv * env)
-    {
-        /**
+void init(JNIEnv * env)
+{
+    /**
      * Scala object will be compiled into two classes, one is with '$' suffix which is normal class,
      * and one is utility class which only has static method.
      *
      * Here, we use utility class.
      */
 
-        const char * classSig = "Lio/glutenproject/execution/CHBroadcastBuildSideCache;";
-        Java_CHBroadcastBuildSideCache = CreateGlobalClassReference(env, classSig);
-        Java_get = GetStaticMethodID(env, Java_CHBroadcastBuildSideCache, "get", "(Ljava/lang/String;)J");
-    }
+    const char * classSig = "Lio/glutenproject/execution/CHBroadcastBuildSideCache;";
+    Java_CHBroadcastBuildSideCache = CreateGlobalClassReference(env, classSig);
+    Java_get = GetStaticMethodID(env, Java_CHBroadcastBuildSideCache, "get", "(Ljava/lang/String;)J");
+}
 
-    void destroy(JNIEnv * env)
-    {
-        env->DeleteGlobalRef(Java_CHBroadcastBuildSideCache);
-    }
+void destroy(JNIEnv * env)
+{
+    env->DeleteGlobalRef(Java_CHBroadcastBuildSideCache);
+}
 
 }
 }

--- a/cpp-ch/local-engine/Join/BroadCastJoinBuilder.h
+++ b/cpp-ch/local-engine/Join/BroadCastJoinBuilder.h
@@ -19,9 +19,10 @@
 #include <jni.h>
 #include <substrait/algebra.pb.h>
 
-// Forward Declarations
-struct JNIEnv_;
-using JNIEnv = JNIEnv_;
+namespace DB
+{
+class ReadBuffer;
+}
 
 namespace local_engine
 {
@@ -29,17 +30,18 @@ class StorageJoinFromReadBuffer;
 namespace BroadCastJoinBuilder
 {
 
-    std::shared_ptr<StorageJoinFromReadBuffer> buildJoin(
-        const std::string & key,
-        jobject input,
-        const std::string & join_keys,
-        substrait::JoinRel_JoinType join_type,
-        const std::string & named_struct);
-    void cleanBuildHashTable(const std::string & hash_table_id, jlong instance);
-    std::shared_ptr<StorageJoinFromReadBuffer> getJoin(const std::string & hash_table_id);
+std::shared_ptr<StorageJoinFromReadBuffer> buildJoin(
+    const std::string & key,
+    DB::ReadBuffer & input,
+    jlong row_count,
+    const std::string & join_keys,
+    substrait::JoinRel_JoinType join_type,
+    const std::string & named_struct);
+void cleanBuildHashTable(const std::string & hash_table_id, jlong instance);
+std::shared_ptr<StorageJoinFromReadBuffer> getJoin(const std::string & hash_table_id);
 
 
-    void init(JNIEnv *);
-    void destroy(JNIEnv *);
+void init(JNIEnv *);
+void destroy(JNIEnv *);
 }
 }

--- a/cpp-ch/local-engine/Join/StorageJoinFromReadBuffer.h
+++ b/cpp-ch/local-engine/Join/StorageJoinFromReadBuffer.h
@@ -33,6 +33,7 @@ class StorageJoinFromReadBuffer
 public:
     StorageJoinFromReadBuffer(
         DB::ReadBuffer & in_,
+        size_t row_count_,
         const DB::Names & key_names_,
         bool use_nulls_,
         std::shared_ptr<DB::TableJoin> table_join_,

--- a/cpp-ch/local-engine/Shuffle/ShuffleReader.h
+++ b/cpp-ch/local-engine/Shuffle/ShuffleReader.h
@@ -34,7 +34,8 @@ class ReadBufferFromJavaInputStream;
 class ShuffleReader : BlockIterator
 {
 public:
-    explicit ShuffleReader(std::unique_ptr<DB::ReadBuffer> in_, bool compressed, Int64 max_shuffle_read_rows_, Int64 max_shuffle_read_bytes_);
+    explicit ShuffleReader(
+        std::unique_ptr<DB::ReadBuffer> in_, bool compressed, Int64 max_shuffle_read_rows_, Int64 max_shuffle_read_bytes_);
     DB::Block * read();
     ~ShuffleReader();
     static jclass input_stream_class;
@@ -51,7 +52,7 @@ private:
 };
 
 
-class ReadBufferFromJavaInputStream : public DB::BufferWithOwnMemory<DB::ReadBuffer>
+class ReadBufferFromJavaInputStream final : public DB::BufferWithOwnMemory<DB::ReadBuffer>
 {
 public:
     explicit ReadBufferFromJavaInputStream(jobject input_stream);
@@ -59,7 +60,19 @@ public:
 
 private:
     jobject java_in;
-    int readFromJava();
+    int readFromJava() const;
+    bool nextImpl() override;
+};
+
+class ReadBufferFromByteArray final : public DB::BufferWithOwnMemory<DB::ReadBuffer>
+{
+public:
+    ReadBufferFromByteArray(const jbyteArray array, const size_t array_size) : array_(array), array_size_(array_size) { }
+
+private:
+    const jbyteArray array_;
+    const size_t array_size_;
+    size_t read_pos_ = 0;
     bool nextImpl() override;
 };
 

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -18,7 +18,9 @@
 #include <regex>
 #include <string>
 #include <jni.h>
+
 #include <Builder/SerializedPlanBuilder.h>
+#include <Compression/CompressedReadBuffer.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Join/BroadCastJoinBuilder.h>
 #include <Operator/BlockCoalesceOperator.h>
@@ -95,7 +97,7 @@ extern "C" {
 
 namespace dbms
 {
-    class LocalExecutor;
+class LocalExecutor;
 }
 
 static jclass spark_row_info_class;
@@ -140,7 +142,8 @@ JNIEXPORT jint JNI_OnLoad(JavaVM * vm, void * /*reserved*/)
     local_engine::SourceFromJavaIter::serialized_record_batch_iterator_next
         = local_engine::GetMethodID(env, local_engine::SourceFromJavaIter::serialized_record_batch_iterator_class, "next", "()[B");
 
-    local_engine::ShuffleReader::input_stream_read = local_engine::GetMethodID(env, local_engine::ShuffleReader::input_stream_class, "read", "(JJ)J");
+    local_engine::ShuffleReader::input_stream_read
+        = local_engine::GetMethodID(env, local_engine::ShuffleReader::input_stream_class, "read", "(JJ)J");
 
     local_engine::NativeSplitter::iterator_has_next
         = local_engine::GetMethodID(env, local_engine::NativeSplitter::iterator_class, "hasNext", "()Z");
@@ -408,9 +411,7 @@ JNIEXPORT jboolean Java_io_glutenproject_vectorized_CHColumnVector_nativeGetBool
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     return nested_col->getBool(row_id);
     LOCAL_ENGINE_JNI_METHOD_END(env, false)
 }
@@ -422,9 +423,7 @@ JNIEXPORT jbyte Java_io_glutenproject_vectorized_CHColumnVector_nativeGetByte(
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     return reinterpret_cast<const jbyte *>(nested_col->getDataAt(row_id).data)[0];
     LOCAL_ENGINE_JNI_METHOD_END(env, 0)
 }
@@ -436,9 +435,7 @@ JNIEXPORT jshort Java_io_glutenproject_vectorized_CHColumnVector_nativeGetShort(
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     return reinterpret_cast<const jshort *>(nested_col->getDataAt(row_id).data)[0];
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)
 }
@@ -450,17 +447,11 @@ JNIEXPORT jint Java_io_glutenproject_vectorized_CHColumnVector_nativeGetInt(
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     if (col.type->getTypeId() == DB::TypeIndex::Date)
-    {
         return nested_col->getUInt(row_id);
-    }
     else
-    {
         return nested_col->getInt(row_id);
-    }
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)
 }
 
@@ -471,9 +462,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHColumnVector_nativeGetLong(
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     return nested_col->getInt(row_id);
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)
 }
@@ -485,9 +474,7 @@ JNIEXPORT jfloat Java_io_glutenproject_vectorized_CHColumnVector_nativeGetFloat(
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     return nested_col->getFloat32(row_id);
     LOCAL_ENGINE_JNI_METHOD_END(env, 0.0)
 }
@@ -499,9 +486,7 @@ JNIEXPORT jdouble Java_io_glutenproject_vectorized_CHColumnVector_nativeGetDoubl
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     return nested_col->getFloat64(row_id);
     LOCAL_ENGINE_JNI_METHOD_END(env, 0.0)
 }
@@ -513,9 +498,7 @@ JNIEXPORT jstring Java_io_glutenproject_vectorized_CHColumnVector_nativeGetStrin
     auto col = getColumnFromColumnVector(env, obj, block_address, column_position);
     DB::ColumnPtr nested_col = col.column;
     if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
-    {
         nested_col = nullable_col->getNestedColumnPtr();
-    }
     const auto * string_col = checkAndGetColumn<DB::ColumnString>(nested_col.get());
     auto result = string_col->getDataAt(row_id);
     return local_engine::charTojstring(env, result.toString().c_str());
@@ -569,7 +552,8 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHStreamReader_createNativeShuf
     LOCAL_ENGINE_JNI_METHOD_START
     auto * input = env->NewGlobalRef(input_stream);
     auto read_buffer = std::make_unique<local_engine::ReadBufferFromJavaInputStream>(input);
-    auto * shuffle_reader = new local_engine::ShuffleReader(std::move(read_buffer), compressed, max_shuffle_read_rows, max_shuffle_read_bytes);
+    auto * shuffle_reader
+        = new local_engine::ShuffleReader(std::move(read_buffer), compressed, max_shuffle_read_rows, max_shuffle_read_bytes);
     return reinterpret_cast<jlong>(shuffle_reader);
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)
 }
@@ -704,13 +688,9 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_CHShuffleSplitterJniWrapper_nat
     auto name = jstring2string(env, short_name);
     local_engine::SplitterHolder * splitter;
     if (prefer_spill)
-    {
         splitter = new local_engine::SplitterHolder{.splitter = local_engine::ShuffleSplitter::create(name, options)};
-    }
     else
-    {
         splitter = new local_engine::SplitterHolder{.splitter = std::make_unique<local_engine::CachedShuffleWriter>(name, options)};
-    }
     return reinterpret_cast<jlong>(splitter);
     LOCAL_ENGINE_JNI_METHOD_END(env, -1)
 }
@@ -852,9 +832,7 @@ Java_io_glutenproject_vectorized_CHBlockConverterJniWrapper_convertColumnarToRow
         jint * values = env->GetIntArrayElements(masks, &is_cp);
         mask = std::make_unique<std::vector<size_t>>();
         for (int j = 0; j < size; j++)
-        {
             mask->push_back(values[j]);
-        }
         env->ReleaseIntArrayElements(masks, values, JNI_ABORT);
     }
     spark_row_info = converter.convertCHColumnToSparkRow(*block, mask);
@@ -1036,19 +1014,22 @@ JNIEXPORT jobject Java_org_apache_spark_sql_execution_datasources_CHDatasourceJn
 }
 
 JNIEXPORT jlong Java_io_glutenproject_vectorized_StorageJoinBuilder_nativeBuild(
-    JNIEnv * env, jclass, jstring hash_table_id_, jobject in, jstring join_key_, jint join_type_, jbyteArray named_struct)
+    JNIEnv * env, jclass, jstring key, jbyteArray in, jlong row_count_, jstring join_key_, jint join_type_, jbyteArray named_struct)
 {
     LOCAL_ENGINE_JNI_METHOD_START
-    auto * input = env->NewGlobalRef(in);
-    auto hash_table_id = jstring2string(env, hash_table_id_);
-    auto join_key = jstring2string(env, join_key_);
-    jsize struct_size = env->GetArrayLength(named_struct);
+    const auto hash_table_id = jstring2string(env, key);
+    const auto join_key = jstring2string(env, join_key_);
+    const jsize struct_size = env->GetArrayLength(named_struct);
     jbyte * struct_address = env->GetByteArrayElements(named_struct, nullptr);
     std::string struct_string;
     struct_string.assign(reinterpret_cast<const char *>(struct_address), struct_size);
-    substrait::JoinRel_JoinType join_type = static_cast<substrait::JoinRel_JoinType>(join_type_);
-    auto * obj = local_engine::make_wrapper(
-        local_engine::BroadCastJoinBuilder::buildJoin(hash_table_id, input, join_key, join_type, struct_string));
+    const auto join_type = static_cast<substrait::JoinRel_JoinType>(join_type_);
+    const jsize length = env->GetArrayLength(in);
+    local_engine::ReadBufferFromByteArray read_buffer_from_java_array(in, length);
+    DB::CompressedReadBuffer input(read_buffer_from_java_array);
+    local_engine::configureCompressedReadBuffer(input);
+    const auto * obj
+        = make_wrapper(local_engine::BroadCastJoinBuilder::buildJoin(hash_table_id, input, row_count_, join_key, join_type, struct_string));
     env->ReleaseByteArrayElements(named_struct, struct_address, JNI_ABORT);
     return obj->instance();
     LOCAL_ENGINE_JNI_METHOD_END(env, 0)
@@ -1074,7 +1055,15 @@ Java_io_glutenproject_vectorized_StorageJoinBuilder_nativeCleanBuildHashTable(JN
 
 // BlockSplitIterator
 JNIEXPORT jlong Java_io_glutenproject_vectorized_BlockSplitIterator_nativeCreate(
-    JNIEnv * env, jobject, jobject in, jstring name, jstring expr, jstring schema, jint partition_num, jint buffer_size, jstring hash_algorithm)
+    JNIEnv * env,
+    jobject,
+    jobject in,
+    jstring name,
+    jstring expr,
+    jstring schema,
+    jint partition_num,
+    jint buffer_size,
+    jstring hash_algorithm)
 {
     LOCAL_ENGINE_JNI_METHOD_START
     local_engine::NativeSplitter::Options options;
@@ -1085,9 +1074,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_BlockSplitIterator_nativeCreate
     auto expr_str = jstring2string(env, expr);
     std::string schema_str;
     if (schema)
-    {
         schema_str = jstring2string(env, schema);
-    }
     options.exprs_buffer.swap(expr_str);
     options.schema_buffer.swap(schema_str);
     local_engine::NativeSplitter::Holder * splitter = new local_engine::NativeSplitter::Holder{


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR has two improvements:

1. Instead of utilizing the `ShuffleInputStream`, it is advantageous to directly copy memory from the Java array for small broadcast scenarios.
2. For larger broadcasts, it is beneficial to allocate hashmap size based on the broadcast size. 

However, there is no significant enhancement observed in end-to-end performance. Nevertheless, let us merge as it did the appropriate work.

Before this pr
```
OpenJDK 64-Bit Server VM 1.8.0_392-8u392-ga-1~20.04-b08 on Linux 5.15.0-91-generic
13th Gen Intel(R) Core(TM) i9-13900KF
Build Broadcast Hash Table with 1000000 rows:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------
build hash table with 15625 rows with 64 hash tables              74             78           3         13.6          73.8       1.0X
build hash table with 31250 rows with 32 hash tables              73             75           2         13.8          72.5       1.0X
build hash table with 62500 rows with 16 hash tables              77             81           2         13.0          76.8       1.0X
build hash table with 125000 rows with 8 hash tables              73             75           2         13.8          72.6       1.0X
build hash table with 250000 rows with 4 hash tables              88             91           2         11.3          88.3       0.8X
build hash table with 500000 rows with 2 hash tables              82            104          27         12.2          82.0       0.9X
build hash table with 1000000 rows with 1 hash tables             94            107          21         10.6          94.1       0.8X
```
After this pr

```
OpenJDK 64-Bit Server VM 1.8.0_392-8u392-ga-1~20.04-b08 on Linux 5.15.0-91-generic
13th Gen Intel(R) Core(TM) i9-13900KF
Build Broadcast Hash Table with 1000000 rows:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------
build hash table with 15625 rows with 64 hash tables              60             62           1         16.6          60.1       1.0X
build hash table with 31250 rows with 32 hash tables              62             63           1         16.3          61.5       1.0X
build hash table with 62500 rows with 16 hash tables              60             63           1         16.6          60.3       1.0X
build hash table with 125000 rows with 8 hash tables              65             69           2         15.4          65.0       0.9X
build hash table with 250000 rows with 4 hash tables              71             74           1         14.1          71.0       0.8X
build hash table with 500000 rows with 2 hash tables              75             78           1         13.3          75.0       0.8X
build hash table with 1000000 rows with 1 hash tables             75             78           2         13.3          75.4       0.8X
```

(Fixes: \#2723)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

