### PR TITLE
[VL] Enable a spark test: handle am-pm timestamp parsing when hour is missing

### DIFF
--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -215,8 +215,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("DateFormat")
     // Legacy mode is not supported, assuming this mode is not commonly used.
     .exclude("to_timestamp exception mode")
-    // A velox bug, will be fixed in velox.
-    .exclude("SPARK-31896: Handle am-pm timestamp parsing when hour is missing")
   enableSuite[GlutenDecimalExpressionSuite]
   enableSuite[GlutenStringFunctionsSuite]
   enableSuite[GlutenRegexpExpressionsSuite]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -148,8 +148,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("DateFormat")
     // Legacy mode is not supported, assuming this mode is not commonly used.
     .exclude("to_timestamp exception mode")
-    // A velox bug, will be fixed in velox.
-    .exclude("SPARK-31896: Handle am-pm timestamp parsing when hour is missing")
   enableSuite[GlutenDecimalExpressionSuite]
   enableSuite[GlutenHashExpressionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -128,8 +128,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("DateFormat")
     // Legacy mode is not supported, assuming this mode is not commonly used.
     .exclude("to_timestamp exception mode")
-    // A velox bug, will be fixed in velox.
-    .exclude("SPARK-31896: Handle am-pm timestamp parsing when hour is missing")
   enableSuite[GlutenDecimalExpressionSuite]
   enableSuite[GlutenHashExpressionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]


### PR DESCRIPTION
## What changes were proposed in this pull request?

This issue has already been fixed by us in upstream velox: https://github.com/facebookincubator/velox/pull/8349.

## How was this patch tested?

N/A.

