### PR TITLE
[GLUTEN-3559][VL] Enable UTs failing due to wrong spark.test.home set earlier

### DIFF
--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.datasources.parquet.{GlutenParquetColumnIn
 import org.apache.spark.sql.execution.datasources.text.{GlutenTextV1Suite, GlutenTextV2Suite}
 import org.apache.spark.sql.execution.datasources.v2.{GlutenDataSourceV2StrategySuite, GlutenFileTableSuite, GlutenV2PredicateSuite}
 import org.apache.spark.sql.execution.exchange.GlutenEnsureRequirementsSuite
-import org.apache.spark.sql.execution.joins.{GlutenExistenceJoinSuite, GlutenInnerJoinSuite, GlutenOuterJoinSuite}
+import org.apache.spark.sql.execution.joins.{GlutenBroadcastJoinSuite, GlutenExistenceJoinSuite, GlutenInnerJoinSuite, GlutenOuterJoinSuite}
 import org.apache.spark.sql.extension.{GlutenCollapseProjectExecTransformerSuite, GlutenSessionExtensionSuite, TestFileSourceScanExecTransformer}
 import org.apache.spark.sql.gluten.GlutenFallbackSuite
 import org.apache.spark.sql.hive.execution.GlutenHiveSQLQuerySuite
@@ -64,14 +64,14 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDeleteFromTableSuite]
   enableSuite[GlutenFileDataSourceV2FallBackSuite]
   enableSuite[GlutenKeyGroupedPartitioningSuite]
-    .exclude("SPARK-44641: duplicated records when SPJ is not triggered")
     // NEW SUITE: disable as they check vanilla spark plan
     .exclude("partitioned join: number of buckets mismatch should trigger shuffle")
     .exclude("partitioned join: only one side reports partitioning")
     .exclude("partitioned join: join with two partition keys and different # of partition keys")
-    // disable as both checks for SMJ node
+    // disable due to check for SMJ node
     .excludeByPrefix("SPARK-41413: partitioned join:")
     .excludeByPrefix("SPARK-42038: partially clustered:")
+    .exclude("SPARK-44641: duplicated records when SPJ is not triggered")
   enableSuite[GlutenLocalScanSuite]
   enableSuite[GlutenMetadataColumnSuite]
   enableSuite[GlutenSupportsCatalogOptionsSuite]
@@ -865,12 +865,12 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenMergedParquetReadSchemaSuite]
   enableSuite[GlutenEnsureRequirementsSuite]
 
-//  enableSuite[GlutenBroadcastJoinSuite]
-//    .exclude("Shouldn't change broadcast join buildSide if user clearly specified")
-//    .exclude("Shouldn't bias towards build right if user didn't specify")
-//    .exclude("SPARK-23192: broadcast hint should be retained after using the cached data")
-//    .exclude("broadcast hint isn't propagated after a join")
-//    .exclude("broadcast join where streamed side's output partitioning is HashPartitioning")
+  enableSuite[GlutenBroadcastJoinSuite]
+    .exclude("Shouldn't change broadcast join buildSide if user clearly specified")
+    .exclude("Shouldn't bias towards build right if user didn't specify")
+    .exclude("SPARK-23192: broadcast hint should be retained after using the cached data")
+    .exclude("broadcast hint isn't propagated after a join")
+    .exclude("broadcast join where streamed side's output partitioning is HashPartitioning")
 
   enableSuite[GlutenExistenceJoinSuite]
   enableSuite[GlutenInnerJoinSuite]
@@ -1060,7 +1060,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDynamicPartitionPruningV2SuiteAEOnDisableScan]
   enableSuite[GlutenDynamicPartitionPruningV2SuiteAEOffDisableScan]
   enableSuite[GlutenExpressionsSchemaSuite]
-    .exclude("Check schemas for expression examples")
   enableSuite[GlutenExtraStrategiesSuite]
   enableSuite[GlutenFileBasedDataSourceSuite]
     // test data path is jar path, rewrite

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
@@ -62,7 +62,7 @@ class GlutenKeyGroupedPartitioningSuite
   private def collectShuffles(plan: SparkPlan): Seq[ShuffleExchangeExec] = {
     // here we skip collecting shuffle operators that are not associated with SHJ
     collect(plan) { case s: ShuffledHashJoinExec => s }.flatMap(
-      smj => collect(smj) { case s: ShuffleExchangeExec => s })
+      shj => collect(shj) { case s: ShuffleExchangeExec => s })
   }
 
   private def collectScans(plan: SparkPlan): Seq[BatchScanExec] = {
@@ -694,6 +694,67 @@ class GlutenKeyGroupedPartitioningSuite
                   Row(1, "aa", 41.0, null),
                   Row(2, "bb", 10.0, 15.0),
                   Row(3, "cc", 15.5, 20.0)
+                )
+              )
+            }
+        }
+    }
+  }
+
+  test(
+    GlutenTestConstants.GLUTEN_TEST +
+      "SPARK-44641: duplicated records when SPJ is not triggered") {
+    val items_partitions = Array(bucket(8, "id"))
+    createTable(items, items_schema, items_partitions)
+    sql(s"""
+        INSERT INTO testcat.ns.$items VALUES
+        (1, 'aa', 40.0, cast('2020-01-01' as timestamp)),
+        (1, 'aa', 41.0, cast('2020-01-15' as timestamp)),
+        (2, 'bb', 10.0, cast('2020-01-01' as timestamp)),
+        (2, 'bb', 10.5, cast('2020-01-01' as timestamp)),
+        (3, 'cc', 15.5, cast('2020-02-01' as timestamp))""")
+
+    val purchases_partitions = Array(bucket(8, "item_id"))
+    createTable(purchases, purchases_schema, purchases_partitions)
+    sql(s"""INSERT INTO testcat.ns.$purchases VALUES
+        (1, 42.0, cast('2020-01-01' as timestamp)),
+        (1, 44.0, cast('2020-01-15' as timestamp)),
+        (1, 45.0, cast('2020-01-15' as timestamp)),
+        (2, 11.0, cast('2020-01-01' as timestamp)),
+        (3, 19.5, cast('2020-02-01' as timestamp))""")
+
+    Seq(true, false).foreach {
+      pushDownValues =>
+        Seq(true, false).foreach {
+          partiallyClusteredEnabled =>
+            withSQLConf(
+              SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key ->
+                partiallyClusteredEnabled.toString
+            ) {
+
+              // join keys are not the same as the partition keys, therefore SPJ is not triggered.
+              val df = sql(s"""
+               SELECT id, name, i.price as purchase_price, p.item_id, p.price as sale_price
+               FROM testcat.ns.$items i JOIN testcat.ns.$purchases p
+               ON i.arrive_time = p.time ORDER BY id, purchase_price, p.item_id, sale_price
+               """)
+
+              val shuffles = collectShuffles(df.queryExecution.executedPlan)
+              assert(shuffles.nonEmpty, "shuffle should exist when SPJ is not used")
+
+              checkAnswer(
+                df,
+                Seq(
+                  Row(1, "aa", 40.0, 1, 42.0),
+                  Row(1, "aa", 40.0, 2, 11.0),
+                  Row(1, "aa", 41.0, 1, 44.0),
+                  Row(1, "aa", 41.0, 1, 45.0),
+                  Row(2, "bb", 10.0, 1, 42.0),
+                  Row(2, "bb", 10.0, 2, 11.0),
+                  Row(2, "bb", 10.5, 1, 42.0),
+                  Row(2, "bb", 10.5, 2, 11.0),
+                  Row(3, "cc", 15.5, 3, 19.5)
                 )
               )
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enables UTs failing with spark 3.4 due to wrong spark.test.home set earlier in pipeline.

(Fixes: \#3559)

## How was this patch tested?

Ran tests locally

