### PR TITLE
[GLUTEN-4388][CH] Adjust celeborn shuffle write time

### DIFF
--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornHashBasedColumnarShuffleWriter.scala
@@ -82,7 +82,7 @@ class CHCelebornHashBasedColumnarShuffleWriter[K, V](
           override def spill(self: MemoryTarget, size: Long): Long = {
             if (nativeShuffleWriter == -1L) {
               throw new IllegalStateException(
-                "Fatal: spill() called before a Celeborn shuffle writer " +
+                "Fatal: spill() called before a celeborn shuffle writer " +
                   "is created. This behavior should be" +
                   "optimized by moving memory " +
                   "allocations from make() to split()")

--- a/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornHashBasedColumnarShuffleWriter.scala
+++ b/gluten-celeborn/clickhouse/src/main/scala/org/apache/spark/shuffle/CHCelebornHashBasedColumnarShuffleWriter.scala
@@ -82,13 +82,13 @@ class CHCelebornHashBasedColumnarShuffleWriter[K, V](
           override def spill(self: MemoryTarget, size: Long): Long = {
             if (nativeShuffleWriter == -1L) {
               throw new IllegalStateException(
-                "Fatal: spill() called before a celeborn shuffle writer " +
+                "Fatal: spill() called before a Celeborn shuffle writer " +
                   "is created. This behavior should be" +
                   "optimized by moving memory " +
                   "allocations from make() to split()")
             }
             logInfo(s"Gluten shuffle writer: Trying to push $size bytes of data")
-            val spilled = jniWrapper.evict(nativeShuffleWriter);
+            val spilled = jniWrapper.evict(nativeShuffleWriter)
             logInfo(s"Gluten shuffle writer: Spilled $spilled / $size bytes of data")
             spilled
           }
@@ -124,7 +124,7 @@ class CHCelebornHashBasedColumnarShuffleWriter[K, V](
     dep.metrics("bytesSpilled").add(splitResult.getTotalBytesSpilled)
     dep.metrics("dataSize").add(splitResult.getTotalBytesWritten)
     writeMetrics.incBytesWritten(splitResult.getTotalBytesWritten)
-    writeMetrics.incWriteTime(splitResult.getTotalWriteTime + splitResult.getTotalSpillTime)
+    writeMetrics.incWriteTime(splitResult.getTotalWriteTime)
 
     partitionLengths = splitResult.getPartitionLengths
     pushMergedDataToCeleborn()


### PR DESCRIPTION
## What changes were proposed in this pull request?
For the current implementation of ch celeborn shuffle write, native's spill time includes native's write time which leads to inaccurate metrics.
I think native's write time is enough now.
(Fixes: \#4338)

## How was this patch tested?
Maually test

