### PR TITLE
[VL] do not write EOS in shuffle by default

### DIFF
--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -858,7 +858,7 @@ object GlutenConfig {
     buildConf("spark.gluten.sql.columnar.shuffle.writeEOS")
       .internal()
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val COLUMNAR_SHUFFLE_REALLOC_THRESHOLD =
     buildConf("spark.gluten.sql.columnar.shuffle.realloc.threshold")


### PR DESCRIPTION


## What changes were proposed in this pull request?

write eos will break batch fetch in shuffle read


## How was this patch tested?

pass AQE tests

