### PR TITLE
[GLUTEN-3559][VL] Fix unit tests in GlutenParquetV2FilterSuite

### DIFF
--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -654,7 +654,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-34562: Bloom filter push down")
     .exclude("SPARK-16371 Do not push down filters when inner name and outer name are the same")
     .exclude("filter pushdown - StringPredicate")
-    .exclude("Gluten - filter pushdown - date")
   enableSuite[GlutenParquetInteroperabilitySuite]
     .exclude("parquet timestamp conversion")
   enableSuite[GlutenParquetIOSuite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetFilterSuite.scala
@@ -622,7 +622,7 @@ class GlutenParquetV2FilterSuite extends GltuenParquetFilterSuite with GlutenSQL
                               "2018-03-20".date,
                               "2018-03-21".date,
                               "2018-03-22".date).map(Literal.apply)),
-                          if (threshold == 3) classOf[Operators.And] else classOf[Operators.Or],
+                          if (threshold == 3) classOf[Operators.In[_]] else classOf[Operators.Or],
                           Seq(
                             Row(resultFun("2018-03-19")),
                             Row(resultFun("2018-03-20")),


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR enables following tests in the suite GlutenParquetV2FilterSuite: 

- Gluten - filter pushdown - date

(Fixes: \#3559)

## How was this patch tested?

Ran this UT to confirm the fix

## Note

Changes are based on https://github.com/apache/spark/commit/fa8d93676941f1009837b5bea74a5586118c3a7e

