### PR TITLE
[VL] Daily Update Velox Version (2024-01-04)

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -416,6 +416,9 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
 
     configs[velox::core::QueryConfig::kArrowBridgeTimestampUnit] = "6";
 
+    // Disable driver cpu time slicing.
+    configs[velox::core::QueryConfig::kDriverCpuTimeSliceLimitMs] = "0";
+
   } catch (const std::invalid_argument& err) {
     std::string errDetails = err.what();
     throw std::runtime_error("Invalid conf arg: " + errDetails);

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_03
+VELOX_BRANCH=2024_01_04
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
fefd586a9 (upstream/main) Fix PrestoQueryRunner::toSql to honor sortingKeys for Aggregates. (#8233)
c1ce705a2 Remove unused exception parameter from velox/expression/SimpleFunctionAdapter.h (#8234)
48127fa01 Document hash table (#8167)
fdb3b3c8a Rename system and spill memory pool (#8239)
f057a461b Refactor and move aggregation arbitration test into AggregationTest (#8242)
b76a9edbb Extend conversion options of tmToString (#8165)
2a463b790 Add .parquet suffix to the file name (#8090)
55343d4bd Unify compareInputs and compareResults in ExpressionVerifier and move it to FuzzerToolKit. (#7990)
551e82f3f Refactor and move arbitration test into OrderByTest (#8212)
552c259fe Change cpu driver slicing limit to 1 second by default (#8228)
9dece1aa9 Remove unused exception parameter from files inc velox/functions/prestosql/types/JsonType.cpp (#8235)
c3098a13d Remove unused exception parameter from files inc velox/exec/Driver.cpp (#8236)
7cfbc83c4 Remove unused exception parameter from velox/type/Timestamp.cpp (#8232)
a51d31f30 Remove unused exception parameter from velox/common/memory/MemoryPool.cpp (#8230)
080947edd Remove unused exception parameter from velox/common/memory/MallocAllocator.cpp (#8231)
b4f66f3a9 Remove unused exception parameter from velox/common/base/AsyncSource.h (#8222)
c4ac51c3c Add yield when process spill input in hash build (#8023)
```