### PR TITLE
[GLUTEN-4266][VL] Support cross join type with Merge join and Hash join

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/ShuffledHashJoinExecTransformer.scala
@@ -118,7 +118,7 @@ case class ShuffledHashJoinExecTransformer(
   }
 
   override protected lazy val substraitJoinType: JoinRel.JoinType = joinType match {
-    case Inner =>
+    case _: InnerLike =>
       JoinRel.JoinType.JOIN_TYPE_INNER
     case FullOuter =>
       JoinRel.JoinType.JOIN_TYPE_OUTER
@@ -143,7 +143,6 @@ case class ShuffledHashJoinExecTransformer(
     case LeftAnti =>
       JoinRel.JoinType.JOIN_TYPE_ANTI
     case _ =>
-      // TODO: Support cross join with Cross Rel
       JoinRel.JoinType.UNRECOGNIZED
   }
 
@@ -173,7 +172,7 @@ case class GlutenBroadcastHashJoinExecTransformer(
     isNullAwareAntiJoin) {
 
   override protected lazy val substraitJoinType: JoinRel.JoinType = joinType match {
-    case Inner =>
+    case _: InnerLike =>
       JoinRel.JoinType.JOIN_TYPE_INNER
     case FullOuter =>
       JoinRel.JoinType.JOIN_TYPE_OUTER

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -767,8 +767,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
         checkOperatorMatch[ShuffledHashJoinExecTransformer]
       }
 
-      withSQLConf(
-        "spark.sql.autoBroadcastJoinThreshold" -> "1MB") {
+      withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "1MB") {
         runQueryAndCompare(
           """
             |select * from t1 cross join t2 on t1.c1 = t2.c1;
@@ -778,8 +777,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
         }
       }
 
-      withSQLConf(
-        "spark.gluten.sql.columnar.forceShuffledHashJoin" -> "false") {
+      withSQLConf("spark.gluten.sql.columnar.forceShuffledHashJoin" -> "false") {
         runQueryAndCompare(
           """
             |select * from t1 cross join t2 on t1.c1 = t2.c1;

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -747,4 +747,47 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       }
     }
   }
+
+  test("test cross join with equi join conditions") {
+    withTable("t1", "t2") {
+      sql("""
+            |create table t1 using parquet as
+            |select cast(id as int) as c1, cast(id as string) c2 from range(100)
+            |""".stripMargin)
+      sql("""
+            |create table t2 using parquet as
+            |select cast(id as int) as c1, cast(id as string) c2 from range(100) order by c1 desc;
+            |""".stripMargin)
+
+      runQueryAndCompare(
+        """
+          |select * from t1 cross join t2 on t1.c1 = t2.c1;
+          |""".stripMargin
+      ) {
+        checkOperatorMatch[ShuffledHashJoinExecTransformer]
+      }
+
+      withSQLConf(
+        "spark.sql.autoBroadcastJoinThreshold" -> "1MB") {
+        runQueryAndCompare(
+          """
+            |select * from t1 cross join t2 on t1.c1 = t2.c1;
+            |""".stripMargin
+        ) {
+          checkOperatorMatch[GlutenBroadcastHashJoinExecTransformer]
+        }
+      }
+
+      withSQLConf(
+        "spark.gluten.sql.columnar.forceShuffledHashJoin" -> "false") {
+        runQueryAndCompare(
+          """
+            |select * from t1 cross join t2 on t1.c1 = t2.c1;
+            |""".stripMargin
+        ) {
+          checkOperatorMatch[SortMergeJoinExecTransformer]
+        }
+      }
+    }
+  }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortMergeJoinExecTransformer.scala
@@ -128,7 +128,7 @@ case class SortMergeJoinExecTransformer(
     requiredOrders(leftKeys) :: requiredOrders(rightKeys) :: Nil
 
   override def outputOrdering: Seq[SortOrder] = joinType match {
-    // For inner join, orders of both sides keys should be kept.
+    // For inner like join, orders of both sides keys should be kept.
     case _: InnerLike =>
       val leftKeyOrdering = getKeyOrdering(leftKeys, left.outputOrdering)
       val rightKeyOrdering = getKeyOrdering(rightKeys, right.outputOrdering)
@@ -198,7 +198,7 @@ case class SortMergeJoinExecTransformer(
 
   // Direct output order of substrait join operation
   protected val substraitJoinType = joinType match {
-    case Inner =>
+    case _: InnerLike =>
       JoinRel.JoinType.JOIN_TYPE_INNER
     case FullOuter =>
       JoinRel.JoinType.JOIN_TYPE_OUTER

--- a/gluten-core/src/main/scala/io/glutenproject/utils/SubstraitUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/SubstraitUtil.scala
@@ -16,13 +16,13 @@
  */
 package io.glutenproject.utils
 
-import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
+import org.apache.spark.sql.catalyst.plans.{FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 
 import io.substrait.proto.JoinRel
 
 object SubstraitUtil {
   def toSubstrait(sparkJoin: JoinType): JoinRel.JoinType = sparkJoin match {
-    case Inner =>
+    case _: InnerLike =>
       JoinRel.JoinType.JOIN_TYPE_INNER
     case FullOuter =>
       JoinRel.JoinType.JOIN_TYPE_OUTER
@@ -36,7 +36,6 @@ object SubstraitUtil {
     case LeftAnti =>
       JoinRel.JoinType.JOIN_TYPE_ANTI
     case _ =>
-      // TODO: Support cross join with Cross Rel
       // TODO: Support existence join
       JoinRel.JoinType.UNRECOGNIZED
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added cross join type in hash and merge join:

Cross join type will only get converted to hash or merge join when there are equi join conditions. Cross join with equi join conditions is actually inner join only. Ideally, users should not even write such queries.

Currently, queries like `select * from TBL1 cross join TBL2 on TBL1.c1 == TBL2.c1` falls back to Spark. which can easily be supported by Gluten by converting cross join substrait inner join type.

(Fixes: \#4266)

## How was this patch tested?
Tested using dummy unit tests
