### PR TITLE
[GLUTEN-4359][DOC] update document

### DIFF
--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -54,8 +54,10 @@ Otherwise, do:
 
 1. clone Kyligence/ClickHouse repo
     ```
+    export GLUTEN_SOURCE=/path/to/gluten
+    read -r CH_VERSION < <(grep -oP 'CH_BRANCH=\K[^=]+' $GLUTEN_SOURCE/cpp-ch/clickhouse.version )
     cd /to/some/place/
-    git clone --recursive --shallow-submodules -b clickhouse_backend https://github.com/Kyligence/ClickHouse.git
+    git clone --recursive --shallow-submodules -b $CH_VERSION https://github.com/Kyligence/ClickHouse.git
     ```
 
 2. Configure cpp-ch
@@ -173,6 +175,7 @@ cp gluten-XXXXX-spark-3.3-jar-with-dependencies.jar jars/
 
 ##### Start Spark Thriftserver on local
 ```
+export LD_PRELOAD=/path_to_clickhouse_library/libch.so
 cd spark-3.2.2-bin-hadoop2.7
 ./sbin/start-thriftserver.sh \
   --master local[3] \


### PR DESCRIPTION
### Problem description

1. when setting up ClickHouse backend development environment,I found the Version of ClickHouse is behind master, some of submodule is missing in dir 'contirb', such as 'google-protobuf'
2. when startting Spark Thriftserver on local,there is an error, unless I set up the environment variables `LD_PRELOAD`
```
Exception in thread "main" java.lang.UnsatisfiedLinkError: /home/zz/IdeaProjects/gluten/cpp-ch/build/utils/extern-local-engine/libch.so: /home/zz/IdeaProjects/gluten/cpp-ch/build/utils/extern-local-engine/libch.so: cannot allocate memory in static TLS block
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1934)
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1817)
	at java.lang.Runtime.load0(Runtime.java:782)
	at java.lang.System.load(System.java:1100)
	at io.glutenproject.vectorized.JniLibLoader.loadFromPath0(JniLibLoader.java:89)
	at io.glutenproject.vectorized.JniLibLoader.loadFromPath(JniLibLoader.java:103)
	at io.glutenproject.backendsapi.clickhouse.CHListenerApi.initialize(CHListenerApi.scala:51)
	at io.glutenproject.backendsapi.clickhouse.CHListenerApi.onDriverStart(CHListenerApi.scala:36)
	at io.glutenproject.GlutenDriverPlugin.init(GlutenPlugin.scala:73)
	at org.apache.spark.internal.plugin.DriverPluginContainer.$anonfun$driverPlugins$1(PluginContainer.scala:53)
	at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:293)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at scala.collection.TraversableLike.flatMap(TraversableLike.scala:293)
	at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:290)
	at scala.collection.AbstractTraversable.flatMap(Traversable.scala:108)
	at org.apache.spark.internal.plugin.DriverPluginContainer.<init>(PluginContainer.scala:46)
	at org.apache.spark.internal.plugin.PluginContainer$.apply(PluginContainer.scala:210)
	at org.apache.spark.internal.plugin.PluginContainer$.apply(PluginContainer.scala:193)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:556)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2690)
	at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:949)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:943)
	at org.apache.spark.sql.hive.thriftserver.SparkSQLEnv$.init(SparkSQLEnv.scala:54)
	at org.apache.spark.sql.hive.thriftserver.HiveThriftServer2$.main(HiveThriftServer2.scala:96)
	at org.apache.spark.sql.hive.thriftserver.HiveThriftServer2.main(HiveThriftServer2.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:955)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1043)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1052)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

### System information

Velox System Info v0.0.2
Commit: e1fbd436b7fe9726302cfcd359086a991a2fdce9
CMake Version: 3.20.0
System: Linux-5.15.0-91-generic
Arch: x86_64
C++ Compiler: /usr/bin/c++
C++ Compiler Version: 10.5.0
C Compiler: /usr/bin/cc
C Compiler Version: 10.5.0
CMake Prefix Path: /usr/local;/usr;/;/usr/local;/usr/local;/usr/X11R6;/usr/pkg;/opt


### CMake log

_No response_