### PR TITLE
[VL] remove validate for timestamp in sortRel

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -700,13 +700,6 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
     return false;
   }
 
-  for (const auto& type : types) {
-    if (type->kind() == TypeKind::TIMESTAMP) {
-      logValidateMsg("native validation failed due to: Timestamp type is not supported in SortRel.");
-      return false;
-    }
-  }
-
   int32_t inputPlanNodeId = 0;
   std::vector<std::string> names;
   names.reserve(types.size());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is added before because timestamp is not fully supported, now looks we can remove this check.

## How was this patch tested?

Existing UT.

