### PR TITLE
[VL] Offload byte type scan

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -88,7 +88,6 @@ object BackendSettings extends BackendSettingsApi {
     format match {
       case ParquetReadFormat =>
         val typeValidator: PartialFunction[StructField, String] = {
-          case StructField(_, ByteType, _, _) => "ByteType not support"
           // Parquet scan of nested array with struct/array as element type is unsupported in Velox.
           case StructField(_, arrayType: ArrayType, _, _)
               if arrayType.elementType.isInstanceOf[StructType] =>


### PR DESCRIPTION
Offload byte data type in parquet scan. It's already supported in velox parquet scan as tinyint.