### PR TITLE
[VL] Pretty log native fallback reason

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -73,6 +73,19 @@ case class CHHashAggregateExecTransformer(
 
   protected val modes: Seq[AggregateMode] = aggregateExpressions.map(_.mode).distinct
 
+  override protected def checkType(dataType: DataType): Boolean = {
+    dataType match {
+      case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
+          StringType | TimestampType | DateType | BinaryType =>
+        true
+      case _: StructType => true
+      case d: DecimalType => true
+      case a: ArrayType => true
+      case n: NullType => true
+      case other => false
+    }
+  }
+
   override def doTransform(context: SubstraitContext): TransformContext = {
     val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
     val operatorId = context.nextOperatorId(this.nodeName)

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -73,19 +73,6 @@ case class CHHashAggregateExecTransformer(
 
   protected val modes: Seq[AggregateMode] = aggregateExpressions.map(_.mode).distinct
 
-  override protected def checkType(dataType: DataType): Boolean = {
-    dataType match {
-      case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
-          StringType | TimestampType | DateType | BinaryType =>
-        true
-      case _: StructType => true
-      case d: DecimalType => true
-      case a: ArrayType => true
-      case n: NullType => true
-      case other => false
-    }
-  }
-
   override def doTransform(context: SubstraitContext): TransformContext = {
     val childCtx = child.asInstanceOf[TransformSupport].doTransform(context)
     val operatorId = context.nextOperatorId(this.nodeName)

--- a/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/execution/CHHashAggregateExecTransformer.scala
@@ -75,14 +75,8 @@ case class CHHashAggregateExecTransformer(
 
   override protected def checkType(dataType: DataType): Boolean = {
     dataType match {
-      case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
-          StringType | TimestampType | DateType | BinaryType =>
-        true
       case _: StructType => true
-      case d: DecimalType => true
-      case a: ArrayType => true
-      case n: NullType => true
-      case other => false
+      case other => super.checkType(other)
     }
   }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -29,20 +29,28 @@
 namespace gluten {
 
 namespace {
-#define LOG_VALIDATION_MSG_FROM_EXCEPTION(err)                                                                                       \
-  logValidateMsg(fmt::format(                                                                                                        \
-      "Validation failed due to exception caught at file:{} line:{} function:{}, thrown from file:{} line:{} function:{} reason:{}", \
-      __FILE__,                                                                                                                      \
-      __LINE__,                                                                                                                      \
-      __FUNCTION__,                                                                                                                  \
-      err.file(),                                                                                                                    \
-      err.line(),                                                                                                                    \
-      err.function(),                                                                                                                \
+static const char* extractFileName(const char* file) {
+  return strrchr(file, '/') ? strrchr(file, '/') + 1 : file;
+}
+
+#define LOG_VALIDATION_MSG_FROM_EXCEPTION(err)                                                                                        \
+  logValidateMsg(fmt::format(                                                                                                         \
+      "Validation failed due to exception caught at file:{} line:{} function:{}, thrown from file:{} line:{} function:{}, reason:{}", \
+      extractFileName(__FILE__),                                                                                                      \
+      __LINE__,                                                                                                                       \
+      __FUNCTION__,                                                                                                                   \
+      extractFileName(err.file()),                                                                                                    \
+      err.line(),                                                                                                                     \
+      err.function(),                                                                                                                 \
       err.message()))
 
-#define LOG_VALIDATION_MSG(reason) \
-  logValidateMsg(fmt::format(      \
-      "Validation failed at file:{}, line:{}, function:{}, reason:{}", __FILE__, __LINE__, __FUNCTION__, reason))
+#define LOG_VALIDATION_MSG(reason)                                     \
+  logValidateMsg(fmt::format(                                          \
+      "Validation failed at file:{}, line:{}, function:{}, reason:{}", \
+      extractFileName(__FILE__),                                       \
+      __LINE__,                                                        \
+      __FUNCTION__,                                                    \
+      reason))
 
 static const std::unordered_set<std::string> kRegexFunctions = {
     "regexp_extract",

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -29,15 +29,15 @@
 namespace gluten {
 
 namespace {
-#define LOG_VALIDATION_MSG_FROM_EXCEPTION(err)                                                                                              \
-  logValidateMsg(fmt::format(                                                                                                               \
-      "native validation failed due to exception caught at file:{} line:{} function:{}, thrown from file:{} line:{} function:{} reason:{}", \
-      __FILE__,                                                                                                                             \
-      __LINE__,                                                                                                                             \
-      __FUNCTION__,                                                                                                                         \
-      err.file(),                                                                                                                           \
-      err.line(),                                                                                                                           \
-      err.function(),                                                                                                                       \
+#define LOG_VALIDATION_MSG_FROM_EXCEPTION(err)                                                                                       \
+  logValidateMsg(fmt::format(                                                                                                        \
+      "Validation failed due to exception caught at file:{} line:{} function:{}, thrown from file:{} line:{} function:{} reason:{}", \
+      __FILE__,                                                                                                                      \
+      __LINE__,                                                                                                                      \
+      __FUNCTION__,                                                                                                                  \
+      err.file(),                                                                                                                    \
+      err.line(),                                                                                                                    \
+      err.function(),                                                                                                                \
       err.message()));
 
 #define LOG_VALIDATION_MSG(reason) \

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -38,11 +38,11 @@ namespace {
       err.file(),                                                                                                                    \
       err.line(),                                                                                                                    \
       err.function(),                                                                                                                \
-      err.message()));
+      err.message()))
 
 #define LOG_VALIDATION_MSG(reason) \
   logValidateMsg(fmt::format(      \
-      "Validation failed at file:{}, line:{}, function:{}, reason:{}", __FILE__, __LINE__, __FUNCTION__, reason));
+      "Validation failed at file:{}, line:{}, function:{}, reason:{}", __FILE__, __LINE__, __FUNCTION__, reason))
 
 static const std::unordered_set<std::string> kRegexFunctions = {
     "regexp_extract",
@@ -71,17 +71,17 @@ bool SubstraitToVeloxPlanValidator::validateInputTypes(
     std::vector<TypePtr>& types) {
   // The input type is wrapped in enhancement.
   if (!extension.has_enhancement()) {
-    LOG_VALIDATION_MSG("Input type is not wrapped in enhancement.")
+    LOG_VALIDATION_MSG("Input type is not wrapped in enhancement.");
     return false;
   }
   const auto& enhancement = extension.enhancement();
   ::substrait::Type inputType;
   if (!enhancement.UnpackTo(&inputType)) {
-    LOG_VALIDATION_MSG("Enhancement can't be unpacked to inputType.")
+    LOG_VALIDATION_MSG("Enhancement can't be unpacked to inputType.");
     return false;
   }
   if (!inputType.has_struct_()) {
-    LOG_VALIDATION_MSG("Input type has no struct.")
+    LOG_VALIDATION_MSG("Input type has no struct.");
     return false;
   }
 
@@ -91,7 +91,7 @@ bool SubstraitToVeloxPlanValidator::validateInputTypes(
     try {
       types.emplace_back(SubstraitParser::parseType(sType));
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
   }
@@ -107,7 +107,7 @@ bool SubstraitToVeloxPlanValidator::validateRound(
   }
 
   if (!arguments[1].value().has_literal()) {
-    LOG_VALIDATION_MSG("Round scale is expected.")
+    LOG_VALIDATION_MSG("Round scale is expected.");
     return false;
   }
 
@@ -119,14 +119,14 @@ bool SubstraitToVeloxPlanValidator::validateRound(
     case ::substrait::Expression_Literal::LiteralTypeCase::kI64:
       return (arguments[1].value().literal().i64() >= 0);
     default:
-      LOG_VALIDATION_MSG("Round scale validation is not supported for type case " + std::to_string(typeCase))
+      LOG_VALIDATION_MSG("Round scale validation is not supported for type case " + std::to_string(typeCase));
       return false;
   }
 }
 
 bool SubstraitToVeloxPlanValidator::validateExtractExpr(const std::vector<core::TypedExprPtr>& params) {
   if (params.size() != 2) {
-    LOG_VALIDATION_MSG("Value expected in variant in ExtractExpr.")
+    LOG_VALIDATION_MSG("Value expected in variant in ExtractExpr.");
     return false;
   }
 
@@ -135,7 +135,7 @@ bool SubstraitToVeloxPlanValidator::validateExtractExpr(const std::vector<core::
     // Get the function argument.
     const auto& variant = functionArg->value();
     if (!variant.hasValue()) {
-      LOG_VALIDATION_MSG("Value expected in variant in ExtractExpr.")
+      LOG_VALIDATION_MSG("Value expected in variant in ExtractExpr.");
       return false;
     }
 
@@ -143,12 +143,12 @@ bool SubstraitToVeloxPlanValidator::validateExtractExpr(const std::vector<core::
     const auto& from = variant.value<std::string>();
     // Hour causes incorrect result.
     if (from == "HOUR") {
-      LOG_VALIDATION_MSG("Extract from hour.")
+      LOG_VALIDATION_MSG("Extract from hour.");
       return false;
     }
     return true;
   }
-  LOG_VALIDATION_MSG("Constant is expected to be the first parameter in extract.")
+  LOG_VALIDATION_MSG("Constant is expected to be the first parameter in extract.");
   return false;
 }
 
@@ -156,19 +156,19 @@ bool SubstraitToVeloxPlanValidator::validateRegexExpr(
     const std::string& name,
     const ::substrait::Expression::ScalarFunction& scalarFunction) {
   if (scalarFunction.arguments().size() < 2) {
-    LOG_VALIDATION_MSG("Wrong number of arguments for " + name)
+    LOG_VALIDATION_MSG("Wrong number of arguments for " + name);
   }
 
   const auto& patternArg = scalarFunction.arguments()[1].value();
   if (!patternArg.has_literal() || !patternArg.literal().has_string()) {
-    LOG_VALIDATION_MSG("Pattern is not string literal for " + name)
+    LOG_VALIDATION_MSG("Pattern is not string literal for " + name);
     return false;
   }
 
   const auto& pattern = patternArg.literal().string();
   std::string error;
   if (!validatePattern(pattern, error)) {
-    LOG_VALIDATION_MSG(name + " due to " + error)
+    LOG_VALIDATION_MSG(name + " due to " + error);
     return false;
   }
   return true;
@@ -198,20 +198,20 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
   } else if (name == "char_length") {
     VELOX_CHECK(types.size() == 1);
     if (types[0] == "vbin") {
-      LOG_VALIDATION_MSG("Binary type is not supported in " + name)
+      LOG_VALIDATION_MSG("Binary type is not supported in " + name);
       return false;
     }
   } else if (name == "map_from_arrays") {
-    LOG_VALIDATION_MSG("map_from_arrays is not supported.")
+    LOG_VALIDATION_MSG("map_from_arrays is not supported.");
     return false;
   } else if (name == "get_array_item") {
-    LOG_VALIDATION_MSG("get_array_item is not supported.")
+    LOG_VALIDATION_MSG("get_array_item is not supported.");
     return false;
   } else if (name == "concat") {
     for (const auto& type : types) {
       if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos ||
           type.find("list") != std::string::npos) {
-        LOG_VALIDATION_MSG(type + " is not supported in concat.")
+        LOG_VALIDATION_MSG(type + " is not supported in concat.");
         return false;
       }
     }
@@ -219,7 +219,7 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
     for (const auto& type : types) {
       if (type.find("struct") != std::string::npos || type.find("map") != std::string::npos ||
           type.find("list") != std::string::npos) {
-        LOG_VALIDATION_MSG(type + " is not supported in murmur3hash.")
+        LOG_VALIDATION_MSG(type + " is not supported in murmur3hash.");
         return false;
       }
     }
@@ -231,7 +231,7 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
   }
 
   if (kBlackList.find(name) != kBlackList.end()) {
-    LOG_VALIDATION_MSG("Function is not supported: " + name)
+    LOG_VALIDATION_MSG("Function is not supported: " + name);
     return false;
   }
 
@@ -243,7 +243,7 @@ bool SubstraitToVeloxPlanValidator::validateLiteral(
     const RowTypePtr& inputType) {
   if (literal.has_list()) {
     if (literal.list().values_size() == 0) {
-      LOG_VALIDATION_MSG("Literal is a list but has no value.")
+      LOG_VALIDATION_MSG("Literal is a list but has no value.");
       return false;
     } else {
       for (auto child : literal.list().values()) {
@@ -255,7 +255,7 @@ bool SubstraitToVeloxPlanValidator::validateLiteral(
     }
   } else if (literal.has_map()) {
     if (literal.map().key_values().empty()) {
-      LOG_VALIDATION_MSG("Literal is a map but has no value.")
+      LOG_VALIDATION_MSG("Literal is a map but has no value.");
       return false;
     } else {
       for (auto child : literal.map().key_values()) {
@@ -278,7 +278,7 @@ bool SubstraitToVeloxPlanValidator::validateCast(
 
   const auto& toType = SubstraitParser::parseType(castExpr.type());
   if (toType->kind() == TypeKind::TIMESTAMP) {
-    LOG_VALIDATION_MSG("Casting to TIMESTAMP is not supported.")
+    LOG_VALIDATION_MSG("Casting to TIMESTAMP is not supported.");
     return false;
   }
 
@@ -287,11 +287,11 @@ bool SubstraitToVeloxPlanValidator::validateCast(
   // Casting from some types is not supported. See CastExpr::applyCast.
   if (input->type()->isDate()) {
     if (toType->kind() == TypeKind::TIMESTAMP) {
-      LOG_VALIDATION_MSG("Casting from DATE to TIMESTAMP is not supported.")
+      LOG_VALIDATION_MSG("Casting from DATE to TIMESTAMP is not supported.");
       return false;
     }
     if (toType->kind() != TypeKind::VARCHAR) {
-      LOG_VALIDATION_MSG("Casting from DATE to " + toType->toString() + " is not supported.")
+      LOG_VALIDATION_MSG("Casting from DATE to " + toType->toString() + " is not supported.");
       return false;
     }
   }
@@ -300,10 +300,10 @@ bool SubstraitToVeloxPlanValidator::validateCast(
     case TypeKind::MAP:
     case TypeKind::ROW:
     case TypeKind::VARBINARY:
-      LOG_VALIDATION_MSG("Invalid input type in casting: ARRAY/MAP/ROW/VARBINARY.")
+      LOG_VALIDATION_MSG("Invalid input type in casting: ARRAY/MAP/ROW/VARBINARY.");
       return false;
     case TypeKind::TIMESTAMP: {
-      LOG_VALIDATION_MSG("Casting from TIMESTAMP is not supported or has incorrect result.")
+      LOG_VALIDATION_MSG("Casting from TIMESTAMP is not supported or has incorrect result.");
       return false;
     }
     default: {
@@ -326,7 +326,7 @@ bool SubstraitToVeloxPlanValidator::validateSingularOrList(
     const RowTypePtr& inputType) {
   for (const auto& option : singularOrList.options()) {
     if (!option.has_literal()) {
-      LOG_VALIDATION_MSG("Option is expected as Literal.")
+      LOG_VALIDATION_MSG("Option is expected as Literal.");
       return false;
     }
     if (!validateLiteral(option.literal(), inputType)) {
@@ -359,7 +359,7 @@ bool SubstraitToVeloxPlanValidator::validateExpression(
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WriteRel& writeRel) {
   if (writeRel.has_input() && !validate(writeRel.input())) {
-    LOG_VALIDATION_MSG("Validation failed for input type validation in WriteRel.")
+    LOG_VALIDATION_MSG("Validation failed for input type validation in WriteRel.");
     return false;
   }
 
@@ -368,7 +368,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WriteRel& writeR
   if (writeRel.has_named_table()) {
     const auto& extension = writeRel.named_table().advanced_extension();
     if (!validateInputTypes(extension, types)) {
-      LOG_VALIDATION_MSG("Validation failed for input type validation in WriteRel.")
+      LOG_VALIDATION_MSG("Validation failed for input type validation in WriteRel.");
       return false;
     }
   }
@@ -391,7 +391,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WriteRel& writeR
           default:
             LOG_VALIDATION_MSG(
                 "Validation failed for input type validation in WriteRel, not support partition column type: " +
-                mapTypeKindToName(types[i]->kind()))
+                mapTypeKindToName(types[i]->kind()));
             return false;
         }
       }
@@ -408,7 +408,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
     const auto& extension = fetchRel.advanced_extension();
     std::vector<TypePtr> types;
     if (!validateInputTypes(extension, types)) {
-      LOG_VALIDATION_MSG("Unsupported input types in ExpandRel.")
+      LOG_VALIDATION_MSG("Unsupported input types in ExpandRel.");
       return false;
     }
 
@@ -422,7 +422,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
   }
 
   if (fetchRel.offset() < 0 || fetchRel.count() < 0) {
-    LOG_VALIDATION_MSG("Offset and count should be valid in FetchRel.")
+    LOG_VALIDATION_MSG("Offset and count should be valid in FetchRel.");
     return false;
   }
 
@@ -438,7 +438,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
         auto result = sortingKeyNames.insert(sortingKey->name());
         if (!result.second) {
           LOG_VALIDATION_MSG(
-              "If the input of fetchRel is a SortRel, we will convert it to a TopNNode. In Velox, it is important to ensure unique sorting keys. However, duplicate keys were found in this case.")
+              "If the input of fetchRel is a SortRel, we will convert it to a TopNNode. In Velox, it is important to ensure unique sorting keys. However, duplicate keys were found in this case.");
           return false;
         }
       }
@@ -450,19 +450,19 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FetchRel& fetchR
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& generateRel) {
   if (generateRel.has_input() && !validate(generateRel.input())) {
-    LOG_VALIDATION_MSG("Input validation fails in GenerateRel.")
+    LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
     return false;
   }
 
   // Get and validate the input types from extension.
   if (!generateRel.has_advanced_extension()) {
-    LOG_VALIDATION_MSG("Input types are expected in GenerateRel.")
+    LOG_VALIDATION_MSG("Input types are expected in GenerateRel.");
     return false;
   }
   const auto& extension = generateRel.advanced_extension();
   std::vector<TypePtr> types;
   if (!validateInputTypes(extension, types)) {
-    LOG_VALIDATION_MSG("Validation failed for input types in GenerateRel.")
+    LOG_VALIDATION_MSG("Validation failed for input types in GenerateRel.");
     return false;
   }
 
@@ -476,7 +476,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
   auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
 
   if (generateRel.has_generator() && !validateExpression(generateRel.generator(), rowType)) {
-    LOG_VALIDATION_MSG("Input validation fails in GenerateRel.")
+    LOG_VALIDATION_MSG("Input validation fails in GenerateRel.");
     return false;
   }
   return true;
@@ -484,7 +484,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::GenerateRel& gen
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expandRel) {
   if (expandRel.has_input() && !validate(expandRel.input())) {
-    LOG_VALIDATION_MSG("Input validation fails in ExpandRel.")
+    LOG_VALIDATION_MSG("Input validation fails in ExpandRel.");
     return false;
   }
   RowTypePtr rowType = nullptr;
@@ -493,7 +493,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expan
     const auto& extension = expandRel.advanced_extension();
     std::vector<TypePtr> types;
     if (!validateInputTypes(extension, types)) {
-      LOG_VALIDATION_MSG("Unsupported input types in ExpandRel.")
+      LOG_VALIDATION_MSG("Unsupported input types in ExpandRel.");
       return false;
     }
 
@@ -516,7 +516,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expan
       if (projectSize == 0) {
         projectSize = projectExprs.size();
       } else if (projectSize != projectExprs.size()) {
-        LOG_VALIDATION_MSG("SwitchingField expressions size should be constant in ExpandRel.")
+        LOG_VALIDATION_MSG("SwitchingField expressions size should be constant in ExpandRel.");
         return false;
       }
 
@@ -528,7 +528,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expan
             case ::substrait::Expression::RexTypeCase::kLiteral:
               break;
             default:
-              LOG_VALIDATION_MSG("Only field or literal is supported in project of ExpandRel.")
+              LOG_VALIDATION_MSG("Only field or literal is supported in project of ExpandRel.");
               return false;
           }
           if (rowType) {
@@ -543,11 +543,11 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ExpandRel& expan
         }
 
       } catch (const VeloxException& err) {
-        LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+        LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
         return false;
       }
     } else {
-      LOG_VALIDATION_MSG("Only SwitchingField is supported in ExpandRel.")
+      LOG_VALIDATION_MSG("Only SwitchingField is supported in ExpandRel.");
       return false;
     }
   }
@@ -571,19 +571,19 @@ bool validateBoundType(::substrait::Expression_WindowFunction_Bound boundType) {
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windowRel) {
   if (windowRel.has_input() && !validate(windowRel.input())) {
-    LOG_VALIDATION_MSG("WindowRel input fails to validate.")
+    LOG_VALIDATION_MSG("WindowRel input fails to validate.");
     return false;
   }
 
   // Get and validate the input types from extension.
   if (!windowRel.has_advanced_extension()) {
-    LOG_VALIDATION_MSG("Input types are expected in WindowRel.")
+    LOG_VALIDATION_MSG("Input types are expected in WindowRel.");
     return false;
   }
   const auto& extension = windowRel.advanced_extension();
   std::vector<TypePtr> types;
   if (!validateInputTypes(extension, types)) {
-    LOG_VALIDATION_MSG("Validation failed for input types in WindowRel.")
+    LOG_VALIDATION_MSG("Validation failed for input types in WindowRel.");
     return false;
   }
 
@@ -610,7 +610,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
           case ::substrait::Expression::RexTypeCase::kLiteral:
             break;
           default:
-            LOG_VALIDATION_MSG("Only field is supported in window functions.")
+            LOG_VALIDATION_MSG("Only field is supported in window functions.");
             return false;
         }
       }
@@ -622,7 +622,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
         default:
           LOG_VALIDATION_MSG(
               "the window type only support ROWS and RANGE, and the input type is " +
-              std::to_string(windowFunction.window_type()))
+              std::to_string(windowFunction.window_type()));
           return false;
       }
 
@@ -631,11 +631,11 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
       if (!boundTypeSupported) {
         LOG_VALIDATION_MSG(
             "Found unsupported Bound Type: upper " + std::to_string(windowFunction.upper_bound().kind_case()) +
-            ", lower " + std::to_string(windowFunction.lower_bound().kind_case()))
+            ", lower " + std::to_string(windowFunction.lower_bound().kind_case()));
         return false;
       }
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
   }
@@ -645,7 +645,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   for (const auto& funcSpec : funcSpecs) {
     auto funcName = SubstraitParser::getNameBeforeDelimiter(funcSpec);
     if (unsupportedFuncs.find(funcName) != unsupportedFuncs.end()) {
-      LOG_VALIDATION_MSG(funcName + " was not supported in WindowRel.")
+      LOG_VALIDATION_MSG(funcName + " was not supported in WindowRel.");
       return false;
     }
   }
@@ -659,7 +659,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
       auto expression = exprConverter_->toVeloxExpr(expr, rowType);
       auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
       if (expr_field == nullptr) {
-        LOG_VALIDATION_MSG("Only field is supported for partition key in Window Operator!")
+        LOG_VALIDATION_MSG("Only field is supported for partition key in Window Operator!");
         return false;
       } else {
         expressions.emplace_back(expression);
@@ -669,7 +669,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
     // mismatched type, exception will be thrown.
     exec::ExprSet exprSet(std::move(expressions), execCtx_);
   } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;
   }
 
@@ -683,7 +683,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
       case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
         break;
       default:
-        LOG_VALIDATION_MSG("in windowRel, unsupported Sort direction " + std::to_string(sort.direction()))
+        LOG_VALIDATION_MSG("in windowRel, unsupported Sort direction " + std::to_string(sort.direction()));
         return false;
     }
 
@@ -692,12 +692,12 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
         auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
         auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
         if (!expr_field) {
-          LOG_VALIDATION_MSG("in windowRel, the sorting key in Sort Operator only support field.")
+          LOG_VALIDATION_MSG("in windowRel, the sorting key in Sort Operator only support field.");
           return false;
         }
         exec::ExprSet exprSet({std::move(expression)}, execCtx_);
       } catch (const VeloxException& err) {
-        LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+        LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
         return false;
       }
     }
@@ -713,14 +713,14 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
 
   // Get and validate the input types from extension.
   if (!sortRel.has_advanced_extension()) {
-    LOG_VALIDATION_MSG("Input types are expected in SortRel.")
+    LOG_VALIDATION_MSG("Input types are expected in SortRel.");
     return false;
   }
 
   const auto& extension = sortRel.advanced_extension();
   std::vector<TypePtr> types;
   if (!validateInputTypes(extension, types)) {
-    LOG_VALIDATION_MSG("Validation failed for input types in SortRel.")
+    LOG_VALIDATION_MSG("Validation failed for input types in SortRel.");
     return false;
   }
 
@@ -741,7 +741,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
       case ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
         break;
       default:
-        LOG_VALIDATION_MSG("unsupported Sort direction " + std::to_string(sort.direction()))
+        LOG_VALIDATION_MSG("unsupported Sort direction " + std::to_string(sort.direction()));
         return false;
     }
 
@@ -750,12 +750,12 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
         auto expression = exprConverter_->toVeloxExpr(sort.expr(), rowType);
         auto expr_field = dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
         if (!expr_field) {
-          LOG_VALIDATION_MSG("in SortRel, the sorting key in Sort Operator only support field.")
+          LOG_VALIDATION_MSG("in SortRel, the sorting key in Sort Operator only support field.");
           return false;
         }
         exec::ExprSet exprSet({std::move(expression)}, execCtx_);
       } catch (const VeloxException& err) {
-        LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+        LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
         return false;
       }
     }
@@ -766,19 +766,19 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::SortRel& sortRel
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ProjectRel& projectRel) {
   if (projectRel.has_input() && !validate(projectRel.input())) {
-    LOG_VALIDATION_MSG("ProjectRel input")
+    LOG_VALIDATION_MSG("ProjectRel input");
     return false;
   }
 
   // Get and validate the input types from extension.
   if (!projectRel.has_advanced_extension()) {
-    LOG_VALIDATION_MSG("Input types are expected in ProjectRel.")
+    LOG_VALIDATION_MSG("Input types are expected in ProjectRel.");
     return false;
   }
   const auto& extension = projectRel.advanced_extension();
   std::vector<TypePtr> types;
   if (!validateInputTypes(extension, types)) {
-    LOG_VALIDATION_MSG("Validation failed for input types in ProjectRel.")
+    LOG_VALIDATION_MSG("Validation failed for input types in ProjectRel.");
     return false;
   }
 
@@ -806,7 +806,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ProjectRel& proj
     // mismatched type, exception will be thrown.
     exec::ExprSet exprSet(std::move(expressions), execCtx_);
   } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;
   }
   return true;
@@ -814,24 +814,24 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ProjectRel& proj
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filterRel) {
   if (filterRel.has_input() && !validate(filterRel.input())) {
-    LOG_VALIDATION_MSG("input of FilterRel validation fails")
+    LOG_VALIDATION_MSG("input of FilterRel validation fails");
     return false;
   }
 
   // Get and validate the input types from extension.
   if (!filterRel.has_advanced_extension()) {
-    LOG_VALIDATION_MSG("Input types are expected in FilterRel.")
+    LOG_VALIDATION_MSG("Input types are expected in FilterRel.");
     return false;
   }
   const auto& extension = filterRel.advanced_extension();
   std::vector<TypePtr> types;
   if (!validateInputTypes(extension, types)) {
-    LOG_VALIDATION_MSG("Validation failed for input types in FilterRel.")
+    LOG_VALIDATION_MSG("Validation failed for input types in FilterRel.");
     return false;
   }
   for (const auto& type : types) {
     if (type->kind() == TypeKind::TIMESTAMP) {
-      LOG_VALIDATION_MSG("Timestamp is not fully supported in Filter.")
+      LOG_VALIDATION_MSG("Timestamp is not fully supported in Filter.");
       return false;
     }
   }
@@ -855,7 +855,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filte
     // or mismatched type, exception will be thrown.
     exec::ExprSet exprSet(std::move(expressions), execCtx_);
   } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;
   }
   return true;
@@ -863,12 +863,12 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::FilterRel& filte
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel) {
   if (joinRel.has_left() && !validate(joinRel.left())) {
-    LOG_VALIDATION_MSG("Validation fails for join left input.")
+    LOG_VALIDATION_MSG("Validation fails for join left input.");
     return false;
   }
 
   if (joinRel.has_right() && !validate(joinRel.right())) {
-    LOG_VALIDATION_MSG("Validation fails for join right input.")
+    LOG_VALIDATION_MSG("Validation fails for join right input.");
     return false;
   }
 
@@ -879,7 +879,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
       case ::substrait::JoinRel_JoinType_JOIN_TYPE_LEFT:
         break;
       default:
-        LOG_VALIDATION_MSG("Sort merge join only support inner and left join.")
+        LOG_VALIDATION_MSG("Sort merge join only support inner and left join.");
         return false;
     }
   }
@@ -893,20 +893,20 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
     case ::substrait::JoinRel_JoinType_JOIN_TYPE_ANTI:
       break;
     default:
-      LOG_VALIDATION_MSG("Sort merge join only support inner and left join.")
+      LOG_VALIDATION_MSG("Sort merge join only support inner and left join.");
       return false;
   }
 
   // Validate input types.
   if (!joinRel.has_advanced_extension()) {
-    LOG_VALIDATION_MSG("Input types are expected in JoinRel.")
+    LOG_VALIDATION_MSG("Input types are expected in JoinRel.");
     return false;
   }
 
   const auto& extension = joinRel.advanced_extension();
   std::vector<TypePtr> types;
   if (!validateInputTypes(extension, types)) {
-    LOG_VALIDATION_MSG("Validation failed for input types in JoinRel.")
+    LOG_VALIDATION_MSG("Validation failed for input types in JoinRel.");
     return false;
   }
 
@@ -923,7 +923,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
     try {
       planConverter_.extractJoinKeys(joinRel.expression(), leftExprs, rightExprs);
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
   }
@@ -933,7 +933,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
       auto expression = exprConverter_->toVeloxExpr(joinRel.post_join_filter(), rowType);
       exec::ExprSet exprSet({std::move(expression)}, execCtx_);
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
   }
@@ -959,7 +959,7 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
         }
       }
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
     auto baseFuncName =
@@ -967,7 +967,7 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
     auto funcName = planConverter_.toAggregationFunctionName(baseFuncName, funcStep);
     auto signaturesOpt = exec::getAggregateFunctionSignatures(funcName);
     if (!signaturesOpt) {
-      LOG_VALIDATION_MSG("can not find function signature for" + funcName + " in AggregateRel.")
+      LOG_VALIDATION_MSG("can not find function signature for" + funcName + " in AggregateRel.");
       return false;
     }
 
@@ -978,7 +978,7 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
         auto resolveType = binder.tryResolveType(
             exec::isPartialOutput(funcStep) ? signature->intermediateType() : signature->returnType());
         if (resolveType == nullptr) {
-          LOG_VALIDATION_MSG("Validation failed for function " + funcName + " resolve type in AggregateRel.")
+          LOG_VALIDATION_MSG("Validation failed for function " + funcName + " resolve type in AggregateRel.");
           return false;
         }
         resolved = true;
@@ -986,7 +986,7 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
       }
     }
     if (!resolved) {
-      LOG_VALIDATION_MSG("Validation failed for function " + funcName + " bind signatures in AggregateRel.")
+      LOG_VALIDATION_MSG("Validation failed for function " + funcName + " bind signatures in AggregateRel.");
       return false;
     }
   }
@@ -995,7 +995,7 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(const ::substrait
 
 bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& aggRel) {
   if (aggRel.has_input() && !validate(aggRel.input())) {
-    LOG_VALIDATION_MSG("Input validation fails in AggregateRel.")
+    LOG_VALIDATION_MSG("Input validation fails in AggregateRel.");
     return false;
   }
 
@@ -1006,7 +1006,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
     // Aggregate always has advanced extension for streaming aggregate optimization,
     // but only some of them have enhancement for validation.
     if (extension.has_enhancement() && !validateInputTypes(extension, types)) {
-      LOG_VALIDATION_MSG("Validation failed for input types in AggregateRel.")
+      LOG_VALIDATION_MSG("Validation failed for input types in AggregateRel.");
       return false;
     }
   }
@@ -1019,7 +1019,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
         case ::substrait::Expression::RexTypeCase::kSelection:
           break;
         default:
-          LOG_VALIDATION_MSG("Only field is supported in groupings.")
+          LOG_VALIDATION_MSG("Only field is supported in groupings.");
           return false;
       }
     }
@@ -1039,7 +1039,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
             case ::substrait::Expression::RexTypeCase::kSelection:
               break;
             default:
-              LOG_VALIDATION_MSG("Only field is supported in aggregate filter expression.")
+              LOG_VALIDATION_MSG("Only field is supported in aggregate filter expression.");
               return false;
           }
         }
@@ -1051,7 +1051,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
       SubstraitParser::parseType(aggFunction.output_type());
       // Validate the size of arguments.
       if (SubstraitParser::getNameBeforeDelimiter(functionSpec) == "count" && aggFunction.arguments().size() > 1) {
-        LOG_VALIDATION_MSG("Count should have only one argument.")
+        LOG_VALIDATION_MSG("Count should have only one argument.");
         // Count accepts only one argument.
         return false;
       }
@@ -1063,12 +1063,12 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
           case ::substrait::Expression::RexTypeCase::kLiteral:
             break;
           default:
-            LOG_VALIDATION_MSG("Only field is supported in aggregate functions.")
+            LOG_VALIDATION_MSG("Only field is supported in aggregate functions.");
             return false;
         }
       }
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
   }
@@ -1104,7 +1104,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
   for (const auto& funcSpec : funcSpecs) {
     auto funcName = SubstraitParser::getNameBeforeDelimiter(funcSpec);
     if (supportedAggFuncs.find(funcName) == supportedAggFuncs.end()) {
-      LOG_VALIDATION_MSG(funcName + " was not supported in AggregateRel.")
+      LOG_VALIDATION_MSG(funcName + " was not supported in AggregateRel.");
       return false;
     }
   }
@@ -1124,7 +1124,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
     }
 
     if (!hasExpr) {
-      LOG_VALIDATION_MSG("Aggregation must specify either grouping keys or aggregates.")
+      LOG_VALIDATION_MSG("Aggregation must specify either grouping keys or aggregates.");
       return false;
     }
   }
@@ -1135,7 +1135,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ReadRel& readRel
   try {
     planConverter_.toVeloxPlan(readRel);
   } catch (const VeloxException& err) {
-    LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+    LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
     return false;
   }
 
@@ -1165,7 +1165,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::ReadRel& readRel
       // or mismatched type, exception will be thrown.
       exec::ExprSet exprSet(std::move(expressions), execCtx_);
     } catch (const VeloxException& err) {
-      LOG_VALIDATION_MSG_FROM_EXCEPTION(err)
+      LOG_VALIDATION_MSG_FROM_EXCEPTION(err);
       return false;
     }
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -108,32 +108,37 @@ abstract class HashAggregateExecBaseTransformer(
 
   override def simpleString(maxFields: Int): String = toString(verbose = false, maxFields)
 
-  protected def checkType(dataType: DataType): Boolean = {
-    dataType match {
-      case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
-          StringType | TimestampType | DateType | BinaryType =>
-        true
-      case _: DecimalType => true
-      case _: ArrayType => true
-      case _: NullType => true
-      case _ => false
-    }
-  }
-
   override protected def doValidateInternal(): ValidationResult = {
     val substraitContext = new SubstraitContext
     val operatorId = substraitContext.nextOperatorId(this.nodeName)
     val aggParams = new AggregationParams
     val relNode = getAggRel(substraitContext, operatorId, aggParams, null, validation = true)
-    if (aggregateAttributes.exists(attr => !checkType(attr.dataType))) {
-      return ValidationResult.notOk(
-        "Found not supported data type in aggregation expression," +
-          s"${aggregateAttributes.map(_.dataType)}")
+
+    val typeValidator = (attr: NamedExpression) => {
+      attr.dataType match {
+        case BooleanType | StringType | TimestampType | DateType | BinaryType =>
+          true
+        case _: NumericType => true
+        case _: ArrayType => true
+        case _: NullType => true
+        case _ => false
+      }
     }
-    if (groupingExpressions.exists(attr => !checkType(attr.dataType))) {
+    val unsupportedAggExprs = aggregateAttributes.filterNot(typeValidator)
+    if (unsupportedAggExprs.nonEmpty) {
       return ValidationResult.notOk(
-        "Found not supported data type in group expression," +
-          s"${groupingExpressions.map(_.dataType)}")
+        "Found unsupported data type in aggregation expression: " +
+          unsupportedAggExprs
+            .map(attr => s"${attr.name}#${attr.exprId.id}:${attr.dataType}")
+            .mkString(", "))
+    }
+    val unsupportedGroupExprs = groupingExpressions.filterNot(typeValidator)
+    if (unsupportedGroupExprs.nonEmpty) {
+      return ValidationResult.notOk(
+        "Found unsupported data type in grouping expression: " +
+          unsupportedGroupExprs
+            .map(attr => s"${attr.name}#${attr.exprId.id}:${attr.dataType}")
+            .mkString(", "))
     }
     aggregateExpressions.foreach {
       expr =>

--- a/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/GlutenPlan.scala
@@ -42,7 +42,7 @@ object ValidationResult {
       ok
     } else {
       val fallbackInfo = info.getFallbackInfo.asScala
-        .mkString("native check failure:", ", ", "")
+        .mkString("Native validation failed:\n  ", "\n  ", "")
       notOk(fallbackInfo)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce two new macros in native to enhance validation log: `LOG_VALIDATION_MSG_FROM_EXCEPTION`, `LOG_VALIDATION_MSG`, then help developer check root cause easily.

Before:
```
(4) SortAggregate: Found unsupported data type in aggregation expression,MapType(StringType,IntegerType,true), BooleanType
(9) SortAggregate: Found unsupported data type in aggregation expression,MapType(StringType,IntegerType,true), BooleanType

(4) SortAggregate: native check failure:native validation failed due to: Validation failed for input type in AggregateRel function due to:Substrait type signature conversion to Velox type not supported for list., native validation failed due to: Validation failed for ProjectRel input.
(9) SortAggregate: native check failure:native validation failed due to: Validation failed for input type in AggregateRel function due to:Substrait type signature conversion to Velox type not supported for list., native validation failed due to: Validation failed for ProjectRel input.
```

After:
```
(4) SortAggregate: Found unsupported data type in aggregation expression: first#18:MapType(StringType,IntegerType,true)
(9) SortAggregate: Found unsupported data type in aggregation expression: first(map#2)()#15:MapType(StringType,IntegerType,true)

(4) SortAggregate: Native validation failed:
  Validation failed due to exception caught at file:SubstraitToVeloxPlanValidator.cc line:962 function:validateAggRelFunctionType, thrown from file:VeloxSubstraitSignature.cc line:171 function:fromSubstraitSignature, reason:Substrait type signature conversion to Velox type not supported for list.
  Validation failed at file:SubstraitToVeloxPlanValidator.cc, line:769, function:validate, reason:ProjectRel input
(9) SortAggregate: Native validation failed:
  Validation failed due to exception caught at file:SubstraitToVeloxPlanValidator.cc line:962 function:validateAggRelFunctionType, thrown from file:VeloxSubstraitSignature.cc line:171 function:fromSubstraitSignature, reason:Substrait type signature conversion to Velox type not supported for list.
  Validation failed at file:SubstraitToVeloxPlanValidator.cc, line:769, function:validate, reason:ProjectRel input
```