### PR TITLE
[CORE] Minor fix needProjection in SortExecTransformer

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/SortExecTransformer.scala
@@ -35,7 +35,6 @@ import io.substrait.proto.SortField
 import java.util.{ArrayList => JArrayList}
 
 import scala.collection.JavaConverters._
-import scala.util.control.Breaks.{break, breakable}
 
 case class SortExecTransformer(
     sortOrder: Seq[SortOrder],
@@ -270,15 +269,8 @@ object SortExecTransformer {
   }
 
   def needProjection(sortOrders: Seq[SortOrder]): Boolean = {
-    var needsProjection = false
-    breakable {
-      for (sortOrder <- sortOrders) {
-        if (!sortOrder.child.isInstanceOf[Attribute]) {
-          needsProjection = true
-          break
-        }
-      }
-    }
-    needsProjection
+    sortOrders
+      .map(_.child)
+      .exists(exp => !exp.isInstanceOf[Attribute] && !exp.isInstanceOf[BoundReference])
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`sortOrders` may come from `FileFormatWriter`, in which case, they are `BoundReference`. 
```
val orderingExpr = bindReferences(
requiredOrdering.map(SortOrder(_, Ascending)),
finalOutputSpec.outputColumns)
val sortPlan = SortExec(orderingExpr, global = false, child = empty2NullPlan)
```

## How was this patch tested?

Pass CI

