### PR TITLE
[VL] Update generic benchmark usage and doc

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run micro benchmarks
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh 'cd /opt/gluten/cpp/build/velox/benchmarks && \
-          ./generic_benchmark --with-shuffle --threads 1 --iterations 1'
+          ./generic_benchmark --run-example --with-shuffle --threads 1 --iterations 1'
       - name: Exit docker container
         if: ${{ always() }}
         run: |

--- a/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
@@ -19,6 +19,8 @@ package io.glutenproject.benchmarks
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution.{VeloxWholeStageTransformerSuite, WholeStageTransformer}
 
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -48,6 +50,12 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
     }
     FileUtils.forceMkdir(dir)
     createTPCHNotNullTables()
+  }
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.gluten.sql.debug", "true")
+      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
   }
 
   test("Test plan json non-empty - AQE off") {
@@ -98,6 +106,7 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
       SQLConf.SHUFFLE_PARTITIONS.key -> "2",
       GlutenConfig.CACHE_WHOLE_STAGE_TRANSFORMER_CONTEXT.key -> "true"
     ) {
+      logWarning(s"Generating inputs for micro benchmark to $generatedPlanDir")
       val q4_lineitem = spark
         .sql(s"""
                 |select l_orderkey from lineitem where l_commitdate < l_receiptdate
@@ -128,27 +137,29 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
         spark.sql("""
                     |select * from q4_orders left semi join q4_lineitem on l_orderkey = o_orderkey
                     |""".stripMargin)
-
-      val executedPlan = df.queryExecution.executedPlan
-      executedPlan.execute()
-
-      val finalPlan =
-        executedPlan match {
-          case aqe: AdaptiveSparkPlanExec =>
-            aqe.executedPlan match {
-              case s: ShuffleQueryStageExec => s.shuffle.child
-              case other => other
-            }
-          case plan => plan
-        }
-      val lastStageTransformer = finalPlan.find(_.isInstanceOf[WholeStageTransformer])
-      assert(lastStageTransformer.nonEmpty)
-      val plan =
-        lastStageTransformer.get.asInstanceOf[WholeStageTransformer].substraitPlanJson.split('\n')
-
-      val exampleJsonFile = Paths.get(generatedPlanDir, "example.json")
-      Files.write(exampleJsonFile, plan.toList.asJava, StandardCharsets.UTF_8)
+      generateSubstraitJson(df, "example.json")
     }
     spark.sparkContext.setLogLevel(logLevel)
+  }
+
+  def generateSubstraitJson(df: DataFrame, file: String): Unit = {
+    val executedPlan = df.queryExecution.executedPlan
+    executedPlan.execute()
+    val finalPlan =
+      executedPlan match {
+        case aqe: AdaptiveSparkPlanExec =>
+          aqe.executedPlan match {
+            case s: ShuffleQueryStageExec => s.shuffle.child
+            case other => other
+          }
+        case plan => plan
+      }
+    val lastStageTransformer = finalPlan.find(_.isInstanceOf[WholeStageTransformer])
+    assert(lastStageTransformer.nonEmpty)
+    val plan =
+      lastStageTransformer.get.asInstanceOf[WholeStageTransformer].substraitPlanJson.split('\n')
+
+    val exampleJsonFile = Paths.get(generatedPlanDir, file)
+    Files.write(exampleJsonFile, plan.toList.asJava, StandardCharsets.UTF_8)
   }
 }

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -47,7 +47,7 @@ DEFINE_bool(iaa_gzip, false, "Use IAA GZIP as shuffle compression codec");
 DEFINE_int32(shuffle_partitions, 200, "Number of shuffle split (reducer) partitions");
 DEFINE_bool(run_example, false, "Run the example and exit.");
 
-DEFINE_string(json, "", "Path to input json file of the substrait plan.");
+DEFINE_string(plan, "", "Path to input json file of the substrait plan.");
 DEFINE_string(split, "", "Path to input json file of the splits. Only valid for simulating the first stage.");
 DEFINE_string(data, "", "Path to input data files in parquet format. Only valid for simulating the middle stage.");
 
@@ -249,7 +249,7 @@ int main(int argc, char** argv) {
   initVeloxBackend(conf);
 
   // Parse substrait plan, split file and data files.
-  std::string substraitJsonFile = FLAGS_json;
+  std::string substraitJsonFile = FLAGS_plan;
   std::string splitFile = FLAGS_split;
   std::vector<std::string> inputFiles{};
   if (!FLAGS_data.empty()) {
@@ -290,7 +290,7 @@ int main(int argc, char** argv) {
                << "If simulating a middle stage, the usage is:" << std::endl
                << "./generic_benchmark "
                << "--plan /absolute-path/to/substrait_json_file "
-               << "--data-file /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
+               << "--data /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
     LOG(ERROR) << "*** Please check docs/developers/MicroBenchmarks.md for the full usage. ***";
     std::exit(EXIT_FAILURE);
   }

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -332,7 +332,7 @@ int main(int argc, char** argv) {
   LOG(INFO) << "write_file: " << FLAGS_write_file;
   LOG(INFO) << "batch_size: " << FLAGS_batch_size;
 
-  if (splitFile.empty()) {
+  if (!splitFile.empty()) {
     GENERIC_BENCHMARK("SkipInput", FileReaderType::kNone);
   } else {
     GENERIC_BENCHMARK("InputFromBatchVector", FileReaderType::kBuffered);

--- a/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0.json
+++ b/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0.json
@@ -138,15 +138,6 @@
                                             }
                                         ]
                                     }
-                                },
-                                "localFiles": {
-                                    "items": [
-                                        {
-                                            "uriFile": "LINEITEM",
-                                            "length": "1863237",
-                                            "parquet": {}
-                                        }
-                                    ]
                                 }
                             }
                         },

--- a/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0_split.json
+++ b/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0_split.json
@@ -1,0 +1,9 @@
+{
+    "items": [
+        {
+            "uriFile": "LINEITEM",
+            "length": "1863237",
+            "parquet": {}
+        }
+    ]
+}


### PR DESCRIPTION
Follow-up of #4177 

Main changes:
- Removed the `--skip-input` flag for the first stage, and added `--plan`, `--split` and `--data` command line flags. `--plan [path]` to specify the plan file of Substrait JSON string. To simulate a first stage, similarly to how users obtain the Substrait JSON string, they need to extract the split JSON string from the executor log, save it to a separate file, and use `--split [path]` to specify the file. To simulate a middle stage, user need to specify the parquet file of inputs with `--data [input_file_1] [input_file_2] ...`
- Refined the error log and documentation.