### PR TITLE
[VL] Daily Update Velox Version (2024-01-23)

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -228,6 +228,7 @@ macro(ADD_VELOX_DEPENDENCIES)
   endif()
   add_velox_dependency(common::compression "${VELOX_COMPONENTS_PATH}/common/compression/libvelox_common_compression.a")
   add_velox_dependency(common::io "${VELOX_COMPONENTS_PATH}/common/io/libvelox_common_io.a")
+  add_velox_dependency(velox::status "${VELOX_COMPONENTS_PATH}/common/base/libvelox_status.a")
   add_velox_dependency(external::simdjson "${VELOX_BUILD_PATH}/_deps/simdjson-build/libsimdjson.a")
 endmacro()
 

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_22
+VELOX_BRANCH=2024_01_23
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
d9f0f1719 Remove static from anonymous namespace in HiveDataSink.cpp (8466)
228745f15 Collect the information about long operator calls on task (8474)
f98fc9917 Back out "Scatter struct nulls when deserializing Presto wire format" (8463)
43bad4e2a Change spill to use iobuf API of WriteFile (8473)
f0be1565c Rename max_arbitrary_buffer_size (part 1) (8472)
3f617ee15 Add TableScan::curStatus_ to track down where TableScan is stuck. (8457)
d747ac331 Fix min/max(x, n) (8311)
ce18fe489 Test side-effect-free of Aggregate::extractXxx (8399)
9397755a6 Use Status as return type for rescaleWithRoundUp (8465)
0b2b07382 Fix json_parse for large number (8455)
6f6c1a843 Skip empty row groups in parquet reader (8000)
713a66a96 Fix flaky test `DecimalUtilTest.divideWithRoundUp` (8380)
5e5684316 Remove gtest dependency for velox_dwio_common_compression (8433)
3777dfc72 Enhance empty file handling (8459)
0d71afa12 Remove unused TTo template parameter from CastBaseTest::testThrow (8464)
e38603a57 Add aggregations over distinct inputs to AggregationFuzzer (8328)
```