### PR TITLE
Revert "[GLUTEN-3942][CORE]fix: Change columnar overrides to accept ShuffleExchangeLike"

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -163,7 +163,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
    * result columns from the projection.
    */
   private def addProjectionForShuffleExchange(
-      plan: ShuffleExchangeLike): (Int, Partitioning, SparkPlan) = {
+      plan: ShuffleExchangeExec): (Int, Partitioning, SparkPlan) = {
     def selectExpressions(
         exprs: Seq[Expression],
         attributes: Seq[Attribute]): (Seq[NamedExpression], Seq[Int]) = {
@@ -397,7 +397,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
         TakeOrderedAndProjectExecTransformer(plan.limit, plan.sortOrder, plan.projectList, child)
-      case plan: ShuffleExchangeLike =>
+      case plan: ShuffleExchangeExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
         if (

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -168,7 +168,7 @@ case class ColumnarShuffleExchangeExec(
 object ColumnarShuffleExchangeExec extends Logging {
 
   def apply(
-      plan: ShuffleExchangeLike,
+      plan: ShuffleExchangeExec,
       child: SparkPlan,
       shuffleOutputAttributes: Seq[Attribute]): ColumnarShuffleExchangeExec = {
     ColumnarShuffleExchangeExec(


### PR DESCRIPTION
Reverts oap-project/gluten#4167

My initial understanding was that ColumnarShuffleExchangeExec would preserve the behavior of ShuffleExchangeExec/ShuffleExchangeLike, but it actually replaces it.

In this case I think my change is incorrect, and the `case plan: ShuffleExchangeLike` in `replaceWithTransformerPlan` should be `case plan: ShuffleExchangeExec` as before. Because ColumnarShuffleExchangeExec is made specifically to replace ShuffleExchangeExec and not any ShuffleExchangeLike.