### PR TITLE
[CORE] Change Hadoop Version for DP 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,12 +159,6 @@
       </properties>
     </profile>
     <profile>
-      <id>dataproc-2.0</id>
-      <properties>
-        <hadoop.version>3.2.2</hadoop.version>
-      </properties>
-    </profile>
-    <profile>
       <id>emr-6.3.0</id>
       <properties>
         <hadoop.version>3.2.2</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
       </properties>
     </profile>
     <profile>
+      <id>dataproc</id>
+      <properties>
+        <hadoop.version>3.3.6</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
       <id>emr-6.3.0</id>
       <properties>
         <hadoop.version>3.2.2</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
       </properties>
     </profile>
     <profile>
-      <id>dataproc</id>
+      <id>dataproc-2.2</id>
       <properties>
         <hadoop.version>3.3.6</hadoop.version>
       </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dataproc now uses Hadoop 3.3.6

## How was this patch tested?

Tested with this version of hadoop locally

