### PR TITLE
[VL] Support write empty rdd and empty iterator

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala
@@ -41,16 +41,16 @@ class SparkWriteFilesCommitProtocol(
   extends Logging {
   assert(committer.isInstanceOf[HadoopMapReduceCommitProtocol])
 
-  private val sparkStageId = TaskContext.get().stageId()
-  private val sparkPartitionId = TaskContext.get().partitionId()
-  private val sparkAttemptNumber = TaskContext.get().taskAttemptId().toInt & Int.MaxValue
+  val sparkStageId = TaskContext.get().stageId()
+  val sparkPartitionId = TaskContext.get().partitionId()
+  val sparkAttemptNumber = TaskContext.get().taskAttemptId().toInt & Int.MaxValue
   private val jobId = createJobID(jobTrackerID, sparkStageId)
 
   private val taskId = new TaskID(jobId, TaskType.MAP, sparkPartitionId)
   private val taskAttemptId = new TaskAttemptID(taskId, sparkAttemptNumber)
 
   // Set up the attempt context required to use in the output committer.
-  private val taskAttemptContext: TaskAttemptContext = {
+  val taskAttemptContext: TaskAttemptContext = {
     // Set up the configuration object
     val hadoopConf = description.serializableHadoopConf.value
     hadoopConf.set("mapreduce.job.id", jobId.toString)

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarWriteFilesExec.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/VeloxColumnarWriteFilesExec.scala
@@ -20,17 +20,19 @@ import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
+import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.{Partition, SparkException, TaskContext, TaskOutputFileAlreadyExistException}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.SparkHadoopWriterUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.shuffle.FetchFailedException
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, GenericInternalRow}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
-import org.apache.spark.sql.execution.datasources.{BasicWriteTaskStats, ExecutedWriteSummary, FileFormat, PartitioningUtils, WriteFilesExec, WriteFilesSpec, WriteTaskResult}
+import org.apache.spark.sql.execution.datasources.{BasicWriteTaskStats, DynamicPartitionDataSingleWriter, EmptyDirectoryDataWriter, ExecutedWriteSummary, FileFormat, PartitioningUtils, SingleDirectoryDataWriter, WriteFilesExec, WriteFilesSpec, WriteTaskResult}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
@@ -91,7 +93,7 @@ class VeloxColumnarWriteFilesRDD(
     jobTrackerID: String)
   extends RDD[WriterCommitMessage](prev) {
 
-  private def collectNativeWriteFilesMetrics(cb: ColumnarBatch): WriteTaskResult = {
+  private def collectNativeWriteFilesMetrics(cb: ColumnarBatch): Option[WriteTaskResult] = {
     // Currently, the cb contains three columns: row, fragments, and context.
     // The first row in the row column contains the number of written numRows.
     // The fragments column contains detailed information about the file writes.
@@ -119,7 +121,7 @@ class VeloxColumnarWriteFilesRDD(
 
       // part1=1/part2=1
       val partitionFragment = metrics.name
-      // Write a non-partitioned table
+      // Write a partitioned table
       if (partitionFragment != "") {
         updatedPartitions += partitionFragment
         val tmpOutputPath = outputPath + "/" + partitionFragment + "/" + targetFileName
@@ -138,6 +140,7 @@ class VeloxColumnarWriteFilesRDD(
         outputMetrics.setRecordsWritten(numWrittenRows)
     }
 
+    val numFiles = loadedCb.numRows() - 1
     val partitionsInternalRows = updatedPartitions.map {
       part =>
         val parts = new Array[Any](1)
@@ -146,13 +149,42 @@ class VeloxColumnarWriteFilesRDD(
     }.toSeq
     val stats = BasicWriteTaskStats(
       partitions = partitionsInternalRows,
-      numFiles = loadedCb.numRows() - 1,
+      numFiles = numFiles,
       numBytes = numBytes,
       numRows = numWrittenRows)
     val summary =
       ExecutedWriteSummary(updatedPartitions = updatedPartitions, stats = Seq(stats))
 
-    WriteTaskResult(new TaskCommitMessage(addedAbsPathFiles.toMap -> updatedPartitions), summary)
+    // write an empty iterator
+    if (numFiles == 0) {
+      None
+    } else {
+      Some(
+        WriteTaskResult(
+          new TaskCommitMessage(addedAbsPathFiles.toMap -> updatedPartitions),
+          summary))
+    }
+  }
+
+  private def writeFilesForEmptyIterator(
+      commitProtocol: SparkWriteFilesCommitProtocol): WriteTaskResult = {
+    val description = writeFilesSpec.description
+    val committer = writeFilesSpec.committer
+    val taskAttemptContext = commitProtocol.taskAttemptContext
+
+    val dataWriter =
+      if (commitProtocol.sparkPartitionId != 0) {
+        // In case of empty job, leave first partition to save meta for file format like parquet.
+        new EmptyDirectoryDataWriter(description, taskAttemptContext, committer)
+      } else if (description.partitionColumns.isEmpty) {
+        new SingleDirectoryDataWriter(description, taskAttemptContext, committer)
+      } else {
+        new DynamicPartitionDataSingleWriter(description, taskAttemptContext, committer)
+      }
+
+    // We have done `setupTask` outside
+    dataWriter.writeWithIterator(Iterator.empty)
+    dataWriter.commit()
   }
 
   override def compute(split: Partition, context: TaskContext): Iterator[WriterCommitMessage] = {
@@ -164,7 +196,7 @@ class VeloxColumnarWriteFilesRDD(
     commitProtocol.setupTask()
     val writePath = commitProtocol.newTaskAttemptTempPath()
     logDebug(s"Velox staging write path: $writePath")
-    var resultColumnarBatch: ColumnarBatch = null
+    var writeTaskResult: WriteTaskResult = null
     try {
       Utils.tryWithSafeFinallyAndFailureCallbacks(block = {
         BackendsApiManager.getIteratorApiInstance.injectWriteFilesTempPath(writePath)
@@ -172,8 +204,19 @@ class VeloxColumnarWriteFilesRDD(
         // Initialize the native plan
         val iter = firstParent[ColumnarBatch].iterator(split, context)
         assert(iter.hasNext)
-        resultColumnarBatch = iter.next()
-        commitProtocol.commitTask()
+        val resultColumnarBatch = iter.next()
+        assert(resultColumnarBatch != null)
+        val nativeWriteTaskResult = collectNativeWriteFilesMetrics(resultColumnarBatch)
+        if (nativeWriteTaskResult.isEmpty) {
+          // If we are writing an empty iterator, then velox would do nothing.
+          // Here we fallback to use vanilla Spark write files to generate an empty file for
+          // metadata only.
+          writeTaskResult = writeFilesForEmptyIterator(commitProtocol)
+          // We have done commit task inside `writeFilesForEmptyIterator`.
+        } else {
+          writeTaskResult = nativeWriteTaskResult.get
+          commitProtocol.commitTask()
+        }
       })(
         catchBlock = {
           // If there is an error, abort the task
@@ -193,8 +236,7 @@ class VeloxColumnarWriteFilesRDD(
           t)
     }
 
-    assert(resultColumnarBatch != null)
-    val writeTaskResult = collectNativeWriteFilesMetrics(resultColumnarBatch)
+    assert(writeTaskResult != null)
     Iterator.single(writeTaskResult)
   }
 
@@ -220,10 +262,44 @@ class VeloxColumnarWriteFilesExec(
 
   override def supportsColumnar(): Boolean = true
 
+  /** Fallback to use vanilla Spark write files to generate an empty file for metadata only. */
+  private def writeFilesForEmptyRDD(
+      writeFilesSpec: WriteFilesSpec,
+      jobTrackerID: String): RDD[WriterCommitMessage] = {
+    val description = writeFilesSpec.description
+    val committer = writeFilesSpec.committer
+    val rddWithNonEmptyPartitions = session.sparkContext.parallelize(Seq.empty[InternalRow], 1)
+    rddWithNonEmptyPartitions.mapPartitionsInternal {
+      iterator =>
+        val sparkStageId = TaskContext.get().stageId()
+        val sparkPartitionId = TaskContext.get().partitionId()
+        val sparkAttemptNumber = TaskContext.get().taskAttemptId().toInt & Int.MaxValue
+
+        val ret = SparkShimLoader.getSparkShims.writeFilesExecuteTask(
+          description,
+          jobTrackerID,
+          sparkStageId,
+          sparkPartitionId,
+          sparkAttemptNumber,
+          committer,
+          iterator
+        )
+        Iterator(ret)
+    }
+  }
+
   override def doExecuteWrite(writeFilesSpec: WriteFilesSpec): RDD[WriterCommitMessage] = {
     assert(child.supportsColumnar)
+
+    val rdd = child.executeColumnar()
     val jobTrackerID = SparkHadoopWriterUtils.createJobTrackerID(new Date())
-    new VeloxColumnarWriteFilesRDD(child.executeColumnar(), writeFilesSpec, jobTrackerID)
+    if (rdd.partitions.length == 0) {
+      // SPARK-23271 If we are attempting to write a zero partition rdd, create a dummy single
+      // partition rdd to make sure we at least set up one write task to write the metadata.
+      writeFilesForEmptyRDD(writeFilesSpec, jobTrackerID)
+    } else {
+      new VeloxColumnarWriteFilesRDD(rdd, writeFilesSpec, jobTrackerID)
+    }
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): WriteFilesExec =

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -779,8 +779,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataSourceStrategySuite]
   enableSuite[GlutenDataSourceSuite]
   enableSuite[GlutenFileFormatWriterSuite]
-    // Velox doesn't write file if the data is null.
-    .exclude("empty file should be skipped while write to file")
   enableSuite[GlutenFileIndexSuite]
   enableSuite[GlutenFileMetadataStructSuite]
   enableSuite[GlutenParquetV1AggregatePushDownSuite]
@@ -1070,9 +1068,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Check schemas for expression examples")
   enableSuite[GlutenExtraStrategiesSuite]
   enableSuite[GlutenFileBasedDataSourceSuite]
-    // The following suites failed because velox will not write empty data frame.
-    .excludeByPrefix("SPARK-15474 Write and read back non-empty schema with empty dataframe ")
-    .excludeByPrefix("SPARK-23271 empty RDD when saved should write a metadata only file ")
     // test data path is jar path, rewrite
     .exclude("Option recursiveFileLookup: disable partition inferring")
     // gluten executor exception cannot get in driver, rewrite
@@ -1164,8 +1159,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Gluten - store and retrieve column stats in different time zones")
     .exclude("SPARK-33687: analyze all tables in a specific database")
   enableSuite[GlutenSubquerySuite]
-    // Velox doesn't write file if the data is null.
-    .exclude("SPARK-42745: Improved AliasAwareOutputExpression works with DSv2")
     .excludeByPrefix(
       "SPARK-26893" // Rewrite this test because it checks Spark's physical operators.
     )

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -18,6 +18,7 @@ package io.glutenproject.sql.shims
 
 import io.glutenproject.expression.Sig
 
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -27,7 +28,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -89,4 +90,15 @@ trait SparkShims {
   def extractSubPlanFromMightContain(expr: Expression): Option[SparkPlan]
 
   def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
+
+  def writeFilesExecuteTask(
+      description: WriteJobDescription,
+      jobTrackerID: String,
+      sparkStageId: Int,
+      sparkPartitionId: Int,
+      sparkAttemptNumber: Int,
+      committer: FileCommitProtocol,
+      iterator: Iterator[InternalRow]): WriteTaskResult = {
+    throw new UnsupportedOperationException()
+  }
 }

--- a/shims/spark34/src/main/scala/io/glutenproject/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/io/glutenproject/sql/shims/spark34/Spark34Shims.scala
@@ -18,10 +18,10 @@ package io.glutenproject.sql.shims.spark34
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.expression.{ExpressionNames, Sig}
-import io.glutenproject.expression.ExpressionNames.EMPTY2NULL
 import io.glutenproject.sql.shims.{ShimDescriptor, SparkShims}
 
 import org.apache.spark.SparkException
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -32,16 +32,15 @@ import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Dist
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.execution.{FileSourceScanLike, PartitionedFileUtil, SparkPlan}
+import org.apache.spark.sql.execution.{PartitionedFileUtil, SparkPlan}
 import org.apache.spark.sql.execution.FileSourceScanExec
-import org.apache.spark.sql.execution.datasources.{BucketingUtils, FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.GlutenFileFormatWriter
+import org.apache.spark.sql.execution.datasources.{BucketingUtils, FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-
-import org.apache.hadoop.fs.Path
 
 class Spark34Shims extends SparkShims {
   override def getShimDescriptor: ShimDescriptor = SparkShimProvider.DESCRIPTOR
@@ -158,4 +157,23 @@ class Spark34Shims extends SparkShims {
   }
 
   override def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = List()
+
+  override def writeFilesExecuteTask(
+      description: WriteJobDescription,
+      jobTrackerID: String,
+      sparkStageId: Int,
+      sparkPartitionId: Int,
+      sparkAttemptNumber: Int,
+      committer: FileCommitProtocol,
+      iterator: Iterator[InternalRow]): WriteTaskResult = {
+    GlutenFileFormatWriter.writeFilesExecuteTask(
+      description,
+      jobTrackerID,
+      sparkStageId,
+      sparkPartitionId,
+      sparkAttemptNumber,
+      committer,
+      iterator
+    )
+  }
 }

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/GlutenFileFormatWriter.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/GlutenFileFormatWriter.scala
@@ -29,7 +29,6 @@ object GlutenFileFormatWriter {
       sparkAttemptNumber: Int,
       committer: FileCommitProtocol,
       iterator: Iterator[InternalRow]): WriteTaskResult = {
-    // Before Spark3.4, this method is private
     FileFormatWriter.executeTask(
       description,
       jobTrackerID,

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/GlutenFileFormatWriter.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/GlutenFileFormatWriter.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{FileFormatWriter, WriteJobDescription, WriteTaskResult}
+
+object GlutenFileFormatWriter {
+  def writeFilesExecuteTask(
+      description: WriteJobDescription,
+      jobTrackerID: String,
+      sparkStageId: Int,
+      sparkPartitionId: Int,
+      sparkAttemptNumber: Int,
+      committer: FileCommitProtocol,
+      iterator: Iterator[InternalRow]): WriteTaskResult = {
+    // Before Spark3.4, this method is private
+    FileFormatWriter.executeTask(
+      description,
+      jobTrackerID,
+      sparkStageId,
+      sparkPartitionId,
+      sparkAttemptNumber,
+      committer,
+      iterator,
+      None
+    )
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr makes native write support write empty rdd and empty iterator. Vanilla Spark will generate an empty file for metadata only if write empty. Gluten should respect the behavior.


## How was this patch tested?

Enable related spark tests
