### PR TITLE
[CORE] Cleanup unnecessary splitInfo in SubstraitContext and ReadRel

### DIFF
--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/ReadRelNode.java
@@ -16,7 +16,6 @@
  */
 package io.glutenproject.substrait.rel;
 
-import io.glutenproject.substrait.SubstraitContext;
 import io.glutenproject.substrait.expression.ExpressionNode;
 import io.glutenproject.substrait.extensions.AdvancedExtensionNode;
 import io.glutenproject.substrait.type.ColumnTypeNode;
@@ -27,64 +26,29 @@ import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
 import io.substrait.proto.RelCommon;
 import io.substrait.proto.Type;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class ReadRelNode implements RelNode, Serializable {
   private final List<TypeNode> types = new ArrayList<>();
   private final List<String> names = new ArrayList<>();
   private final List<ColumnTypeNode> columnTypeNodes = new ArrayList<>();
-  private final SubstraitContext context;
   private final ExpressionNode filterNode;
-  private StructType dataSchema;
-  private Map<String, String> properties;
   private final AdvancedExtensionNode extensionNode;
 
   ReadRelNode(
       List<TypeNode> types,
       List<String> names,
-      SubstraitContext context,
       ExpressionNode filterNode,
       List<ColumnTypeNode> columnTypeNodes,
       AdvancedExtensionNode extensionNode) {
     this.types.addAll(types);
     this.names.addAll(names);
-    this.context = context;
     this.filterNode = filterNode;
     this.columnTypeNodes.addAll(columnTypeNodes);
     this.extensionNode = extensionNode;
-  }
-
-  // TODO: remove setDataSchema and setProperties
-  //  and codes about splitInfo in substrait context
-  public void setDataSchema(StructType schema) {
-    this.dataSchema = new StructType();
-    for (StructField field : schema.fields()) {
-      boolean found = false;
-      for (int i = 0; i < names.size(); i++) {
-        // Case-insensitive schema matching
-        if (field.name().equalsIgnoreCase(names.get(i))) {
-          this.dataSchema =
-              this.dataSchema.add(
-                  names.get(i), field.dataType(), field.nullable(), field.metadata());
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
-        this.dataSchema = this.dataSchema.add(field);
-      }
-    }
-  }
-
-  public void setProperties(Map<String, String> properties) {
-    this.properties = properties;
   }
 
   @Override
@@ -112,21 +76,9 @@ public class ReadRelNode implements RelNode, Serializable {
     ReadRel.Builder readBuilder = ReadRel.newBuilder();
     readBuilder.setCommon(relCommonBuilder.build());
     readBuilder.setBaseSchema(nStructBuilder.build());
+
     if (filterNode != null) {
       readBuilder.setFilter(filterNode.toProtobuf());
-    }
-    if (context.getSplitInfos() != null && !context.getSplitInfos().isEmpty()) {
-      SplitInfo currentSplitInfo = context.getCurrentSplitInfo();
-      if (currentSplitInfo instanceof LocalFilesNode) {
-        LocalFilesNode filesNode = (LocalFilesNode) currentSplitInfo;
-        if (dataSchema != null) {
-          filesNode.setFileSchema(dataSchema);
-          filesNode.setFileReadProperties(properties);
-        }
-        readBuilder.setLocalFiles(((LocalFilesNode) currentSplitInfo).toProtobuf());
-      } else if (currentSplitInfo instanceof ExtensionTableNode) {
-        readBuilder.setExtensionTable(((ExtensionTableNode) currentSplitInfo).toProtobuf());
-      }
     }
 
     if (extensionNode != null) {

--- a/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/rel/RelBuilder.java
@@ -93,17 +93,6 @@ public class RelBuilder {
     return new AggregateRelNode(input, groupings, aggregateFunctionNodes, filters, extensionNode);
   }
 
-  // CH
-  public static RelNode makeReadRel(
-      List<TypeNode> types,
-      List<String> names,
-      ExpressionNode filter,
-      SubstraitContext context,
-      Long operatorId) {
-    return makeReadRel(types, names, null, filter, null, context, operatorId);
-  }
-
-  // VL
   public static RelNode makeReadRel(
       List<TypeNode> types,
       List<String> names,
@@ -113,7 +102,7 @@ public class RelBuilder {
       SubstraitContext context,
       Long operatorId) {
     context.registerRelToOperator(operatorId);
-    return new ReadRelNode(types, names, context, filter, columnTypeNodes, extensionNode);
+    return new ReadRelNode(types, names, filter, columnTypeNodes, extensionNode);
   }
 
   public static RelNode makeReadRelForInputIterator(

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -132,9 +132,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
 
   def substraitPlan: PlanNode = {
     if (wholeStageTransformerContext.isDefined) {
-      // TODO: remove this work around after we make `RelNode#toProtobuf` idempotent
-      //    see `SubstraitContext#initSplitInfosIndex`.
-      wholeStageTransformerContext.get.substraitContext.initSplitInfosIndex(0)
       wholeStageTransformerContext.get.root
     } else {
       generateWholeStageTransformContext().root

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -17,10 +17,8 @@
 package io.glutenproject.substrait
 
 import io.glutenproject.substrait.ddlplan.InsertOutputNode
-import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
-import io.glutenproject.substrait.rel.SplitInfo
 
-import java.lang.{Integer => JInt, Long => JLong}
+import java.lang.{Long => JLong}
 import java.security.InvalidParameterException
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
@@ -68,37 +66,10 @@ class SubstraitContext extends Serializable {
   // A map stores the relationship between aggregation operator id and its param.
   private val aggregationParamsMap = new JHashMap[JLong, AggregationParams]()
 
-  private var splitInfosIndex: JInt = 0
-  private var splitInfos: Seq[SplitInfo] = _
   private var iteratorIndex: JLong = 0L
-  private var fileFormat: JList[ReadFileFormat] = new JArrayList[ReadFileFormat]()
   private var insertOutputNode: InsertOutputNode = _
   private var operatorId: JLong = 0L
   private var relId: JLong = 0L
-
-  def initSplitInfosIndex(splitInfosIndex: JInt): Unit = {
-    this.splitInfosIndex = splitInfosIndex
-  }
-
-  def getSplitInfos: Seq[SplitInfo] = splitInfos
-
-  // FIXME Hongze 22/11/28
-  // This makes calls to ReadRelNode#toProtobuf non-idempotent which doesn't seem to be
-  // optimal in regard to the method name "toProtobuf".
-  def getCurrentSplitInfo: SplitInfo = {
-    if (getSplitInfos != null && getSplitInfos.size > splitInfosIndex) {
-      val res = getSplitInfos(splitInfosIndex)
-      splitInfosIndex += 1
-      res
-    } else {
-      throw new IllegalStateException(
-        s"LocalFilesNodes index $splitInfosIndex exceeds the size of the LocalFilesNodes.")
-    }
-  }
-
-  def setSplitInfos(SplitInfos: Seq[SplitInfo]): Unit = {
-    this.splitInfos = SplitInfos
-  }
 
   def getInsertOutputNode: InsertOutputNode = insertOutputNode
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Now `LocalFilesNode` have been completely decoupled from `RealRel` for both velox and ch backend, we can cleanup unnecessary `splitInfo` in `SubstraitContext` and `ReadRel`.


## How was this patch tested?

Pass CI

