### PR TITLE
[VL] Code cleanups against whole stage transform: Consolidate C++ iterator stage types

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHIteratorApi.scala
@@ -177,7 +177,6 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
       rootNode: PlanNode,
       pipelineTime: SQLMetric,
       updateNativeMetrics: IMetrics => Unit,
-      buildRelationBatchHolder: Seq[ColumnarBatch],
       materializeInput: Boolean): Iterator[ColumnarBatch] = {
     // scalastyle:on argcount
     GlutenConfig.getConf
@@ -221,7 +220,6 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
 
     def close(): Unit = {
       closed = true
-      buildRelationBatchHolder.foreach(_.close) // fixing: ref cnt goes nagative
       nativeIterator.close()
       // relationHolder.clear()
     }

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -192,7 +192,6 @@ class IteratorApiImpl extends IteratorApi with Logging {
       rootNode: PlanNode,
       pipelineTime: SQLMetric,
       updateNativeMetrics: IMetrics => Unit,
-      buildRelationBatchHolder: Seq[ColumnarBatch],
       materializeInput: Boolean): Iterator[ColumnarBatch] = {
 
     ExecutorManager.tryTaskSet(numaBindingInfo)

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -210,8 +210,8 @@ auto BM_Generic = [](::benchmark::State& state,
         });
 
     auto* rawIter = static_cast<gluten::WholeStageResultIterator*>(resultIter->getInputIter());
-    const auto& task = rawIter->task_;
-    const auto& planNode = rawIter->veloxPlan_;
+    const auto* task = rawIter->task();
+    const auto* planNode = rawIter->veloxPlan();
     auto statsStr = facebook::velox::exec::printPlanWithStats(*planNode, task->taskStats(), true);
     LOG(INFO) << statsStr;
   }
@@ -280,8 +280,7 @@ int main(int argc, char** argv) {
   do {                                                                                                                \
     auto* bm =                                                                                                        \
         ::benchmark::RegisterBenchmark(NAME, BM_Generic, substraitJsonFile, splitFile, inputFiles, conf, READER_TYPE) \
-            ->MeasureProcessCPUTime()                                                                                 \
-            ->UseRealTime();                                                                                          \
+            -> MeasureProcessCPUTime() -> UseRealTime();                                                              \
     if (FLAGS_threads > 0) {                                                                                          \
       bm->Threads(FLAGS_threads);                                                                                     \
     } else {                                                                                                          \

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -280,7 +280,8 @@ int main(int argc, char** argv) {
   do {                                                                                                                \
     auto* bm =                                                                                                        \
         ::benchmark::RegisterBenchmark(NAME, BM_Generic, substraitJsonFile, splitFile, inputFiles, conf, READER_TYPE) \
-            -> MeasureProcessCPUTime() -> UseRealTime();                                                              \
+            ->MeasureProcessCPUTime()                                                                                 \
+            ->UseRealTime();                                                                                          \
     if (FLAGS_threads > 0) {                                                                                          \
       bm->Threads(FLAGS_threads);                                                                                     \
     } else {                                                                                                          \

--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -121,18 +121,9 @@ std::shared_ptr<ResultIterator> VeloxRuntime::createResultIterator(
   getInfoAndIds(veloxPlanConverter.splitInfos(), veloxPlan_->leafPlanNodeIds(), scanInfos, scanIds, streamIds);
 
   auto* vmm = toVeloxMemoryManager(memoryManager);
-  if (scanInfos.size() == 0) {
-    // Source node is not required.
-    auto wholestageIter = std::make_unique<WholeStageResultIteratorMiddleStage>(
-        vmm, veloxPlan_, streamIds, spillDir, sessionConf, taskInfo_);
-    auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
-    return resultIter;
-  } else {
-    auto wholestageIter = std::make_unique<WholeStageResultIteratorFirstStage>(
-        vmm, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
-    auto resultIter = std::make_shared<ResultIterator>(std::move(wholestageIter), this);
-    return resultIter;
-  }
+  auto wholestageIter = std::make_unique<WholeStageResultIterator>(
+      vmm, veloxPlan_, scanIds, scanInfos, streamIds, spillDir, sessionConf, taskInfo_);
+  return std::make_shared<ResultIterator>(std::move(wholestageIter), this);
 }
 
 std::shared_ptr<ColumnarToRowConverter> VeloxRuntime::createColumnar2RowConverter(MemoryManager* memoryManager) {

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -95,17 +95,77 @@ const std::string kHiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__";
 WholeStageResultIterator::WholeStageResultIterator(
     VeloxMemoryManager* memoryManager,
     const std::shared_ptr<const facebook::velox::core::PlanNode>& planNode,
+    const std::vector<facebook::velox::core::PlanNodeId>& scanNodeIds,
+    const std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
+    const std::vector<facebook::velox::core::PlanNodeId>& streamIds,
+    const std::string spillDir,
     const std::unordered_map<std::string, std::string>& confMap,
     const SparkTaskInfo& taskInfo)
-    : veloxPlan_(planNode),
+    : memoryManager_(memoryManager),
       veloxCfg_(std::make_shared<const facebook::velox::core::MemConfigMutable>(confMap)),
       taskInfo_(taskInfo),
-      memoryManager_(memoryManager) {
+      veloxPlan_(planNode),
+      scanNodeIds_(scanNodeIds),
+      scanInfos_(scanInfos),
+      streamIds_(streamIds) {
 #ifdef ENABLE_HDFS
   gluten::updateHdfsTokens(veloxCfg_.get());
 #endif
   spillStrategy_ = veloxCfg_->get<std::string>(kSpillStrategy, kSpillStrategyDefaultValue);
   getOrderedNodeIds(veloxPlan_, orderedNodeIds_);
+
+  // Set task parameters, then create task instance.
+  std::unordered_set<velox::core::PlanNodeId> emptySet;
+  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
+  std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
+  task_ = velox::exec::Task::create(
+      fmt::format("Gluten_Stage_{}_TID_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
+      std::move(planFragment),
+      0,
+      std::move(queryCtx));
+  if (!task_->supportsSingleThreadedExecution()) {
+    throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());
+  }
+  auto fileSystem = velox::filesystems::getFileSystem(spillDir, nullptr);
+  GLUTEN_CHECK(fileSystem != nullptr, "File System for spilling is null!");
+  fileSystem->mkdir(spillDir);
+  task_->setSpillDirectory(spillDir);
+
+  // Generate splits for all scan nodes.
+  splits_.reserve(scanInfos.size());
+  if (scanNodeIds.size() != scanInfos.size()) {
+    throw std::runtime_error("Invalid scan information.");
+  }
+
+  for (const auto& scanInfo : scanInfos) {
+    // Get the information for TableScan.
+    // Partition index in scan info is not used.
+    const auto& paths = scanInfo->paths;
+    const auto& starts = scanInfo->starts;
+    const auto& lengths = scanInfo->lengths;
+    const auto& format = scanInfo->format;
+    const auto& partitionColumns = scanInfo->partitionColumns;
+
+    std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> connectorSplits;
+    connectorSplits.reserve(paths.size());
+    for (int idx = 0; idx < paths.size(); idx++) {
+      auto partitionColumn = partitionColumns[idx];
+      std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
+      constructPartitionColumns(partitionKeys, partitionColumn);
+      auto split = std::make_shared<velox::connector::hive::HiveConnectorSplit>(
+          kHiveConnectorId, paths[idx], format, starts[idx], lengths[idx], partitionKeys);
+      connectorSplits.emplace_back(split);
+    }
+
+    std::vector<velox::exec::Split> scanSplits;
+    scanSplits.reserve(connectorSplits.size());
+    for (const auto& connectorSplit : connectorSplits) {
+      // Bucketed group id (-1 means 'none').
+      int32_t groupId = -1;
+      scanSplits.emplace_back(velox::exec::Split(folly::copy(connectorSplit), groupId));
+    }
+    splits_.emplace_back(scanSplits);
+  }
 }
 
 std::shared_ptr<velox::core::QueryCtx> WholeStageResultIterator::createNewVeloxQueryCtx() {
@@ -123,7 +183,7 @@ std::shared_ptr<velox::core::QueryCtx> WholeStageResultIterator::createNewVeloxQ
 }
 
 std::shared_ptr<ColumnarBatch> WholeStageResultIterator::next() {
-  addSplits_(task_.get());
+  tryAddSplitsToTask();
   if (task_->isFinished()) {
     return nullptr;
   }
@@ -216,6 +276,36 @@ void WholeStageResultIterator::getOrderedNodeIds(
     getOrderedNodeIds(sourceNode, nodeIds);
   }
   nodeIds.emplace_back(planNode->id());
+}
+
+void WholeStageResultIterator::constructPartitionColumns(
+    std::unordered_map<std::string, std::optional<std::string>>& partitionKeys,
+    const std::unordered_map<std::string, std::string>& map) {
+  for (const auto& partitionColumn : map) {
+    auto key = partitionColumn.first;
+    const auto value = partitionColumn.second;
+    if (!veloxCfg_->get<bool>(kCaseSensitive, false)) {
+      folly::toLowerAscii(key);
+    }
+    if (value == kHiveDefaultPartition) {
+      partitionKeys[key] = std::nullopt;
+    } else {
+      partitionKeys[key] = value;
+    }
+  }
+}
+
+void WholeStageResultIterator::tryAddSplitsToTask() {
+  if (noMoreSplits_) {
+    return;
+  }
+  for (int idx = 0; idx < scanNodeIds_.size(); idx++) {
+    for (auto& split : splits_[idx]) {
+      task_->addSplit(scanNodeIds_[idx], std::move(split));
+    }
+    task_->noMoreSplits(scanNodeIds_[idx]);
+  }
+  noMoreSplits_ = true;
 }
 
 void WholeStageResultIterator::collectMetrics() {
@@ -438,137 +528,6 @@ std::shared_ptr<velox::Config> WholeStageResultIterator::createConnectorConfig()
       std::to_string(veloxCfg_->get<int32_t>(kMaxPartitions, 10000));
 
   return std::make_shared<velox::core::MemConfig>(configs);
-}
-
-WholeStageResultIteratorFirstStage::WholeStageResultIteratorFirstStage(
-    VeloxMemoryManager* memoryManager,
-    const std::shared_ptr<const velox::core::PlanNode>& planNode,
-    const std::vector<velox::core::PlanNodeId>& scanNodeIds,
-    const std::vector<std::shared_ptr<SplitInfo>>& scanInfos,
-    const std::vector<velox::core::PlanNodeId>& streamIds,
-    const std::string spillDir,
-    const std::unordered_map<std::string, std::string>& confMap,
-    const SparkTaskInfo& taskInfo)
-    : WholeStageResultIterator(memoryManager, planNode, confMap, taskInfo),
-      scanNodeIds_(scanNodeIds),
-      scanInfos_(scanInfos),
-      streamIds_(streamIds) {
-  // Generate splits for all scan nodes.
-  splits_.reserve(scanInfos.size());
-  if (scanNodeIds.size() != scanInfos.size()) {
-    throw std::runtime_error("Invalid scan information.");
-  }
-
-  for (const auto& scanInfo : scanInfos) {
-    // Get the information for TableScan.
-    // Partition index in scan info is not used.
-    const auto& paths = scanInfo->paths;
-    const auto& starts = scanInfo->starts;
-    const auto& lengths = scanInfo->lengths;
-    const auto& format = scanInfo->format;
-    const auto& partitionColumns = scanInfo->partitionColumns;
-
-    std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> connectorSplits;
-    connectorSplits.reserve(paths.size());
-    for (int idx = 0; idx < paths.size(); idx++) {
-      auto partitionColumn = partitionColumns[idx];
-      std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-      constructPartitionColumns(partitionKeys, partitionColumn);
-      auto split = std::make_shared<velox::connector::hive::HiveConnectorSplit>(
-          kHiveConnectorId, paths[idx], format, starts[idx], lengths[idx], partitionKeys);
-      connectorSplits.emplace_back(split);
-    }
-
-    std::vector<velox::exec::Split> scanSplits;
-    scanSplits.reserve(connectorSplits.size());
-    for (const auto& connectorSplit : connectorSplits) {
-      // Bucketed group id (-1 means 'none').
-      int32_t groupId = -1;
-      scanSplits.emplace_back(velox::exec::Split(folly::copy(connectorSplit), groupId));
-    }
-    splits_.emplace_back(scanSplits);
-  }
-
-  // Set task parameters.
-  std::unordered_set<velox::core::PlanNodeId> emptySet;
-  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
-  std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
-
-  task_ = velox::exec::Task::create(
-      fmt::format("Gluten_Stage_{}_TID_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
-      std::move(planFragment),
-      0,
-      std::move(queryCtx));
-
-  if (!task_->supportsSingleThreadedExecution()) {
-    throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());
-  }
-  auto fileSystem = velox::filesystems::getFileSystem(spillDir, nullptr);
-  GLUTEN_CHECK(fileSystem != nullptr, "File System for spilling is null!");
-  fileSystem->mkdir(spillDir);
-  task_->setSpillDirectory(spillDir);
-  addSplits_ = [&](velox::exec::Task* task) {
-    if (noMoreSplits_) {
-      return;
-    }
-    for (int idx = 0; idx < scanNodeIds_.size(); idx++) {
-      for (auto& split : splits_[idx]) {
-        task->addSplit(scanNodeIds_[idx], std::move(split));
-      }
-      task->noMoreSplits(scanNodeIds_[idx]);
-    }
-    noMoreSplits_ = true;
-  };
-}
-
-void WholeStageResultIteratorFirstStage::constructPartitionColumns(
-    std::unordered_map<std::string, std::optional<std::string>>& partitionKeys,
-    const std::unordered_map<std::string, std::string>& map) {
-  for (const auto& partitionColumn : map) {
-    auto key = partitionColumn.first;
-    const auto value = partitionColumn.second;
-    if (!veloxCfg_->get<bool>(kCaseSensitive, false)) {
-      folly::toLowerAscii(key);
-    }
-    if (value == kHiveDefaultPartition) {
-      partitionKeys[key] = std::nullopt;
-    } else {
-      partitionKeys[key] = value;
-    }
-  }
-}
-
-WholeStageResultIteratorMiddleStage::WholeStageResultIteratorMiddleStage(
-    VeloxMemoryManager* memoryManager,
-    const std::shared_ptr<const velox::core::PlanNode>& planNode,
-    const std::vector<velox::core::PlanNodeId>& streamIds,
-    const std::string spillDir,
-    const std::unordered_map<std::string, std::string>& confMap,
-    const SparkTaskInfo& taskInfo)
-    : WholeStageResultIterator(memoryManager, planNode, confMap, taskInfo), streamIds_(streamIds) {
-  std::unordered_set<velox::core::PlanNodeId> emptySet;
-  velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
-  std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();
-
-  task_ = velox::exec::Task::create(
-      fmt::format("Gluten_Stage_{}_TID_{}", std::to_string(taskInfo_.stageId), std::to_string(taskInfo_.taskId)),
-      std::move(planFragment),
-      0,
-      std::move(queryCtx));
-
-  if (!task_->supportsSingleThreadedExecution()) {
-    throw std::runtime_error("Task doesn't support single thread execution: " + planNode->toString());
-  }
-  auto fileSystem = velox::filesystems::getFileSystem(spillDir, nullptr);
-  GLUTEN_CHECK(fileSystem != nullptr, "File System for spilling is null!");
-  fileSystem->mkdir(spillDir);
-  task_->setSpillDirectory(spillDir);
-  addSplits_ = [&](velox::exec::Task* task) {
-    if (noMoreSplits_) {
-      return;
-    }
-    noMoreSplits_ = true;
-  };
 }
 
 } // namespace gluten

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -114,7 +114,7 @@ WholeStageResultIterator::WholeStageResultIterator(
   spillStrategy_ = veloxCfg_->get<std::string>(kSpillStrategy, kSpillStrategyDefaultValue);
   getOrderedNodeIds(veloxPlan_, orderedNodeIds_);
 
-  // Set task parameters, then create task instance.
+  // Create task instance.
   std::unordered_set<velox::core::PlanNodeId> emptySet;
   velox::core::PlanFragment planFragment{planNode, velox::core::ExecutionStrategy::kUngrouped, 1, emptySet};
   std::shared_ptr<velox::core::QueryCtx> queryCtx = createNewVeloxQueryCtx();

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -57,6 +57,14 @@ class WholeStageResultIterator : public ColumnarBatchIterator {
     return metrics_.get();
   }
 
+  const facebook::velox::exec::Task* task() const {
+    return task_.get();
+  }
+
+  const facebook::velox::core::PlanNode* veloxPlan() const {
+    return veloxPlan_.get();
+  }
+
  private:
   /// Get the Spark confs to Velox query context.
   std::unordered_map<std::string, std::string> getQueryContextConf();

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
@@ -76,7 +76,6 @@ trait IteratorApi {
       rootNode: PlanNode,
       pipelineTime: SQLMetric,
       updateNativeMetrics: IMetrics => Unit,
-      buildRelationBatchHolder: Seq[ColumnarBatch],
       materializeInput: Boolean = false): Iterator[ColumnarBatch]
   // scalastyle:on argcount
 

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -319,7 +319,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
         )
       )
     } else {
-      val buildRelationBatchHolder: mutable.ListBuffer[ColumnarBatch] = mutable.ListBuffer()
 
       /**
        * the whole stage contains NO BasicScanExecTransformer. this the default case for:
@@ -339,7 +338,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
         sparkConf,
         resCtx,
         pipelineTime,
-        buildRelationBatchHolder,
         BackendsApiManager.getMetricsApiInstance.metricsUpdatingFunction(
           child,
           resCtx.substraitContext.registeredRelMap,

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
@@ -25,8 +25,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import scala.collection.mutable
-
 private[glutenproject] class ZippedPartitionsPartition(
     override val index: Int,
     val inputColumnarRDDPartitions: Seq[Partition])

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageZippedPartitionsRDD.scala
@@ -39,7 +39,6 @@ class WholeStageZippedPartitionsRDD(
     sparkConf: SparkConf,
     resCtx: WholeStageTransformContext,
     pipelineTime: SQLMetric,
-    buildRelationBatchHolder: mutable.ListBuffer[ColumnarBatch],
     updateNativeMetrics: IMetrics => Unit,
     materializeInput: Boolean)
   extends RDD[ColumnarBatch](sc, rdds.getDependencies) {
@@ -58,7 +57,6 @@ class WholeStageZippedPartitionsRDD(
             resCtx.root,
             pipelineTime,
             updateNativeMetrics,
-            buildRelationBatchHolder,
             materializeInput
           )
     }


### PR DESCRIPTION
1. Remove unused variable `buildRelationBatchHolder`
2. In C++, consolidate `WholeStageResultIteratorMiddleStage` and `WholeStageResultIteratorFirstStage`
3. TBD in next PR