### PR TITLE
[CORE] Propagate fallback reason to union and shuffle exchange

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -307,7 +307,7 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
             wrapChild(r)
           case r2c: RowToCHNativeColumnarExec =>
             wrapChild(r2c)
-          case union: UnionExecTransformer =>
+          case union: ColumnarUnionExec =>
             wrapChild(union)
           case other =>
             throw new UnsupportedOperationException(

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -44,10 +44,11 @@ import scala.collection.mutable.ListBuffer
 case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBase(child = child) {
 
   override def doExecuteColumnarInternal(): RDD[ColumnarBatch] = {
-    if (!new ValidatorApiImpl().doSchemaValidate(schema)) {
-      throw new UnsupportedOperationException(
-        s"Input schema contains unsupported type when convert row to columnar, " +
-          s"${schema.toString()}")
+    new ValidatorApiImpl().doSchemaValidate(schema).foreach {
+      reason =>
+        throw new UnsupportedOperationException(
+          s"Input schema contains unsupported type when convert row to columnar for $schema " +
+            s"due to $reason")
     }
 
     val numInputRows = longMetric("numInputRows")

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -27,6 +27,7 @@ import io.glutenproject.memory.nmm.NativeMemoryManagers
 import io.glutenproject.utils.{ArrowAbiUtil, Iterators}
 import io.glutenproject.vectorized.ColumnarBatchSerializerJniWrapper
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
@@ -77,7 +78,7 @@ case class CachedColumnarBatch(
  *     -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
  */
 // spotless:on
-class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHelper {
+class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHelper with Logging {
   private lazy val rowBasedCachedBatchSerializer = new DefaultCachedBatchSerializer
 
   private def toStructType(schema: Seq[Attribute]): StructType = {
@@ -90,7 +91,13 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
   }
 
   private def validateSchema(schema: StructType): Boolean = {
-    new ValidatorApiImpl().doSchemaValidate(schema)
+    val reason = new ValidatorApiImpl().doSchemaValidate(schema)
+    if (reason.isDefined) {
+      logInfo(s"Columnar cache does not support schema $schema, due to ${reason.get}")
+      false
+    } else {
+      true
+    }
   }
 
   override def supportsColumnarInput(schema: Seq[Attribute]): Boolean = {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -383,8 +383,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
                          |""".stripMargin) {
       df =>
         {
-          getExecutedPlan(df).exists(
-            plan => plan.find(_.isInstanceOf[UnionExecTransformer]).isDefined)
+          getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[ColumnarUnionExec]).isDefined)
         }
     }
   }
@@ -401,8 +400,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
                          |""".stripMargin) {
       df =>
         {
-          getExecutedPlan(df).exists(
-            plan => plan.find(_.isInstanceOf[UnionExecTransformer]).isDefined)
+          getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[ColumnarUnionExec]).isDefined)
         }
     }
   }
@@ -417,8 +415,7 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
                                   |""".stripMargin) {
       df =>
         {
-          getExecutedPlan(df).exists(
-            plan => plan.find(_.isInstanceOf[UnionExecTransformer]).isDefined)
+          getExecutedPlan(df).exists(plan => plan.find(_.isInstanceOf[ColumnarUnionExec]).isDefined)
         }
     }
   }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -248,7 +248,7 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
                          |""".stripMargin) {
       df =>
         {
-          assert(getExecutedPlan(df).exists(plan => plan.isInstanceOf[UnionExecTransformer]))
+          assert(getExecutedPlan(df).exists(plan => plan.isInstanceOf[ColumnarUnionExec]))
         }
     }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -247,7 +247,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
                          |""".stripMargin) {
       df =>
         {
-          assert(getExecutedPlan(df).exists(plan => plan.isInstanceOf[UnionExecTransformer]))
+          assert(getExecutedPlan(df).exists(plan => plan.isInstanceOf[ColumnarUnionExec]))
         }
     }
 

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/ValidatorApi.scala
@@ -98,14 +98,14 @@ trait ValidatorApi {
    * types.
    *
    * @return
-   *   true by default
+   *   An option contain a validation failure reason, none means ok
    */
-  def doSchemaValidate(schema: DataType): Boolean = true
+  def doSchemaValidate(schema: DataType): Option[String] = None
 
   /** Validate against ColumnarShuffleExchangeExec. */
   def doColumnarShuffleExchangeExecValidate(
       outputPartitioning: Partitioning,
-      child: SparkPlan): Boolean
+      child: SparkPlan): Option[String]
 
   /** Validate against Generator expression. */
   def doGeneratorValidate(generator: Generator, outer: Boolean): ValidationResult =

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -280,7 +280,7 @@ object ProjectExecTransformer {
 }
 
 // An alternatives for UnionExec.
-case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with GlutenPlan {
+case class ColumnarUnionExec(children: Seq[SparkPlan]) extends SparkPlan with GlutenPlan {
   children.foreach(
     child =>
       child match {
@@ -308,7 +308,7 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
   }
 
   override protected def withNewChildrenInternal(
-      newChildren: IndexedSeq[SparkPlan]): UnionExecTransformer =
+      newChildren: IndexedSeq[SparkPlan]): ColumnarUnionExec =
     copy(children = newChildren)
 
   def columnarInputRDD: RDD[ColumnarBatch] = {
@@ -329,10 +329,12 @@ case class UnionExecTransformer(children: Seq[SparkPlan]) extends SparkPlan with
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = columnarInputRDD
 
   override protected def doValidateInternal(): ValidationResult = {
-    if (!BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)) {
-      return ValidationResult.notOk(s"Found schema check failure for $schema in $nodeName")
-    }
-    ValidationResult.ok
+    BackendsApiManager.getValidatorApiInstance
+      .doSchemaValidate(schema)
+      .map {
+        reason => ValidationResult.notOk(s"Found schema check failure for $schema, due to: $reason")
+      }
+      .getOrElse(ValidationResult.ok)
   }
 }
 

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -366,7 +366,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
       case plan: UnionExec =>
         val children = plan.children.map(replaceWithTransformerPlan)
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
-        UnionExecTransformer(children)
+        ColumnarUnionExec(children)
       case plan: ExpandExec =>
         val child = replaceWithTransformerPlan(plan.child)
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -506,7 +506,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
           if (!enableColumnarUnion) {
             TransformHints.tagNotTransformable(plan, "columnar Union is not enabled in UnionExec")
           } else {
-            val transformer = UnionExecTransformer(plan.children)
+            val transformer = ColumnarUnionExec(plan.children)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
         case plan: ExpandExec =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -106,14 +106,14 @@ case class ColumnarShuffleExchangeExec(
   var cachedShuffleRDD: ShuffledColumnarBatchRDD = _
 
   override protected def doValidateInternal(): ValidationResult = {
-    if (
-      !BackendsApiManager.getValidatorApiInstance.doColumnarShuffleExchangeExecValidate(
-        outputPartitioning,
-        child)
-    ) {
-      return ValidationResult.notOk("Found schema check failure in shuffle exchange.")
-    }
-    ValidationResult.ok
+    BackendsApiManager.getValidatorApiInstance
+      .doColumnarShuffleExchangeExecValidate(outputPartitioning, child)
+      .map {
+        reason =>
+          ValidationResult.notOk(
+            s"Found schema check failure for schema ${child.schema} due to: $reason")
+      }
+      .getOrElse(ValidationResult.ok)
   }
 
   override def nodeName: String = "ColumnarExchange"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr does two things

- propagate fallback reason to union and shuffle exchange during validation
- rename UnionExecTransformer to ColumnarUnionExec since we do not transform union in fact 

## How was this patch tested?

Pass CI
