### PR TITLE
[GLUTEN-4452] [CH] fix may get wrong hash table when multi joins in a task

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/joins/ClickHouseBuildSideRelation.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/joins/ClickHouseBuildSideRelation.scala
@@ -45,14 +45,17 @@ case class ClickHouseBuildSideRelation(
       broadCastContext: BroadCastHashJoinContext): ClickHouseBuildSideRelation = this
 
   private var hashTableData: Long = 0L
+  private var hashTableName: String = ""
+
   def buildHashTable(
       broadCastContext: BroadCastHashJoinContext): (Long, ClickHouseBuildSideRelation) =
     synchronized {
-      if (hashTableData == 0) {
+      if (hashTableData == 0 || hashTableName != broadCastContext.buildHashTableId) {
         logDebug(
           s"BHJ value size: " +
             s"${broadCastContext.buildHashTableId} = ${batches.length}")
         // Build the hash table
+        hashTableName = broadCastContext.buildHashTableId
         hashTableData = StorageJoinBuilder.build(
           batches,
           numOfRows,
@@ -67,6 +70,7 @@ case class ClickHouseBuildSideRelation(
 
   def reset(): Unit = synchronized {
     hashTableData = 0
+    hashTableName = ""
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fix the bug that it may get wrong hash table when there are multi joins in a task

(Fixes: \#4452)

## How was this patch tested?

This patch was tested by manual tests.


