### PR TITLE
[VL] Make velox orc scan configurable and keep it on by default.

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -111,20 +111,21 @@ object BackendSettings extends BackendSettingsApi {
           val typeValidator: PartialFunction[StructField, String] = {
             case StructField(_, ByteType, _, _) => "ByteType not support"
             case StructField(_, arrayType: ArrayType, _, _)
-              if arrayType.elementType.isInstanceOf[StructType] =>
+                if arrayType.elementType.isInstanceOf[StructType] =>
               "StructType as element in ArrayType"
             case StructField(_, arrayType: ArrayType, _, _)
-              if arrayType.elementType.isInstanceOf[ArrayType] =>
+                if arrayType.elementType.isInstanceOf[ArrayType] =>
               "ArrayType as element in ArrayType"
-            case StructField(_, mapType: MapType, _, _) if mapType.keyType.isInstanceOf[StructType] =>
+            case StructField(_, mapType: MapType, _, _)
+                if mapType.keyType.isInstanceOf[StructType] =>
               "StructType as Key in MapType"
             case StructField(_, mapType: MapType, _, _)
-              if mapType.valueType.isInstanceOf[ArrayType] =>
+                if mapType.valueType.isInstanceOf[ArrayType] =>
               "ArrayType as Value in MapType"
             case StructField(_, stringType: StringType, _, metadata)
-              if CharVarcharUtils
-                .getRawTypeString(metadata)
-                .getOrElse(stringType.catalogString) != stringType.catalogString =>
+                if CharVarcharUtils
+                  .getRawTypeString(metadata)
+                  .getOrElse(stringType.catalogString) != stringType.catalogString =>
               CharVarcharUtils.getRawTypeString(metadata) + " not support"
             case StructField(_, TimestampType, _, _) => "TimestampType not support"
           }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -105,27 +105,31 @@ object BackendSettings extends BackendSettingsApi {
         validateTypes(typeValidator)
       case DwrfReadFormat => ValidationResult.ok
       case OrcReadFormat =>
-        val typeValidator: PartialFunction[StructField, String] = {
-          case StructField(_, ByteType, _, _) => "ByteType not support"
-          case StructField(_, arrayType: ArrayType, _, _)
+        if (!GlutenConfig.getConf.veloxOrcScanEnabled) {
+          ValidationResult.notOk(s"Velox ORC scan is turned off.")
+        } else {
+          val typeValidator: PartialFunction[StructField, String] = {
+            case StructField(_, ByteType, _, _) => "ByteType not support"
+            case StructField(_, arrayType: ArrayType, _, _)
               if arrayType.elementType.isInstanceOf[StructType] =>
-            "StructType as element in ArrayType"
-          case StructField(_, arrayType: ArrayType, _, _)
+              "StructType as element in ArrayType"
+            case StructField(_, arrayType: ArrayType, _, _)
               if arrayType.elementType.isInstanceOf[ArrayType] =>
-            "ArrayType as element in ArrayType"
-          case StructField(_, mapType: MapType, _, _) if mapType.keyType.isInstanceOf[StructType] =>
-            "StructType as Key in MapType"
-          case StructField(_, mapType: MapType, _, _)
+              "ArrayType as element in ArrayType"
+            case StructField(_, mapType: MapType, _, _) if mapType.keyType.isInstanceOf[StructType] =>
+              "StructType as Key in MapType"
+            case StructField(_, mapType: MapType, _, _)
               if mapType.valueType.isInstanceOf[ArrayType] =>
-            "ArrayType as Value in MapType"
-          case StructField(_, stringType: StringType, _, metadata)
+              "ArrayType as Value in MapType"
+            case StructField(_, stringType: StringType, _, metadata)
               if CharVarcharUtils
                 .getRawTypeString(metadata)
                 .getOrElse(stringType.catalogString) != stringType.catalogString =>
-            CharVarcharUtils.getRawTypeString(metadata) + " not support"
-          case StructField(_, TimestampType, _, _) => "TimestampType not support"
+              CharVarcharUtils.getRawTypeString(metadata) + " not support"
+            case StructField(_, TimestampType, _, _) => "TimestampType not support"
+          }
+          validateTypes(typeValidator)
         }
-        validateTypes(typeValidator)
       case _ => ValidationResult.notOk(s"Unsupported file format for $format.")
     }
   }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -94,6 +94,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def enableCommonSubexpressionEliminate: Boolean =
     conf.getConf(ENABLE_COMMON_SUBEXPRESSION_ELIMINATE)
 
+  def veloxOrcScanEnabled: Boolean =
+    conf.getConf(VELOX_ORC_SCAN_ENABLED)
+
   // whether to use ColumnarShuffleManager
   def isUseColumnarShuffleManager: Boolean =
     conf
@@ -1594,4 +1597,11 @@ object GlutenConfig {
       .doc("Log granularity of AWS C++ SDK in velox.")
       .stringConf
       .createWithDefault("FATAL")
+
+  val VELOX_ORC_SCAN_ENABLED =
+    buildStaticConf("spark.gluten.sql.columnar.backend.velox.orc.scan.enabled")
+      .internal()
+      .doc(" Enable velox orc scan. If disabled, vanilla spark orc scan will be used.")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1603,5 +1603,5 @@ object GlutenConfig {
       .internal()
       .doc(" Enable velox orc scan. If disabled, vanilla spark orc scan will be used.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Velox ORC scan is leading to data correctness check failures. While ORC scan is fixed, this PR makes enabling of velox ORC scans configurable and turn it off by default.

## How was this patch tested?

Local build.

