### PR TITLE
[VL]Fallback complex type in native write

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -109,7 +109,7 @@ object BackendSettings extends BackendSettingsApi {
             "StructType as element in ArrayType"
           case StructField(_, arrayType: ArrayType, _, _)
               if arrayType.elementType.isInstanceOf[ArrayType] =>
-            "ArrayType as element in ArrayType"
+            "A rrayType as element in ArrayType"
           case StructField(_, mapType: MapType, _, _) if mapType.keyType.isInstanceOf[StructType] =>
             "StructType as Key in MapType"
           case StructField(_, mapType: MapType, _, _)
@@ -146,14 +146,12 @@ object BackendSettings extends BackendSettingsApi {
         field =>
           field.dataType match {
             case _: TimestampType => Some("TimestampType")
-            case struct: StructType if validateDateTypes(struct.fields).nonEmpty =>
-              Some("StructType(TimestampType)")
-            case array: ArrayType if array.elementType.isInstanceOf[TimestampType] =>
-              Some("ArrayType(TimestampType)")
-            case map: MapType
-                if map.keyType.isInstanceOf[TimestampType] ||
-                  map.valueType.isInstanceOf[TimestampType] =>
-              Some("MapType(TimestampType)")
+            case struct: StructType =>
+              Some("StructType")
+            case array: ArrayType =>
+              Some("ArrayType")
+            case map: MapType =>
+              Some("MapType")
             case _ => None
           }
       }.headOption

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -691,9 +691,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-40128 read DELTA_LENGTH_BYTE_ARRAY encoded strings")
     // Timestamp is read as INT96
     .exclude("Read TimestampNTZ and TimestampLTZ for various logical TIMESTAMP types")
-    // Native writer: Field name must not be empty.
-    .exclude(
-      "SPARK-23173 Writing a file with data converted from JSON with and incorrect user schema")
   enableSuite[GlutenParquetV1PartitionDiscoverySuite]
     // Timezone is not supported yet.
     .exclude("Resolve type conflicts - decimals, dates and timestamps in partition column")
@@ -946,10 +943,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-39557 INSERT INTO statements with tables with array defaults")
     .exclude("SPARK-39557 INSERT INTO statements with tables with struct defaults")
     .exclude("SPARK-39557 INSERT INTO statements with tables with map defaults")
-    // Native writer: Field name must not be empty.
-    .exclude("INSERT INTO TABLE - complex type but different names")
-    // Native writer: An unsupported nested encoding was found.
-    .exclude("SPARK-21203 wrong results of insertion of Array of Struct")
   enableSuite[GlutenPartitionedWriteSuite]
     // Velox doesn't support maxRecordsPerFile parameter.
     .exclude("maxRecordsPerFile setting in non-partitioned write path")

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenReadSchemaSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenReadSchemaSuite.scala
@@ -16,9 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources
 
-import io.glutenproject.utils.BackendTestUtils
-
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{GlutenSQLTestsBaseTrait, GlutenTestConstants}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -136,48 +133,12 @@ class GlutenMergedOrcReadSchemaSuite
   extends MergedOrcReadSchemaSuite
   with GlutenSQLTestsBaseTrait {}
 
-class GlutenParquetReadSchemaSuite extends ParquetReadSchemaSuite with GlutenSQLTestsBaseTrait {
-  override def sparkConf: SparkConf = if (BackendTestUtils.isVeloxBackendLoaded()) {
-    // Disable native write because of below failure in :
-    // 'add a nested column at the end of the leaf struct column'
-    // Reason: Field name must not be empty.
-    // Function: validateSchemaRecursive
-    // File: ../../velox/dwio/parquet/writer/Writer.cpp
-    // Line: 151
-    super.sparkConf.set("spark.gluten.sql.native.writer.enabled", "false")
-  } else {
-    super.sparkConf
-  }
-}
+class GlutenParquetReadSchemaSuite extends ParquetReadSchemaSuite with GlutenSQLTestsBaseTrait {}
 
 class GlutenVectorizedParquetReadSchemaSuite
   extends VectorizedParquetReadSchemaSuite
-  with GlutenSQLTestsBaseTrait {
-  override def sparkConf: SparkConf = if (BackendTestUtils.isVeloxBackendLoaded()) {
-    // Disable native write because of below failure in :
-    // 'add a nested column at the end of the leaf struct column'
-    // Reason: Field name must not be empty.
-    // Function: validateSchemaRecursive
-    // File: ../../velox/dwio/parquet/writer/Writer.cpp
-    // Line: 151
-    super.sparkConf.set("spark.gluten.sql.native.writer.enabled", "false")
-  } else {
-    super.sparkConf
-  }
-}
+  with GlutenSQLTestsBaseTrait {}
 
 class GlutenMergedParquetReadSchemaSuite
   extends MergedParquetReadSchemaSuite
-  with GlutenSQLTestsBaseTrait {
-  override def sparkConf: SparkConf = if (BackendTestUtils.isVeloxBackendLoaded()) {
-    // Disable native write because of below failure in :
-    // 'add a nested column at the end of the leaf struct column'
-    // Reason: Field name must not be empty.
-    // Function: validateSchemaRecursive
-    // File: ../../velox/dwio/parquet/writer/Writer.cpp
-    // Line: 151
-    super.sparkConf.set("spark.gluten.sql.native.writer.enabled", "false")
-  } else {
-    super.sparkConf
-  }
-}
+  with GlutenSQLTestsBaseTrait {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox doesn't support nested type encoding when converting the rowVector to arrow data https://github.com/facebookincubator/velox/blob/main/velox/vector/arrow/Bridge.cpp#L795. So we fallback nested type in native write.

## How was this patch tested?

existing tests.

