### PR TITLE
[Velox] soft affinity support placing duplicate reading to same executors

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -59,7 +59,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
         val (paths, starts, lengths, partitionColumns) =
           constructSplitInfo(partitionSchema, f.files)
         val preferredLocations =
-          SoftAffinity.getFilePartitionLocations(paths.asScala.toArray, f.preferredLocations())
+          SoftAffinity.getFilePartitionLocations(f)
         LocalFilesBuilder.makeLocalFiles(
           f.index,
           paths,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -329,6 +329,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
               currentPartitions(i) match {
                 case f: FilePartition =>
                   SoftAffinity.updateFilePartitionLocations(f, rdd.id)
+                case _ =>
               })
         })
       rdd

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -30,10 +30,12 @@ import io.glutenproject.utils.SubstraitPlanPrinterUtil
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.softaffinity.SoftAffinity
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -305,7 +307,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
             substraitPlanLogLevel,
             s"$nodeName generating the substrait plan took: $t ms."))
 
-      new GlutenWholeStageColumnarRDD(
+      val rdd = new GlutenWholeStageColumnarRDD(
         sparkContext,
         inputPartitions,
         inputRDDs,
@@ -318,6 +320,18 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
           wsCtx.substraitContext.registeredAggregationParams
         )
       )
+      val allScanPartitions = basicScanExecTransformers.map(_.getPartitions)
+      (0 until allScanPartitions.head.size).foreach(
+        i => {
+          val currentPartitions = allScanPartitions.map(_(i))
+          currentPartitions.indices.foreach(
+            i =>
+              currentPartitions(i) match {
+                case f: FilePartition =>
+                  SoftAffinity.updateFilePartitionLocations(f, rdd.id)
+              })
+        })
+      rdd
     } else {
 
       /**

--- a/gluten-core/src/main/scala/io/glutenproject/softaffinity/SoftAffinityManager.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/softaffinity/SoftAffinityManager.scala
@@ -67,9 +67,9 @@ abstract class AffinityManager extends LogLevelUtil with Logging {
   val querySoftAffinityDetectMissInfo = new ConcurrentHashMap[Long, Int]()
   val querySoftAffinityDetectResultInfo = new ConcurrentHashMap[Long, Int]()
 
-  // we need keep three map: rdd id -> patition id, file path, start, length
+  // rdd id -> patition id, file path, start, length
   val rddPartitionInfoMap = new ConcurrentHashMap[Int, Array[(Int, String, Long, Long)]]()
-  //  stage id -> execution id + rdd ids: job start / execution end
+  // stage id -> execution id + rdd ids: job start / execution end
   val stageInfoMap = new ConcurrentHashMap[Int, Array[Int]]()
   // final result: partition composed key("path1_start_length,path2_start_length") --> array_host
   val duplicateReadingInfos =

--- a/gluten-core/src/main/scala/io/glutenproject/softaffinity/scheduler/SoftAffinityListener.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/softaffinity/scheduler/SoftAffinityListener.scala
@@ -19,9 +19,22 @@ package io.glutenproject.softaffinity.scheduler
 import io.glutenproject.softaffinity.SoftAffinityManager
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorAdded, SparkListenerExecutorRemoved}
+import org.apache.spark.scheduler._
+import org.apache.spark.sql.execution.ui._
 
 class SoftAffinityListener extends SparkListener with Logging {
+
+  override def onStageSubmitted(event: SparkListenerStageSubmitted): Unit = {
+    SoftAffinityManager.updateStageMap(event)
+  }
+
+  override def onStageCompleted(event: SparkListenerStageCompleted): Unit = {
+    SoftAffinityManager.cleanMiddleStatusMap(event)
+  }
+
+  override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+    SoftAffinityManager.updateHostMap(taskEnd)
+  }
 
   override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
     val execId = executorAdded.executorId
@@ -32,5 +45,11 @@ class SoftAffinityListener extends SparkListener with Logging {
   override def onExecutorRemoved(executorRemoved: SparkListenerExecutorRemoved): Unit = {
     val execId = executorRemoved.executorId
     SoftAffinityManager.handleExecutorRemoved(execId)
+  }
+
+  override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
+    case e: SparkListenerSQLExecutionStart => SoftAffinityManager.onExecutionStart(e)
+    case e: SparkListenerSQLExecutionEnd => SoftAffinityManager.onExecutionEnd(e)
+    case _ => // Ignore
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/softaffinity/scheduler/SoftAffinityListener.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/softaffinity/scheduler/SoftAffinityListener.scala
@@ -20,7 +20,6 @@ import io.glutenproject.softaffinity.SoftAffinityManager
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
-import org.apache.spark.sql.execution.ui._
 
 class SoftAffinityListener extends SparkListener with Logging {
 
@@ -45,11 +44,5 @@ class SoftAffinityListener extends SparkListener with Logging {
   override def onExecutorRemoved(executorRemoved: SparkListenerExecutorRemoved): Unit = {
     val execId = executorRemoved.executorId
     SoftAffinityManager.handleExecutorRemoved(execId)
-  }
-
-  override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
-    case e: SparkListenerSQLExecutionStart => SoftAffinityManager.onExecutionStart(e)
-    case e: SparkListenerSQLExecutionEnd => SoftAffinityManager.onExecutionEnd(e)
-    case _ => // Ignore
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/listener/GlutenListenerFactory.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/listener/GlutenListenerFactory.scala
@@ -16,6 +16,9 @@
  */
 package org.apache.spark.listener
 
+import io.glutenproject.GlutenConfig
+import io.glutenproject.softaffinity.scheduler.SoftAffinityListener
+
 import org.apache.spark.SparkContext
 import org.apache.spark.rpc.GlutenDriverEndpoint
 
@@ -23,5 +26,13 @@ object GlutenListenerFactory {
   def addToSparkListenerBus(sc: SparkContext): Unit = {
     sc.listenerBus.addToStatusQueue(
       new GlutenSQLAppStatusListener(GlutenDriverEndpoint.glutenDriverEndpointRef))
+    if (
+      sc.getConf.getBoolean(
+        GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED,
+        GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED_DEFAULT_VALUE
+      )
+    ) {
+      sc.listenerBus.addToStatusQueue(new SoftAffinityListener())
+    }
   }
 }

--- a/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
@@ -95,7 +95,7 @@ class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession wit
       // check location (executor 0) of dulicate reading is returned.
       val locations = SoftAffinity.getFilePartitionLocations(filePartition)
 
-      val nativePartition = new GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+      val nativePartition = new GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations = locations)
 
       assertResult(Set("executor_host-0_0")) {
         nativePartition.preferredLocations().toSet

--- a/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
@@ -92,7 +92,7 @@ class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession wit
       softAffinityListener.onStageSubmitted(stage1SubmitEvent)
       softAffinityListener.onTaskEnd(taskEnd1)
       assert(SoftAffinityManager.duplicateReadingInfos.size == 1)
-      // check location (executor 0) od dulicate reading is retuened.
+      // check location (executor 0) of dulicate reading is returned.
       val locations = SoftAffinity.getFilePartitionLocations(filePartition)
 
       val nativePartition = new GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
@@ -101,7 +101,7 @@ class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession wit
         nativePartition.preferredLocations().toSet
       }
       softAffinityListener.onStageCompleted(stage1EndEvent)
-      // stage 1 complated, check all middle status is cleared.
+      // stage 1 completed, check all middle status is cleared.
       assert(SoftAffinityManager.rddPartitionInfoMap.size == 0)
       assert(SoftAffinityManager.stageInfoMap.size == 0)
       softAffinityListener.onExecutorRemoved(removedEvent0)

--- a/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.softaffinity
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.execution.GlutenPartition
+import io.glutenproject.softaffinity.SoftAffinityManager
+import io.glutenproject.softaffinity.scheduler.SoftAffinityListener
+import io.glutenproject.sql.shims.SparkShimLoader
+import io.glutenproject.substrait.plan.PlanBuilder
+
+import org.apache.spark.SparkConf
+import org.apache.spark.scheduler.{SparkListenerExecutorAdded, SparkListenerExecutorRemoved, SparkListenerStageCompleted, SparkListenerStageSubmitted, SparkListenerTaskEnd, StageInfo, TaskInfo, TaskLocality}
+import org.apache.spark.scheduler.cluster.ExecutorInfo
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.sql.execution.datasources.FilePartition
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.storage.{RDDInfo, StorageLevel}
+
+class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession with PredicateHelper {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED, "true")
+    .set(GlutenConfig.GLUTEN_SOFT_AFFINITY_DUPLICATE_READING_DETECT_ENABLED, "true")
+    .set(GlutenConfig.GLUTEN_SOFT_AFFINITY_REPLICATIONS_NUM, "2")
+    .set(GlutenConfig.GLUTEN_SOFT_AFFINITY_MIN_TARGET_HOSTS, "2")
+    .set(GlutenConfig.SOFT_AFFINITY_LOG_LEVEL, "INFO")
+
+  test("Soft Affinity Scheduler with duplicate reading detection") {
+    if (SparkShimLoader.getSparkShims.supportDuplicateReadingTracking) {
+      val addEvent0 = SparkListenerExecutorAdded(
+        System.currentTimeMillis(),
+        "0",
+        new ExecutorInfo("host-0", 3, null))
+      val addEvent1 = SparkListenerExecutorAdded(
+        System.currentTimeMillis(),
+        "1",
+        new ExecutorInfo("host-1", 3, null))
+      val removedEvent0 = SparkListenerExecutorRemoved(System.currentTimeMillis(), "0", "")
+      val removedEvent1 = SparkListenerExecutorRemoved(System.currentTimeMillis(), "1", "")
+      val rdd1 = new RDDInfo(1, "", 3, StorageLevel.NONE, false, Seq.empty)
+      val rdd2 = new RDDInfo(2, "", 3, StorageLevel.NONE, false, Seq.empty)
+      var stage1 = new StageInfo(1, 0, "", 1, Seq(rdd1, rdd2), Seq.empty, "", resourceProfileId = 0)
+      val stage1SubmitEvent = SparkListenerStageSubmitted(stage1)
+      val stage1EndEvent = SparkListenerStageCompleted(stage1)
+      val taskEnd1 = SparkListenerTaskEnd(
+        1,
+        0,
+        "",
+        org.apache.spark.Success,
+        // this is little tricky here for 3.2 compatibility, we use -1 for partition id.
+        new TaskInfo(1, 1, 1, 1L, "0", "host-0", TaskLocality.ANY, false),
+        null,
+        null
+      )
+      val files = Seq(
+        SparkShimLoader.getSparkShims.generatePartitionedFile(
+          InternalRow.empty,
+          "fakePath0",
+          0,
+          100,
+          Array("host-3")),
+        SparkShimLoader.getSparkShims.generatePartitionedFile(
+          InternalRow.empty,
+          "fakePath0",
+          100,
+          200,
+          Array("host-3"))
+      ).toArray
+      val filePartition = FilePartition(-1, files)
+      val softAffinityListener = new SoftAffinityListener()
+      softAffinityListener.onExecutorAdded(addEvent0)
+      softAffinityListener.onExecutorAdded(addEvent1)
+      SoftAffinityManager.updatePartitionMap(filePartition, 1)
+      assert(SoftAffinityManager.rddPartitionInfoMap.size == 1)
+      softAffinityListener.onStageSubmitted(stage1SubmitEvent)
+      softAffinityListener.onTaskEnd(taskEnd1)
+      assert(SoftAffinityManager.duplicateReadingInfos.size == 1)
+      // check location (executor 0) od dulicate reading is retuened.
+      val locations = SoftAffinity.getFilePartitionLocations(filePartition)
+
+      val nativePartition = new GlutenPartition(0, PlanBuilder.EMPTY_PLAN, locations)
+
+      assertResult(Set("executor_host-0_0")) {
+        nativePartition.preferredLocations().toSet
+      }
+      softAffinityListener.onStageCompleted(stage1EndEvent)
+      // stage 1 complated, check all middle status is cleared.
+      assert(SoftAffinityManager.rddPartitionInfoMap.size == 0)
+      assert(SoftAffinityManager.stageInfoMap.size == 0)
+      softAffinityListener.onExecutorRemoved(removedEvent0)
+      softAffinityListener.onExecutorRemoved(removedEvent1)
+      // executor 0 is removed, return empty.
+      assert(SoftAffinityManager.askExecutors(filePartition).isEmpty)
+    }
+  }
+}

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -63,9 +63,7 @@ object GlutenIcebergSourceUtil {
                 s"find different file format $fileFormat and $currentFileFormat")
           }
       }
-      val preferredLoc = SoftAffinity.getFilePartitionLocations(
-        paths.asScala.toArray,
-        inputPartition.preferredLocations())
+      val preferredLoc = SoftAffinity.getFilePartitionLocations(inputPartition)
       IcebergLocalFilesBuilder.makeIcebergLocalFiles(
         index,
         paths,

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -63,7 +63,9 @@ object GlutenIcebergSourceUtil {
                 s"find different file format $fileFormat and $currentFileFormat")
           }
       }
-      val preferredLoc = SoftAffinity.getFilePartitionLocations(inputPartition)
+      val preferredLoc = SoftAffinity.getFilePartitionLocations(
+        paths.asScala.toArray,
+        inputPartition.preferredLocations())
       IcebergLocalFilesBuilder.makeIcebergLocalFiles(
         index,
         paths,

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -423,6 +423,15 @@ object GlutenConfig {
   val GLUTEN_SOFT_AFFINITY_MIN_TARGET_HOSTS = "spark.gluten.soft-affinity.min.target-hosts"
   val GLUTEN_SOFT_AFFINITY_MIN_TARGET_HOSTS_DEFAULT_VALUE = 1
 
+  // Enable Soft Affinity duplicate reading detection, defalut value is true
+  val GLUTEN_SOFT_AFFINITY_DUPLICATE_READING_DETECT_ENABLED =
+    "spark.gluten.soft-affinity.duplicateReadingDetect.enabled"
+  val GLUTEN_SOFT_AFFINITY_DUPLICATE_READING_DETECT_ENABLED_DEFAULT_VALUE = true
+  // Enable Soft Affinity duplicate reading detection, defalut value is 10000
+  val GLUTEN_SOFT_AFFINITY_MAX_DUPLICATE_READING_RECORDS =
+    "spark.gluten.soft-affinity.maxDuplicateReading.records"
+  val GLUTEN_SOFT_AFFINITY_MAX_DUPLICATE_READING_RECORDS_DEFAULT_VALUE = 10000
+
   // Pass through to native conf
   val GLUTEN_SAVE_DIR = "spark.gluten.saveDir"
 

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -20,6 +20,7 @@ import io.glutenproject.expression.Sig
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.{ShuffleHandle, ShuffleReader, ShuffleReadMetricsReporter}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -119,4 +120,10 @@ trait SparkShims {
       startPartition: Int,
       endPartition: Int)
       : Tuple2[Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])], Boolean]
+
+  // Partition id in TaskInfo is only available after spark 3.3.
+  def getPratitionId(taskInfo: TaskInfo): Int
+
+  // Because above, this feature is only supported after spark 3.3
+  def supportDuplicateReadingTracking: Boolean
 }

--- a/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
+++ b/shims/spark32/src/main/scala/io/glutenproject/sql/shims/spark32/Spark32Shims.scala
@@ -21,6 +21,7 @@ import io.glutenproject.expression.{ExpressionNames, Sig}
 import io.glutenproject.sql.shims.{ShimDescriptor, SparkShims}
 
 import org.apache.spark.{ShuffleUtils, TaskContext, TaskContextUtils}
+import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -129,4 +130,10 @@ class Spark32Shims extends SparkShims {
       : Tuple2[Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])], Boolean] = {
     ShuffleUtils.getReaderParam(handle, startMapIndex, endMapIndex, startPartition, endPartition)
   }
+
+  override def getPratitionId(taskInfo: TaskInfo): Int = {
+    throw new IllegalStateException("This is not supported.")
+  }
+
+  override def supportDuplicateReadingTracking: Boolean = false
 }

--- a/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/io/glutenproject/sql/shims/spark33/Spark33Shims.scala
@@ -22,6 +22,7 @@ import io.glutenproject.expression.{ExpressionNames, Sig}
 import io.glutenproject.sql.shims.{ShimDescriptor, SparkShims}
 
 import org.apache.spark.{ShuffleDependency, ShuffleUtils, SparkEnv, SparkException, TaskContext, TaskContextUtils}
+import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.shuffle.ShuffleHandle
 import org.apache.spark.sql.SparkSession
@@ -174,4 +175,10 @@ class Spark33Shims extends SparkShims {
       : Tuple2[Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])], Boolean] = {
     ShuffleUtils.getReaderParam(handle, startMapIndex, endMapIndex, startPartition, endPartition)
   }
+
+  override def getPratitionId(taskInfo: TaskInfo): Int = {
+    taskInfo.partitionId
+  }
+
+  override def supportDuplicateReadingTracking: Boolean = true
 }

--- a/shims/spark34/src/main/scala/io/glutenproject/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/io/glutenproject/sql/shims/spark34/Spark34Shims.scala
@@ -23,6 +23,7 @@ import io.glutenproject.sql.shims.{ShimDescriptor, SparkShims}
 import org.apache.spark.{ShuffleUtils, SparkException, TaskContext, TaskContextUtils}
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.paths.SparkPath
+import org.apache.spark.scheduler.TaskInfo
 import org.apache.spark.shuffle.ShuffleHandle
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -210,4 +211,10 @@ class Spark34Shims extends SparkShims {
       : Tuple2[Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])], Boolean] = {
     ShuffleUtils.getReaderParam(handle, startMapIndex, endMapIndex, startPartition, endPartition)
   }
+
+  override def getPratitionId(taskInfo: TaskInfo): Int = {
+    taskInfo.partitionId
+  }
+
+  override def supportDuplicateReadingTracking: Boolean = true
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We add two APIs in Soft Affinity to implement the optimization of handling duplicate data reads by preferentially scheduling them on the same executor. This differs from the hash-based method in that it only sets the prefer location during repeated reads; the initial read is not affected by this. This approach reduces the observed uneven distribution of tasks caused by hash conflicts.
With the new APIs and spark events consumption, we obtain information about the relationships between partitions, RDDs, tasks, and executors. Eventually, we simplify this information into a mapping of partitions to executors. This allows us to determine which partition has been read on which executor. When duplicate partitions arrive, we can then allocate the corresponding tasks to the executor where the partition has been read as much as possible.

Its limitation is in assuming that the cache size will always be sufficient, and all reads will be cached. However, this assumption may not always hold true in practice.

## How was this patch tested?
UT.

Velox cache enabled (mem only 8GB) + soft affinity: 9.7%.
Velox cache enabled (mem only 8GB) + soft affinity (duplicate reading detecting): 14.3%.
For details please see, https://github.com/oap-project/gluten/pull/4400#issue-2081288878

Fixes: #4762

