### PR TITLE
[GLUTEN-4279][CH]Bug fix hour diff

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -2442,7 +2442,8 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
     val tbl_create_sql = "create table test_tbl_4279(id bigint, data string) using parquet";
     val tbl_insert_sql = "insert into test_tbl_4279 values(1, '2024-01-04 11:22:33'), " +
       "(2, '2024-01-04 11:22:33.456+08'), (3, '2024'), (4, '2024-01'), (5, '2024-01-04'), " +
-      "(6, '2024-01-04 12'), (7, '2024-01-04 12:12'), (8, '11:22:33'), (9, '22:33')"
+      "(6, '2024-01-04 12'), (7, '2024-01-04 12:12'), (8, '11:22:33'), (9, '22:33')," +
+      "(10, '2024-01-04 '), (11, '2024-01-04 11.22.33.')"
     val select_sql = "select id, hour(data) from test_tbl_4279 order by id"
     spark.sql(tbl_create_sql)
     spark.sql(tbl_insert_sql)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetSuite.scala
@@ -2437,5 +2437,17 @@ class GlutenClickHouseTPCHParquetSuite extends GlutenClickHouseTPCHAbstractSuite
       runQueryAndCompare(sql)({ _ => })
     }
   }
+
+  test("GLUTEN-4279: Bug fix hour diff") {
+    val tbl_create_sql = "create table test_tbl_4279(id bigint, data string) using parquet";
+    val tbl_insert_sql = "insert into test_tbl_4279 values(1, '2024-01-04 11:22:33'), " +
+      "(2, '2024-01-04 11:22:33.456+08'), (3, '2024'), (4, '2024-01'), (5, '2024-01-04'), " +
+      "(6, '2024-01-04 12'), (7, '2024-01-04 12:12'), (8, '11:22:33'), (9, '22:33')"
+    val select_sql = "select id, hour(data) from test_tbl_4279 order by id"
+    spark.sql(tbl_create_sql)
+    spark.sql(tbl_insert_sql)
+    compareResultsAgainstVanillaSpark(select_sql, true, { _ => })
+    spark.sql("drop table test_tbl_4279")
+  }
 }
 // scalastyle:on line.size.limit

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDate.cpp
@@ -37,7 +37,7 @@ namespace local_engine
 class SparkFunctionConvertToDate : public DB::FunctionToDate32OrNull
 {
 public:
-    static constexpr auto name = "spark_to_date";
+    static constexpr auto name = "sparkToDate";
     static DB::FunctionPtr create(DB::ContextPtr) { return std::make_shared<SparkFunctionConvertToDate>(); }
     SparkFunctionConvertToDate() = default;
     ~SparkFunctionConvertToDate() override = default;

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDateTime.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDateTime.cpp
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Functions/SparkFunctionToDateTime.h>
+
+namespace local_engine
+{
+
+REGISTER_FUNCTION(SparkToDateTime)
+{
+    factory.registerFunction<SparkFunctionConvertToDateTime>();
+}
+
+}

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDateTime.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDateTime.h
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Common/LocalDate.h>
+#include <Common/DateLUT.h>
+#include <Common/DateLUTImpl.h>
+#include <Columns/ColumnsDateTime.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <Functions/FunctionsConversion.h>
+#include <Functions/FunctionFactory.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/parseDateTimeBestEffort.h>
+#include <IO/ReadHelpers.h>
+#include <ctime>
+
+using namespace DB;
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int ILLEGAL_COLUMN;
+}
+}
+
+namespace local_engine
+{
+class SparkFunctionConvertToDateTime : public DB::FunctionToDateTime64OrNull
+{
+public:
+    static constexpr auto name = "sparkToDateTime";
+    static DB::FunctionPtr create(DB::ContextPtr) { return std::make_shared<SparkFunctionConvertToDateTime>(); }
+    SparkFunctionConvertToDateTime() = default;
+    ~SparkFunctionConvertToDateTime() override = default;
+    String getName() const override { return name; }
+
+    bool checkDateTimeFormat(DB::ReadBuffer & buf, size_t buf_size, UInt8 & can_be_parsed) const
+    {        
+        auto checkNumbericASCII = [&](DB::ReadBuffer & rb, size_t start, size_t length) -> bool
+        {
+            for (size_t i = start; i < start + length; ++i)
+            {
+                if (!isNumericASCII(*(rb.position() + i)))
+                    return false;
+            }
+            return true;
+        };
+        auto checkDelimiter = [&](DB::ReadBuffer & rb, size_t pos, char delim) -> bool
+        {
+            if (*(rb.position() + pos) != delim)
+                return false;
+            else
+                return true;
+        };
+        if (buf_size < 4 || !isNumericASCII(*(buf.position() + buf_size - 1)))
+        {
+            can_be_parsed = 0;
+            return false;
+        }
+        else if (buf_size == 10
+            && checkNumbericASCII(buf, 0, 4) && checkDelimiter(buf, 4, '-')
+            && checkNumbericASCII(buf, 5, 2) && checkDelimiter(buf, 7, '-')
+            && checkNumbericASCII(buf, 8, 2))
+        {
+            return true;
+        }
+        else if (buf_size < 19)
+            return false;
+        else if (buf_size == 19 
+            && (!checkNumbericASCII(buf, 0, 4) || !checkDelimiter(buf, 4, '-')
+            || !checkNumbericASCII(buf, 5, 2) || !checkDelimiter(buf, 7, '-')
+            || !checkNumbericASCII(buf, 8, 2) || !checkDelimiter(buf, 10, ' ')
+            || !checkNumbericASCII(buf, 11, 2) || !checkDelimiter(buf, 13, ':')
+            || !checkNumbericASCII(buf, 14, 2) || !checkDelimiter(buf, 16, ':')
+            || !checkNumbericASCII(buf, 17, 2)))
+        {
+            can_be_parsed = 0;
+            return false;
+        }
+        else if (buf_size > 19)
+        {
+            for (size_t i = 19; i < buf_size; ++i)
+            {
+                if (i == 19 && !checkDelimiter(buf, i, '.'))
+                {
+                    can_be_parsed = 0;
+                    return false;
+                }
+                else if (i != 19 && !isNumericASCII(*(buf.position() + i)))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    DB::DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        UInt32 scale = 6;
+        if (arguments.size() > 1)
+            scale = extractToDecimalScale(arguments[1]);
+        const auto timezone = extractTimeZoneNameFromFunctionArguments(arguments, 2, 0, false);
+        return makeNullable(std::make_shared<DataTypeDateTime64>(scale, timezone));
+    }
+
+    DB::ColumnPtr executeImpl(const DB::ColumnsWithTypeAndName & arguments, const DB::DataTypePtr & result_type, size_t input_rows) const override
+    {
+         if (arguments.size() != 1 && arguments.size() != 2)
+            throw DB::Exception(DB::ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function {}'s arguments number must be 1 or 2.", name);
+        
+        if (!result_type->isNullable())
+            throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s return type must be nullable", name);
+        
+        if (!isDateTime64(removeNullable(result_type)))
+            throw DB::Exception(DB::ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {}'s return type must be datetime.", name);
+        
+        size_t size = arguments[0].column->size();
+        const DB::DataTypeDateTime64 * datetime_64_type = checkAndGetDataType<DB::DataTypeDateTime64>(removeNullable(result_type).get());
+        UInt32 scale = datetime_64_type->getScale();
+        auto data_col = DB::ColumnDateTime64::create(size, scale);
+        auto null_map_col = DB::ColumnUInt8::create(size);
+        executeInternal(arguments[0].column, scale, data_col->getData(), null_map_col->getData());
+        return DB::ColumnNullable::create(std::move(data_col), std::move(null_map_col));
+    }
+
+    void executeInternal(const DB::ColumnPtr & src, const UInt32 & scale, PaddedPODArray<DB::DateTime64> & dst_data, PaddedPODArray<UInt8> & null_map_data) const
+    {
+        const DateLUTImpl * local_time_zone = &DateLUT::instance();
+        const DateLUTImpl * utc_time_zone = &DateLUT::instance("UTC");
+        for (size_t i = 0; i < src->size(); ++i)
+        {
+            const StringRef data = src->getDataAt(i);
+            DB::ReadBufferFromMemory buf(data.data, data.size);
+            while(!buf.eof() && *buf.position() == ' ')
+            {
+                    buf.position() ++;
+            }
+            UInt8 can_be_parsed = 1;
+            if (checkDateTimeFormat(buf, buf.buffer().end() - buf.position(), can_be_parsed) && can_be_parsed)
+            {
+                readDateTime64Text(dst_data[i], scale, buf, *local_time_zone);
+                null_map_data[i] = 0;
+            }
+            else if (!can_be_parsed)
+            {
+                dst_data[i] = 0;
+                null_map_data[i] = 1;
+            }
+            else
+            {
+                parseDateTime64BestEffort(dst_data[i], scale, buf, *local_time_zone, *utc_time_zone);
+                null_map_data[i] = 0;
+            }
+        }
+    }
+};
+
+}

--- a/cpp-ch/local-engine/Functions/SparkFunctionToDateTime.h
+++ b/cpp-ch/local-engine/Functions/SparkFunctionToDateTime.h
@@ -67,41 +67,42 @@ public:
             else
                 return true;
         };
-        if (buf_size < 4 || !isNumericASCII(*(buf.position() + buf_size - 1)))
-        {
-            can_be_parsed = 0;
-            return false;
-        }
-        else if (buf_size == 10
+        if ((buf_size == 10 || buf_size == 11)
             && checkNumbericASCII(buf, 0, 4) && checkDelimiter(buf, 4, '-')
             && checkNumbericASCII(buf, 5, 2) && checkDelimiter(buf, 7, '-')
             && checkNumbericASCII(buf, 8, 2))
         {
-            return true;
-        }
-        else if (buf_size < 19)
+            if (buf_size == 10)
+                return true;
+            else if (*(buf.position() + 10) != ' ')
+                can_be_parsed = 0;
             return false;
-        else if (buf_size == 19 
-            && (!checkNumbericASCII(buf, 0, 4) || !checkDelimiter(buf, 4, '-')
-            || !checkNumbericASCII(buf, 5, 2) || !checkDelimiter(buf, 7, '-')
-            || !checkNumbericASCII(buf, 8, 2) || !checkDelimiter(buf, 10, ' ')
-            || !checkNumbericASCII(buf, 11, 2) || !checkDelimiter(buf, 13, ':')
-            || !checkNumbericASCII(buf, 14, 2) || !checkDelimiter(buf, 16, ':')
-            || !checkNumbericASCII(buf, 17, 2)))
+        }
+        else if ((buf_size == 19 || buf_size == 20) 
+            && (checkNumbericASCII(buf, 0, 4) && checkDelimiter(buf, 4, '-')
+            && checkNumbericASCII(buf, 5, 2) && checkDelimiter(buf, 7, '-')
+            && checkNumbericASCII(buf, 8, 2) && checkDelimiter(buf, 10, ' ')
+            && checkNumbericASCII(buf, 11, 2) && checkDelimiter(buf, 13, ':')
+            && checkNumbericASCII(buf, 14, 2) && checkDelimiter(buf, 16, ':')
+            && checkNumbericASCII(buf, 17, 2)))
+        {
+            if (buf_size == 19)
+                return true;
+            else
+                return *(buf.position() + 19) == '.';
+        }
+        else if (buf_size < 4 || !isNumericASCII(*(buf.position() + buf_size - 1)))
         {
             can_be_parsed = 0;
             return false;
         }
-        else if (buf_size > 19)
+        else if (buf_size < 19)
+            return false;
+        else if (buf_size > 20)
         {
-            for (size_t i = 19; i < buf_size; ++i)
+            for (size_t i = 20; i < buf_size; ++i)
             {
-                if (i == 19 && !checkDelimiter(buf, i, '.'))
-                {
-                    can_be_parsed = 0;
-                    return false;
-                }
-                else if (i != 19 && !isNumericASCII(*(buf.position() + i)))
+                if (!isNumericASCII(*(buf.position() + i)))
                     return false;
             }
         }

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1563,7 +1563,6 @@ const ActionsDAG::Node * SerializedPlanParser::parseExpression(ActionsDAGPtr act
         case substrait::Expression::RexTypeCase::kCast: {
             if (!rel.cast().has_type() || !rel.cast().has_input())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Doesn't have type or input in cast node.");
-
             DB::ActionsDAG::NodeRawConstPtrs args;
 
             const auto & input = rel.cast().input();
@@ -1573,7 +1572,11 @@ const ActionsDAG::Node * SerializedPlanParser::parseExpression(ActionsDAGPtr act
             const ActionsDAG::Node * function_node = nullptr;
             if (DB::isString(DB::removeNullable(args.back()->result_type)) && substrait_type.has_date())
             {
-                function_node = toFunctionNode(actions_dag, "spark_to_date", args);
+                function_node = toFunctionNode(actions_dag, "sparkToDate", args);
+            }
+            else if(DB::isString(DB::removeNullable(args.back()->result_type)) && substrait_type.has_timestamp())
+            {
+                function_node = toFunctionNode(actions_dag, "sparkToDateTime", args);
             }
             else if (substrait_type.has_binary())
             {

--- a/cpp-ch/local-engine/tests/CMakeLists.txt
+++ b/cpp-ch/local-engine/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
         benchmark_spark_row.cpp
         benchmark_unix_timestamp_function.cpp
         benchmark_spark_floor_function.cpp
-        benchmark_cast_float_function.cpp)
+        benchmark_cast_float_function.cpp
+        benchmark_to_datetime_function.cpp)
     target_link_libraries(benchmark_local_engine PRIVATE gluten_clickhouse_backend_libs ch_contrib::gbenchmark_all loggers ch_parquet)
 endif()

--- a/cpp-ch/local-engine/tests/benchmark_to_datetime_function.cpp
+++ b/cpp-ch/local-engine/tests/benchmark_to_datetime_function.cpp
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <Core/Block.h>
+#include <Columns/IColumn.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionsConversion.h>
+#include <Functions/SparkFunctionToDateTime.h>
+#include <Parser/SerializedPlanParser.h>
+#include <Parser/FunctionParser.h>
+#include <benchmark/benchmark.h>
+
+using namespace DB;
+
+static Block createDataBlock(size_t rows)
+{
+    auto type = DataTypeFactory::instance().get("String");
+    auto column = type->createColumn();
+    for (size_t i = 0; i < rows; ++i)
+    {
+        column->insert("2024-01-05 12:12:12");
+    }
+    Block block;
+    block.insert(ColumnWithTypeAndName(std::move(column), type, "d"));
+    return std::move(block);
+}
+
+static void BM_CHParseDateTime64(benchmark::State & state)
+{
+    using namespace DB;
+    auto & factory = FunctionFactory::instance();
+    auto function = factory.get("toDateTime64OrNull", local_engine::SerializedPlanParser::global_context);
+    Block block = createDataBlock(30000000);
+    auto executable = function->build(block.getColumnsWithTypeAndName());
+    for (auto _ : state)[[maybe_unused]]
+        auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
+}
+
+
+static void BM_SparkParseDateTime64(benchmark::State & state)
+{
+    using namespace DB;
+    auto & factory = FunctionFactory::instance();
+    auto function = factory.get("sparkToDateTime", local_engine::SerializedPlanParser::global_context);
+    Block block = createDataBlock(30000000);
+    auto executable = function->build(block.getColumnsWithTypeAndName());
+    for (auto _ : state)[[maybe_unused]]
+         auto result = executable->execute(block.getColumnsWithTypeAndName(), executable->getResultType(), block.rows());
+}
+
+BENCHMARK(BM_CHParseDateTime64)->Unit(benchmark::kMillisecond)->Iterations(10);
+BENCHMARK(BM_SparkParseDateTime64)->Unit(benchmark::kMillisecond)->Iterations(10);


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#4279)

## How was this patch tested?
test by UT

#### 端到端测试
对比原生Spark测试
3000W 行正常日期时间格式数据，表定义：test_tbl(d string) 测试sql `select count(1) from test_tbl where hour(d) > 1`
原生spark 耗时：18.302s 18.508s 16.208s
PR改动前耗时：5.18s 5.665s  5.164s
PR 改动后耗时：5.705s 5.926s 6.108s

PR改动后相对于改动之前约有10% ～20%的性能回退，但是相对于spark 而言，仍然有3倍左右的提升

#### benchmark 测试
通过开发的benchmark_to_datetime_function.cpp 测试， 结果如下
```
2024-01-09T20:28:11+08:00
Running ./benchmark_local_engine
Run on (32 X 2100 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 1024 KiB (x16)
  L3 Unified 11264 KiB (x2)
Load Average: 25.19, 35.96, 41.70
--------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations
--------------------------------------------------------------------------------
BM_CHParseDateTime64/iterations:10          1386 ms         1385 ms           10
BM_SparkParseDateTime64/iterations:10       1767 ms         1764 ms           10
```
可见整体而言，相对于CH 的 `toDateTime64OrNull` 约回退了27% 左右