### PR TITLE
[VL] Refactor 'getLiteralValue' logic

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -277,6 +277,83 @@ std::vector<TypePtr> SubstraitParser::sigToTypes(const std::string& signature) {
   return types;
 }
 
+
+template <typename T>
+T SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& /* literal */) {
+  VELOX_NYI();
+}
+
+template <>
+int8_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return static_cast<int8_t>(literal.i8());
+}
+
+template <>
+int16_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return static_cast<int16_t>(literal.i16());
+}
+
+template <>
+int32_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  if (literal.has_date()) {
+    return int32_t(literal.date());
+  }
+  return literal.i32();
+}
+
+template <>
+int64_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  if (literal.has_decimal()) {
+    auto decimal = literal.decimal().value();
+    int128_t decimalValue;
+    memcpy(&decimalValue, decimal.c_str(), 16);
+    return static_cast<int64_t>(decimalValue);
+  }
+  return literal.i64();
+}
+
+template <>
+int128_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  auto decimal = literal.decimal().value();
+  int128_t decimalValue;
+  memcpy(&decimalValue, decimal.c_str(), 16);
+  return HugeInt::build(static_cast<uint64_t>(decimalValue >> 64), static_cast<uint64_t>(decimalValue));
+}
+
+template <>
+double SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.fp64();
+}
+
+template <>
+float SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.fp32();
+}
+
+template <>
+bool SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return literal.boolean();
+}
+
+template <>
+Timestamp SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  return Timestamp::fromMicros(literal.timestamp());
+}
+
+template <>
+StringView SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
+  if (literal.has_string()) {
+    return StringView(literal.string());
+  } else if (literal.has_var_char()) {
+    return StringView(literal.var_char().value());
+  } else if (literal.has_binary()) {
+    return StringView(literal.binary());
+  } else {
+    VELOX_FAIL("Unexpected string or binary literal");
+  }
+}
+
+
 std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunctionMap_ = {
     {"is_not_null", "isnotnull"}, /*Spark functions.*/
     {"is_null", "isnull"},

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -277,7 +277,6 @@ std::vector<TypePtr> SubstraitParser::sigToTypes(const std::string& signature) {
   return types;
 }
 
-
 template <typename T>
 T SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& /* literal */) {
   VELOX_NYI();
@@ -352,7 +351,6 @@ StringView SubstraitParser::getLiteralValue(const ::substrait::Expression::Liter
     VELOX_FAIL("Unexpected string or binary literal");
   }
 }
-
 
 std::unordered_map<std::string, std::string> SubstraitParser::substraitVeloxFunctionMap_ = {
     {"is_not_null", "isnotnull"}, /*Spark functions.*/

--- a/cpp/velox/substrait/SubstraitParser.h
+++ b/cpp/velox/substrait/SubstraitParser.h
@@ -92,6 +92,10 @@ class SubstraitParser {
   /// Extract input types from Substrait function signature.
   static std::vector<facebook::velox::TypePtr> sigToTypes(const std::string& functionSig);
 
+  // Get values for the different supported types.
+  template <typename T>
+  static T getLiteralValue(const ::substrait::Expression::Literal& /* literal */);
+
  private:
   /// A map used for mapping Substrait function keywords into Velox functions'
   /// keywords. Key: the Substrait function keyword, Value: the Velox function

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -174,10 +174,12 @@ std::shared_ptr<core::ConstantTypedExpr> constructConstantVector(
     const TypePtr& type) {
   VELOX_CHECK(type->isPrimitiveType());
   if (substraitLit.has_binary()) {
-    return std::make_shared<core::ConstantTypedExpr>(type, variant::binary(gluten::SubstraitParser::getLiteralValue<StringView>(substraitLit)));
+    return std::make_shared<core::ConstantTypedExpr>(
+        type, variant::binary(gluten::SubstraitParser::getLiteralValue<StringView>(substraitLit)));
   } else {
     using T = typename TypeTraits<kind>::NativeType;
-    return std::make_shared<core::ConstantTypedExpr>(type, variant(gluten::SubstraitParser::getLiteralValue<T>(substraitLit)));
+    return std::make_shared<core::ConstantTypedExpr>(
+        type, variant(gluten::SubstraitParser::getLiteralValue<T>(substraitLit)));
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change moves `getLiteralValue` logic to `SubstraitParser`. then they can be used by `SubstraitToVeloxPlanConverter` also.
This is a refactor change to reduce duplicate logic.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

