### PR TITLE
[CH] Minor change to pin `install_ubuntu.sh` clang version to 16

### DIFF
--- a/ep/build-clickhouse/src/install_ubuntu.sh
+++ b/ep/build-clickhouse/src/install_ubuntu.sh
@@ -20,7 +20,9 @@ echo "Install Prerequisites"
 sudo apt-get install git cmake ccache python3 ninja-build nasm yasm gawk lsb-release wget software-properties-common gnupg
 
 echo "Install and Use the Clang compiler"
-sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 16
 
 echo "add CC and CXX to .bashrc"
 echo "export CC=clang-16" >> ~/.bashrc


### PR DESCRIPTION
## What changes were proposed in this pull request?
Pin `install_ubuntu.sh` clang version to 16 because the latest default version is 17.

## How was this patch tested?
Maually test.

