### PR TITLE
[GLUTEN-1551][VL][FOLLOW-UP] Explicitly set Charset to UTF-8 for leading/trailing whitespace string cast test

### DIFF
--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestData.TestData2
 import org.apache.spark.sql.types.StringType
 
+import java.nio.charset.StandardCharsets
+
 import scala.util.Random
 
 class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
@@ -355,7 +357,7 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
       Seq(" abc", "abc ", " abc ", "\u2000abc\n\n\n", "abc\r\r\r", "abc\f\f\f", "abc\u000C")
     // scalastyle:on nonascii
     rawData.toDF("col1").createOrReplaceTempView("t1")
-    val expectedBinaryResult = rawData.map(d => Row(d.getBytes())).seq
+    val expectedBinaryResult = rawData.map(d => Row(d.getBytes(StandardCharsets.UTF_8))).seq
     df = spark.sql("select cast(col1 as binary) from t1")
     checkResult(df, expectedBinaryResult)
   }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestData.TestData2
 import org.apache.spark.sql.types.StringType
 
+import java.nio.charset.StandardCharsets
+
 import scala.util.Random
 
 class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
@@ -356,7 +358,7 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
       Seq(" abc", "abc ", " abc ", "\u2000abc\n\n\n", "abc\r\r\r", "abc\f\f\f", "abc\u000C")
     // scalastyle:on nonascii
     rawData.toDF("col1").createOrReplaceTempView("t1")
-    val expectedBinaryResult = rawData.map(d => Row(d.getBytes())).seq
+    val expectedBinaryResult = rawData.map(d => Row(d.getBytes(StandardCharsets.UTF_8))).seq
     df = spark.sql("select cast(col1 as binary) from t1")
     checkResult(df, expectedBinaryResult)
   }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestData.TestData2
 import org.apache.spark.sql.types.StringType
 
+import java.nio.charset.StandardCharsets
+
 import scala.util.Random
 
 class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
@@ -356,7 +358,7 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
       Seq(" abc", "abc ", " abc ", "\u2000abc\n\n\n", "abc\r\r\r", "abc\f\f\f", "abc\u000C")
     // scalastyle:on nonascii
     rawData.toDF("col1").createOrReplaceTempView("t1")
-    val expectedBinaryResult = rawData.map(d => Row(d.getBytes())).seq
+    val expectedBinaryResult = rawData.map(d => Row(d.getBytes(StandardCharsets.UTF_8))).seq
     df = spark.sql("select cast(col1 as binary) from t1")
     checkResult(df, expectedBinaryResult)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`String. getBytes()` would convert a String into a sequence of bytes in the platform's default charset. While inside spark `String` is internally held as `UTF8String`, so if the platform's default charset is not `UTF-8`, this test could fail. We need to explicitly use `UTF-8` here.

```java
- Gluten - Allow leading/trailing whitespace in string before casting *** FAILED ***
== Results ==
  !== Correct Answer - 7 ==                     == Gluten Answer - 7 ==
  !struct<>                                     struct<col1:binary>
  ![WrappedArray(32, 97, 98, 99)]               [WrappedArray(-30, -128, -128, 97, 98, 99, 10, 10, 10)]
  ![WrappedArray(32, 97, 98, 99, 32)]           [WrappedArray(32, 97, 98, 99)]
  ![WrappedArray(63, 97, 98, 99, 10, 10, 10)]   [WrappedArray(32, 97, 98, 99, 32)]
   [WrappedArray(97, 98, 99, 12)]               [WrappedArray(97, 98, 99, 12)]
   [WrappedArray(97, 98, 99, 12, 12, 12)]       [WrappedArray(97, 98, 99, 12, 12, 12)]
   [WrappedArray(97, 98, 99, 13, 13, 13)]       [WrappedArray(97, 98, 99, 13, 13, 13)]
   [WrappedArray(97, 98, 99, 32)]               [WrappedArray(97, 98, 99, 32)] (GlutenSQLTestsTrait.scala:141)
```

"\u2000" is `[63]` since it's not supported in `ASCII`, while in `UTF-8` is [-30, -128, -128]

## How was this patch tested?

Manually tested under a non `utf-8` charset platform, and the tests can pass

