### PR TITLE
[VL][CI] Optimization of Docker Build: Integrating Maven Commands into Dockerfile

### DIFF
--- a/tools/gluten-te/centos/dockerfile-build
+++ b/tools/gluten-te/centos/dockerfile-build
@@ -63,6 +63,8 @@ RUN if [ "$BUILD_BACKEND_TYPE" == "velox" ]; \
       EXTRA_MAVEN_OPTIONS="-Pspark-3.2 \
                            -Pbackends-velox \
                            -Prss \
+                           -Piceberg \
+                           -Pdelta \
                            -DskipTests \
                            -Dscalastyle.skip=true \
                            -Dcheckstyle.skip=true"; \

--- a/tools/gluten-te/ubuntu/dockerfile-build
+++ b/tools/gluten-te/ubuntu/dockerfile-build
@@ -63,6 +63,8 @@ RUN if [ "$BUILD_BACKEND_TYPE" == "velox" ]; \
       EXTRA_MAVEN_OPTIONS="-Pspark-3.2 \
                            -Pbackends-velox \
                            -Prss \
+                           -Piceberg \
+                           -Pdelta \
                            -DskipTests \
                            -Dscalastyle.skip=true \
                            -Dcheckstyle.skip=true"; \


### PR DESCRIPTION
Shift the Maven build process from GHA to the Docker image building stage. The specific change involves adding the mvn clean install -Piceberg -Pdelta command to the Dockerfile. This modification allows dependencies installation and project building to be completed during the Docker image construction
