### PR TITLE
[VL] Daily Update Velox Version (2024-01-15)

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -349,10 +349,6 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
   // Find offheap size from Spark confs. If found, set the max memory usage of partial aggregation.
   // FIXME this uses process-wise off-heap memory which is not for task
   try {
-    // To align with Spark's behavior, set casting to int to be truncating.
-    configs[velox::core::QueryConfig::kCastToIntByTruncate] = std::to_string(true);
-    // To align with Spark's behavior, unset to support non-ISO8601 standard strings.
-    configs[velox::core::QueryConfig::kCastStringToDateIsIso8601] = std::to_string(false);
     auto defaultTimezone = veloxCfg_->get<std::string>(kDefaultSessionTimezone, "");
     configs[velox::core::QueryConfig::kSessionTimezone] =
         veloxCfg_->get<std::string>(kSessionTimezone, defaultTimezone);

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_12
+VELOX_BRANCH=2024_01_15
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
0b4876 Improve error message in check-function-signatures CI job (8316)
72c795 Fix a crash in conv Spark function (8046)
a0146d migrate from nested-name WriteHolder (8243)
373eda Fix ParquetReaderBenchmark (8274)
281dbf Avoid throwing in OutputBufferManager::updateNumDrivers(). (8357)
912897 Refactor common code in RowContainer::equalWithNulls and equalNoNulls (8323)
5e3816 Expand push_back for arrayWriter support to generics and strings. (8334)
d345e3 Delete the flag declaration of 'velox_use_malloc' (7041)
34607d Fix emptyOutput in trimUnicodeWhiteSpace (8368)
ef1b38f Assert addressable range in bits::scatterBits (8353)
96d701 Refactor thriftCodecToCompressionKind() as an utility function (7643)
3cb4ec Move velox/external/date to vendored namespace (8332)
```