### PR TITLE
[VL] A couple of code optimizations to TaskResources

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -340,6 +340,14 @@ jobs:
           docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -Piceberg -Pdelta -DskipTests'
+      - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2
+        run: |
+          docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
+          mvn clean install -Pspark-3.2 \
+          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
+            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 \
+          && GLUTEN_IT_JVM_ARGS=-Xmx20G sbin/gluten-it.sh queries-compare \
+            --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=40g -s=10.0 --threads=32 --iterations=1'
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2 with Celeborn
         run: |
           docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c \

--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -340,14 +340,6 @@ jobs:
           docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c '
           cd /opt/gluten && \
           mvn clean install -Pspark-3.2 -Pbackends-velox -Prss -Piceberg -Pdelta -DskipTests'
-      - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2
-        run: |
-          docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c 'cd /opt/gluten/tools/gluten-it && \
-          mvn clean install -Pspark-3.2 \
-          && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
-            --local --preset=velox --benchmark-type=h --error-on-memleak --disable-aqe --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 \
-          && GLUTEN_IT_JVM_ARGS=-Xmx20G sbin/gluten-it.sh queries-compare \
-            --local --preset=velox --benchmark-type=ds --error-on-memleak --off-heap-size=40g -s=10.0 --threads=32 --iterations=1'
       - name: TPC-H SF1.0 && TPC-DS SF10.0 Parquet local spark3.2 with Celeborn
         run: |
           docker exec ubuntu2204-test-$GITHUB_RUN_ID bash -c \

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -50,30 +50,31 @@ case class CachedColumnarBatch(
 // spotless:off
 /**
  * Feature:
- *   1. This serializer supports column pruning 2. TODO: support push down filter 3. Super TODO:
- *      support store offheap object directly
+ * 1. This serializer supports column pruning
+ * 2. TODO: support push down filter
+ * 3. Super TODO: support store offheap object directly
  *
  * The data transformation pipeline:
  *
  *   - Serializer ColumnarBatch -> CachedColumnarBatch
- * -> serialize to byte[]
+ *     -> serialize to byte[]
  *
  *   - Deserializer CachedColumnarBatch -> ColumnarBatch
- * -> deserialize to byte[] to create Velox ColumnarBatch
+ *     -> deserialize to byte[] to create Velox ColumnarBatch
  *
  *   - Serializer InternalRow -> CachedColumnarBatch (support RowToColumnar)
- * -> Convert InternalRow to ColumnarBatch
- * -> Serializer ColumnarBatch -> CachedColumnarBatch
+ *     -> Convert InternalRow to ColumnarBatch
+ *     -> Serializer ColumnarBatch -> CachedColumnarBatch
  *
  *   - Serializer InternalRow -> DefaultCachedBatch (unsupport RowToColumnar)
- * -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
+ *     -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
  *
  *   - Deserializer CachedColumnarBatch -> InternalRow (support ColumnarToRow)
- * -> Deserializer CachedColumnarBatch -> ColumnarBatch
- * -> Convert ColumnarBatch to InternalRow
+ *     -> Deserializer CachedColumnarBatch -> ColumnarBatch
+ *     -> Convert ColumnarBatch to InternalRow
  *
  *   - Deserializer DefaultCachedBatch -> InternalRow (unsupport ColumnarToRow)
- * -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
+ *     -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
  */
 // spotless:on
 class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHelper {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -50,31 +50,30 @@ case class CachedColumnarBatch(
 // spotless:off
 /**
  * Feature:
- * 1. This serializer supports column pruning
- * 2. TODO: support push down filter
- * 3. Super TODO: support store offheap object directly
+ *   1. This serializer supports column pruning 2. TODO: support push down filter 3. Super TODO:
+ *      support store offheap object directly
  *
  * The data transformation pipeline:
  *
  *   - Serializer ColumnarBatch -> CachedColumnarBatch
- *     -> serialize to byte[]
+ * -> serialize to byte[]
  *
  *   - Deserializer CachedColumnarBatch -> ColumnarBatch
- *     -> deserialize to byte[] to create Velox ColumnarBatch
+ * -> deserialize to byte[] to create Velox ColumnarBatch
  *
  *   - Serializer InternalRow -> CachedColumnarBatch (support RowToColumnar)
- *     -> Convert InternalRow to ColumnarBatch
- *     -> Serializer ColumnarBatch -> CachedColumnarBatch
+ * -> Convert InternalRow to ColumnarBatch
+ * -> Serializer ColumnarBatch -> CachedColumnarBatch
  *
  *   - Serializer InternalRow -> DefaultCachedBatch (unsupport RowToColumnar)
- *     -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
+ * -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
  *
  *   - Deserializer CachedColumnarBatch -> InternalRow (support ColumnarToRow)
- *     -> Deserializer CachedColumnarBatch -> ColumnarBatch
- *     -> Convert ColumnarBatch to InternalRow
+ * -> Deserializer CachedColumnarBatch -> ColumnarBatch
+ * -> Convert ColumnarBatch to InternalRow
  *
  *   - Deserializer DefaultCachedBatch -> InternalRow (unsupport ColumnarToRow)
- *     -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
+ * -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
  */
 // spotless:on
 class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHelper {
@@ -230,14 +229,15 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
     val timezoneId = SQLConf.get.sessionLocalTimeZone
     input.mapPartitions {
       it =>
+        val jniWrapper = ColumnarBatchSerializerJniWrapper
+          .create()
         val nmm = NativeMemoryManagers
           .contextInstance("ColumnarCachedBatchSerializer read")
         val schema = SparkArrowUtil.toArrowSchema(localSchema, timezoneId)
         val arrowAlloc = ArrowBufferAllocators.contextInstance()
         val cSchema = ArrowSchema.allocateNew(arrowAlloc)
         ArrowAbiUtil.exportSchema(arrowAlloc, schema, cSchema)
-        val deserializerHandle = ColumnarBatchSerializerJniWrapper
-          .create()
+        val deserializerHandle = jniWrapper
           .init(
             cSchema.memoryAddress(),
             nmm.getNativeInstanceHandle
@@ -251,8 +251,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
             override def next(): ColumnarBatch = {
               val cachedBatch = it.next().asInstanceOf[CachedColumnarBatch]
               val batchHandle =
-                ColumnarBatchSerializerJniWrapper
-                  .create()
+                jniWrapper
                   .deserialize(deserializerHandle, cachedBatch.bytes)
               val batch = ColumnarBatches.create(Runtimes.contextInstance(), batchHandle)
               if (shouldSelectAttributes) {
@@ -267,7 +266,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
             }
           })
           .recycleIterator {
-            ColumnarBatchSerializerJniWrapper.create().close(deserializerHandle)
+            jniWrapper.close(deserializerHandle)
           }
           .recyclePayload(_.close())
           .create()

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -83,9 +83,9 @@ private class CelebornColumnarBatchSerializerInstance(
       }
     val compressionCodecBackend =
       GlutenConfig.getConf.columnarShuffleCodecBackend.orNull
+    val jniWrapper = ShuffleReaderJniWrapper.create()
     val batchSize = GlutenConfig.getConf.maxBatchSize
-    val handle = ShuffleReaderJniWrapper
-      .create()
+    val handle = jniWrapper
       .make(
         cSchema.memoryAddress(),
         nmm.getNativeInstanceHandle,
@@ -98,7 +98,7 @@ private class CelebornColumnarBatchSerializerInstance(
     // was used to create all buffers read from shuffle reader. The pool
     // should keep alive before all buffers to finish consuming.
     TaskResources.addRecycler(s"CelebornShuffleReaderHandle_$handle", 50) {
-      ShuffleReaderJniWrapper.create().close(handle)
+      jniWrapper.close(handle)
       cSchema.release()
       cSchema.close()
       allocator.close()

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -21,7 +21,7 @@ import io.glutenproject.exec.Runtimes
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
 import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.ArrowAbiUtil
-import io.glutenproject.vectorized.{ColumnarBatchOutIterator, GeneralOutIterator, JniByteInputStream, JniByteInputStreams, ShuffleReaderJniWrapper}
+import io.glutenproject.vectorized._
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
@@ -31,7 +31,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.TaskResources
+import org.apache.spark.util.{TaskResource, TaskResources}
 
 import org.apache.arrow.c.ArrowSchema
 import org.apache.arrow.memory.BufferAllocator
@@ -39,6 +39,8 @@ import org.apache.celeborn.client.read.CelebornInputStream
 
 import java.io._
 import java.nio.ByteBuffer
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.reflect.ClassTag
 
@@ -70,7 +72,7 @@ private class CelebornColumnarBatchSerializerInstance(
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)
     val arrowSchema =
       SparkSchemaUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)
-    val cSchema = ArrowSchema.allocateNew(ArrowBufferAllocators.contextInstance())
+    val cSchema = ArrowSchema.allocateNew(allocator)
     ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
     val conf = SparkEnv.get.conf
     val compressionCodec =
@@ -96,128 +98,154 @@ private class CelebornColumnarBatchSerializerInstance(
     // was used to create all buffers read from shuffle reader. The pool
     // should keep alive before all buffers to finish consuming.
     TaskResources.addRecycler(s"CelebornShuffleReaderHandle_$handle", 50) {
-      cSchema.close()
       ShuffleReaderJniWrapper.create().close(handle)
+      cSchema.release()
+      cSchema.close()
       allocator.close()
     }
     handle
   }
 
   override def deserializeStream(in: InputStream): DeserializationStream = {
-    new DeserializationStream {
-      private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
-      private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
-        Runtimes.contextInstance(),
-        ShuffleReaderJniWrapper
-          .create()
-          .readStream(shuffleReaderHandle, byteIn),
-        nmm)
+    val uuid = UUID.randomUUID().toString
+    TaskResources.addResource(uuid, new TaskDeserializationStream(uuid, in))
+  }
 
-      private var cb: ColumnarBatch = _
+  private class TaskDeserializationStream(resourceId: String, in: InputStream)
+    extends DeserializationStream
+    with TaskResource {
+    private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
+    private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
+      Runtimes.contextInstance(),
+      ShuffleReaderJniWrapper
+        .create()
+        .readStream(shuffleReaderHandle, byteIn),
+      nmm)
 
-      private var numBatchesTotal: Long = _
-      private var numRowsTotal: Long = _
+    private var cb: ColumnarBatch = _
 
-      private var isClosed: Boolean = false
+    private var numBatchesTotal: Long = _
+    private var numRowsTotal: Long = _
 
-      private val isEmptyStream: Boolean = in.equals(CelebornInputStream.empty())
+    private var isClosed: Boolean = false
 
-      override def asKeyValueIterator: Iterator[(Any, Any)] = new Iterator[(Any, Any)] {
-        private var gotNext = false
-        private var nextValue: (Any, Any) = _
-        private var finished = false
+    private val isEmptyStream: Boolean = in.equals(CelebornInputStream.empty())
 
-        def getNext: (Any, Any) = {
-          try {
-            (readKey[Any](), readValue[Any]())
-          } catch {
-            case eof: EOFException =>
-              finished = true
-              null
-          }
-        }
+    override def asKeyValueIterator: Iterator[(Any, Any)] = new Iterator[(Any, Any)] {
+      private var gotNext = false
+      private var nextValue: (Any, Any) = _
+      private var finished = false
 
-        override def hasNext: Boolean = {
-          if (!isEmptyStream && !finished) {
-            if (!gotNext) {
-              nextValue = getNext
-              gotNext = true
-            }
-          }
-          !isEmptyStream && !finished
-        }
-
-        override def next(): (Any, Any) = {
-          if (!hasNext) {
-            throw new NoSuchElementException("End of stream")
-          }
-          gotNext = false
-          nextValue
+      def getNext: (Any, Any) = {
+        try {
+          (readKey[Any](), readValue[Any]())
+        } catch {
+          case eof: EOFException =>
+            finished = true
+            null
         }
       }
 
-      override def asIterator: Iterator[Any] = {
-        // This method is never called by shuffle code.
-        throw new UnsupportedOperationException
-      }
-
-      override def readKey[T: ClassTag](): T = {
-        // We skipped serialization of the key in writeKey(), so just return a dummy value since
-        // this is going to be discarded anyways.
-        null.asInstanceOf[T]
-      }
-
-      @throws(classOf[EOFException])
-      override def readValue[T: ClassTag](): T = {
-        if (cb != null) {
-          cb.close()
-          cb = null
-        }
-        val batch = {
-          val maybeBatch =
-            try {
-              wrappedOut.next()
-            } catch {
-              case ioe: IOException =>
-                this.close()
-                logError("Failed to load next RecordBatch", ioe)
-                throw ioe
-            }
-          if (maybeBatch == null) {
-            // EOF reached
-            this.close()
-            throw new EOFException
+      override def hasNext: Boolean = {
+        if (!isEmptyStream && !finished) {
+          if (!gotNext) {
+            nextValue = getNext
+            gotNext = true
           }
-          maybeBatch
         }
-        val numRows = batch.numRows()
-        logDebug(s"Read ColumnarBatch of $numRows rows")
-        numBatchesTotal += 1
-        numRowsTotal += numRows
-        cb = batch
-        cb.asInstanceOf[T]
+        !isEmptyStream && !finished
       }
 
-      override def readObject[T: ClassTag](): T = {
-        // This method is never called by shuffle code.
-        throw new UnsupportedOperationException
-      }
-
-      override def close(): Unit = {
-        if (!isClosed) {
-          if (numBatchesTotal > 0) {
-            readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
-          }
-          numOutputRows += numRowsTotal
-          wrappedOut.close()
-          byteIn.close()
-          if (cb != null) {
-            cb.close()
-          }
-          isClosed = true
+      override def next(): (Any, Any) = {
+        if (!hasNext) {
+          throw new NoSuchElementException("End of stream")
         }
+        gotNext = false
+        nextValue
       }
     }
+
+    override def asIterator: Iterator[Any] = {
+      // This method is never called by shuffle code.
+      throw new UnsupportedOperationException
+    }
+
+    override def readKey[T: ClassTag](): T = {
+      // We skipped serialization of the key in writeKey(), so just return a dummy value since
+      // this is going to be discarded anyways.
+      null.asInstanceOf[T]
+    }
+
+    @throws(classOf[EOFException])
+    override def readValue[T: ClassTag](): T = {
+      if (cb != null) {
+        cb.close()
+        cb = null
+      }
+      val batch = {
+        val maybeBatch =
+          try {
+            wrappedOut.next()
+          } catch {
+            case ioe: IOException =>
+              this.close()
+              logError("Failed to load next RecordBatch", ioe)
+              throw ioe
+          }
+        if (maybeBatch == null) {
+          // EOF reached
+          this.close()
+          throw new EOFException
+        }
+        maybeBatch
+      }
+      val numRows = batch.numRows()
+      logDebug(s"Read ColumnarBatch of $numRows rows")
+      numBatchesTotal += 1
+      numRowsTotal += numRows
+      cb = batch
+      cb.asInstanceOf[T]
+    }
+
+    override def readObject[T: ClassTag](): T = {
+      // This method is never called by shuffle code.
+      throw new UnsupportedOperationException
+    }
+
+    // Otherwise calling close() twice would cause resource ID not found error.
+    private val closeCalled: AtomicBoolean = new AtomicBoolean(false)
+
+    // Otherwise calling release() twice would cause #close0() to be called twice.
+    private val releaseCalled: AtomicBoolean = new AtomicBoolean(false)
+
+    override def close(): Unit = {
+      if (!closeCalled.compareAndSet(false, true)) {
+        return
+      }
+      // Would remove the resource object from registry to lower GC pressure.
+      TaskResources.releaseResource(resourceId)
+    }
+
+    override def release(): Unit = {
+      if (!releaseCalled.compareAndSet(false, true)) {
+        return
+      }
+      close0()
+    }
+
+    private def close0(): Unit = {
+      if (numBatchesTotal > 0) {
+        readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
+      }
+      numOutputRows += numRowsTotal
+      wrappedOut.close()
+      byteIn.close()
+      if (cb != null) {
+        cb.close()
+      }
+    }
+
+    override def resourceName(): String = getClass.getName
   }
 
   // Columnar shuffle write process don't need this.

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -64,9 +64,9 @@ private class CelebornColumnarBatchSerializerInstance(
   extends SerializerInstance
   with Logging {
 
-  private lazy val nmm = NativeMemoryManagers.contextInstance("ShuffleReader")
+  private val nmm = NativeMemoryManagers.contextInstance("ShuffleReader")
 
-  private lazy val shuffleReaderHandle = {
+  private val shuffleReaderHandle = {
     val allocator: BufferAllocator = ArrowBufferAllocators
       .contextInstance(classOf[CelebornColumnarBatchSerializerInstance].getSimpleName)
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -113,8 +113,8 @@ private class CelebornColumnarBatchSerializerInstance(
   private class TaskDeserializationStream(in: InputStream)
     extends DeserializationStream
     with TaskResource {
-    private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
-    private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
+    private val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
+    private val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
       Runtimes.contextInstance(),
       ShuffleReaderJniWrapper
         .create()

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -107,11 +107,10 @@ private class CelebornColumnarBatchSerializerInstance(
   }
 
   override def deserializeStream(in: InputStream): DeserializationStream = {
-    val uuid = UUID.randomUUID().toString
-    TaskResources.addResource(uuid, new TaskDeserializationStream(uuid, in))
+    new TaskDeserializationStream(in)
   }
 
-  private class TaskDeserializationStream(resourceId: String, in: InputStream)
+  private class TaskDeserializationStream(in: InputStream)
     extends DeserializationStream
     with TaskResource {
     private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
@@ -127,9 +126,17 @@ private class CelebornColumnarBatchSerializerInstance(
     private var numBatchesTotal: Long = _
     private var numRowsTotal: Long = _
 
-    private var isClosed: Boolean = false
-
     private val isEmptyStream: Boolean = in.equals(CelebornInputStream.empty())
+
+    // Otherwise calling close() twice would cause resource ID not found error.
+    private val closeCalled: AtomicBoolean = new AtomicBoolean(false)
+
+    // Otherwise calling release() twice would cause #close0() to be called twice.
+    private val releaseCalled: AtomicBoolean = new AtomicBoolean(false)
+
+    private val resourceId = UUID.randomUUID().toString
+
+    TaskResources.addResource(resourceId, this)
 
     override def asKeyValueIterator: Iterator[(Any, Any)] = new Iterator[(Any, Any)] {
       private var gotNext = false
@@ -211,12 +218,6 @@ private class CelebornColumnarBatchSerializerInstance(
       // This method is never called by shuffle code.
       throw new UnsupportedOperationException
     }
-
-    // Otherwise calling close() twice would cause resource ID not found error.
-    private val closeCalled: AtomicBoolean = new AtomicBoolean(false)
-
-    // Otherwise calling release() twice would cause #close0() to be called twice.
-    private val releaseCalled: AtomicBoolean = new AtomicBoolean(false)
 
     override def close(): Unit = {
       if (!closeCalled.compareAndSet(false, true)) {

--- a/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/gluten-celeborn/velox/src/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -68,7 +68,7 @@ private class CelebornColumnarBatchSerializerInstance(
 
   private lazy val shuffleReaderHandle = {
     val allocator: BufferAllocator = ArrowBufferAllocators
-      .contextInstance()
+      .contextInstance(classOf[CelebornColumnarBatchSerializerInstance].getSimpleName)
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)
     val arrowSchema =
       SparkSchemaUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -210,7 +210,15 @@ class TaskResourceRegistry extends Logging {
     )
     table.forEach {
       _.getValue.asScala.toSeq.reverse
-        .foreach(_.release()) // lifo for all resources within the same priority
+        .foreach {
+          r =>
+            // scalastyle:off println
+            println(
+              s"Releasing ${r.resourceName()},${r.priority()} " +
+                s"from task ${TaskContext.get().taskAttemptId()}...")
+            // scalastyle:on println
+            r.release()
+        } // lifo for all resources within the same priority
     }
     priorityToResourcesMapping.clear()
     resources.clear()
@@ -230,6 +238,11 @@ class TaskResourceRegistry extends Logging {
     if (!samePrio.contains(resource)) {
       throw new IllegalStateException("TaskResource not found in priority mapping")
     }
+    // scalastyle:off println
+    println(
+      s"[SINGLE] Releasing ${resource.resourceName()},${resource.priority()} " +
+        s"from task ${TaskContext.get().taskAttemptId()}...")
+    // scalastyle:on println
     resource.release()
     samePrio.remove(resource)
     resources.remove(id)

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -203,7 +203,9 @@ class TaskResourceRegistry extends Logging {
           o1: util.Map.Entry[Int, util.LinkedHashSet[TaskResource]],
           o2: util.Map.Entry[Int, util.LinkedHashSet[TaskResource]]) => {
         val diff = o2.getKey - o1.getKey // descending by priority
-        if (diff > 0) 1 else if (diff < 0) -1 else 0
+        if (diff > 0) 1
+        else if (diff < 0) -1
+        else throw new IllegalStateException("Unreachable code")
       }
     )
     table.forEach {

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -25,7 +25,6 @@ import _root_.io.glutenproject.utils.TaskListener
 
 import java.util
 import java.util.{Collections, UUID}
-import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.JavaConverters._

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -210,15 +210,7 @@ class TaskResourceRegistry extends Logging {
     )
     table.forEach {
       _.getValue.asScala.toSeq.reverse
-        .foreach {
-          r =>
-            // scalastyle:off println
-            println(
-              s"Releasing ${r.resourceName()},${r.priority()} " +
-                s"from task ${TaskContext.get().taskAttemptId()}...")
-            // scalastyle:on println
-            r.release()
-        } // lifo for all resources within the same priority
+        .foreach(_.release()) // lifo for all resources within the same priority
     }
     priorityToResourcesMapping.clear()
     resources.clear()
@@ -238,11 +230,6 @@ class TaskResourceRegistry extends Logging {
     if (!samePrio.contains(resource)) {
       throw new IllegalStateException("TaskResource not found in priority mapping")
     }
-    // scalastyle:off println
-    println(
-      s"[SINGLE] Releasing ${resource.resourceName()},${resource.priority()} " +
-        s"from task ${TaskContext.get().taskAttemptId()}...")
-    // scalastyle:on println
     resource.release()
     samePrio.remove(resource)
     resources.remove(id)

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -199,11 +199,11 @@ class TaskResourceRegistry extends Logging {
   }
   private def exclusiveLock[T](body: => T): T = {
     synchronized {
+      if (exclusiveLockAcquired) {
+        throw new ConcurrentModificationException
+      }
+      exclusiveLockAcquired = true
       try {
-        if (exclusiveLockAcquired) {
-          throw new ConcurrentModificationException
-        }
-        exclusiveLockAcquired = true
         body
       } finally {
         exclusiveLockAcquired = false

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -24,8 +24,10 @@ import _root_.io.glutenproject.memory.SimpleMemoryUsageRecorder
 import _root_.io.glutenproject.utils.TaskListener
 
 import java.util
-import java.util.{Comparator, PriorityQueue, UUID}
+import java.util.{Collections, UUID}
 import java.util.concurrent.atomic.AtomicLong
+
+import scala.collection.JavaConverters._
 
 object TaskResources extends TaskListener with Logging {
   // And open java assert mode to get memory stack
@@ -94,24 +96,12 @@ object TaskResources extends TaskListener with Logging {
     })
   }
 
-  def addRecycler(id: String, name: String, prio: Int)(f: => Unit): Unit = {
-    addResource(
-      id,
-      new TaskResource {
-        override def release(): Unit = f
-
-        override def priority(): Int = prio
-
-        override def resourceName(): String = name
-      })
-  }
-
   def addResource[T <: TaskResource](id: String, resource: T): T = {
     getTaskResourceRegistry().addResource(id, resource)
   }
 
-  def removeResource(id: String): Unit = {
-    getTaskResourceRegistry().removeResource(id)
+  def releaseResource(id: String): Unit = {
+    getTaskResourceRegistry().releaseResource(id)
   }
 
   def addResourceIfNotRegistered[T <: TaskResource](id: String, factory: () => T): T = {
@@ -193,51 +183,60 @@ object TaskResources extends TaskListener with Logging {
 // thread safe
 class TaskResourceRegistry extends Logging {
   private val sharedUsage = new SimpleMemoryUsageRecorder()
-  type TaskResourceWithOrdering = (TaskResource, Int)
-  private val resources = new util.HashMap[String, TaskResourceWithOrdering]()
-  // A monotonically increasing accumulator to specify the task resource ordering
-  // when inserting into queue
-  private var resourceOrdering = 0
-  // 0 is lowest, Int.MaxValue is highest
-  private val resourcesPriorityQueue =
-    new PriorityQueue[TaskResourceWithOrdering](new Comparator[TaskResourceWithOrdering]() {
-      override def compare(t1: TaskResourceWithOrdering, t2: TaskResourceWithOrdering): Int = {
-        val diff = t2._1.priority() - t1._1.priority()
-        if (diff == 0) {
-          // If the task resource has same priority, we should follow the LIFO
-          t2._2 - t1._2
-        } else {
-          diff
-        }
-      }
-    })
+  private val resources = new util.HashMap[String, TaskResource]()
+  private val priorityToResourcesMapping: util.HashMap[Int, util.LinkedHashSet[TaskResource]] =
+    new util.HashMap[Int, util.LinkedHashSet[TaskResource]]()
 
   private def addResource0(id: String, resource: TaskResource): Unit = synchronized {
-    val resourceWithOrdering = (resource, resourceOrdering)
-    resources.put(id, resourceWithOrdering)
-    resourcesPriorityQueue.add(resourceWithOrdering)
-    resourceOrdering += 1
+    resources.put(id, resource)
+    priorityToResourcesMapping
+      .computeIfAbsent(resource.priority(), _ => new util.LinkedHashSet[TaskResource]())
+      .add(resource)
   }
 
   /** Release all managed resources according to priority and reversed order */
   private[util] def releaseAll(): Unit = synchronized {
-    while (!resourcesPriorityQueue.isEmpty) {
-      val resource = resourcesPriorityQueue.poll()._1
-      try {
-        resource.release()
-      } catch {
-        case e: Throwable =>
-          logWarning(s"Failed to call release() on task resource ${resource.resourceName()}", e)
+    val table = new util.ArrayList(priorityToResourcesMapping.entrySet())
+    Collections.sort(
+      table,
+      (
+          o1: util.Map.Entry[Int, util.LinkedHashSet[TaskResource]],
+          o2: util.Map.Entry[Int, util.LinkedHashSet[TaskResource]]) => {
+        val diff = o2.getKey - o1.getKey // descending by priority
+        if (diff > 0) 1 else if (diff < 0) -1 else 0
       }
+    )
+    table.forEach {
+      _.getValue.asScala.toSeq.reverse
+        .foreach(_.release()) // lifo for all resources within the same priority
     }
+    priorityToResourcesMapping.clear()
     resources.clear()
-    resourceOrdering = 0
+  }
+
+  /** Release single resource by ID */
+  private[util] def releaseResource(id: String): Unit = synchronized {
+    if (!resources.containsKey(id)) {
+      throw new IllegalArgumentException(
+        String.format("TaskResource with ID %s is not registered", id))
+    }
+    val resource = resources.get(id)
+    if (!priorityToResourcesMapping.containsKey(resource.priority())) {
+      throw new IllegalStateException("TaskResource's priority not found in priority mapping")
+    }
+    val samePrio = priorityToResourcesMapping.get(resource.priority())
+    if (!samePrio.contains(resource)) {
+      throw new IllegalStateException("TaskResource not found in priority mapping")
+    }
+    resource.release()
+    samePrio.remove(resource)
+    resources.remove(id)
   }
 
   private[util] def addResourceIfNotRegistered[T <: TaskResource](id: String, factory: () => T): T =
     synchronized {
       if (resources.containsKey(id)) {
-        return resources.get(id)._1.asInstanceOf[T]
+        return resources.get(id).asInstanceOf[T]
       }
       val resource = factory.apply()
       addResource0(id, resource)
@@ -262,19 +261,10 @@ class TaskResourceRegistry extends Logging {
       throw new IllegalArgumentException(
         String.format("TaskResource with ID %s is not registered", id))
     }
-    resources.get(id)._1.asInstanceOf[T]
+    resources.get(id).asInstanceOf[T]
   }
 
   private[util] def getSharedUsage(): SimpleMemoryUsageRecorder = synchronized {
     sharedUsage
-  }
-
-  private[util] def removeResource(id: String): Unit = synchronized {
-    if (!resources.containsKey(id)) {
-      throw new IllegalArgumentException(
-        String.format("TaskResource with ID %s is not registered", id))
-    }
-    resourcesPriorityQueue.remove(resources.get(id))
-    resources.remove(id)
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/TaskResources.scala
@@ -198,7 +198,7 @@ class TaskResourceRegistry extends Logging {
     }
   }
   private def exclusiveLock[T](body: => T): T = {
-    lock {
+    synchronized {
       try {
         if (exclusiveLockAcquired) {
           throw new ConcurrentModificationException

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -41,18 +41,25 @@ public class ArrowBufferAllocators {
     return GLOBAL;
   }
 
+  // FIXME: Remove this then use contextInstance(name) instead
   public static BufferAllocator contextInstance() {
+    return contextInstance("Default");
+  }
+
+  public static BufferAllocator contextInstance(String name) {
     if (!TaskResources.inSparkTask()) {
       throw new IllegalStateException("This method must be called in a Spark task.");
     }
-    String id = ArrowBufferAllocatorManager.class.toString();
-    return TaskResources.addResourceIfNotRegistered(id, ArrowBufferAllocatorManager::new).managed;
+    String id = "ArrowBufferAllocatorManager:" + name;
+    return TaskResources.addResourceIfNotRegistered(id, () -> new ArrowBufferAllocatorManager(name))
+        .managed;
   }
 
   public static class ArrowBufferAllocatorManager implements TaskResource {
     private static Logger LOGGER = LoggerFactory.getLogger(ArrowBufferAllocatorManager.class);
     private static final List<BufferAllocator> LEAKED = new Vector<>();
     private final AllocationListener listener;
+    private final String name;
 
     {
       final TaskMemoryManager tmm = TaskResources.getLocalTaskContext().taskMemoryManager();
@@ -69,7 +76,9 @@ public class ArrowBufferAllocators {
 
     private final BufferAllocator managed = new RootAllocator(listener, Long.MAX_VALUE);
 
-    public ArrowBufferAllocatorManager() {}
+    public ArrowBufferAllocatorManager(String name) {
+      this.name = name;
+    }
 
     private void close() {
       managed.close();
@@ -106,7 +115,7 @@ public class ArrowBufferAllocators {
 
     @Override
     public String resourceName() {
-      return "ArrowBufferAllocatorManager";
+      return name;
     }
   }
 }

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -21,6 +21,7 @@ import io.glutenproject.memory.memtarget.MemoryTargets;
 import org.apache.arrow.memory.AllocationListener;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.spark.TaskContext;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.util.TaskResource;
 import org.apache.spark.util.TaskResources;
@@ -90,9 +91,9 @@ public class ArrowBufferAllocators {
       long accumulated = TaskResources.ACCUMULATED_LEAK_BYTES().addAndGet(leakBytes);
       LOGGER.warn(
           String.format(
-              "Detected leaked Arrow allocator [%s], size: %d, "
+              "Detected leaked Arrow allocator [%s][%s], size: %d, "
                   + "process accumulated leaked size: %d...",
-              resourceName(), leakBytes, accumulated));
+              TaskContext.get().taskAttemptId(), resourceName(), leakBytes, accumulated));
       if (TaskResources.DEBUG()) {
         LOGGER.warn(String.format("Leaked allocator stack %s", managed.toVerboseString()));
         LEAKED.add(managed);

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -81,9 +81,9 @@ public class ArrowBufferAllocators {
       long accumulated = TaskResources.ACCUMULATED_LEAK_BYTES().addAndGet(leakBytes);
       LOGGER.warn(
           String.format(
-              "Detected leaked Arrow allocator, size: %d, "
+              "Detected leaked Arrow allocator [%s], size: %d, "
                   + "process accumulated leaked size: %d...",
-              leakBytes, accumulated));
+              resourceName(), leakBytes, accumulated));
       if (TaskResources.DEBUG()) {
         LOGGER.warn(String.format("Leaked allocator stack %s", managed.toVerboseString()));
         LEAKED.add(managed);

--- a/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/arrowalloc/ArrowBufferAllocators.java
@@ -21,7 +21,6 @@ import io.glutenproject.memory.memtarget.MemoryTargets;
 import org.apache.arrow.memory.AllocationListener;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.spark.TaskContext;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.util.TaskResource;
 import org.apache.spark.util.TaskResources;
@@ -91,9 +90,9 @@ public class ArrowBufferAllocators {
       long accumulated = TaskResources.ACCUMULATED_LEAK_BYTES().addAndGet(leakBytes);
       LOGGER.warn(
           String.format(
-              "Detected leaked Arrow allocator [%s][%s], size: %d, "
+              "Detected leaked Arrow allocator [%s], size: %d, "
                   + "process accumulated leaked size: %d...",
-              TaskContext.get().taskAttemptId(), resourceName(), leakBytes, accumulated));
+              resourceName(), leakBytes, accumulated));
       if (TaskResources.DEBUG()) {
         LOGGER.warn(String.format("Leaked allocator stack %s", managed.toVerboseString()));
         LEAKED.add(managed);

--- a/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManagers.java
+++ b/gluten-data/src/main/java/io/glutenproject/memory/nmm/NativeMemoryManagers.java
@@ -43,8 +43,9 @@ public final class NativeMemoryManagers {
     if (!TaskResources.inSparkTask()) {
       throw new IllegalStateException("This method must be called in a Spark task.");
     }
+    String id = "NativeMemoryManager:" + name;
     return TaskResources.addResourceIfNotRegistered(
-        name, () -> createNativeMemoryManager(name, Collections.emptyList()));
+        id, () -> createNativeMemoryManager(name, Collections.emptyList()));
   }
 
   /** Create a temporary memory manager, caller should call NativeMemoryManager#release manually. */

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -80,7 +80,7 @@ private class ColumnarBatchSerializerInstance(
   private lazy val nmm = NativeMemoryManagers.contextInstance("ShuffleReader")
   private lazy val shuffleReaderHandle = {
     val allocator: BufferAllocator = ArrowBufferAllocators
-      .contextInstance()
+      .contextInstance(classOf[ColumnarBatchSerializerInstance].getSimpleName)
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)
     val arrowSchema =
       SparkSchemaUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -130,8 +130,8 @@ private class ColumnarBatchSerializerInstance(
   private class TaskDeserializationStream(in: InputStream)
     extends DeserializationStream
     with TaskResource {
-    private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
-    private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
+    private val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
+    private val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
       Runtimes.contextInstance(),
       ShuffleReaderJniWrapper
         .create()

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.TaskResources
+import org.apache.spark.util.{TaskResource, TaskResources}
 
 import org.apache.arrow.c.ArrowSchema
 import org.apache.arrow.memory.BufferAllocator
@@ -39,6 +39,7 @@ import org.apache.arrow.memory.BufferAllocator
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.reflect.ClassTag
 
@@ -83,7 +84,7 @@ private class ColumnarBatchSerializerInstance(
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)
     val arrowSchema =
       SparkSchemaUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)
-    val cSchema = ArrowSchema.allocateNew(ArrowBufferAllocators.contextInstance())
+    val cSchema = ArrowSchema.allocateNew(allocator)
     ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
     val conf = SparkEnv.get.conf
     val compressionCodec =
@@ -114,114 +115,124 @@ private class ColumnarBatchSerializerInstance(
       ipcTime += readerMetrics.getIpcTime
       deserializeTime += readerMetrics.getDeserializeTime
 
-      cSchema.close()
       jniWrapper.close(shuffleReaderHandle)
+      cSchema.release()
+      cSchema.close()
       allocator.close()
     }
     shuffleReaderHandle
   }
 
   override def deserializeStream(in: InputStream): DeserializationStream = {
-    new DeserializationStream {
-      private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
-      private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
-        Runtimes.contextInstance(),
-        ShuffleReaderJniWrapper
-          .create()
-          .readStream(shuffleReaderHandle, byteIn),
-        nmm)
+    val uuid = UUID.randomUUID().toString
+    TaskResources.addResource(uuid, new TaskDeserializationStream(uuid, in))
+  }
 
-      private var cb: ColumnarBatch = _
+  private class TaskDeserializationStream(resourceId: String, in: InputStream)
+    extends DeserializationStream
+    with TaskResource {
+    private lazy val byteIn: JniByteInputStream = JniByteInputStreams.create(in)
+    private lazy val wrappedOut: GeneralOutIterator = new ColumnarBatchOutIterator(
+      Runtimes.contextInstance(),
+      ShuffleReaderJniWrapper
+        .create()
+        .readStream(shuffleReaderHandle, byteIn),
+      nmm)
 
-      private var numBatchesTotal: Long = _
-      private var numRowsTotal: Long = _
+    private var cb: ColumnarBatch = _
 
-      private var isClosed: Boolean = false
+    private var numBatchesTotal: Long = _
+    private var numRowsTotal: Long = _
 
-      // We don't yet have a path to propagate `close` calls from Velox's value stream
-      // to Spark-side's endpoint like this place.
-      //
-      // E.g. A Velox limit operator may suddenly drop the input stream after emitting enough
-      // rows. In the case DeserializationStream#close() will not be called. Spark doesn't
-      // call close() either. So we should handle the case especially.
-      private val resourceId = UUID.randomUUID().toString
-      TaskResources.addRecycler(
-        resourceId,
-        s"ShuffleReaderDeserializationStream_${wrappedOut.getId}",
-        50) {
-        if (!isClosed) {
-          this.close0()
-          isClosed = true
-        }
+    private var isClosed: Boolean = false
+
+    override def asIterator: Iterator[Any] = {
+      // This method is never called by shuffle code.
+      throw new UnsupportedOperationException
+    }
+
+    override def readKey[T: ClassTag](): T = {
+      // We skipped serialization of the key in writeKey(), so just return a dummy value since
+      // this is going to be discarded anyways.
+      null.asInstanceOf[T]
+    }
+
+    @throws(classOf[EOFException])
+    override def readValue[T: ClassTag](): T = {
+      if (cb != null) {
+        cb.close()
+        cb = null
       }
-
-      override def asIterator: Iterator[Any] = {
-        // This method is never called by shuffle code.
-        throw new UnsupportedOperationException
-      }
-
-      override def readKey[T: ClassTag](): T = {
-        // We skipped serialization of the key in writeKey(), so just return a dummy value since
-        // this is going to be discarded anyways.
-        null.asInstanceOf[T]
-      }
-
-      @throws(classOf[EOFException])
-      override def readValue[T: ClassTag](): T = {
-        if (cb != null) {
-          cb.close()
-          cb = null
-        }
-        val batch = {
-          val maybeBatch =
-            try {
-              wrappedOut.next()
-            } catch {
-              case ioe: IOException =>
-                this.close()
-                logError("Failed to load next RecordBatch", ioe)
-                throw ioe
-            }
-          if (maybeBatch == null) {
-            // EOF reached
-            this.close()
-            throw new EOFException
+      val batch = {
+        val maybeBatch =
+          try {
+            wrappedOut.next()
+          } catch {
+            case ioe: IOException =>
+              this.close()
+              logError("Failed to load next RecordBatch", ioe)
+              throw ioe
           }
-          maybeBatch
+        if (maybeBatch == null) {
+          // EOF reached
+          this.close()
+          throw new EOFException
         }
-        val numRows = batch.numRows()
-        logDebug(s"Read ColumnarBatch of $numRows rows")
-        numBatchesTotal += 1
-        numRowsTotal += numRows
-        cb = batch
-        cb.asInstanceOf[T]
+        maybeBatch
       }
+      val numRows = batch.numRows()
+      logDebug(s"Read ColumnarBatch of $numRows rows")
+      numBatchesTotal += 1
+      numRowsTotal += numRows
+      cb = batch
+      cb.asInstanceOf[T]
+    }
 
-      override def readObject[T: ClassTag](): T = {
-        // This method is never called by shuffle code.
-        throw new UnsupportedOperationException
+    override def readObject[T: ClassTag](): T = {
+      // This method is never called by shuffle code.
+      throw new UnsupportedOperationException
+    }
+
+    // Otherwise calling close() twice would cause resource ID not found error.
+    private val closeCalled: AtomicBoolean = new AtomicBoolean(false)
+
+    // Otherwise calling release() twice would cause #close0() to be called twice.
+    private val releaseCalled: AtomicBoolean = new AtomicBoolean(false)
+
+    override def close(): Unit = {
+      if (!closeCalled.compareAndSet(false, true)) {
+        return
       }
+      // Would remove the resource object from registry to lower GC pressure.
+      TaskResources.releaseResource(resourceId)
+    }
 
-      override def close(): Unit = {
-        if (!isClosed) {
-          TaskResources.removeResource(resourceId)
-          close0()
-          isClosed = true
-        }
+    // We don't yet have a path to propagate `close` calls from Velox's value stream
+    // to Spark-side's endpoint like this place.
+    //
+    // E.g. A Velox limit operator may suddenly drop the input stream after emitting enough
+    // rows. In the case DeserializationStream#close() will not be called. Spark doesn't
+    // call close() either. So we should handle the case especially.
+    override def release(): Unit = {
+      if (!releaseCalled.compareAndSet(false, true)) {
+        return
       }
+      close0()
+    }
 
-      private def close0(): Unit = {
-        if (numBatchesTotal > 0) {
-          readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
-        }
-        numOutputRows += numRowsTotal
-        wrappedOut.close()
-        byteIn.close()
-        if (cb != null) {
-          cb.close()
-        }
+    private def close0(): Unit = {
+      if (numBatchesTotal > 0) {
+        readBatchNumRows.set(numRowsTotal.toDouble / numBatchesTotal)
+      }
+      numOutputRows += numRowsTotal
+      wrappedOut.close()
+      byteIn.close()
+      if (cb != null) {
+        cb.close()
       }
     }
+
+    override def resourceName(): String = getClass.getName
   }
 
   // Columnar shuffle write process don't need this.

--- a/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/vectorized/ColumnarBatchSerializer.scala
@@ -77,8 +77,8 @@ private class ColumnarBatchSerializerInstance(
   extends SerializerInstance
   with Logging {
 
-  private lazy val nmm = NativeMemoryManagers.contextInstance("ShuffleReader")
-  private lazy val shuffleReaderHandle = {
+  private val nmm = NativeMemoryManagers.contextInstance("ShuffleReader")
+  private val shuffleReaderHandle = {
     val allocator: BufferAllocator = ArrowBufferAllocators
       .contextInstance(classOf[ColumnarBatchSerializerInstance].getSimpleName)
       .newChildAllocator("GlutenColumnarBatch deserialize", 0, Long.MaxValue)


### PR DESCRIPTION
Following #4276:

1. In resources' priority table, replace `PriorityQueue` with `LinkedHashSet` for efficient removing operation; (`PriorityQueue` was good until we added API to remove a single instance in #4276)
2. Make `DeserializationStream` a resource type to replace advanced use case of `addRecycler`
3. Mirror relevant changes to `VeloxCelebornColumnarBatchSerializer`

Update:

The patch will also add restriction to user defined `release()` method to disallow it from accessing task registry recursively, which may cause internal inconsistency leading to invalid state or memory leak.