### PR TITLE
[VL] Build & install spark-3.4.2 in docker and correct spark version in pom.xml

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -115,7 +115,7 @@ jobs:
           docker exec ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           ./compile.sh --build_velox_backend=ON --velox_home=/opt/velox'
-      - name: Build and run unit test for Spark 3.2.2(slow tests)
+      - name: Build and run unit test for Spark 3.2.2 (slow tests)
         run: |
           docker exec ubuntu2004-test-slow-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
@@ -152,7 +152,7 @@ jobs:
           docker exec ubuntu2004-test-spark33-slow-$GITHUB_RUN_ID bash -l -c '
           cd /opt/gluten/cpp && \
           ./compile.sh --build_velox_backend=ON --velox_home=/opt/velox'
-      - name: Build and Run unit test for Spark 3.3.1(slow tests)
+      - name: Build and Run unit test for Spark 3.3.1 (slow tests)
         run: |
           docker exec ubuntu2004-test-spark33-slow-$GITHUB_RUN_ID bash -l -c 'cd /opt/gluten && \
           mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -Piceberg -Pdelta -Pspark-ut -DargLine="-Dspark.test.home=/opt/spark331" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
@@ -188,7 +188,7 @@ jobs:
           docker exec ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           ./compile.sh --build_velox_backend=ON --velox_home=/opt/velox --build_examples=ON'
-      - name: Build and Run unit test for Spark 3.3.1(other tests)
+      - name: Build and Run unit test for Spark 3.3.1 (other tests)
         run: |
           docker exec ubuntu2004-test-spark33-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
           mvn clean install -Pspark-3.3 -Pbackends-velox -Prss -Piceberg -Pdelta -Pspark-ut -DargLine="-Dspark.test.home=/opt/spark331" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,io.glutenproject.tags.UDFTest,io.glutenproject.tags.SkipTestTags && \
@@ -218,7 +218,7 @@ jobs:
           docker exec ubuntu2004-test-spark34-slow-$GITHUB_RUN_ID bash -l -c '
           cd /opt/gluten/cpp && \
           ./compile.sh --build_velox_backend=ON --velox_home=/opt/velox '
-      - name: Build and Run unit test for Spark 3.4.1(slow tests)
+      - name: Build and Run unit test for Spark 3.4.2 (slow tests)
         run: |
           docker exec ubuntu2004-test-spark34-slow-$GITHUB_RUN_ID bash -l -c 'cd /opt/gluten && \
           mvn clean install -Pspark-3.4 -Pbackends-velox -Prss -Piceberg -Pdelta -Pspark-ut -DargLine="-Dspark.test.home=/opt/spark331" -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest'
@@ -254,7 +254,7 @@ jobs:
           docker exec ubuntu2004-test-spark34-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten/cpp && \
           ./compile.sh --build_velox_backend=ON --velox_home=/opt/velox --build_examples=ON'
-      - name: Build and Run unit test for Spark 3.4.1(other tests)
+      - name: Build and Run unit test for Spark 3.4.2 (other tests)
         run: |
           docker exec ubuntu2004-test-spark34-$GITHUB_RUN_ID bash -c 'cd /opt/gluten && \
           mvn clean install -Pspark-3.4 -Pbackends-velox -Prss -Piceberg -Pdelta -Pspark-ut -DargLine="-Dspark.test.home=/opt/spark331" -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,io.glutenproject.tags.UDFTest,io.glutenproject.tags.SkipTestTags && \
@@ -297,7 +297,7 @@ jobs:
             --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 \
           && GLUTEN_IT_JVM_ARGS=-Xmx20G sbin/gluten-it.sh queries-compare \
             --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=30g -s=10.0 --threads=32 --iterations=1'
-      - name: Build for Spark 3.4.1
+      - name: Build for Spark 3.4.2
         run: |
           docker exec ubuntu2204-test-spark33-spark34-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <scala.version>2.12.15</scala.version>
     <spark.major.version>3</spark.major.version>
     <sparkbundle.version>3.2</sparkbundle.version>
-    <spark.version>3.4.1</spark.version>
+    <spark.version>3.4.2</spark.version>
     <sparkshim.artifactId>spark-sql-columnar-shims-spark32</sparkshim.artifactId>
     <celeborn.version>0.3.0-incubating</celeborn.version>
     <arrow.version>14.0.1</arrow.version>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -19,7 +19,7 @@
     <scala.library.version>2.12.15</scala.library.version>
     <spark32.version>3.2.2</spark32.version>
     <spark33.version>3.3.1</spark33.version>
-    <spark34.version>3.4.1</spark34.version>
+    <spark34.version>3.4.2</spark34.version>
     <spark.version>${spark32.version}</spark.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spark.major.version>3</spark.major.version>

--- a/tools/gluten-te/ubuntu/dockerfile-buildenv
+++ b/tools/gluten-te/ubuntu/dockerfile-buildenv
@@ -110,9 +110,9 @@ RUN cd /opt/spark322 && ./build/mvn -Pyarn -DskipTests clean install
 RUN cd /opt && git clone --depth 1 --branch v3.3.1 https://github.com/apache/spark.git spark331
 RUN cd /opt/spark331 && ./build/mvn -Pyarn -DskipTests clean install
 
-# Build & install Spark 3.4.1
-RUN cd /opt && git clone --depth 1 --branch v3.4.1 https://github.com/apache/spark.git spark341
-RUN cd /opt/spark341 && ./build/mvn -Pyarn -DskipTests clean install
+# Build & install Spark 3.4.2
+RUN cd /opt && git clone --depth 1 --branch v3.4.2 https://github.com/apache/spark.git spark342
+RUN cd /opt/spark342 && ./build/mvn -Pyarn -DskipTests clean install
 
 # Prepare entry command
 COPY scripts/cmd.sh /root/.cmd.sh


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have made spark-3.4.2 the official support version at https://github.com/oap-project/gluten/commit/8d46bec8105ac02bbcdb05ff21e1c57c3fab1365. Therefore, we need to build & install spark-3.4.2 inside docker for test to use.

## How was this patch tested?

Exiting tests.

