### PR TITLE
[VL] Put fmt lib back to vcpkg.json and bump the version

### DIFF
--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -109,6 +109,6 @@
     }
   },
   "overrides": [
-    { "name": "fmt", "version": "8.0.1" }
+    { "name": "fmt", "version": "10.1.1" }
   ]
 }

--- a/dev/vcpkg/vcpkg.json
+++ b/dev/vcpkg/vcpkg.json
@@ -22,6 +22,7 @@
         "glog",
         "snappy",
         "libdwarf",
+        "fmt",
         {
           "name": "folly",
           "features": ["zstd", "lz4", "lzma", "snappy"]
@@ -106,5 +107,8 @@
         }
       ]
     }
-  }
+  },
+  "overrides": [
+    { "name": "fmt", "version": "8.0.1" }
+  ]
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add fmt lib back to vcpkg.json to let vcpkg build the static lib. In velox, fmt_SOURCE=AUTO, so the lib will be firstly searched from system. If not found, velox will build from SOURCE. With fmt managed by vcpkg, velox will directly use the pre-built  lib found from vcpkg installation path. This pr also bumped the version to align with velox.

## How was this patch tested?

Compile pass.

