### PR TITLE
[VL] Improve native write files fallback

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHBackend.scala
@@ -25,6 +25,7 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat._
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, DenseRank, Lag, Lead, NamedExpression, Rank, RowNumber}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning}
@@ -273,5 +274,7 @@ object CHBackendSettings extends BackendSettingsApi with Logging {
 
   override def supportWriteFilesExec(
       format: FileFormat,
-      fields: Array[StructField]): Option[String] = None
+      fields: Array[StructField],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String]): Option[String] = Some("Unsupported")
 }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -111,7 +111,7 @@ object BackendSettings extends BackendSettingsApi {
             "StructType as element in ArrayType"
           case StructField(_, arrayType: ArrayType, _, _)
               if arrayType.elementType.isInstanceOf[ArrayType] =>
-            "A rrayType as element in ArrayType"
+            "ArrayType as element in ArrayType"
           case StructField(_, mapType: MapType, _, _) if mapType.keyType.isInstanceOf[StructType] =>
             "StructType as Key in MapType"
           case StructField(_, mapType: MapType, _, _)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -147,17 +147,14 @@ object BackendSettings extends BackendSettingsApi {
     }
 
     // Validate if all types are supported.
-    def validateDateTypes(fields: Array[StructField]): Option[String] = {
+    def validateDateTypes(): Option[String] = {
       fields.flatMap {
         field =>
           field.dataType match {
             case _: TimestampType => Some("TimestampType")
-            case struct: StructType =>
-              Some("StructType")
-            case array: ArrayType =>
-              Some("ArrayType")
-            case map: MapType =>
-              Some("MapType")
+            case _: StructType => Some("StructType")
+            case _: ArrayType => Some("ArrayType")
+            case _: MapType => Some("MapType")
             case _ => None
           }
       }.headOption
@@ -199,7 +196,7 @@ object BackendSettings extends BackendSettingsApi {
     validateCompressionCodec()
       .orElse(validateFileFormat())
       .orElse(validateFieldMetadata())
-      .orElse(validateDateTypes(fields))
+      .orElse(validateDateTypes())
       .orElse(validateWriteFilesOptions())
       .orElse(validateBucketSpec())
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -361,6 +361,9 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WriteRel& writeR
           case TypeKind::VARBINARY:
             break;
           default:
+            logValidateMsg(
+                "Validation failed for input type validation in WriteRel, not support partition column type: " +
+                mapTypeKindToName(types[i]->kind()));
             return false;
         }
       }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
@@ -21,6 +21,7 @@ import io.glutenproject.extension.ValidationResult
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
@@ -35,7 +36,11 @@ trait BackendSettingsApi {
       fields: Array[StructField],
       partTable: Boolean,
       paths: Seq[String]): ValidationResult = ValidationResult.ok
-  def supportWriteFilesExec(format: FileFormat, fields: Array[StructField]): Option[String]
+  def supportWriteFilesExec(
+      format: FileFormat,
+      fields: Array[StructField],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String]): Option[String]
   def supportExpandExec(): Boolean = false
   def supportSortExec(): Boolean = false
   def supportSortMergeJoinExec(): Boolean = true

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
@@ -28,11 +28,15 @@ import io.glutenproject.substrait.rel.{RelBuilder, RelNode}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.internal.SQLConf
 
 import com.google.protobuf.{Any, StringValue}
+import org.apache.parquet.hadoop.ParquetOutputFormat
+
+import java.util.Locale
 
 import scala.collection.JavaConverters._
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
@@ -58,11 +62,11 @@ case class WriteFilesExecTransformer(
 
   override def output: Seq[Attribute] = Seq.empty
 
-  def genWriteParameters(): Any = {
-    val compressionCodec = if (options.get("parquet.compression").nonEmpty) {
-      options.get("parquet.compression").get.toLowerCase().capitalize
-    } else SQLConf.get.parquetCompressionCodec.toLowerCase().capitalize
+  private val caseInsensitiveOptions = CaseInsensitiveMap(options)
 
+  def genWriteParameters(): Any = {
+    val compressionCodec =
+      WriteFilesExecTransformer.getCompressionCodec(caseInsensitiveOptions).capitalize
     val writeParametersStr = new StringBuffer("WriteParameters:")
     writeParametersStr.append("is").append(compressionCodec).append("=1").append("\n")
     val message = StringValue
@@ -131,13 +135,11 @@ case class WriteFilesExecTransformer(
     val supportedWrite =
       BackendsApiManager.getSettings.supportWriteFilesExec(
         fileFormat,
-        child.output.toStructType.fields)
+        child.output.toStructType.fields,
+        bucketSpec,
+        caseInsensitiveOptions)
     if (supportedWrite.nonEmpty) {
       return ValidationResult.notOk("Unsupported native write: " + supportedWrite.get)
-    }
-
-    if (bucketSpec.nonEmpty) {
-      return ValidationResult.notOk("Unsupported native write: bucket write is not supported.")
     }
 
     val substraitContext = new SubstraitContext
@@ -157,4 +159,16 @@ case class WriteFilesExecTransformer(
 
   override protected def withNewChildInternal(newChild: SparkPlan): WriteFilesExecTransformer =
     copy(child = newChild)
+}
+
+object WriteFilesExecTransformer {
+  def getCompressionCodec(options: Map[String, String]): String = {
+    // From `ParquetOptions`
+    val parquetCompressionConf = options.get(ParquetOutputFormat.COMPRESSION)
+    options
+      .get("compression")
+      .orElse(parquetCompressionConf)
+      .getOrElse(SQLConf.get.parquetCompressionCodec)
+      .toLowerCase(Locale.ROOT)
+  }
 }

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -942,8 +942,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-39557 INSERT INTO statements with tables with struct defaults")
     .exclude("SPARK-39557 INSERT INTO statements with tables with map defaults")
   enableSuite[GlutenPartitionedWriteSuite]
-    // Velox doesn't support maxRecordsPerFile parameter.
-    .exclude("maxRecordsPerFile setting in non-partitioned write path")
   enableSuite[GlutenPathOptionSuite]
   enableSuite[GlutenPrunedScanSuite]
   enableSuite[GlutenResolvedDataSourceSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?

If people set maxRecordsPerFile, then we should fallback to vanilla Spark write files. This pr also moves the write files transformer validation to velox backend.

## How was this patch tested?

enable test
