### PR TITLE
[CORE][VL] Enable from_unixtime function and fix test failure

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -64,7 +64,6 @@ static const std::unordered_set<std::string> kBlackList = {
     "concat_ws",
     "from_json",
     "json_array_length",
-    "from_unixtime",
     "repeat",
     "trunc",
     "sequence",

--- a/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/DateTimeExpressionsTransformer.scala
@@ -87,40 +87,6 @@ case class DateDiffTransformer(
   }
 }
 
-case class FromUnixTimeTransformer(
-    substraitExprName: String,
-    sec: ExpressionTransformer,
-    format: ExpressionTransformer,
-    timeZoneId: Option[String] = None,
-    original: FromUnixTime)
-  extends ExpressionTransformer {
-
-  override def doTransform(args: java.lang.Object): ExpressionNode = {
-    val secNode = sec.doTransform(args)
-    val formatNode = format.doTransform(args)
-
-    val dataTypes = if (timeZoneId.isDefined) {
-      Seq(original.sec.dataType, original.format.dataType, StringType)
-    } else {
-      Seq(original.sec.dataType, original.format.dataType)
-    }
-    val functionMap = args.asInstanceOf[JHashMap[String, JLong]]
-    val functionId = ExpressionBuilder.newScalarFunction(
-      functionMap,
-      ConverterUtils.makeFuncName(substraitExprName, dataTypes))
-
-    val expressionNodes = new JArrayList[ExpressionNode]()
-    expressionNodes.add(secNode)
-    expressionNodes.add(formatNode)
-    if (timeZoneId.isDefined) {
-      expressionNodes.add(ExpressionBuilder.makeStringLiteral(timeZoneId.get))
-    }
-
-    val typeNode = ConverterUtils.getTypeNode(original.dataType, original.nullable)
-    ExpressionBuilder.makeScalarFunction(functionId, expressionNodes, typeNode)
-  }
-}
-
 /**
  * The failOnError depends on the config for ANSI. ANSI is not supported currently. And timeZoneId
  * is passed to backend config.

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -198,14 +198,6 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         BoundReferenceTransformer(b.ordinal, b.dataType, b.nullable)
       case l: Literal =>
         LiteralTransformer(l)
-      case f: FromUnixTime =>
-        FromUnixTimeTransformer(
-          substraitExprName,
-          replaceWithExpressionTransformerInternal(f.sec, attributeSeq, expressionsMap),
-          replaceWithExpressionTransformerInternal(f.format, attributeSeq, expressionsMap),
-          f.timeZoneId,
-          f
-        )
       case d: DateDiff =>
         DateDiffTransformer(
           substraitExprName,

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -704,6 +704,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("TruncTimestamp")
     .exclude("unsupported fmt fields for trunc/date_trunc results null")
     .exclude("from_unixtime")
+    .exclude(GLUTEN_TEST + "from_unixtime")
     .exclude("unix_timestamp")
     .exclude("to_unix_timestamp")
     .exclude("to_utc_timestamp")

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -215,6 +215,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("DateFormat")
     // Legacy mode is not supported, assuming this mode is not commonly used.
     .exclude("to_timestamp exception mode")
+    // Replaced by a gluten test to pass timezone through config.
+    .exclude("from_unixtime")
   enableSuite[GlutenDecimalExpressionSuite]
   enableSuite[GlutenStringFunctionsSuite]
   enableSuite[GlutenRegexpExpressionsSuite]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -745,6 +745,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("TruncTimestamp")
     .exclude("unsupported fmt fields for trunc/date_trunc results null")
     .exclude("from_unixtime")
+    .exclude(GLUTEN_TEST + "from_unixtime")
     .exclude("unix_timestamp")
     .exclude("to_unix_timestamp")
     .exclude("to_utc_timestamp")

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -149,6 +149,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("DateFormat")
     // Legacy mode is not supported, assuming this mode is not commonly used.
     .exclude("to_timestamp exception mode")
+    // Replaced by a gluten test to pass timezone through config.
+    .exclude("from_unixtime")
   enableSuite[GlutenDecimalExpressionSuite]
   enableSuite[GlutenHashExpressionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/clickhouse/ClickHouseTestSettings.scala
@@ -582,6 +582,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("TruncTimestamp")
     .exclude("unsupported fmt fields for trunc/date_trunc results null")
     .exclude("from_unixtime")
+    .exclude(GLUTEN_TEST + "from_unixtime")
     .exclude("unix_timestamp")
     .exclude("to_unix_timestamp")
     .exclude("to_utc_timestamp")

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -128,6 +128,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("DateFormat")
     // Legacy mode is not supported, assuming this mode is not commonly used.
     .exclude("to_timestamp exception mode")
+    // Replaced by a gluten test to pass timezone through config.
+    .exclude("from_unixtime")
   enableSuite[GlutenDecimalExpressionSuite]
   enableSuite[GlutenHashExpressionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenDateExpressionsSuite.scala
@@ -343,4 +343,72 @@ class GlutenDateExpressionsSuite extends DateExpressionsSuite with GlutenTestsTr
         }
     }
   }
+
+  test(GLUTEN_TEST + "from_unixtime") {
+    val outstandingTimezonesIds: Seq[String] = Seq(
+      // Velox doesn't support timezones like "UTC".
+      // "UTC",
+      // Not supported in velox.
+      // PST.getId,
+      // CET.getId,
+      "Africa/Dakar",
+      LA.getId,
+      "Asia/Urumqi",
+      "Asia/Hong_Kong",
+      "Europe/Brussels"
+    )
+    val outstandingZoneIds: Seq[ZoneId] = outstandingTimezonesIds.map(getZoneId)
+    Seq("legacy", "corrected").foreach {
+      legacyParserPolicy =>
+        for (zid <- outstandingZoneIds) {
+          withSQLConf(
+            SQLConf.LEGACY_TIME_PARSER_POLICY.key -> legacyParserPolicy,
+            SQLConf.SESSION_LOCAL_TIMEZONE.key -> zid.getId) {
+            val fmt1 = "yyyy-MM-dd HH:mm:ss"
+            val sdf1 = new SimpleDateFormat(fmt1, Locale.US)
+            val fmt2 = "yyyy-MM-dd HH:mm:ss.SSS"
+            val sdf2 = new SimpleDateFormat(fmt2, Locale.US)
+            val timeZoneId = Option(zid.getId)
+            val tz = TimeZone.getTimeZone(zid)
+            sdf1.setTimeZone(tz)
+            sdf2.setTimeZone(tz)
+
+            checkEvaluation(
+              FromUnixTime(Literal(0L), Literal(fmt1), timeZoneId),
+              sdf1.format(new Timestamp(0)))
+            checkEvaluation(
+              FromUnixTime(Literal(1000L), Literal(fmt1), timeZoneId),
+              sdf1.format(new Timestamp(1000000)))
+            checkEvaluation(
+              FromUnixTime(Literal(-1000L), Literal(fmt2), timeZoneId),
+              sdf2.format(new Timestamp(-1000000)))
+            checkEvaluation(
+              FromUnixTime(
+                Literal.create(null, LongType),
+                Literal.create(null, StringType),
+                timeZoneId),
+              null)
+            checkEvaluation(
+              FromUnixTime(Literal.create(null, LongType), Literal(fmt1), timeZoneId),
+              null)
+            checkEvaluation(
+              FromUnixTime(Literal(1000L), Literal.create(null, StringType), timeZoneId),
+              null)
+
+            // SPARK-28072 The codegen path for non-literal input should also work
+            checkEvaluation(
+              expression = FromUnixTime(
+                BoundReference(ordinal = 0, dataType = LongType, nullable = true),
+                BoundReference(ordinal = 1, dataType = StringType, nullable = true),
+                timeZoneId),
+              expected = UTF8String.fromString(sdf1.format(new Timestamp(0))),
+              inputRow = InternalRow(0L, UTF8String.fromString(fmt1))
+            )
+          }
+        }
+    }
+    // Test escaping of format
+    GenerateUnsafeProjection.generate(FromUnixTime(Literal(0L), Literal("\""), UTC_OPT) :: Nil)
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make from_unixtime expression transformed through generic path, no need to specially handle timezone by passing it to substrait as function arg. Because timezone has been passed to backend config and will be acquired in function's processing. Refer to: https://github.com/oap-project/gluten/issues/2804

## How was this patch tested?

Spark UT.
