### PR TITLE
[VL] Daily Update Velox Version (2024-01-17)

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -86,6 +86,7 @@ macro(ADD_VELOX_OBJECTS)
           "${VELOX_COMPONENTS_PATH}/connectors/hive/CMakeFiles/velox_hive_connector.dir/PartitionIdGenerator.cpp.o"
           "${VELOX_COMPONENTS_PATH}/connectors/hive/CMakeFiles/velox_hive_connector.dir/SplitReader.cpp.o"
           "${VELOX_COMPONENTS_PATH}/connectors/hive/CMakeFiles/velox_hive_connector.dir/TableHandle.cpp.o"
+          "${VELOX_COMPONENTS_PATH}/connectors/hive/CMakeFiles/velox_hive_connector.dir/HiveConnectorUtil.cpp.o"
           )
   target_link_libraries(velox PUBLIC velox_objects)
 endmacro()

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_16
+VELOX_BRANCH=2024_01_17
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
4e3684 Refactor HiveDataSource (8104)
1bf01e Setup AggregationFuzzer to use Presto as source of truth in experimental jobs. (8314)
31caef Create the parent path if not exist when writing data in HDFS filesystem (8343)
95b436 Update rawInputPositions for Exchange operator (8370)
21cb99 Fix shadowed variable in velox/expression/ExprCompiler.cpp (8393)
fa432b Fix shadowed variable in velox/common/caching/CachedFactory.h (8394)
87ec92 Move ngrams registration to its separate registration file for faster compilation time. (8383)
9c1b76 Fix shadowed variable in velox/exec/Aggregate.cpp (8392)
65b967 Fix shadowed variable in velox/tpch/gen/dbgen/bm_utils.cpp (8391)
e7cb79 Fix shadowed variable in velox/functions/prestosql/ArrayConstructor.cpp (8384)
8353f7 Fix shadowed variable in velox/dwio/common/FilterNode.h (8389)
2dd839 Fix shadowed variable in velox/dwio/common/BitPackDecoder.cpp (8390)
```