### PR TITLE
[GLUTEN-4480][CH] Decouple LocalFiles from plan to improve driver generating substrait plan

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
+++ b/backends-clickhouse/src/main/java/io/glutenproject/vectorized/ExpressionEvaluatorJniWrapper.java
@@ -46,6 +46,7 @@ public class ExpressionEvaluatorJniWrapper {
   public native long nativeCreateKernelWithIterator(
       long allocatorId,
       byte[] wsPlan,
+      byte[][] splitInfo,
       GeneralInIterator[] batchItr,
       byte[] confArray,
       boolean materializeInput);

--- a/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/CHDatasourceJniWrapper.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/CHDatasourceJniWrapper.java
@@ -22,7 +22,12 @@ public class CHDatasourceJniWrapper {
       String filePath, String[] preferredColumnNames, String formatHint);
 
   public native long nativeInitMergeTreeWriterWrapper(
-      byte[] schema, String uuid, String taskId, String partition_dir, String bucket_dir);
+      byte[] plan,
+      byte[] splitInfo,
+      String uuid,
+      String taskId,
+      String partition_dir,
+      String bucket_dir);
 
   public native void write(long instanceId, long blockAddress);
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseMetricsUTUtils.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseMetricsUTUtils.scala
@@ -50,6 +50,7 @@ object GlutenClickHouseMetricsUTUtils {
     val resIter: GeneralOutIterator = transKernel.createKernelWithBatchIterator(
       mockMemoryAllocator.getNativeInstanceId,
       substraitPlan.toByteArray,
+      new Array[Array[Byte]](0),
       inBatchIters)
     val iter = new Iterator[Any] {
       private var outputRowCount = 0L

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHParquetReadBenchmark.scala
@@ -115,6 +115,7 @@ object CHParquetReadBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchmark
       spark.sparkContext,
       WholeStageTransformContext(planNode, substraitContext),
       chFileScan.getSplitInfos,
+      chFileScan,
       numOutputRows,
       numOutputVectors,
       scanTime

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/IteratorApiImpl.scala
@@ -78,7 +78,8 @@ class IteratorApiImpl extends IteratorApi with Logging {
   /** Generate native row partition. */
   override def genPartitions(
       wsCtx: WholeStageTransformContext,
-      splitInfos: Seq[Seq[SplitInfo]]): Seq[BaseGlutenPartition] = {
+      splitInfos: Seq[Seq[SplitInfo]],
+      scans: Seq[BasicScanExecTransformer]): Seq[BaseGlutenPartition] = {
     // Only serialize plan once, save lots time when plan is complex.
     val planByteArray = wsCtx.root.toProtobuf.toByteArray
 
@@ -226,6 +227,7 @@ class IteratorApiImpl extends IteratorApi with Logging {
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
       splitInfos: Seq[SplitInfo],
+      scan: BasicScanExecTransformer,
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch] = {

--- a/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
+++ b/cpp-ch/local-engine/Parser/MergeTreeRelParser.h
@@ -37,7 +37,10 @@ using namespace DB;
 class MergeTreeRelParser : public RelParser
 {
 public:
-    static std::shared_ptr<CustomStorageMergeTree> parseStorage(const substrait::Rel & rel_, ContextMutablePtr context);
+    static std::shared_ptr<CustomStorageMergeTree> parseStorage(
+        const substrait::Rel & rel_,
+        const substrait::ReadRel::ExtensionTable & extension_table,
+        ContextMutablePtr context);
 
     explicit MergeTreeRelParser(
         SerializedPlanParser * plan_paser_, ContextPtr & context_, QueryContext & query_context_, ContextMutablePtr & global_context_)
@@ -48,7 +51,17 @@ public:
     ~MergeTreeRelParser() override = default;
 
     DB::QueryPlanPtr
-    parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_) override;
+    parse(DB::QueryPlanPtr query_plan, const substrait::Rel & rel, std::list<const substrait::Rel *> & rel_stack_) override
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeRelParser can't call parse(), call parseReadRel instead.");
+    }
+
+    DB::QueryPlanPtr
+    parseReadRel(
+        DB::QueryPlanPtr query_plan,
+        const substrait::ReadRel & read_rel,
+        const substrait::ReadRel::ExtensionTable & extension_table,
+        std::list<const substrait::Rel *> & rel_stack_);
 
     const substrait::Rel & getSingleInput(const substrait::Rel &) override
     {

--- a/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/FormatFile.h
@@ -57,13 +57,6 @@ public:
     /// Create a new input format for reading this file
     virtual InputFormatPtr createInputFormat(const DB::Block & header) = 0;
 
-    virtual DB::NamesAndTypesList getSchema() const
-    {
-        const auto & schema = file_info.schema();
-        auto header = TypeParser::buildBlockFromNamedStructWithoutDFS(schema);
-        return header.getNamesAndTypesList();
-    }
-
     /// Spark would split a large file into small segements and read in different tasks
     /// If this file doesn't support the split feacture, only the task with offset 0 will generate data.
     virtual bool supportSplit() const { return false; }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/TextFormatFile.h
@@ -31,6 +31,13 @@ public:
 
     FormatFile::InputFormatPtr createInputFormat(const DB::Block & header) override;
 
+    DB::NamesAndTypesList getSchema() const
+    {
+        const auto & schema = file_info.schema();
+        auto header = TypeParser::buildBlockFromNamedStructWithoutDFS(schema);
+        return header.getNamesAndTypesList();
+    }
+
     bool supportSplit() const override { return true; }
     String getFileFormat() const override { return "HiveText"; }
 };

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -237,6 +237,7 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_n
     jobject /*obj*/,
     jlong allocator_id,
     jbyteArray plan,
+    jobjectArray split_infos,
     jobjectArray iter_arr,
     jbyteArray conf_plan,
     jboolean materialize_input)
@@ -259,6 +260,16 @@ JNIEXPORT jlong Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_n
         iter = env->NewGlobalRef(iter);
         parser.addInputIter(iter, materialize_input);
     }
+
+    for (jsize i = 0, split_info_arr_size = env->GetArrayLength(split_infos); i < split_info_arr_size; i++) {
+        jbyteArray split_info = static_cast<jbyteArray>(env->GetObjectArrayElement(split_infos, i));
+        jsize split_info_size = env->GetArrayLength(split_info);
+        jbyte * split_info_addr = env->GetByteArrayElements(split_info, nullptr);
+        std::string split_info_str;
+        split_info_str.assign(reinterpret_cast<const char *>(split_info_addr), split_info_size);
+        parser.addSplitInfo(split_info_str);
+    }
+
     jsize plan_size = env->GetArrayLength(plan);
     jbyte * plan_address = env->GetByteArrayElements(plan, nullptr);
     std::string plan_string;
@@ -974,17 +985,23 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
 }
 
 JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniWrapper_nativeInitMergeTreeWriterWrapper(
-    JNIEnv * env, jobject, jbyteArray schema_, jstring uuid_, jstring task_id_, jstring partition_dir_, jstring bucket_dir_)
+    JNIEnv * env, jobject, jbyteArray plan_, jbyteArray split_info_, jstring uuid_, jstring task_id_, jstring partition_dir_, jstring bucket_dir_)
 {
     LOCAL_ENGINE_JNI_METHOD_START
     const auto uuid_str = jstring2string(env, uuid_);
     const auto task_id = jstring2string(env, task_id_);
     const auto partition_dir = jstring2string(env, partition_dir_);
     const auto bucket_dir = jstring2string(env, bucket_dir_);
-    jsize plan_buf_size = env->GetArrayLength(schema_);
-    jbyte * plan_buf_addr = env->GetByteArrayElements(schema_, nullptr);
-    std::string schema_str;
-    schema_str.assign(reinterpret_cast<const char *>(plan_buf_addr), plan_buf_size);
+
+    jsize plan_buf_size = env->GetArrayLength(plan_);
+    jbyte * plan_buf_addr = env->GetByteArrayElements(plan_, nullptr);
+    std::string plan_str;
+    plan_str.assign(reinterpret_cast<const char *>(plan_buf_addr), plan_buf_size);
+
+    jsize split_info_size = env->GetArrayLength(split_info_);
+    jbyte * split_info_addr = env->GetByteArrayElements(split_info_, nullptr);
+    std::string split_info_str;
+    split_info_str.assign(reinterpret_cast<const char *>(split_info_addr), split_info_size);
 
     auto plan_ptr = std::make_unique<substrait::Plan>();
     /// https://stackoverflow.com/questions/52028583/getting-error-parsing-protobuf-data
@@ -992,21 +1009,24 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
     /// Here, set a limit large enough to avoid this problem.
     /// Once this problem occurs, it is difficult to troubleshoot, because the pb of c++ will not provide any valid information
     google::protobuf::io::CodedInputStream coded_in(
-        reinterpret_cast<const uint8_t *>(schema_str.data()), static_cast<int>(schema_str.size()));
+        reinterpret_cast<const uint8_t *>(plan_str.data()), static_cast<int>(plan_str.size()));
     coded_in.SetRecursionLimit(100000);
 
     auto ok = plan_ptr->ParseFromCodedStream(&coded_in);
     if (!ok)
         throw DB::Exception(DB::ErrorCodes::CANNOT_PARSE_PROTOBUF_SCHEMA, "Parse substrait::Plan from string failed");
 
+    substrait::ReadRel::ExtensionTable extension_table =
+        local_engine::SerializedPlanParser::parseExtensionTable(split_info_str);
 
     auto storage = local_engine::MergeTreeRelParser::parseStorage(
-        plan_ptr->relations()[0].root().input(), local_engine::SerializedPlanParser::global_context);
+        plan_ptr->relations()[0].root().input(), extension_table, local_engine::SerializedPlanParser::global_context);
     auto uuid = uuid_str + "_" + task_id;
     auto * writer = new local_engine::SparkMergeTreeWriter(
         *storage, storage->getInMemoryMetadataPtr(), local_engine::SerializedPlanParser::global_context, uuid, partition_dir, bucket_dir);
 
-    env->ReleaseByteArrayElements(schema_, plan_buf_addr, JNI_ABORT);
+    env->ReleaseByteArrayElements(plan_, plan_buf_addr, JNI_ABORT);
+    env->ReleaseByteArrayElements(split_info_, split_info_addr, JNI_ABORT);
     return reinterpret_cast<jlong>(writer);
     LOCAL_ENGINE_JNI_METHOD_END(env, 0)
 }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -100,7 +100,7 @@ public class RelBuilder {
       ExpressionNode filter,
       SubstraitContext context,
       Long operatorId) {
-    return makeReadRel(types, names, null, filter, context, operatorId);
+    return makeReadRel(types, names, null, filter, null, context, operatorId);
   }
 
   // VL
@@ -109,10 +109,11 @@ public class RelBuilder {
       List<String> names,
       List<ColumnTypeNode> columnTypeNodes,
       ExpressionNode filter,
+      AdvancedExtensionNode extensionNode,
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
-    return new ReadRelNode(types, names, context, filter, columnTypeNodes);
+    return new ReadRelNode(types, names, context, filter, columnTypeNodes, extensionNode);
   }
 
   public static RelNode makeReadRelForInputIterator(

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/IteratorApi.scala
@@ -17,7 +17,7 @@
 package io.glutenproject.backendsapi
 
 import io.glutenproject.GlutenNumaBindingInfo
-import io.glutenproject.execution.{BaseGlutenPartition, BroadCastHashJoinContext, WholeStageTransformContext}
+import io.glutenproject.execution.{BaseGlutenPartition, BasicScanExecTransformer, BroadCastHashJoinContext, WholeStageTransformContext}
 import io.glutenproject.metrics.IMetrics
 import io.glutenproject.substrait.plan.PlanNode
 import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
@@ -42,7 +42,8 @@ trait IteratorApi {
   /** Generate native row partition. */
   def genPartitions(
       wsCtx: WholeStageTransformContext,
-      splitInfos: Seq[Seq[SplitInfo]]): Seq[BaseGlutenPartition]
+      splitInfos: Seq[Seq[SplitInfo]],
+      scans: Seq[BasicScanExecTransformer]): Seq[BaseGlutenPartition]
 
   /**
    * Inject the task attempt temporary path for native write files, this method should be called
@@ -84,6 +85,7 @@ trait IteratorApi {
       sparkContext: SparkContext,
       wsCxt: WholeStageTransformContext,
       splitInfos: Seq[SplitInfo],
+      scan: BasicScanExecTransformer,
       numOutputRows: SQLMetric,
       numOutputBatches: SQLMetric,
       scanTime: SQLMetric): RDD[ColumnarBatch]

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -296,7 +296,10 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
       val (wsCtx, inputPartitions) = GlutenTimeMetric.withMillisTime {
         val wsCtx = doWholeStageTransform()
         val partitions =
-          BackendsApiManager.getIteratorApiInstance.genPartitions(wsCtx, allScanSplitInfos)
+          BackendsApiManager.getIteratorApiInstance.genPartitions(
+            wsCtx,
+            allScanSplitInfos,
+            basicScanExecTransformers)
 
         (wsCtx, partitions)
       }(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Applied for CH backend following velox does  https://github.com/oap-project/gluten/pull/4177

The time taken to generate the substrait plan has decreased from `249938ms` to `4486ms` for `163180` partitions after this pach.

(Fixes: \#4480)

## How was this patch tested?

Pass CI