### PR TITLE
[VL] add missed validation for in expr and pushdown filter

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -795,4 +795,15 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       checkOperatorMatch[BatchScanExecTransformer]
     }
   }
+
+  test("timestamp cast fallback") {
+    withTempPath {
+      path =>
+        (0 to 3).toDF("x").write.parquet(path.getCanonicalPath)
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("view")
+        runQueryAndCompare(
+          "SELECT x FROM view WHERE cast(x as timestamp) " +
+            "IN ('1970-01-01 08:00:00.001','1970-01-01 08:00:00.2')")(_)
+    }
+  }
 }

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -406,7 +406,7 @@ core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
   std::vector<::substrait::Expression::Literal> literals;
   literals.reserve(options.size());
   for (const auto& option : options) {
-    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
+    VELOX_CHECK(option.has_literal(), "Option is expected as Literal.");
     literals.emplace_back(option.literal());
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -315,7 +315,7 @@ bool SubstraitToVeloxPlanValidator::validateSingularOrList(
     const ::substrait::Expression::SingularOrList& singularOrList,
     const RowTypePtr& inputType) {
   for (const auto& option : singularOrList.options()) {
-    if(!option.has_literal()) {
+    if (!option.has_literal()) {
       logValidateMsg("native validation failed due to: Option is expected as Literal.");
       return false;
     }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -271,7 +271,6 @@ bool SubstraitToVeloxPlanValidator::validateCast(
   }
 
   core::TypedExprPtr input = exprConverter_->toVeloxExpr(castExpr.input(), inputType);
-
   // Casting from some types is not supported. See CastExpr::applyCast.
   if (input->type()->isDate()) {
     if (toType->kind() == TypeKind::TIMESTAMP) {
@@ -311,6 +310,22 @@ bool SubstraitToVeloxPlanValidator::validateIfThen(
   return true;
 }
 
+bool SubstraitToVeloxPlanValidator::validateSingularOrList(
+    const ::substrait::Expression::SingularOrList& singularOrList,
+    const RowTypePtr& inputType) {
+  for (const auto& option : singularOrList.options()) {
+    if(!option.has_literal()) {
+      logValidateMsg("native validation failed due to: Option is expected as Literal.");
+      return false;
+    }
+    if (!validateLiteral(option.literal(), inputType)) {
+      return false;
+    }
+  }
+
+  return validateExpression(singularOrList.value(), inputType);
+}
+
 bool SubstraitToVeloxPlanValidator::validateExpression(
     const ::substrait::Expression& expression,
     const RowTypePtr& inputType) {
@@ -324,6 +339,8 @@ bool SubstraitToVeloxPlanValidator::validateExpression(
       return validateCast(expression.cast(), inputType);
     case ::substrait::Expression::RexTypeCase::kIfThen:
       return validateIfThen(expression.if_then(), inputType);
+    case ::substrait::Expression::RexTypeCase::kSingularOrList:
+      return validateSingularOrList(expression.singular_or_list(), inputType);
     default:
       return true;
   }
@@ -1147,6 +1164,9 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ReadRel& readRel
     auto rowType = std::make_shared<RowType>(std::move(names), std::move(veloxTypeList));
     std::vector<core::TypedExprPtr> expressions;
     try {
+      if (!validateExpression(readRel.filter(), rowType)) {
+        return false;
+      }
       expressions.emplace_back(exprConverter_->toVeloxExpr(readRel.filter(), rowType));
       // Try to compile the expressions. If there is any unregistered function
       // or mismatched type, exception will be thrown.

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -271,6 +271,7 @@ bool SubstraitToVeloxPlanValidator::validateCast(
   }
 
   core::TypedExprPtr input = exprConverter_->toVeloxExpr(castExpr.input(), inputType);
+
   // Casting from some types is not supported. See CastExpr::applyCast.
   if (input->type()->isDate()) {
     if (toType->kind() == TypeKind::TIMESTAMP) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -129,7 +129,8 @@ class SubstraitToVeloxPlanValidator {
 
   /// Validate Substrait IN expression.
   bool validateSingularOrList(
-      const ::substrait::Expression::SingularOrList& singularOrList, const RowTypePtr& inputType);
+      const ::substrait::Expression::SingularOrList& singularOrList,
+      const RowTypePtr& inputType);
 
   /// Add necessary log for fallback
   void logValidateMsg(const std::string& log) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -127,6 +127,10 @@ class SubstraitToVeloxPlanValidator {
   /// Validate Substrait if-then expression.
   bool validateIfThen(const ::substrait::Expression_IfThen& ifThen, const RowTypePtr& inputType);
 
+  /// Validate Substrait IN expression.
+  bool validateSingularOrList(
+      const ::substrait::Expression::SingularOrList& singularOrList, const RowTypePtr& inputType);
+
   /// Add necessary log for fallback
   void logValidateMsg(const std::string& log) {
     validateLog_.emplace_back(log);


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
(0 to 3).toDF("x").write.parquet("time_x")
spark.read.parquet("time_x").createOrReplaceTempView("timestamps")
spark.sql("SELECT x FROM timestamps WHERE cast(x as timestamp) IN ('1970-01-01 08:00:01','1970-01-01 08:00:02')").collect
```
Because timestamp cast is not fallback, wrong result is generated.
```
(1) Scan parquet 
Output [1]: [x#0]
Batched: true
Location: InMemoryFileIndex [file:/var/git/time_x]
ReadSchema: struct<x:int>

(2) FilterExecTransformer
Input [1]: [x#0]
Arguments: cast(x#0 as timestamp) IN (1970-01-01 08:00:01,1970-01-01 08:00:02)

```

## How was this patch tested?

UT.

