### PR TITLE
[CORE] Add simpleString for InputIteratorTransformer

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -27,6 +27,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.metric.SQLMetric
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -46,6 +47,10 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
   @transient
   override lazy val metrics: Map[String, SQLMetric] =
     BackendsApiManager.getMetricsApiInstance.genInputIteratorTransformerMetrics(sparkContext)
+
+  override def simpleString(maxFields: Int): String = {
+    s"$nodeName${truncatedString(child.output, "[", ", ", "]", maxFields)}"
+  }
 
   override def metricsUpdater(): MetricsUpdater =
     BackendsApiManager.getMetricsApiInstance.genInputIteratorTransformerMetricsUpdater(metrics)

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -49,7 +49,7 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
     BackendsApiManager.getMetricsApiInstance.genInputIteratorTransformerMetrics(sparkContext)
 
   override def simpleString(maxFields: Int): String = {
-    s"$nodeName${truncatedString(child.output, "[", ", ", "]", maxFields)}"
+    s"$nodeName${truncatedString(output, "[", ", ", "]", maxFields)}"
   }
 
   override def metricsUpdater(): MetricsUpdater =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add `simpleString` for `InputIteratorTransformer`. This facilitates tracking of inputs when viewing the plan in the Spark UI.

## How was this patch tested?

Just UI info, no tests.

