### PR TITLE
[VL] Fix Filter node falling back to Spark whenever there is Timestamp column in input (child node)

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -21,7 +21,7 @@ import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
-import org.apache.spark.sql.execution.{FileSourceScanExec, GenerateExec, RDDScanExec}
+import org.apache.spark.sql.execution.{GenerateExec, RDDScanExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{avg, col, lit, udf}
 import org.apache.spark.sql.internal.SQLConf

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -793,17 +793,11 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
       // Fallback should only happen when there is a filter on timestamp column
       runQueryAndCompare(
         "select c1, c2 from ts where" +
-          " c2 = timestamp'1965-01-01 10:11:12.123456'") {
-        df: DataFrame =>
-          assert(df.queryExecution.executedPlan.find(_.isInstanceOf[FileSourceScanExec]).isDefined)
-      }
+          " c2 = timestamp'1965-01-01 10:11:12.123456'") { _ => }
 
       runQueryAndCompare(
         "select c1, c2 from ts where" +
-          " c1 = 1 and c2 = timestamp'1965-01-01 10:11:12.123456'") {
-        df: DataFrame =>
-          assert(df.queryExecution.executedPlan.find(_.isInstanceOf[FileSourceScanExec]).isDefined)
-      }
+          " c1 = 1 and c2 = timestamp'1965-01-01 10:11:12.123456'") { _ => }
     }
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -24,7 +24,6 @@
 #include "velox/core/ExpressionEvaluator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/Expr.h"
-#include "velox/expression/FieldReference.h"
 #include "velox/expression/SignatureBinder.h"
 
 namespace gluten {

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -858,15 +858,6 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filte
     // Try to compile the expressions. If there is any unregistered function
     // or mismatched type, exception will be thrown.
     exec::ExprSet exprSet(std::move(expressions), execCtx_);
-
-    // Check for timestamp column filter
-    for (const auto& fieldRef : exprSet.distinctFields()) {
-      auto idx = rowType->getChildIdx(fieldRef->field());
-      if (rowType->childAt(idx)->isTimestamp()) {
-        LOG_VALIDATION_MSG("Timestamp is not fully supported in Filter");
-        return false;
-      }
-    }
   } catch (const VeloxException& err) {
     LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -24,6 +24,7 @@
 #include "velox/core/ExpressionEvaluator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/FieldReference.h"
 #include "velox/expression/SignatureBinder.h"
 
 namespace gluten {
@@ -838,12 +839,6 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filte
     LOG_VALIDATION_MSG("Validation failed for input types in FilterRel.");
     return false;
   }
-  for (const auto& type : types) {
-    if (type->kind() == TypeKind::TIMESTAMP) {
-      LOG_VALIDATION_MSG("Timestamp is not fully supported in Filter.");
-      return false;
-    }
-  }
 
   int32_t inputPlanNodeId = 0;
   // Create the fake input names to be used in row type.
@@ -863,6 +858,15 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filte
     // Try to compile the expressions. If there is any unregistered function
     // or mismatched type, exception will be thrown.
     exec::ExprSet exprSet(std::move(expressions), execCtx_);
+
+    // Check for timestamp column filter
+    for (const auto& fieldRef : exprSet.distinctFields()) {
+      auto idx = rowType->getChildIdx(fieldRef->field());
+      if (rowType->childAt(idx)->isTimestamp()) {
+        LOG_VALIDATION_MSG("Timestamp is not fully supported in Filter");
+        return false;
+      }
+    }
   } catch (const VeloxException& err) {
     LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently if the input to filter node contains any timestamp column, it fallbacks to Spark even though filter predicate may not be on timestamp column. Current check is very strict.

(Fixes: \#ISSUE-ID)

## How was this patch tested?
Unit tests in PR

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

