### PR TITLE
[VL] Daily Update Velox Version (2024-01-02)

### DIFF
--- a/cpp/CMake/BuildMemkind.cmake
+++ b/cpp/CMake/BuildMemkind.cmake
@@ -17,6 +17,12 @@
 
 include(ExternalProject)
 
+if("${MAKE}" STREQUAL "")
+  if(NOT MSVC)
+    find_program(MAKE make)
+  endif()
+endif()
+
 macro(build_hwloc)
   message(STATUS "Building hwloc from source")
   set(HWLOC_BUILD_VERSION "2.8.0")
@@ -43,7 +49,7 @@ macro(build_hwloc)
           URL_HASH "SHA256=${HWLOC_BUILD_SHA256_CHECKSUM}"
           SOURCE_DIR ${HWLOC_SOURCE_DIR}
           CONFIGURE_COMMAND ./configure ${HWLOC_CONFIGURE_ARGS}
-          BUILD_COMMAND $(MAKE)
+          BUILD_COMMAND ${MAKE}
           BUILD_BYPRODUCTS ${HWLOC_STATIC_LIB_TARGETS}
           BUILD_IN_SOURCE 1)
 
@@ -90,7 +96,7 @@ macro(build_memkind)
           URL_HASH "SHA256=${MEMKIND_BUILD_SHA256_CHECKSUM}"
           SOURCE_DIR ${MEMKIND_SOURCE_DIR}
           CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env LDFLAGS=-L${HWLOC_LIB_DIR} env CFLAGS=-I${HWLOC_INCLUDE_DIR} env CXXFLAGS=-I${HWLOC_INCLUDE_DIR} ./configure ${MEMKIND_CONFIGURE_ARGS}
-          BUILD_COMMAND $(MAKE)
+          BUILD_COMMAND ${MAKE}
           BUILD_BYPRODUCTS ${MEMKIND_STATIC_LIB_TARGETS}
           BUILD_IN_SOURCE 1)
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2023_12_29
+VELOX_BRANCH=2024_01_02
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_02
+VELOX_BRANCH=update
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
e907a8001 (upstream/main) Remove the legacy memory allocator code (#8208)
523e561d3 Enable VELOX_ENABLE_PARSE with VELOX_BUILD_TEST_UTILS (#8206)
79bd41051 Fix slow scale writer in Prestissimo (#8172)
aae50540f Guard against AppendWindow destructor throw (#8203)
7c961b25d Fix join spill under split group execution mode (#8178)
da76973af Fix estimateRowSize with wrapper (#8199)
0c02963d8 Add VectorFuzzer::Options in VectorTestBase::createVectors (#8197)
6080a6a69 Memory allocator management refactor (#8094)
```

As the API has changed, this PR removed HBM allocator for Velox. Currently, HBM is mainly used for shuffle (arrow allocator). We should clean up the HBM memory allocator and use [autoHBW](https://manpages.debian.org/experimental/libmemkind-dev/autohbw.7.en.html) in the future.