### PR TITLE
[VL] Fix wrong native plan string

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1272,9 +1272,6 @@ std::string SubstraitToVeloxPlanConverter::findFuncSpec(uint64_t id) {
 }
 
 int32_t SubstraitToVeloxPlanConverter::getStreamIndex(const ::substrait::ReadRel& sRead) {
-  if (validationMode_) {
-    return -1;
-  }
   if (sRead.has_local_files()) {
     const auto& fileList = sRead.local_files().items();
     if (fileList.size() == 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In validationMode, we should also respect the iterator index, otherwise the native plan string will always be `TableScan`.

## How was this patch tested?

add test