### PR TITLE
[VL] Daily Update Velox Version (2024-01-25)

### DIFF
--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -136,7 +136,7 @@ int32_t SubstraitParser::parseReferenceSegment(const ::substrait::Expression::Re
       return refSegment.struct_field().field();
     }
     default:
-      VELOX_NYI("Substrait conversion not supported for ReferenceSegment '{}'", typeCase);
+      VELOX_NYI("Substrait conversion not supported for ReferenceSegment '{}'", std::to_string(typeCase));
   }
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -150,7 +150,7 @@ bool isNullOnFailure(::substrait::Expression::Cast::FailureBehavior failureBehav
     case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
       return true;
     default:
-      VELOX_NYI("The given failure behavior is NOT supported: '{}'", failureBehavior);
+      VELOX_NYI("The given failure behavior is NOT supported: '{}'", std::to_string(failureBehavior));
   }
 }
 
@@ -223,7 +223,7 @@ std::shared_ptr<const core::FieldAccessTypedExpr> SubstraitVeloxExprConverter::t
       return fieldAccess;
     }
     default:
-      VELOX_NYI("Substrait conversion not supported for Reference '{}'", typeCase);
+      VELOX_NYI("Substrait conversion not supported for Reference '{}'", std::to_string(typeCase));
   }
 }
 
@@ -375,7 +375,7 @@ std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::toVe
         auto kind = veloxType->kind();
         return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(constructConstantVector, kind, substraitLit, veloxType);
       }
-      VELOX_NYI("Substrait conversion not supported for type case '{}'", typeCase);
+      VELOX_NYI("Substrait conversion not supported for type case '{}'", std::to_string(typeCase));
   }
 }
 
@@ -463,7 +463,7 @@ VectorPtr SubstraitVeloxExprConverter::literalsToVector(
         return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
             constructFlatVector, kind, elementAtFunc, childSize, veloxType, pool_);
       }
-      VELOX_NYI("literals not supported for type case '{}'", childTypeCase);
+      VELOX_NYI("literals not supported for type case '{}'", std::to_string(childTypeCase));
   }
 }
 
@@ -509,7 +509,7 @@ RowVectorPtr SubstraitVeloxExprConverter::literalsToRowVector(const ::substrait:
               VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(constructFlatVectorForStruct, kind, child, 1, veloxType, pool_);
           vectors.emplace_back(vecPtr);
         } else {
-          VELOX_NYI("literalsToRowVector not supported for type case '{}'", typeCase);
+          VELOX_NYI("literalsToRowVector not supported for type case '{}'", std::to_string(typeCase));
         }
     }
   }
@@ -579,7 +579,7 @@ core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
     case ::substrait::Expression::RexTypeCase::kSingularOrList:
       return toVeloxExpr(substraitExpr.singular_or_list(), inputType);
     default:
-      VELOX_NYI("Substrait conversion not supported for Expression '{}'", typeCase);
+      VELOX_NYI("Substrait conversion not supported for Expression '{}'", std::to_string(typeCase));
   }
 }
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -303,7 +303,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
       break;
     }
     default:
-      VELOX_NYI("Unsupported Join type: {}", sJoin.type());
+      VELOX_NYI("Unsupported Join type: {}", std::to_string(sJoin.type()));
   }
 
   // extract join keys from join expression
@@ -745,7 +745,7 @@ const core::WindowNode::Frame createWindowFrame(
       frame.type = core::WindowNode::WindowType::kRange;
       break;
     default:
-      VELOX_FAIL("the window type only support ROWS and RANGE, and the input type is ", type);
+      VELOX_FAIL("the window type only support ROWS and RANGE, and the input type is ", std::to_string(type));
   }
 
   auto boundTypeConversion = [](::substrait::Expression_WindowFunction_Bound boundType) -> core::WindowNode::BoundType {
@@ -1263,7 +1263,7 @@ void SubstraitToVeloxPlanConverter::flattenConditions(
       break;
     }
     default:
-      VELOX_NYI("GetFlatConditions not supported for type '{}'", typeCase);
+      VELOX_NYI("GetFlatConditions not supported for type '{}'", std::to_string(typeCase));
   }
 }
 
@@ -1742,7 +1742,7 @@ void SubstraitToVeloxPlanConverter::setFilterInfo(
         substraitLit = param.value().literal();
         break;
       default:
-        VELOX_NYI("Substrait conversion not supported for arg type '{}'", typeCase);
+        VELOX_NYI("Substrait conversion not supported for arg type '{}'", std::to_string(typeCase));
     }
   }
 
@@ -1788,7 +1788,7 @@ void SubstraitToVeloxPlanConverter::setFilterInfo(
       // Doing nothing here can let filter IsNotNull still work.
       break;
     default:
-      VELOX_NYI("Subfield filters creation not supported for input type '{}' in setFilterInfo", inputType);
+      VELOX_NYI("Subfield filters creation not supported for input type '{}' in setFilterInfo", inputType->toString());
   }
 
   setColumnFilterInfo(functionName, val, columnToFilterInfo[colIdxVal], reverse);
@@ -2011,7 +2011,8 @@ void SubstraitToVeloxPlanConverter::constructSubfieldFilters(
         filters[common::Subfield(inputName)] = std::move(std::make_unique<common::IsNull>());
       } else {
         VELOX_NYI(
-            "Only IsNotNull and IsNull are supported in constructSubfieldFilters for input type '{}'.", inputType);
+            "Only IsNotNull and IsNull are supported in constructSubfieldFilters for input type '{}'.",
+            inputType->toString());
       }
     }
   } else {
@@ -2204,7 +2205,8 @@ connector::hive::SubfieldFilters SubstraitToVeloxPlanConverter::mapToFilters(
               colIdx, inputNameList[colIdx], inputType, columnToFilterInfo[colIdx], filters);
           break;
         default:
-          VELOX_NYI("Subfield filters creation not supported for input type '{}' in mapToFilters", inputType);
+          VELOX_NYI(
+              "Subfield filters creation not supported for input type '{}' in mapToFilters", inputType->toString());
       }
     }
   }

--- a/cpp/velox/tests/JsonToProtoConverter.cc
+++ b/cpp/velox/tests/JsonToProtoConverter.cc
@@ -28,5 +28,9 @@ void JsonToProtoConverter::readFromFile(const std::string& msgPath, google::prot
   buffer << msgJson.rdbuf();
   std::string msgData = buffer.str();
   auto status = google::protobuf::util::JsonStringToMessage(msgData, &msg);
-  VELOX_CHECK(status.ok(), "Failed to parse Substrait JSON: {} {}", status.code(), status.message());
+  VELOX_CHECK(
+      status.ok(),
+      "Failed to parse Substrait JSON: {} {}",
+      static_cast<int8_t>(status.code()),
+      status.message().ToString());
 }

--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_01_24
+VELOX_BRANCH=2024_01_25
 VELOX_HOME=""
 
 #Set on run gluten on HDFS


### PR DESCRIPTION
```
71bb6d0f9 Fix hash join spill issue caused by new internal state (#8520)
147ff3032 Signal timeout when locking task in getLongRunningOpCalls (#8511)
54e87d8eb Refactor TableWriter arbitration test (#8504)
077fd735d Add CAST(varchar as decimal) (#5307)
4cd32e367 Fix ExchangeBenchmark and PrefixSortAlgorithmBenchmark (#8493)
5fa64970f Refactor ParquetReader header to prevent including thrift headers (#8484)
b03643eac Add from_unixtime Spark function (#7532)
ef8783fa0 Avoid creating BlockingState for a yield driver thread (#8490)
1deb0368b Upgrade fmt to 10.1.1 (from 8.0.1) (#7941)
aa6bc30ea Add memory arbitration time runtime stats for operator (#8482)
```