### PR TITLE
[GLUTEN-4260][VL] Fix velox build summary by covering new build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you want to use Gluten **ClickHouse** backend, see [Build with ClickHouse Bac
 
 ### 3.2.3 Build options
 
-See [Gluten Usage](./docs/get-started/GlutenUsage.md).
+See [Gluten build guide](./docs/get-started/build-guide.md).
 
 # 4 Contribution
 

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -141,12 +141,12 @@ function concat_velox_param {
 
     # check velox branch
     if [[ -n $VELOX_BRANCH ]]; then
-	VELOX_PARAMETER+="--velox_branch=$VELOX_BRANCH "
+        VELOX_PARAMETER+="--velox_branch=$VELOX_BRANCH "
     fi
 
     # check velox home
     if [[ -n $VELOX_HOME ]]; then
-	VELOX_PARAMETER+="--velox_home=$VELOX_HOME "
+        VELOX_PARAMETER+="--velox_home=$VELOX_HOME "
     fi
 }
 

--- a/docs/get-started/GlutenUsage.md
+++ b/docs/get-started/GlutenUsage.md
@@ -4,58 +4,73 @@ title: Build Parameters for Velox Backend
 nav_order: 4
 parent: Getting-Started
 ---
-# Build parameters
-## Parameters for buildbundle-veloxbe.sh or builddeps-veloxbe.sh
+## Build Parameters
+### Native build parameters for buildbundle-veloxbe.sh or builddeps-veloxbe.sh
 Please set them via `--`, e.g. `--build_type=Release`.
 
-| Parameters       | Description                                         | Default value |
-|------------------|-----------------------------------------------------|---------------|
-| build_type       | build type for velox & gluten cpp, CMAKE_BUILD_TYPE | Release       |
-| build_tests      | build test code in cpp folder                       | OFF           |
-| build_benchmarks | build benchmark code in cpp folder                  | OFF           |
-| build_jemalloc   | build with jemalloc                                 | ON            |
-| build_protobuf   | build protobuf lib                                  | ON            |
-| enable_qat       | enable QAT for shuffle data de/compression          | OFF           |
-| enable_iaa       | enable IAA for shuffle data de/compression          | OFF           |
-| enable_hbm       | enable HBM allocator                                | OFF           |
-| enable_s3        | build with s3 lib                                   | OFF           |
-| enable_gcs       | build with gcs lib                                  | OFF           |
-| enable_hdfs      | build with hdfs lib                                 | OFF           |
-| enable_ep_cache  | enable caching for external project build (Velox)   | OFF           |
-| enable_vcpkg     | enable vcpkg for static build                       | OFF           |
-| enable_abfs      | build with abfs lib                                 | OFF           |
-| build_velox_tests| build with velox tests                              | OFF           |
-| build_velox_benchmarks| build velox benchmarks(velox_tests and connectors will be disabled if ON)                | OFF           |
+| Parameters             | Description                                                                | Default |
+|------------------------|----------------------------------------------------------------------------|---------|
+| build_type             | Build type for Velox & gluten cpp, CMAKE_BUILD_TYPE.                       | Release |
+| build_tests            | Build gluten cpp tests.                                                    | OFF     |
+| build_examples         | Build udf example.                                                         | OFF     |
+| build_benchmarks       | Build gluten cpp benchmarks.                                               | OFF     |
+| build_jemalloc         | Build with jemalloc.                                                       | ON      |
+| build_protobuf         | Build protobuf lib.                                                        | ON      |
+| enable_qat             | Enable QAT for shuffle data de/compression.                                | OFF     |
+| enable_iaa             | Enable IAA for shuffle data de/compression.                                | OFF     |
+| enable_hbm             | Enable HBM allocator.                                                      | OFF     |
+| enable_s3              | Build with S3 support.                                                     | OFF     |
+| enable_gcs             | Build with GCs support.                                                    | OFF     |
+| enable_hdfs            | Build with HDFS support.                                                   | OFF     |
+| enable_abfs            | Build with ABFS support.                                                   | OFF     |
+| enable_ep_cache        | Enable caching for external project build (Velox).                         | OFF     |
+| enable_vcpkg           | Enable vcpkg for static build.                                             | OFF     |
+| run_setup_script       | Run setup script to install Velox dependencies.                            | ON      |
+| velox_repo             | Specify your own Velox repo to build.                                      | ""      |
+| velox_branch           | Specify your own Velox branch to build.                                    | ""      |
+| velox_home             | Specify your own Velox source path to build.                               | ""      |
+| build_velox_tests      | Build Velox tests.                                                         | OFF     |
+| build_velox_benchmarks | Build Velox benchmarks (velox_tests and connectors will be disabled if ON) | OFF     |
+| compile_arrow_java     | Compile arrow java for gluten build to use to fix invalid pointer issues.  | OFF     |
 
-## Parameters for build_velox.sh
+### Velox build parameters for build_velox.sh
 Please set them via `--`, e.g., `--velox_home=/YOUR/PATH`.
 
-| Parameters | Description | Default value |
-| ---------- | ----------- | ------------- |
-| velox_home | Velox build path                          | GLUTEN_DIR/ep/build-velox/build/velox_ep|
-| build_type | Velox build type, CMAKE_BUILD_TYPE        | Release|
-| enable_s3  | Build Velox with -DENABLE_S3              | OFF           |
-| enable_gcs  | Build Velox with -DENABLE_GCS            | OFF           |
-| enable_hdfs | Build Velox with -DENABLE_HDFS           | OFF           |
-| build_protobuf | build protobuf from source            | ON           |
-| run_setup_script | Run Velox setup script before build | ON           |
+| Parameters         | Description                                                             | Default                                  |
+|--------------------|-------------------------------------------------------------------------|------------------------------------------|
+| velox_home         | Specify Velox source path to build.                                     | GLUTEN_SRC/ep/build-velox/build/velox_ep |
+| build_type         | Velox build type, i.e., CMAKE_BUILD_TYPE.                               | Release                                  |
+| enable_s3          | Build Velox with S3 support.                                            | OFF                                      |
+| enable_gcs         | Build Velox with GCS support.                                           | OFF                                      |
+| enable_hdfs        | Build Velox with HDFS support.                                          | OFF                                      |
+| enable_abfs        | Build Velox with ABFS support.                                          | OFF                                      |
+| run_setup_script   | Run setup script to install Velox dependencies before build.            | ON                                       |
+| enable_ep_cache    | Enable and reuse cache of Velox build.                                  | OFF                                      |
+| build_test_utils   | Build Velox with cmake arg -DVELOX_BUILD_TEST_UTILS=ON if ON.           | OFF                                      |
+| build_tests        | Build Velox test.                                                       | OFF                                      |
+| build_benchmarks   | Build Velox benchmarks.                                                 | OFF                                      |
+| compile_arrow_java | Build arrow java for gluten build to use to fix invalid pointer issues. | OFF                                      |
 
-## Maven building parameters
-To build different backends, there are 3 parameters can be set via `-P` for mvn.
+### Maven build parameters
+The below parameters can be set via `-P` for mvn.
 
-| Parameters          | Description                                                                                    | Activation state by default |
-|---------------------|------------------------------------------------------------------------------------------------|-----------------------------|
-| backends-velox      | Add -Pbackends-velox in maven command to compile the JVM part of Velox backend.                | disabled                    |
-| backends-clickhouse | Add -Pbackends-clickhouse in maven command to compile the JVM part of ClickHouse backend.      | disabled                    |
-| rss                 | Add -Prss in maven command to compile the JVM part of rss, current only support Velox backend. | disabled                    |
+| Parameters          | Description                                                                  | Default state |
+|---------------------|------------------------------------------------------------------------------|---------------|
+| backends-velox      | Build Gluten Velox backend.                                                  | disabled      |
+| backends-clickhouse | Build Gluten ClickHouse backend.                                             | disabled      |
+| rss                 | Build Gluten with Remote Shuffle Service, only applicable for Velox backend. | disabled      |
+| delta               | Build Gluten with Delta Lake support.                                        | disabled      |
+| iceberg             | Build Gluten with Iceberg support.                                           | disabled      |
+| spark-3.2           | Build Gluten for Spark 3.2.                                                  | enabled       |
+| spark-3.3           | Build Gluten for Spark 3.3.                                                  | disabled      |
+| spark-3.4           | Build Gluten for Spark 3.4.                                                  | disabled      |
 
-# Gluten jar for deployment
+## Gluten jar for Deployment
+The gluten jar built out is under `GLUTEN_SRC/package/target/`.
+It's name pattern is `gluten-<backend_type>-bundle-spark<spark.bundle.version>_<scala.binary.version>-<os.detected.release>_<os.detected.release.version>-<project.version>.jar`.
 
-The gluten jar's name pattern is `gluten-<backend_type>-bundle-spark<sparkbundle.version>_<scala.binary.version>-<os.detected.release>_<os.detected.release.version>-<project.version>.jar`.
-
-| Spark Version | sparkbundle.version | scala.binary.version |
-| ---------- | ----------- | ------------- |
-| 3.2.2 | 3.2 | 2.12 |
-| 3.3.1 | 3.3 | 2.12 |
-
-The velox backend and the clickhouse backend support both spark-3.2.2 and spark-3.3.1.
+| Spark Version | spark.bundle.version | scala.binary.version |
+|---------------|----------------------|----------------------|
+| 3.2.2         | 3.2                  | 2.12                 |
+| 3.3.1         | 3.3                  | 2.12                 |
+| 3.4.3         | 3.4                  | 2.12                 |

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -42,8 +42,8 @@ git clone https://github.com/oap-project/gluten.git
 
 # Build Gluten with Velox Backend
 
-It's recommended to use buildbundle-veloxbe.sh and build gluten in one script.
-[Gluten Usage](./GlutenUsage.md) listed the parameters and their default value of build command for your reference.
+It's recommended to use buildbundle-veloxbe.sh to build gluten in one script.
+[Gluten build guide](./build-guide.md) listed the parameters and their default value of build command for your reference.
 
 **For x86_64 build**
 
@@ -758,7 +758,7 @@ cat tpch_parquet.scala | spark-shell --name tpch_powertest_velox \
   --conf spark.driver.maxResultSize=32g
 ```
 
-Refer to [Gluten parameters ](../Configuration.md) for more details of each parameter used by Gluten.
+Refer to [Gluten configuration](../Configuration.md) for more details.
 
 ## Result
 *wholestagetransformer* indicates that the offload works.

--- a/docs/get-started/build-guide.md
+++ b/docs/get-started/build-guide.md
@@ -65,7 +65,7 @@ The below parameters can be set via `-P` for mvn.
 | spark-3.3           | Build Gluten for Spark 3.3.                                                  | disabled      |
 | spark-3.4           | Build Gluten for Spark 3.4.                                                  | disabled      |
 
-## Gluten jar for Deployment
+## Gluten Jar for Deployment
 The gluten jar built out is under `GLUTEN_SRC/package/target/`.
 It's name pattern is `gluten-<backend_type>-bundle-spark<spark.bundle.version>_<scala.binary.version>-<os.detected.release>_<os.detected.release.version>-<project.version>.jar`.
 
@@ -73,4 +73,4 @@ It's name pattern is `gluten-<backend_type>-bundle-spark<spark.bundle.version>_<
 |---------------|----------------------|----------------------|
 | 3.2.2         | 3.2                  | 2.12                 |
 | 3.3.1         | 3.3                  | 2.12                 |
-| 3.4.3         | 3.4                  | 2.12                 |
+| 3.4.2         | 3.4                  | 2.12                 |

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -15,23 +15,27 @@
 # limitations under the License.
 
 set -exu
-#Set on run gluten on S3
+# New build option may need to be included in get_build_summary to ensure EP build cache workable.
+# Enable S3 connector.
 ENABLE_S3=OFF
-#Set on run gluten on GCS
+# Enable GCS connector.
 ENABLE_GCS=OFF
-#Set on run gluten on HDFS
+# Enable HDFS connector.
 ENABLE_HDFS=OFF
-#Set on run gluten on ABFS
+# Enable ABFS connector.
 ENABLE_ABFS=OFF
 BUILD_TYPE=release
 VELOX_HOME=""
 ENABLE_EP_CACHE=OFF
+# May be deprecated in Gluten build.
 ENABLE_BENCHMARK=OFF
+# May be deprecated in Gluten build.
 ENABLE_TESTS=OFF
+# Set to ON for gluten cpp test build.
 BUILD_TEST_UTILS=OFF
 RUN_SETUP_SCRIPT=ON
-OTHER_ARGUMENTS=""
 COMPILE_ARROW_JAVA=OFF
+OTHER_ARGUMENTS=""
 
 OS=`uname -s`
 ARCH=`uname -m`
@@ -171,7 +175,12 @@ function compile {
 function get_build_summary {
   COMMIT_HASH=$1
   # Ideally all script arguments should be put into build summary.
-  echo "ENABLE_S3=$ENABLE_S3,ENABLE_GCS=$ENABLE_GCS,ENABLE_HDFS=$ENABLE_HDFS,BUILD_TYPE=$BUILD_TYPE,VELOX_HOME=$VELOX_HOME,ENABLE_EP_CACHE=$ENABLE_EP_CACHE,ENABLE_BENCHMARK=$ENABLE_BENCHMARK,ENABLE_TESTS=$ENABLE_TESTS,RUN_SETUP_SCRIPT=$RUN_SETUP_SCRIPT,OTHER_ARGUMENTS=$OTHER_ARGUMENTS,COMMIT_HASH=$COMMIT_HASH"
+  # ENABLE_EP_CACHE is excluded. Thus, in current build with ENABLE_EP_CACHE=ON, we can use EP cache
+  # from last build with ENABLE_EP_CACHE=OFF,
+  echo "ENABLE_S3=$ENABLE_S3,ENABLE_GCS=$ENABLE_GCS,ENABLE_HDFS=$ENABLE_HDFS,ENABLE_ABFS=$ENABLE_ABFS,\
+BUILD_TYPE=$BUILD_TYPE,VELOX_HOME=$VELOX_HOME,ENABLE_BENCHMARK=$ENABLE_BENCHMARK,\
+ENABLE_TESTS=$ENABLE_TESTS,BUILD_TEST_UTILS=$BUILD_TEST_UTILS,RUN_SETUP_SCRIPT=$RUN_SETUP_SCRIPT,\
+COMPILE_ARROW_JAVA=$COMPILE_ARROW_JAVA,OTHER_ARGUMENTS=$OTHER_ARGUMENTS,COMMIT_HASH=$COMMIT_HASH"
 }
 
 function check_commit {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox build summary is helpful to track last build. Thus, velox build cache can be reused when enable_ep_cache=ON. Recently added new build options should be covered in the build summary. Also updated glute build guide.

## How was this patch tested?

Existing tests.

