### PR TITLE
[VL] Fix MicroBenchmark input batch size

### DIFF
--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -234,7 +234,7 @@ int main(int argc, char** argv) {
   std::vector<std::string> inputFiles;
   std::unordered_map<std::string, std::string> conf;
 
-  conf.insert({gluten::kSparkBatchSize, FLAGS_batch_size});
+  conf.insert({gluten::kSparkBatchSize, std::to_string(FLAGS_batch_size)});
   conf.insert({kDebugModeEnabled, "true"});
   initVeloxBackend(conf);
 
@@ -280,14 +280,12 @@ int main(int argc, char** argv) {
     }                                                                                                             \
   } while (0)
 
-#if 0
-  LOG(INFO) << "FLAGS_threads:" << FLAGS_threads ;
-  LOG(INFO) << "FLAGS_iterations:" << FLAGS_iterations ;
-  LOG(INFO) << "FLAGS_cpu:" << FLAGS_cpu ;
-  LOG(INFO) << "FLAGS_print_result:" << FLAGS_print_result ;
-  LOG(INFO) << "FLAGS_write_file:" << FLAGS_write_file ;
-  LOG(INFO) << "FLAGS_batch_size:" << FLAGS_batch_size ;
-#endif
+  DLOG(INFO) << "FLAGS_threads:" << FLAGS_threads;
+  DLOG(INFO) << "FLAGS_iterations:" << FLAGS_iterations;
+  DLOG(INFO) << "FLAGS_cpu:" << FLAGS_cpu;
+  DLOG(INFO) << "FLAGS_print_result:" << FLAGS_print_result;
+  DLOG(INFO) << "FLAGS_write_file:" << FLAGS_write_file;
+  DLOG(INFO) << "FLAGS_batch_size:" << FLAGS_batch_size;
 
   if (FLAGS_skip_input) {
     GENERIC_BENCHMARK("SkipInput", FileReaderType::kNone);

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.cc
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.cc
@@ -28,18 +28,14 @@ namespace fs = std::filesystem;
 
 DEFINE_bool(print_result, true, "Print result for execution");
 DEFINE_string(write_file, "", "Write the output to parquet file, file absolute path");
-DEFINE_string(batch_size, "4096", "To set velox::core::QueryConfig::kPreferredOutputBatchSize.");
+DEFINE_int64(batch_size, 4096, "To set velox::core::QueryConfig::kPreferredOutputBatchSize.");
 DEFINE_int32(cpu, -1, "Run benchmark on specific CPU");
 DEFINE_int32(threads, 1, "The number of threads to run this benchmark");
 DEFINE_int32(iterations, 1, "The number of iterations to run this benchmark");
 
 namespace {
 
-std::unordered_map<std::string, std::string> bmConfMap = {{gluten::kSparkBatchSize, FLAGS_batch_size}};
-
-gluten::Runtime* veloxRuntimeFactory(const std::unordered_map<std::string, std::string>& sparkConf) {
-  return new gluten::VeloxRuntime(sparkConf);
-}
+std::unordered_map<std::string, std::string> bmConfMap = {{gluten::kSparkBatchSize, std::to_string(FLAGS_batch_size)}};
 
 } // namespace
 

--- a/cpp/velox/benchmarks/common/BenchmarkUtils.h
+++ b/cpp/velox/benchmarks/common/BenchmarkUtils.h
@@ -38,7 +38,7 @@
 
 DECLARE_bool(print_result);
 DECLARE_string(write_file);
-DECLARE_string(batch_size);
+DECLARE_int64(batch_size);
 DECLARE_int32(cpu);
 DECLARE_int32(threads);
 DECLARE_int32(iterations);

--- a/cpp/velox/benchmarks/common/ParquetReaderIterator.h
+++ b/cpp/velox/benchmarks/common/ParquetReaderIterator.h
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "benchmarks/common/BenchmarkUtils.h"
 #include "benchmarks/common/FileReaderIterator.h"
 #include "utils/macros.h"
 
@@ -28,6 +29,7 @@ class ParquetReaderIterator : public FileReaderIterator {
 
   void createReader() override {
     parquet::ArrowReaderProperties properties = parquet::default_arrow_reader_properties();
+    properties.set_batch_size(FLAGS_batch_size);
     GLUTEN_THROW_NOT_OK(parquet::arrow::FileReader::Make(
         arrow::default_memory_pool(), parquet::ParquetFileReader::OpenFile(path_), properties, &fileReader_));
     GLUTEN_THROW_NOT_OK(


### PR DESCRIPTION
The input batch size of micro benchmark uses arrow default value 64k. This PR fix it by using the command line argument `--batch-size`

issue: #4386