### PR TITLE
[VL] Daily Update Velox Version (2024-01-19)

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -431,6 +431,8 @@ std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig()
   // The semantics of reading as lower case is opposite with case-sensitive.
   configs[velox::connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession] =
       veloxCfg_->get<bool>(kCaseSensitive, false) == false ? "true" : "false";
+  configs[velox::connector::hive::HiveConfig::kPartitionPathAsLowerCaseSession] =
+      veloxCfg_->get<bool>(kCaseSensitive, false) == false ? "true" : "false";
   configs[velox::connector::hive::HiveConfig::kArrowBridgeTimestampUnit] = "6";
   configs[velox::connector::hive::HiveConfig::kMaxPartitionsPerWritersSession] =
       std::to_string(veloxCfg_->get<int32_t>(kMaxPartitions, 10000));

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_18
+VELOX_BRANCH=2024_01_19
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLInsertTestSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenSQLInsertTestSuite.scala
@@ -16,20 +16,8 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.SparkConf
-
 class GlutenFileSourceSQLInsertTestSuite
   extends FileSourceSQLInsertTestSuite
-  with GlutenSQLTestsTrait {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+  with GlutenSQLTestsTrait {}
 
-class GlutenDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+class GlutenDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite {}

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetPartitionDiscoverySuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetPartitionDiscoverySuite.scala
@@ -16,23 +16,12 @@
  */
 package org.apache.spark.sql.execution.datasources.parquet
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql._
 
 class GlutenParquetV1PartitionDiscoverySuite
   extends ParquetV1PartitionDiscoverySuite
-  with GlutenSQLTestsBaseTrait {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+  with GlutenSQLTestsBaseTrait {}
 
 class GlutenParquetV2PartitionDiscoverySuite
   extends ParquetV2PartitionDiscoverySuite
-  with GlutenSQLTestsBaseTrait {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+  with GlutenSQLTestsBaseTrait {}

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSQLInsertTestSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSQLInsertTestSuite.scala
@@ -16,20 +16,8 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.SparkConf
-
 class GlutenFileSourceSQLInsertTestSuite
   extends FileSourceSQLInsertTestSuite
-  with GlutenSQLTestsTrait {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+  with GlutenSQLTestsTrait {}
 
-class GlutenDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+class GlutenDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite {}

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1110,6 +1110,8 @@ class VeloxTestSettings extends BackendTestSettings {
   // following UT is removed in spark3.3.1
   // enableSuite[GlutenSimpleShowCreateTableSuite]
   enableSuite[GlutenFileSourceSQLInsertTestSuite]
+    .exclude(
+      "SPARK-34556: checking duplicate static partition columns should respect case sensitive conf")
   enableSuite[GlutenDSV2SQLInsertTestSuite]
   enableSuite[GlutenSQLQuerySuite]
     // Decimal precision exceeds.

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLInsertTestSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLInsertTestSuite.scala
@@ -16,20 +16,8 @@
  */
 package org.apache.spark.sql
 
-import org.apache.spark.SparkConf
-
 class GlutenFileSourceSQLInsertTestSuite
   extends FileSourceSQLInsertTestSuite
-  with GlutenSQLTestsTrait {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+  with GlutenSQLTestsTrait {}
 
-class GlutenDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite {
-  override def sparkConf: SparkConf = {
-    // Timezone is not supported yet.
-    super.sparkConf.set("spark.sql.session.timeZone", "UTC")
-  }
-}
+class GlutenDSV2SQLInsertTestSuite extends DSV2SQLInsertTestSuite {}


### PR DESCRIPTION
```
de2f01 Fix aggregation over all-null keys with ignoreNullKeys = true (8422)
ec3bb6 Use same max-output-buffer-size config for all types of output buffers (8426)
a0dc74 Presto serializer code cleanup (8420)
f6a14d Document setNoCopy and setEmpty Simple Function APIs (8382)
0a2267 Clear hash table for each spilled partition in RowNumber (8413)
f62ac7 Add kPartitionPathAsLowerCase to control whether make the partition path as lower case (8409)
3486c7 Add hour Spark Function (8237)
d05045 Add new config API in AssertQueryBuilder (8431)
a33890 Extract the task utilities to ArbitratorTestUtil (8417)
e09a92 Treat timestamp partition value as local time (8432)
44cdc9 Fix simd::gatherBits for Mac M1 or when AVX2 is disabled (8415)
ccd54d Remove unused variables in velox/functions/lib/DateTimeFormatter.cpp (8436)
0a4eae Remove unused function from velox/functions/FunctionRegistry.cpp (8444)
afda02 Remove unused function from velox/parse/Expressions.cpp (8442)
e65967 Remove unused function from velox/tpch/gen/dbgen/text.cpp (8441)
000899 Remove unused variables in velox/common/memory/MemoryArbitrator.cpp (8440)
03af39 Remove unused variables in velox/tpch/gen/dbgen/speed_seed.cpp (8435)
46331f Remove unused variables in velox/common/base/SpillStats.cpp (8439)
88b81e Remove unused variables in velox/common/caching/SsdFile.cpp (8437)
f24fea Remove unused function from velox/serializers/PrestoSerializer.cpp (8443)
8ed27b Remove unused function from velox/dwio/dwrf/common/Common.cpp (8156)
f68bd2 Add support for arrays of complex types to array_min/max Presto functions (8430)
2e081d Add reverse(varbinary) Presto function (8429)
1ab046 Add hex Spark function (8202)
3154f7 Mismatched tags (8445)
264561 Scatter struct nulls when deserializing Presto wire format (8318)
f0ac5f Add support for UNKNOWN key to map_agg Presto aggregate function (8452)
3cf1f3 Remove deprecated configs kCastToIntByTruncate and `kCastStringToDateIsIso8601` (8352)
e4d05f Fix bucket counts in histogram metrics (8458)
```