### PR TITLE
[VL] Fix failed tests TestRuntime.GetResultIterator

### DIFF
--- a/cpp/velox/tests/RuntimeTest.cc
+++ b/cpp/velox/tests/RuntimeTest.cc
@@ -104,10 +104,7 @@ class DummyRuntime final : public Runtime {
       }
       hasNext_ = false;
 
-      auto fArrInt32 = arrow::field("f_int32", arrow::int32());
-      auto rbSchema = arrow::schema({fArrInt32});
-      auto rb = arrow::RecordBatch::Make(rbSchema, 1, std::vector<std::shared_ptr<arrow::Array>>{});
-      return std::make_shared<ArrowColumnarBatch>(rb);
+      return gluten::createZeroColumnBatch(1);
     }
 
    private:


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we build debug velox version, `TestRuntime.GetResultIterator` could fail since it passes an empty columns with an int schema(arrow has a debug check here):

```c++
DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
```

We can simply call `gluten::createZeroColumnBatch(1)` to avoid it.

## How was this patch tested?

manually test it with Debug Velox version

