### PR TITLE
[VL] Disable system curl to build cpr

### DIFF
--- a/ep/build-velox/src/modify_velox.patch
+++ b/ep/build-velox/src/modify_velox.patch
@@ -35,17 +35,6 @@ index d49115f12..1aaa8e532 100644
 +          IMPORTED_LOCATION_DEBUG "${LZ4_LIBRARY_DEBUG}")
 +  endif()
  endif()
-diff --git a/CMake/resolve_dependency_modules/cpr.cmake b/CMake/resolve_dependency_modules/cpr.cmake
-index 4e5bf23ed..1f8deb0d2 100644
---- a/CMake/resolve_dependency_modules/cpr.cmake
-+++ b/CMake/resolve_dependency_modules/cpr.cmake
-@@ -30,5 +30,5 @@ FetchContent_Declare(
-   PATCH_COMMAND git apply
-                 ${CMAKE_CURRENT_LIST_DIR}/cpr/cpr-libcurl-compatible.patch)
- set(BUILD_SHARED_LIBS OFF)
--set(CPR_USE_SYSTEM_CURL OFF)
-+set(CPR_USE_SYSTEM_CURL ON)
- FetchContent_MakeAvailable(cpr)
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index e2ff67fa5..e03b246e3 100644
 --- a/CMakeLists.txt


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox disables system curl to build cpr to avoid any conflicts from pr: https://github.com/facebookincubator/velox/pull/7718
But it introduce other tests issues like https://github.com/facebookincubator/velox/pull/7718#issuecomment-1850056124
Which is being resolved in https://github.com/facebookincubator/velox/pull/7965

So it would be nice we can disable system curl also to avoid conflicts.

## How was this patch tested?

Existing tests

