### PR TITLE
[GLUTEN-4243][CH] Improve sparkFloor function performance with avx2

### DIFF
--- a/cpp-ch/local-engine/CMakeLists.txt
+++ b/cpp-ch/local-engine/CMakeLists.txt
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+if (ENABLE_MULTITARGET_CODE)
+    add_definitions(-DENABLE_MULTITARGET_CODE=1)
+else()
+    add_definitions(-DENABLE_MULTITARGET_CODE=0)
+endif()
+
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w -ffunction-sections -fdata-sections")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -ffunction-sections -fdata-sections")
 set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-export-dynamic -Wl,--gc-sections")

--- a/cpp-ch/local-engine/Functions/SparkFunctionFloor.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionFloor.h
@@ -105,7 +105,7 @@ DECLARE_AVX2_SPECIFIC_CODE(
             __m256d is_neg_inf = _mm256_cmp_pd(values, neg_inf, _CMP_EQ_OQ);
             __m256d is_nan = _mm256_cmp_pd(values, values, _CMP_NEQ_UQ);
             __m256d is_null = _mm256_or_pd(_mm256_or_pd(is_inf, is_neg_inf), is_nan);
-            __m256d new_values = _mm256_blendv_ps(values, zero, is_null);
+            __m256d new_values = _mm256_blendv_pd(values, zero, is_null);
 
             _mm256_storeu_pd(&data[i], new_values);
 

--- a/cpp-ch/local-engine/Functions/SparkFunctionFloor.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionFloor.h
@@ -60,7 +60,7 @@ static void checkAndSetNullable(T & t, UInt8 & null_flag)
 
 DECLARE_AVX2_SPECIFIC_CODE(
 
-    inline void checkNullFloat32SIMD(Float32 * data, UInt8 * null_map, size_t size) {
+    inline void checkFloat32AndSetNullable(Float32 * data, UInt8 * null_map, size_t size) {
         const __m256 inf = _mm256_set1_ps(INFINITY);
         const __m256 neg_inf = _mm256_set1_ps(-INFINITY);
         const __m256 zero = _mm256_set1_ps(0.0f);
@@ -91,7 +91,7 @@ DECLARE_AVX2_SPECIFIC_CODE(
             checkAndSetNullable(data[i], null_map[i]);
     }
 
-    inline void checkNullFloat64SIMD(Float64 * data, UInt8 * null_map, size_t size) {
+    inline void checkFloat64AndSetNullable(Float64 * data, UInt8 * null_map, size_t size) {
         const __m256d inf = _mm256_set1_pd(INFINITY);
         const __m256d neg_inf = _mm256_set1_pd(-INFINITY);
         const __m256d zero = _mm256_set1_pd(0.0);
@@ -160,9 +160,9 @@ public:
         if (isArchSupported(TargetArch::AVX2))
         {
             if constexpr (std::is_same_v<T, Float32>)
-                TargetSpecific::AVX2::checkNullFloat32SIMD(out.data(), null_map.data(), out.size());
+                TargetSpecific::AVX2::checkFloat32AndSetNullable(out.data(), null_map.data(), out.size());
             else if constexpr (std::is_same_v<T, Float64>)
-                TargetSpecific::AVX2::checkNullFloat64SIMD(out.data(), null_map.data(), out.size());
+                TargetSpecific::AVX2::checkFloat64AndSetNullable(out.data(), null_map.data(), out.size());
         }
         else
         {

--- a/cpp-ch/local-engine/Shuffle/ShuffleSplitter.h
+++ b/cpp-ch/local-engine/Shuffle/ShuffleSplitter.h
@@ -119,6 +119,7 @@ class ShuffleSplitter : public ShuffleWriterBase
 {
 public:
     inline const static std::vector<std::string> compress_methods =  {"", "ZSTD", "LZ4"};
+
     static ShuffleSplitterPtr create(const std::string & short_name, const SplitOptions & options_);
 
     explicit ShuffleSplitter(const SplitOptions & options);

--- a/cpp-ch/local-engine/tests/benchmark_local_engine.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_local_engine.cpp
@@ -396,7 +396,7 @@ DB::ContextMutablePtr global_context;
     {
         auto read_buffer = std::make_unique<ReadBufferFromFile>("/tmp/test_shuffle/ZSTD/data.dat");
         //        read_buffer->seek(357841655, SEEK_SET);
-        auto shuffle_reader = local_engine::ShuffleReader(std::move(read_buffer), true);
+        auto shuffle_reader = local_engine::ShuffleReader(std::move(read_buffer), true, -1, -1);
         Block * block;
         int sum = 0;
         do

--- a/cpp-ch/local-engine/tests/benchmark_local_engine.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_local_engine.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <iostream>
 #include <Builder/SerializedPlanBuilder.h>
+#include <Compression/CompressedReadBuffer.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/HashJoin.h>

--- a/cpp-ch/local-engine/tests/benchmark_spark_floor_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_floor_function.cpp
@@ -38,7 +38,11 @@ static Block createDataBlock(String type_str, size_t rows)
     auto column = type->createColumn();
     for (size_t i = 0; i < rows; ++i)
     {
-        if (isInt(type))
+        if (i % 100)
+        {
+            column->insertDefault();
+        }
+        else if (isInt(type))
         {
             column->insert(i);
         }
@@ -58,7 +62,7 @@ static void BM_CHFloorFunction_For_Int64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("floor", local_engine::SerializedPlanParser::global_context);
-    Block int64_block = createDataBlock("Int64", 65536);
+    Block int64_block = createDataBlock("Nullable(Int64)", 65536);
     auto executable = function->build(int64_block.getColumnsWithTypeAndName());
     for (auto _ : state)
     {
@@ -72,7 +76,7 @@ static void BM_CHFloorFunction_For_Float64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("floor", local_engine::SerializedPlanParser::global_context);
-    Block float64_block = createDataBlock("Float64", 65536);
+    Block float64_block = createDataBlock("Nullable(Float64)", 65536);
     auto executable = function->build(float64_block.getColumnsWithTypeAndName());
     for (auto _ : state)
     {
@@ -86,7 +90,7 @@ static void BM_SparkFloorFunction_For_Int64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("sparkFloor", local_engine::SerializedPlanParser::global_context);
-    Block int64_block = createDataBlock("Int64", 65536);
+    Block int64_block = createDataBlock("Nullable(Int64)", 65536);
     auto executable = function->build(int64_block.getColumnsWithTypeAndName());
     for (auto _ : state)
     {
@@ -100,7 +104,7 @@ static void BM_SparkFloorFunction_For_Float64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("sparkFloor", local_engine::SerializedPlanParser::global_context);
-    Block float64_block = createDataBlock("Float64", 65536);
+    Block float64_block = createDataBlock("Nullable(Float64)", 65536);
     auto executable = function->build(float64_block.getColumnsWithTypeAndName());
     for (auto _ : state)
     {
@@ -133,7 +137,7 @@ static void BMNanInfToNullAutoOpt(benchmark::State & state)
         benchmark::DoNotOptimize(null_map);
     }
 }
-BENCHMARK(BMNanInfToNullAutoOpt)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+BENCHMARK(BMNanInfToNullAutoOpt);
 
 DECLARE_AVX2_SPECIFIC_CODE(
 
@@ -172,7 +176,7 @@ static void BMNanInfToNullAVX2(benchmark::State & state)
         benchmark::DoNotOptimize(null_map);
     }
 }
-BENCHMARK(BMNanInfToNullAVX2)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+BENCHMARK(BMNanInfToNullAVX2);
 
 
 DECLARE_AVX512F_SPECIFIC_CODE(
@@ -211,7 +215,7 @@ static void BMNanInfToNullAVX512(benchmark::State & state)
         benchmark::DoNotOptimize(null_map);
     }
 }
-BENCHMARK(BMNanInfToNullAVX512)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+BENCHMARK(BMNanInfToNullAVX512);
 
 static void nanInfToNull(const float * data, uint8_t * null_map, size_t size)
 {
@@ -238,13 +242,9 @@ static void BMNanInfToNull(benchmark::State & state)
         benchmark::DoNotOptimize(null_map);
     }
 }
-BENCHMARK(BMNanInfToNull)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+BENCHMARK(BMNanInfToNull);
 
 
-// BENCHMARK(BM_CHFloorFunction_For_Int64)->Unit(benchmark::kMillisecond)->Iterations(100);
-// BENCHMARK(BM_CHFloorFunction_For_Float64)->Unit(benchmark::kMillisecond)->Iterations(100);
-// BENCHMARK(BM_SparkFloorFunction_For_Int64)->Unit(benchmark::kMillisecond)->Iterations(100);
-// BENCHMARK(BM_SparkFloorFunction_For_Float64)->Unit(benchmark::kMillisecond)->Iterations(100);
 BENCHMARK(BM_CHFloorFunction_For_Int64);
 BENCHMARK(BM_CHFloorFunction_For_Float64);
 BENCHMARK(BM_SparkFloorFunction_For_Int64);

--- a/cpp-ch/local-engine/tests/benchmark_spark_floor_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_spark_floor_function.cpp
@@ -15,15 +15,20 @@
  * limitations under the License.
  */
 
-#include <Core/Block.h>
+#if USE_MULTITARGET_CODE
+#include <immintrin.h>
+#endif
+
 #include <Columns/IColumn.h>
-#include <DataTypes/IDataType.h>
+#include <Core/Block.h>
 #include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
-#include <Functions/SparkFunctionFloor.h>
 #include <Functions/FunctionsRound.h>
+#include <Functions/SparkFunctionFloor.h>
 #include <Parser/SerializedPlanParser.h>
 #include <benchmark/benchmark.h>
+#include <Common/TargetSpecific.h>
 
 using namespace DB;
 
@@ -53,10 +58,13 @@ static void BM_CHFloorFunction_For_Int64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("floor", local_engine::SerializedPlanParser::global_context);
-    Block int64_block = createDataBlock("Int64", 30000000);
+    Block int64_block = createDataBlock("Int64", 65536);
     auto executable = function->build(int64_block.getColumnsWithTypeAndName());
-    for (auto _ : state)[[maybe_unused]]
+    for (auto _ : state)
+    {
         auto result = executable->execute(int64_block.getColumnsWithTypeAndName(), executable->getResultType(), int64_block.rows());
+        benchmark::DoNotOptimize(result);
+    }
 }
 
 static void BM_CHFloorFunction_For_Float64(benchmark::State & state)
@@ -64,10 +72,13 @@ static void BM_CHFloorFunction_For_Float64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("floor", local_engine::SerializedPlanParser::global_context);
-    Block float64_block = createDataBlock("Float64", 30000000);
+    Block float64_block = createDataBlock("Float64", 65536);
     auto executable = function->build(float64_block.getColumnsWithTypeAndName());
-    for (auto _ : state)[[maybe_unused]]
+    for (auto _ : state)
+    {
         auto result = executable->execute(float64_block.getColumnsWithTypeAndName(), executable->getResultType(), float64_block.rows());
+        benchmark::DoNotOptimize(result);
+    }
 }
 
 static void BM_SparkFloorFunction_For_Int64(benchmark::State & state)
@@ -75,10 +86,13 @@ static void BM_SparkFloorFunction_For_Int64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("sparkFloor", local_engine::SerializedPlanParser::global_context);
-    Block int64_block = createDataBlock("Int64", 30000000);
+    Block int64_block = createDataBlock("Int64", 65536);
     auto executable = function->build(int64_block.getColumnsWithTypeAndName());
-    for (auto _ : state) [[maybe_unused]]
+    for (auto _ : state)
+    {
         auto result = executable->execute(int64_block.getColumnsWithTypeAndName(), executable->getResultType(), int64_block.rows());
+        benchmark::DoNotOptimize(result);
+    }
 }
 
 static void BM_SparkFloorFunction_For_Float64(benchmark::State & state)
@@ -86,13 +100,152 @@ static void BM_SparkFloorFunction_For_Float64(benchmark::State & state)
     using namespace DB;
     auto & factory = FunctionFactory::instance();
     auto function = factory.get("sparkFloor", local_engine::SerializedPlanParser::global_context);
-    Block float64_block = createDataBlock("Float64", 30000000);
+    Block float64_block = createDataBlock("Float64", 65536);
     auto executable = function->build(float64_block.getColumnsWithTypeAndName());
-    for (auto _ : state) [[maybe_unused]] 
+    for (auto _ : state)
+    {
         auto result = executable->execute(float64_block.getColumnsWithTypeAndName(), executable->getResultType(), float64_block.rows());
+        benchmark::DoNotOptimize(result);
+    }
 }
 
-BENCHMARK(BM_CHFloorFunction_For_Int64)->Unit(benchmark::kMillisecond)->Iterations(10);
-BENCHMARK(BM_CHFloorFunction_For_Float64)->Unit(benchmark::kMillisecond)->Iterations(10);
-BENCHMARK(BM_SparkFloorFunction_For_Int64)->Unit(benchmark::kMillisecond)->Iterations(10);
-BENCHMARK(BM_SparkFloorFunction_For_Float64)->Unit(benchmark::kMillisecond)->Iterations(10);
+static void nanInfToNullAutoOpt(const float * data, uint8_t * null_map, size_t size)
+{
+    for (size_t i = 0; i < size; ++i)
+    {
+        uint8_t is_nan = (data[i] != data[i]);
+        uint8_t is_inf = ((*reinterpret_cast<const uint32_t *>(&data[i]) & 0b01111111111111111111111111111111) == 0b01111111100000000000000000000000);
+        null_map[i] = is_nan | is_inf;
+    }
+}
+
+static void BMNanInfToNullAutoOpt(benchmark::State & state)
+{
+    constexpr size_t size = 8192;
+    float data[size];
+    uint8_t null_map[size] = {0};
+    for (size_t i = 0; i < size; ++i)
+        data[i] = static_cast<float>(rand()) / rand();
+
+    for (auto _ : state)
+    {
+        nanInfToNullAutoOpt(data, null_map, size);
+        benchmark::DoNotOptimize(null_map);
+    }
+}
+BENCHMARK(BMNanInfToNullAutoOpt)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+
+DECLARE_AVX2_SPECIFIC_CODE(
+
+    void nanInfToNullSIMD(const float * data, uint8_t * null_map, size_t size) {
+        __m256 inf = _mm256_set1_ps(INFINITY);
+        __m256 neg_inf = _mm256_set1_ps(-INFINITY);
+
+        for (size_t i = 0; i < size; i += 8)
+        {
+            __m256 values = _mm256_loadu_ps(&data[i]);
+
+            __m256 cmp_result_inf = _mm256_cmp_ps(values, inf, _CMP_EQ_OQ);
+            __m256 cmp_result_neg_inf = _mm256_cmp_ps(values, neg_inf, _CMP_EQ_OQ);
+            __m256 cmp_result_nan = _mm256_cmp_ps(values, values, _CMP_NEQ_UQ);
+
+            __m256 cmp_result = _mm256_or_ps(_mm256_or_ps(cmp_result_inf, cmp_result_neg_inf), cmp_result_nan);
+
+            int mask = _mm256_movemask_ps(cmp_result);
+            for (size_t j = 0; j < 8; ++j)
+                null_map[i + j] = (mask & (1 << j)) != 0;
+        }
+    }
+)
+
+static void BMNanInfToNullAVX2(benchmark::State & state)
+{
+    constexpr size_t size = 8192;
+    float data[size];
+    uint8_t null_map[size] = {0};
+    for (size_t i = 0; i < size; ++i)
+        data[i] = static_cast<float>(rand()) / rand();
+
+    for (auto _ : state)
+    {
+        ::TargetSpecific::AVX2::nanInfToNullSIMD(data, null_map, size);
+        benchmark::DoNotOptimize(null_map);
+    }
+}
+BENCHMARK(BMNanInfToNullAVX2)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+
+
+DECLARE_AVX512F_SPECIFIC_CODE(
+
+    void nanInfToNullSIMD(const float * data, uint8_t * null_map, size_t size) {
+        __m512 inf = _mm512_set1_ps(INFINITY);
+        __m512 neg_inf = _mm512_set1_ps(-INFINITY);
+
+        for (size_t i = 0; i < size; i += 16)
+        {
+            __m512 values = _mm512_loadu_ps(&data[i]);
+
+            __mmask16 cmp_result_inf = _mm512_cmp_ps_mask(values, inf, _CMP_EQ_OQ);
+            __mmask16 cmp_result_neg_inf = _mm512_cmp_ps_mask(values, neg_inf, _CMP_EQ_OQ);
+            __mmask16 cmp_result_nan = _mm512_cmp_ps_mask(values, values, _CMP_NEQ_UQ);
+
+            __mmask16 cmp_result = cmp_result_inf | cmp_result_neg_inf | cmp_result_nan;
+
+            for (size_t j = 0; j < 16; ++j)
+                null_map[i + j] = (cmp_result & (1 << j)) != 0;
+        }
+    }
+)
+
+static void BMNanInfToNullAVX512(benchmark::State & state)
+{
+    constexpr size_t size = 8192;
+    float data[size];
+    uint8_t null_map[size] = {0};
+    for (size_t i = 0; i < size; ++i)
+        data[i] = static_cast<float>(rand()) / rand();
+
+    for (auto _ : state)
+    {
+        ::TargetSpecific::AVX512F::nanInfToNullSIMD(data, null_map, size);
+        benchmark::DoNotOptimize(null_map);
+    }
+}
+BENCHMARK(BMNanInfToNullAVX512)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+
+static void nanInfToNull(const float * data, uint8_t * null_map, size_t size)
+{
+    for (size_t i = 0; i < size; ++i)
+        if (data[i] != data[i])
+            null_map[i] = 1;
+        else if ((*reinterpret_cast<const uint32_t *>(&data[i]) & 0b01111111111111111111111111111111) == 0b01111111100000000000000000000000)
+            null_map[i] = 1;
+        else
+            null_map[i] = 0;
+}
+
+static void BMNanInfToNull(benchmark::State & state)
+{
+    constexpr size_t size = 8192;
+    float data[size];
+    uint8_t null_map[size] = {0};
+    for (size_t i = 0; i < size; ++i)
+        data[i] = static_cast<float>(rand()) / rand();
+
+    for (auto _ : state)
+    {
+        nanInfToNull(data, null_map, size);
+        benchmark::DoNotOptimize(null_map);
+    }
+}
+BENCHMARK(BMNanInfToNull)->Unit(benchmark::kMicrosecond)->Iterations(10000);
+
+
+// BENCHMARK(BM_CHFloorFunction_For_Int64)->Unit(benchmark::kMillisecond)->Iterations(100);
+// BENCHMARK(BM_CHFloorFunction_For_Float64)->Unit(benchmark::kMillisecond)->Iterations(100);
+// BENCHMARK(BM_SparkFloorFunction_For_Int64)->Unit(benchmark::kMillisecond)->Iterations(100);
+// BENCHMARK(BM_SparkFloorFunction_For_Float64)->Unit(benchmark::kMillisecond)->Iterations(100);
+BENCHMARK(BM_CHFloorFunction_For_Int64);
+BENCHMARK(BM_CHFloorFunction_For_Float64);
+BENCHMARK(BM_SparkFloorFunction_For_Int64);
+BENCHMARK(BM_SparkFloorFunction_For_Float64);


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)   

Fixes: \#4243    cc @KevinyhZou 


``` bash
./build_gcc/utils/extern-local-engine/tests/benchmark_local_engine --benchmark_filter="BM.*Floor.*Float64"               


# 优化前
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_CHFloorFunction_For_Float64         36547 ns        36547 ns        18987
BM_SparkFloorFunction_For_Float64     134542 ns       134537 ns         5219



# 优化1：去掉checkAndSetNullable中的if, 自动simd，相比优化前提升10%
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_CHFloorFunction_For_Float64         36972 ns        36971 ns        18573
BM_SparkFloorFunction_For_Float64     121571 ns       121566 ns         5756


# 优化2: intel intrinsics手动simd，相比优化前提升14%
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_CHFloorFunction_For_Float64         36880 ns        36878 ns        18867
BM_SparkFloorFunction_For_Float64     118141 ns       118135 ns         5939 

```