### PR TITLE
[GLUTEN-4405][CORE] Sort values of In/InSet transformer for deterministic behavior

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
@@ -60,6 +60,9 @@ object InExpressionTransformer {
     val expressionNodes = new java.util.ArrayList[ExpressionNode](
       values
         .map(value => ExpressionBuilder.makeLiteral(value, valueType, value == null))
+        .toSeq
+        // Sort elements for deterministic behaviours
+        .sortBy(_.toString)
         .asJava)
 
     ExpressionBuilder.makeSingularOrListNode(leftNode, expressionNodes)

--- a/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
@@ -60,7 +60,7 @@ object InExpressionTransformer {
     val expressionNodes = new java.util.ArrayList[ExpressionNode](
       values.toSeq
         // Sort elements for deterministic behaviours
-        .sortBy(value => if (value == null) "NULL"  else value.toString)
+        .sortBy(Literal(_, valueType).toString())
         .map(value => ExpressionBuilder.makeLiteral(value, valueType, value == null))
         .asJava)
 

--- a/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
@@ -58,11 +58,10 @@ object InExpressionTransformer {
       values: Set[Any],
       valueType: DataType): ExpressionNode = {
     val expressionNodes = new java.util.ArrayList[ExpressionNode](
-      values
-        .map(value => ExpressionBuilder.makeLiteral(value, valueType, value == null))
-        .toSeq
+      values.toSeq
         // Sort elements for deterministic behaviours
-        .sortBy(_.toString)
+        .sortBy(value => if (value == null) "NULL"  else value.toString)
+        .map(value => ExpressionBuilder.makeLiteral(value, valueType, value == null))
         .asJava)
 
     ExpressionBuilder.makeSingularOrListNode(leftNode, expressionNodes)


### PR DESCRIPTION
## What changes were proposed in this pull request?

#4405

Spark has a declaration logic for In Set functions that keeps the output in a consistent order, so let's make input array sorted when we call transformer.

https://github.com/apache/spark/blob/1bdb81b2b5473793697083fdd9ec1a07ae605528/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala#L605-L612


## How was this patch tested?

None