### PR TITLE
[VL] Remove fmt lib from vcpkg.json

### DIFF
--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -22,7 +22,6 @@
         "glog",
         "snappy",
         "libdwarf",
-        "fmt",
         {
           "name": "folly",
           "features": ["zstd", "lz4", "lzma", "snappy"]
@@ -107,8 +106,5 @@
         }
       ]
     }
-  },
-  "overrides": [
-    { "name": "fmt", "version": "8.0.1" }
-  ]
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I note fmt is already statically linked to velox libs. And gluten cpp doesn't depend on it.

## How was this patch tested?

Static build test in CI.

