### PR TITLE
[CORE] Add RemoveKnownFloatingPointNormalized Rule

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -774,4 +774,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       }
     }
   }
+
+  test("knownfloatingpointnormalized") {
+    runQueryAndCompare("""
+                         |select avg(l_quantity) from lineitem
+                         |group by cast(l_orderkey as double);
+                         |""".stripMargin) {
+      checkOperatorMatch[HashAggregateExecTransformer]
+    }
+  }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -787,6 +787,7 @@ case class ColumnarOverrideRules(session: SparkSession)
         (spark: SparkSession) => PlanOneRowRelation(spark),
         (_: SparkSession) => FallbackEmptySchemaRelation(),
         (_: SparkSession) => AddTransformHintRule(),
+        (_: SparkSession) => RemoveKnownFloatingPointNormalized,
         (_: SparkSession) => FallbackBloomFilterAggIfNeeded(),
         (_: SparkSession) => TransformPreOverrides(isAdaptiveContext),
         (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/RemoveKnownFloatingPointNormalized.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/RemoveKnownFloatingPointNormalized.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension
+
+import io.glutenproject.extension.columnar.TransformHints
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+
+/**
+ * [[KnownFloatingPointNormalized]] in Gluten is useless. When converting plans, it directly takes
+ * its child. We can reverse the KnownFloatingPointNormalized added by
+ * NormalizeFloatingNumbers.normalize in Gluten without affecting the results. Otherwise, pulling
+ * out pre-project in the logical plan is not sufficient. The KnownFloatingPointNormalized will be
+ * added to the groupingExpressions of the aggregate in the physical plan.
+ */
+object RemoveKnownFloatingPointNormalized extends Rule[SparkPlan] {
+
+  private def normalizeExpressionExists(expressions: Seq[Expression]): Boolean = {
+    expressions.exists(_.find(_.isInstanceOf[KnownFloatingPointNormalized]).isDefined)
+  }
+
+  /**
+   * If the groupingExpressions of the aggregate are expressions, an Alias will be added on the
+   * outside. After removing the KnownFloatingPointNormalized, it is necessary to remove this
+   * redundant Alias.
+   */
+  private def removeRedundantAlias(expression: Expression): Expression = expression match {
+    case _ @Alias(child: Attribute, _) => child
+    case other => other
+  }
+
+  private def supportTransform(plan: SparkPlan): Boolean =
+    TransformHints.isAlreadyTagged(plan) && TransformHints.isTransformable(plan)
+
+  override def apply(plan: SparkPlan): SparkPlan = applyWithValidation(plan)
+
+  def applyWithValidation(plan: SparkPlan, validation: Boolean = false): SparkPlan =
+    plan.transform {
+      // Only remove KnownFloatingPointNormalized when agg is transformable.
+      case agg: BaseAggregateExec
+          if normalizeExpressionExists(agg.groupingExpressions) &&
+            (validation || supportTransform(plan)) =>
+        val newGroupingExprs = agg.groupingExpressions.toIndexedSeq.map {
+          expr =>
+            val transformedExpr = expr.transform {
+              case _ @KnownFloatingPointNormalized(_ @NormalizeNaNAndZero(child)) => child
+              case _ @KnownFloatingPointNormalized(_ @If(_ @IsNull(expr), _, _)) => expr
+              case _ @KnownFloatingPointNormalized(_ @ArrayTransform(expr, _)) => expr
+              case other => other
+            }
+            removeRedundantAlias(transformedExpr)
+        }
+        agg match {
+          case hash: HashAggregateExec =>
+            hash.copy(groupingExpressions = newGroupingExprs.asInstanceOf[Seq[NamedExpression]])
+          case objectHash: ObjectHashAggregateExec =>
+            objectHash.copy(groupingExpressions =
+              newGroupingExprs.asInstanceOf[Seq[NamedExpression]])
+          case sort: SortAggregateExec =>
+            sort.copy(groupingExpressions = newGroupingExprs.asInstanceOf[Seq[NamedExpression]])
+          case _ =>
+            throw new UnsupportedOperationException(s"Unknown agg $agg")
+        }
+    }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension.columnar
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
-import io.glutenproject.extension.{GlutenPlan, ValidationResult}
+import io.glutenproject.extension.{GlutenPlan, RemoveKnownFloatingPointNormalized, ValidationResult}
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.utils.PhysicalPlanSelector
 
@@ -452,15 +452,19 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar HashAggregate is not enabled in HashAggregateExec")
           } else {
+            val transformedPlan =
+              RemoveKnownFloatingPointNormalized
+                .applyWithValidation(plan, validation = true)
+                .asInstanceOf[HashAggregateExec]
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
-                plan.requiredChildDistributionExpressions,
-                plan.groupingExpressions,
-                plan.aggregateExpressions,
-                plan.aggregateAttributes,
-                plan.initialInputBufferOffset,
-                plan.resultExpressions,
-                plan.child
+                transformedPlan.requiredChildDistributionExpressions,
+                transformedPlan.groupingExpressions,
+                transformedPlan.aggregateExpressions,
+                transformedPlan.aggregateAttributes,
+                transformedPlan.initialInputBufferOffset,
+                transformedPlan.resultExpressions,
+                transformedPlan.child
               )
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
@@ -473,15 +477,19 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar HashAgg is not enabled in SortAggregateExec")
           }
+          val transformedPlan =
+            RemoveKnownFloatingPointNormalized
+              .applyWithValidation(plan, validation = true)
+              .asInstanceOf[SortAggregateExec]
           val transformer = BackendsApiManager.getSparkPlanExecApiInstance
             .genHashAggregateExecTransformer(
-              plan.requiredChildDistributionExpressions,
-              plan.groupingExpressions,
-              plan.aggregateExpressions,
-              plan.aggregateAttributes,
-              plan.initialInputBufferOffset,
-              plan.resultExpressions,
-              plan.child
+              transformedPlan.requiredChildDistributionExpressions,
+              transformedPlan.groupingExpressions,
+              transformedPlan.aggregateExpressions,
+              transformedPlan.aggregateAttributes,
+              transformedPlan.initialInputBufferOffset,
+              transformedPlan.resultExpressions,
+              transformedPlan.child
             )
           TransformHints.tag(plan, transformer.doValidate().toTransformHint)
         case plan: ObjectHashAggregateExec =>
@@ -490,15 +498,19 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar HashAgg is not enabled in ObjectHashAggregateExec")
           } else {
+            val transformedPlan =
+              RemoveKnownFloatingPointNormalized
+                .applyWithValidation(plan, validation = true)
+                .asInstanceOf[ObjectHashAggregateExec]
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
-                plan.requiredChildDistributionExpressions,
-                plan.groupingExpressions,
-                plan.aggregateExpressions,
-                plan.aggregateAttributes,
-                plan.initialInputBufferOffset,
-                plan.resultExpressions,
-                plan.child
+                transformedPlan.requiredChildDistributionExpressions,
+                transformedPlan.groupingExpressions,
+                transformedPlan.aggregateExpressions,
+                transformedPlan.aggregateAttributes,
+                transformedPlan.initialInputBufferOffset,
+                transformedPlan.resultExpressions,
+                transformedPlan.child
               )
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We plan to pull out the pre-project of agg in the logical plan. However, due to some historical reasons, Spark's agg `groupingExpressions` will add `KnownFloatingPointNormalized` to certain specific data types when converting to a physical plan. These expressions need to be pull out into the pre-project during native execution, but we have not pulled out the pre-project of agg in the physical plan. `KnownFloatingPointNormalized` does not actually serve any purpose in Gluten, and during plan conversion, we directly processes its child, so we can remove it.

## How was this patch tested?

ClickHouse backend already have a "knownfloatingpointnormalized" test case in `GlutenClickHouseFileFormatSuite`. Add a "knownfloatingpointnormalized" test case in Velox backend `TestOperator`.

