### PR TITLE
[CORE] Optimize some code in HashAggregateExecBaseTransformer

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/StorageJoinBuilder.java
@@ -69,7 +69,7 @@ public class StorageJoinBuilder {
         keys.stream()
             .map(
                 (Expression key) -> {
-                  Attribute attr = converter.getAttrFromExpr(key, false);
+                  Attribute attr = converter.getAttrFromExpr(key);
                   return converter.genColumnNameWithExprId(attr);
                 })
             .collect(Collectors.joining(","));

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -36,6 +36,7 @@ import com.google.protobuf.{Any, StringValue}
 import java.util
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 object CHHashAggregateExecTransformer {
   def getAggregateResultAttributes(
@@ -415,5 +416,58 @@ case class CHHashAggregateExecTransformer(
         StringValue.newBuilder.setValue(optimizationContent).build)
     ExtensionBuilder.makeAdvancedExtension(optimization, enhancement)
 
+  }
+
+  override protected def getAttrForAggregateExprs(
+      aggregateExpressions: Seq[AggregateExpression],
+      aggregateAttributeList: Seq[Attribute]): List[Attribute] = {
+    val aggregateAttr = new ListBuffer[Attribute]()
+    val size = aggregateExpressions.size
+    var resIndex = 0
+    for (expIdx <- 0 until size) {
+      val exp: AggregateExpression = aggregateExpressions(expIdx)
+      resIndex = getAttrForAggregateExpr(exp, aggregateAttributeList, aggregateAttr, resIndex)
+    }
+    aggregateAttr.toList
+  }
+
+  protected def getAttrForAggregateExpr(
+      exp: AggregateExpression,
+      aggregateAttributeList: Seq[Attribute],
+      aggregateAttr: ListBuffer[Attribute],
+      index: Int): Int = {
+    var resIndex = index
+    val aggregateFunc = exp.aggregateFunction
+    // First handle the custom aggregate functions
+    if (
+      ExpressionMappings.expressionExtensionTransformer.extensionExpressionsMapping.contains(
+        aggregateFunc.getClass)
+    ) {
+      ExpressionMappings.expressionExtensionTransformer
+        .getAttrsIndexForExtensionAggregateExpr(
+          aggregateFunc,
+          exp.mode,
+          exp,
+          aggregateAttributeList,
+          aggregateAttr,
+          index)
+    } else {
+      exp.mode match {
+        case Partial | PartialMerge =>
+          val aggBufferAttr = aggregateFunc.inputAggBufferAttributes
+          for (index <- aggBufferAttr.indices) {
+            val attr = ConverterUtils.getAttrFromExpr(aggBufferAttr(index))
+            aggregateAttr += attr
+          }
+          resIndex += aggBufferAttr.size
+          resIndex
+        case Final =>
+          aggregateAttr += aggregateAttributeList(resIndex)
+          resIndex += 1
+          resIndex
+        case other =>
+          throw new UnsupportedOperationException(s"Unsupported aggregate mode: $other.")
+      }
+    }
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ConverterUtils.scala
@@ -36,12 +36,14 @@ import scala.collection.JavaConverters._
 
 object ConverterUtils extends Logging {
 
-  def getAttrFromExpr(expr: Expression, skipAlias: Boolean = false): Attribute = {
-    if (skipAlias) {
-      expr.references.head
-    } else {
-      expr.transformDown { case alias: Alias => alias.toAttribute }.references.head
-    }
+  /**
+   * Get the source Attribute for the input Expression. It will traverse the Expression tree in a
+   * pre-order manner and find the first encountered Attribute. When encountering an Alias, it will
+   * not continue to traverse its child but instead directly return the Attribute output by the
+   * Alias.
+   */
+  def getAttrFromExpr(expr: Expression): Attribute = {
+    expr.transformDown { case alias: Alias => alias.toAttribute }.references.head
   }
 
   def normalizeColName(name: String): String = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. We should move `aggregateFunction` validation to `doValidateInternal`.
2. For `getAttrForAggregateExprs`, we can use simpler implementation to get the correct attributes from `aggregateExpressions`.
3. For `ConverterUtils.getAttrFromExpr`, we can use the `Expression.references` method to obtain the desired Attribute. In the original implementation, when iterating over `BinaryLike` types, the left child is used for iteration. We can use `reference.head` to get the same Attribute.

Due to the inclusion of custom agg in ClickHouse, the original logic has been retained, and the `getAttrForAggregateExprs` has been abstracted as an interface to accommodate different logics implemented by Velox and ClickHouse.

## How was this patch tested?

Exists CI.

