### PR TITLE
[VL][CORE] Refactor and fix the columnar cartesian product

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -226,12 +226,13 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
   override def genCartesianProductExecTransformer(
       left: SparkPlan,
       right: SparkPlan,
-      condition: Option[Expression]): CartesianProductExecTransformer =
+      condition: Option[Expression]): CartesianProductExecTransformer = {
     CartesianProductExecTransformer(
-      left,
-      right,
+      ColumnarCartesianProductBridge(left),
+      ColumnarCartesianProductBridge(right),
       condition
     )
+  }
 
   override def genHashExpressionTransformer(
       substraitExprName: String,

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -696,9 +696,10 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
             TransformHints.tagNotTransformable(
               plan,
               "conversion to CartesianProductTransformer is not enabled.")
+          } else {
+            val transformer = CartesianProductExecTransformer(plan.left, plan.right, plan.condition)
+            TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
-          val transformer = CartesianProductExecTransformer(plan.left, plan.right, plan.condition)
-          TransformHints.tag(plan, transformer.doValidate().toTransformHint)
         case plan: WindowExec =>
           if (!enableColumnarWindow) {
             TransformHints.tagNotTransformable(plan, "columnar window is not enabled in WindowExec")

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -150,12 +150,6 @@ case class ColumnarCollapseTransformStages(
   /** Inserts an InputIteratorTransformer on top of those that do not support transform. */
   private def insertInputIteratorTransformer(plan: SparkPlan): SparkPlan = {
     plan match {
-      case p: CartesianProductExecTransformer =>
-        p.withNewChildren(
-          p.children.map(
-            child =>
-              ColumnarCollapseTransformStages.wrapInputIteratorTransformer(
-                insertWholeStageTransformer(child))))
       case p if !supportTransform(p) =>
         ColumnarCollapseTransformStages.wrapInputIteratorTransformer(insertWholeStageTransformer(p))
       case p =>
@@ -165,9 +159,6 @@ case class ColumnarCollapseTransformStages(
 
   private def insertWholeStageTransformer(plan: SparkPlan): SparkPlan = {
     plan match {
-      case t: CartesianProductExecTransformer =>
-        WholeStageTransformer(insertInputIteratorTransformer(t))(
-          transformStageCounter.incrementAndGet())
       case t if supportTransform(t) =>
         WholeStageTransformer(t.withNewChildren(t.children.map(insertInputIteratorTransformer)))(
           transformStageCounter.incrementAndGet())

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/InputIteratorMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/InputIteratorMetricsUpdater.scala
@@ -23,8 +23,15 @@ case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric]) extends 
       val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
       metrics("cpuCount") += operatorMetrics.cpuCount
       metrics("wallNanos") += operatorMetrics.wallNanos
-      metrics("outputRows") += operatorMetrics.outputRows
-      metrics("outputVectors") += operatorMetrics.outputVectors
+      if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
+        // Sometimes, velox does not update metrics for intermediate operator,
+        // here we try to use the input metrics
+        metrics("outputRows") += operatorMetrics.inputRows
+        metrics("outputVectors") += operatorMetrics.inputVectors
+      } else {
+        metrics("outputRows") += operatorMetrics.outputRows
+        metrics("outputVectors") += operatorMetrics.outputVectors
+      }
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr refactors the code of `CartesianProductExecTransformer` to fix some issues, e.g., before the `CartesianProductExecTransformer` work with other join together would fail.

This pr adds a bridge `ColumnarCartesianProductBridge` connect left/right children and `CartesianProductExecTransformer` to avoid wrapping  them into one `WholeStageTransformer`. The reason is that, `WholeStageTransformer` always assume the input partitions are same, but it is not true for `CartesianProductExec`. The dag after this pr would like.

<img width="934" alt="image" src="https://github.com/oap-project/gluten/assets/12025282/0d248f5e-a007-403d-a2fa-33684027042c">


## How was this patch tested?

add tests
