### PR TITLE
[VL] Follow-up: decouple velox test build from gluten cpp test build and use VELOX_BUILD_TEST_UTILS instead

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -63,7 +63,7 @@ jobs:
           docker exec ubuntu2004-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/ep/build-velox/src && \
           ./get_velox.sh --velox_home=/opt/velox && \
-          ./build_velox.sh --velox_home=/opt/velox --enable_ep_cache=ON --build_tests=ON'
+          ./build_velox.sh --velox_home=/opt/velox --enable_ep_cache=ON --build_test_utils=ON'
       - name: Build Gluten CPP library
         run: |
           docker exec ubuntu2004-test-$GITHUB_RUN_ID bash -c '

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -160,9 +160,9 @@ fi
 concat_velox_param
 cd $GLUTEN_DIR/ep/build-velox/src
 ./get_velox.sh --enable_hdfs=$ENABLE_HDFS --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --enable_abfs=$ENABLE_ABFS $VELOX_PARAMETER
-# When BUILD_TESTS is on for gluten cpp, we need turn on --build_test_utils because of the dependency.
+# When BUILD_TESTS is on for gluten cpp, we need turn on VELOX_BUILD_TEST_UTILS via build_test_utils.
 ./build_velox.sh --run_setup_script=$RUN_SETUP_SCRIPT --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_test_utils=$BUILD_TESTS --build_tests=$BUILD_VELOX_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS \
+                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_test_utils=$BUILD_TESTS --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS \
                  --compile_arrow_java=$COMPILE_ARROW_JAVA
 
 ## compile gluten cpp

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -160,8 +160,9 @@ fi
 concat_velox_param
 cd $GLUTEN_DIR/ep/build-velox/src
 ./get_velox.sh --enable_hdfs=$ENABLE_HDFS --build_protobuf=$BUILD_PROTOBUF --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --enable_abfs=$ENABLE_ABFS $VELOX_PARAMETER
+# When BUILD_TESTS is on for gluten cpp, we need turn on --build_test_utils because of the dependency.
 ./build_velox.sh --run_setup_script=$RUN_SETUP_SCRIPT --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_tests=$BUILD_VELOX_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS \
+                 --enable_abfs=$ENABLE_ABFS --enable_ep_cache=$ENABLE_EP_CACHE --build_test_utils=$BUILD_TESTS --build_tests=$BUILD_VELOX_TESTS --build_velox_benchmarks=$BUILD_VELOX_BENCHMARKS \
                  --compile_arrow_java=$COMPILE_ARROW_JAVA
 
 ## compile gluten cpp

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -74,7 +74,7 @@ for arg in "$@"; do
     ENABLE_TESTS=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
-  --build_velox_benchmarks=*)
+  --build_benchmarks=*)
     ENABLE_BENCHMARK=("${arg#*=}")
     shift # Remove argument name from processing
     ;;

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -28,6 +28,7 @@ VELOX_HOME=""
 ENABLE_EP_CACHE=OFF
 ENABLE_BENCHMARK=OFF
 ENABLE_TESTS=OFF
+BUILD_TEST_UTILS=OFF
 RUN_SETUP_SCRIPT=ON
 OTHER_ARGUMENTS=""
 COMPILE_ARROW_JAVA=OFF
@@ -65,6 +66,10 @@ for arg in "$@"; do
     ENABLE_EP_CACHE=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
+  --build_test_utils=*)
+    BUILD_TEST_UTILS=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
   --build_tests=*)
     ENABLE_TESTS=("${arg#*=}")
     shift # Remove argument name from processing
@@ -100,7 +105,10 @@ function compile {
     fi
   fi
 
-  COMPILE_OPTION="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF -DVELOX_BUILD_TEST_UTILS=OFF -DVELOX_ENABLE_DUCKDB=OFF -DVELOX_ENABLE_PARSE=OFF"
+  COMPILE_OPTION="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF"
+  if [ $BUILD_TEST_UTILS == "ON" ]; then
+      COMPILE_OPTION="$COMPILE_OPTION -DVELOX_BUILD_TEST_UTILS=ON"
+  fi
   if [ $ENABLE_HDFS == "ON" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_HDFS=ON"
   fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up work for https://github.com/oap-project/gluten/pull/4153. There are some dependencies lacked for gluten cpp test build after that PR. Here, we turn on VELOX_BUILD_TEST_UTILS when gluten cpp build test is on. Maybe, we can deprecate `build_velox_test`, `build_velox_benchmark` in the future.

## How was this patch tested?

Pass CI build and local build.