### PR TITLE
[VL] fix delta column mapping for struct type columns

### DIFF
--- a/gluten-delta/src/main/scala/io/glutenproject/extension/DeltaRewriteTransformerRules.scala
+++ b/gluten-delta/src/main/scala/io/glutenproject/extension/DeltaRewriteTransformerRules.scala
@@ -76,8 +76,14 @@ object DeltaRewriteTransformerRules {
       // transform HadoopFsRelation
       val relation = plan.relation
       val newFsRelation = relation.copy(
-        partitionSchema = fmt.prepareSchema(relation.partitionSchema),
-        dataSchema = fmt.prepareSchema(relation.dataSchema)
+        partitionSchema = DeltaColumnMapping.createPhysicalSchema(
+          relation.partitionSchema,
+          fmt.referenceSchema,
+          fmt.columnMappingMode),
+        dataSchema = DeltaColumnMapping.createPhysicalSchema(
+          relation.dataSchema,
+          fmt.referenceSchema,
+          fmt.columnMappingMode)
       )(SparkSession.active)
       // transform output's name into physical name so Reader can read data correctly
       // should keep the columns order the same as the origin output
@@ -128,7 +134,10 @@ object DeltaRewriteTransformerRules {
       val scanExecTransformer = new DeltaScanTransformer(
         newFsRelation,
         newOutput,
-        fmt.prepareSchema(plan.requiredSchema),
+        DeltaColumnMapping.createPhysicalSchema(
+          plan.requiredSchema,
+          fmt.referenceSchema,
+          fmt.columnMappingMode),
         newPartitionFilters,
         plan.optionalBucketSet,
         plan.optionalNumCoalescedBuckets,

--- a/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxDeltaSuite.scala
+++ b/gluten-delta/src/test/scala/io/glutenproject/execution/VeloxDeltaSuite.scala
@@ -134,7 +134,7 @@ class VeloxDeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithSpecifiedSparkVersion("column mapping with complex type", Some("3.3.1")) {
+  testWithSpecifiedSparkVersion("column mapping with complex type") {
     withTable("t1") {
       val simpleNestedSchema = new StructType()
         .add("a", StringType, true)

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -65,6 +65,8 @@ class FileSourceScanExecShim(
 
   def hasMetadataColumns: Boolean = false
 
+  def isMetadataColumn(attr: Attribute): Boolean = false
+
   def hasFieldIds: Boolean = false
 
   // The codes below are copied from FileSourceScanExec in Spark,

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -66,6 +66,8 @@ class FileSourceScanExecShim(
 
   def hasMetadataColumns: Boolean = metadataColumns.nonEmpty
 
+  def isMetadataColumn(attr: Attribute): Boolean = metadataColumns.contains(attr)
+
   def hasFieldIds: Boolean = ParquetUtils.hasFieldIds(requiredSchema)
 
   // The codes below are copied from FileSourceScanExec in Spark,

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -67,6 +67,8 @@ class FileSourceScanExecShim(
 
   def hasMetadataColumns: Boolean = metadataColumns.nonEmpty
 
+  def isMetadataColumn(attr: Attribute): Boolean = metadataColumns.contains(attr)
+
   def hasFieldIds: Boolean = ParquetUtils.hasFieldIds(requiredSchema)
 
   private def isDynamicPruningFilter(e: Expression): Boolean =


### PR DESCRIPTION
## What changes were proposed in this pull request?

We only handles column mapping for top layers, if there are struct type columns, then it would cause wrong result (null for struct type columns). This change leverage delta API to map the schema and attributes to solve the above issue.

Repro:
```
import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
import org.apache.spark.sql.functions._
import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructType}
import scala.collection.JavaConverters._
val simpleNestedSchema = new StructType().add("a", StringType, true).add("b",new StructType().add("c", StringType, true).add("d", IntegerType, true)).add("map", MapType(StringType, StringType), true).add("arr", ArrayType(IntegerType), true)
val simpleNestedData = spark.createDataFrame(Seq(Row("str1", Row("str1.1", 1), Map("k1" -> "v1"), Array(1, 11)),Row("str2", Row("str1.2", 2), Map("k2" -> "v2"), Array(2, 22))).asJava, simpleNestedSchema)
spark.sql("CREATE TABLE t1 (a STRING,b STRUCT<c: STRING NOT NULL, d: INT>,map MAP<STRING, STRING>,arr ARRAY<INT>) USING DELTA PARTITIONED BY (`a`) TBLPROPERTIES ('delta.columnMapping.mode' = 'name')")
simpleNestedData.write.format("delta").mode("append").saveAsTable("t1")
spark.sql("select * from t1")
```

Result:
```
+----+----+----------+-------+
|a   |b   |map       |arr    |
+----+----+----------+-------+
|str2|**null**|{k2 -> v2}|[2, 22]|
|str1|**null**|{k1 -> v1}|[1, 11]|
+----+----+----------+-------+
```

Wrong plan:
```
-- Project[expressions: (n1_4:ROW<c:VARCHAR,d:INTEGER>, "n0_0"), (n1_5:MAP<VARCHAR,VARCHAR>, "n0_1"), (n1_6:ARRAY<INTEGER>, "n0_2"), (n1_7:VARCHAR, "n0_3")] -> n1_4:ROW<c:VARCHAR,d:INTEGER>, n1_5:MAP<VARCHAR,VARCHAR>, n1_6:ARRAY<INTEGER>, n1_7:VARCHAR
  -- TableScan[table: hive_table] -> n0_0:ROW<c:VARCHAR,d:INTEGER>, n0_1:MAP<VARCHAR,VARCHAR>, n0_2:ARRAY<INTEGER>, n0_3:VARCHAR

-->n0_0:ROW<c:VARCHAR,d:INTEGER>
```

Expected Result:
```
+----+-----------+----------+-------+
|a   |b          |map       |arr    |
+----+-----------+----------+-------+
|str2|{str1.2, 2}|{k2 -> v2}|[2, 22]|
|str1|{str1.1, 1}|{k1 -> v1}|[1, 11]|
+----+-----------+----------+-------+
```
Expected plan:
```
-- Project[expressions: (n1_4:VARCHAR, "n0_3"), (n1_5:ROW<"col-0dab91d3-baa7-4e3a-8633-b436d7cbe1dc":VARCHAR,"col-e394acdc-73fb-4e78-9b79-258e53143547":INTEGER>, "n0_0"), (n1_6:MAP<VARCHAR,VARCHAR>, "n0_1"), (n1_7:ARRAY<INTEGER>, "n0_2")] -> n1_4:VARCHAR, n1_5:ROW<"col-0dab91d3-baa7-4e3a-8633-b436d7cbe1dc":VARCHAR,"col-e394acdc-73fb-4e78-9b79-258e53143547":INTEGER>, n1_6:MAP<VARCHAR,VARCHAR>, n1_7:ARRAY<INTEGER>
  -- TableScan[table: hive_table] -> n0_0:ROW<"col-0dab91d3-baa7-4e3a-8633-b436d7cbe1dc":VARCHAR,"col-e394acdc-73fb-4e78-9b79-258e53143547":INTEGER>, n0_1:MAP<VARCHAR,VARCHAR>, n0_2:ARRAY<INTEGER>, n0_3:VARCHAR

--> n0_0:ROW<"col-0dab91d3-baa7-4e3a-8633-b436d7cbe1dc":VARCHAR,"col-e394acdc-73fb-4e78-9b79-258e53143547":INTEGER>
```

## How was this patch tested?
UT.

