### PR TITLE
[VL] Fix shuffle writer invalid write

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -961,6 +961,8 @@ arrow::Status VeloxShuffleWriter::splitFixedWidthValueBuffer(const facebook::vel
           binaryBuf.valuePtr = valueBuffer->mutable_data();
           binaryBuf.valueCapacity = capacity;
           dstValuePtr = binaryBuf.valuePtr + valueOffset - stringLen;
+          // Need to update dstOffsetBase because lengthPtr can be updated if Reserve triggers spill.
+          dstOffsetBase = (BinaryArrayLengthBufferType*)(binaryBuf.lengthPtr) + partitionBufferIdxBase_[pid];
         }
 
         // 2. copy value


### PR DESCRIPTION
Fix Invalid write reported by valgrind

```
/usr/bin/valgrind gluten/cpp/build/velox/tests/velox_shuffle_writer_test --gtest_filter=VeloxShuffleWriterMemoryTest.resizeBinaryBufferTriggerSpill

[ RUN      ] VeloxShuffleWriterMemoryTest.resizeBinaryBufferTriggerSpill
I1225 19:09:26.151989 714619 VeloxShuffleWriter.cc:1227] Evicted all cached payloads. 0 bytes released
==714619== Invalid write of size 4
==714619==    at 0xF9D664D: gluten::VeloxShuffleWriter::splitBinaryType(unsigned int, facebook::velox::FlatVector<facebook::velox::StringView> const&, std::vector<gluten::VeloxShuffleWriter::BinaryBuf, std::allocator<gluten::VeloxShuffleWriter::BinaryBuf> >&) (VeloxShuffleWriter.cc:746)
==714619==    by 0xF9D6A78: gluten::VeloxShuffleWriter::splitBinaryArray(facebook::velox::RowVector const&) (VeloxShuffleWriter.cc:787)
==714619==    by 0xF9D4D51: gluten::VeloxShuffleWriter::splitRowVector(facebook::velox::RowVector const&) (VeloxShuffleWriter.cc:474)
==714619==    by 0xF9D4ADF: gluten::VeloxShuffleWriter::doSplit(facebook::velox::RowVector const&, long) (VeloxShuffleWriter.cc:460)
==714619==    by 0xF9D3B64: gluten::VeloxShuffleWriter::split(std::shared_ptr<gluten::ColumnarBatch>, long) (VeloxShuffleWriter.cc:361)
==714619==    by 0x2E0E7F: gluten::VeloxShuffleWriterTestBase::splitRowVector(gluten::VeloxShuffleWriter&, std::shared_ptr<facebook::velox::RowVector>) (VeloxShuffleWriterTestBase.h:183)
==714619==    by 0x2C9609: gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}::operator()() const (VeloxShuffleWriterTest.cc:674)
==714619==    by 0x2CC4C7: void std::__invoke_impl<void, gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}&>(std::__invoke_other, gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}&) (invoke.h:61)
==714619==    by 0x2CBDFC: std::enable_if<is_invocable_r_v<void, gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}&>, void>::type std::__invoke_r<void, gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}&>(gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}&) (invoke.h:111)
==714619==    by 0x2CB151: std::_Function_handler<void (), gluten::VeloxShuffleWriterMemoryTest_resizeBinaryBufferTriggerSpill_Test::TestBody()::{lambda()#1}>::_M_invoke(std::_Any_data const&) (std_function.h:290)
==714619==    by 0xFAC7D05: std::function<void ()>::operator()() const (std_function.h:590)
==714619==    by 0xFAC7384: gluten::SelfEvictedMemoryPool::checkEvict(long, std::function<void ()>) (MemoryPoolUtils.cc:71)
==714619==  Address 0x27ec8444 is 10,244 bytes inside a block of size 16,384 free'd
==714619==    at 0x484DCD3: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==714619==    by 0x20EC25F0: gluten::StdMemoryAllocator::reallocate(void*, long, long, void**) (MemoryAllocator.cc:126)
==714619==    by 0x20EC26A6: gluten::StdMemoryAllocator::reallocateAligned(void*, unsigned long, long, long, void**) (MemoryAllocator.cc:139)
==714619==    by 0x20EC38A8: gluten::ArrowMemoryPool::Reallocate(long, long, long, unsigned char**) (ArrowMemoryPool.cc:37)
==714619==    by 0xFAC7646: gluten::SelfEvictedMemoryPool::Reallocate(long, long, long, unsigned char**) (MemoryPoolUtils.cc:102)
==714619==    by 0x20EF2998: gluten::ShuffleMemoryPool::Reallocate(long, long, long, unsigned char**) (ShuffleMemoryPool.cc:37)
==714619==    by 0x226BD81F: arrow::PoolBuffer::Resize(long, bool) (memory_pool.cc:886)
==714619==    by 0x2CFDD3: arrow::ResizableBuffer::Resize(long) (buffer.h:493)
==714619==    by 0xF9DB86F: gluten::VeloxShuffleWriter::resizePartitionBuffer(unsigned int, long, bool) (VeloxShuffleWriter.cc:1273)
==714619==    by 0xF9DC03F: gluten::VeloxShuffleWriter::shrinkPartitionBuffer(unsigned int) (VeloxShuffleWriter.cc:1340)
==714619==    by 0xF9DC6F1: gluten::VeloxShuffleWriter::shrinkPartitionBuffersMinSize(long) (VeloxShuffleWriter.cc:1423)
==714619==    by 0xF9DAE6F: gluten::VeloxShuffleWriter::reclaimFixedSize(long, long*) (VeloxShuffleWriter.cc:1206)
==714619==  Block was alloc'd at
==714619==    at 0x484E120: memalign (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==714619==    by 0x20EC2594: gluten::StdMemoryAllocator::allocateAligned(unsigned long, long, void**) (MemoryAllocator.cc:120)
==714619==    by 0x20EC3700: gluten::ArrowMemoryPool::Allocate(long, long, unsigned char**) (ArrowMemoryPool.cc:30)
==714619==    by 0xFAC7523: gluten::SelfEvictedMemoryPool::Allocate(long, long, unsigned char**) (MemoryPoolUtils.cc:95)
==714619==    by 0x20EF285D: gluten::ShuffleMemoryPool::Allocate(long, long, unsigned char**) (ShuffleMemoryPool.cc:25)
==714619==    by 0x226BD675: arrow::PoolBuffer::Reserve(long) (memory_pool.cc:867)
==714619==    by 0x226BD8C3: arrow::PoolBuffer::Resize(long, bool) (memory_pool.cc:891)
==714619==    by 0x226BA102: arrow::Result<std::unique_ptr<arrow::ResizableBuffer, std::default_delete<arrow::ResizableBuffer> > > arrow::(anonymous namespace)::ResizePoolBuffer<std::unique_ptr<arrow::ResizableBuffer, std::default_delete<arrow::ResizableBuffer> >, std::unique_ptr<arrow::PoolBuffer, std::default_delete<arrow::PoolBuffer> > >(std::unique_ptr<arrow::PoolBuffer, std::default_delete<arrow::PoolBuffer> >&&, long) (memory_pool.cc:931)
==714619==    by 0x226B9B8D: arrow::AllocateResizableBuffer(long, long, arrow::MemoryPool*) (memory_pool.cc:958)
==714619==    by 0x226B9B19: arrow::AllocateResizableBuffer(long, arrow::MemoryPool*) (memory_pool.cc:951)
==714619==    by 0xF9D88AF: gluten::VeloxShuffleWriter::allocatePartitionBuffer(unsigned int, unsigned int) (VeloxShuffleWriter.cc:1009)
==714619==    by 0xF9DD1A6: gluten::VeloxShuffleWriter::preAllocPartitionBuffers(unsigned int) (VeloxShuffleWriter.cc:1491)
```