### PR TITLE
[GLUTEN-4314][CH]Dump pipeline's details upon completion

### DIFF
--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.h
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.h
@@ -411,6 +411,9 @@ private:
     DB::QueryPlanPtr current_query_plan;
     RelMetricPtr metric;
     std::vector<QueryPlanPtr> extra_plan_holder;
+
+    /// Dump processor runtime information to log
+    std::string dumpPipeline();
 };
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

Fixes: #4314 

set `spark.gluten.sql.columnar.backend.ch.runtime_config.dump_pipeline=true` to enable this log

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

