### PR TITLE
[GLUTEN-4299][VL] support to set CPU_TARGET by environment variables

### DIFF
--- a/dev/package.sh
+++ b/dev/package.sh
@@ -10,7 +10,7 @@ VERSION=$(. /etc/os-release && echo ${VERSION_ID})
 ARCH=`uname -m`
 
 # compile gluten jar
-export CPU_TARGET="${ARCH}"
+export CPU_TARGET="${CPU_TARGET:-$ARCH}"
 $GLUTEN_DIR/dev/builddeps-veloxbe.sh --build_tests=ON --build_benchmarks=ON --enable_s3=ON --enable_hdfs=ON
 mvn clean package -Pbackends-velox -Prss -Pspark-3.2 -DskipTests
 mvn clean package -Pbackends-velox -Prss -Pspark-3.3 -DskipTests


### PR DESCRIPTION
## What changes were proposed in this pull request?

before that, building gluten may throw the errors like the issues. after that, you can build gluten successfully  by  setting  CPU_TARGET by environment variables.

## How was this patch tested?

 manual tests and the script like that : 
`export CPU_TARGET="avx"`
`./dev/package.sh`
