### PR TITLE
[GLUTEN-4510][CORE] DatasetTransformer should skip collect `ReusedExchangeExec` node fallback info

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffl
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 
 import scala.collection.mutable
@@ -110,6 +111,7 @@ object GlutenImplicits {
           case _: InputIteratorTransformer =>
           case _: ColumnarToRowTransition =>
           case _: RowToColumnarTransition =>
+          case p: ReusedExchangeExec =>
           case p: AdaptiveSparkPlanExec if isFinalAdaptivePlan(p) =>
             collect(p.executedPlan)
           case p: AdaptiveSparkPlanExec =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

As titie

Fix #4510

## How was this patch tested?

No

