### PR TITLE
[CORE] Add junitxml path of scalatest-maven-plugin for backends-velox, spark33 and spark34

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -215,6 +215,7 @@
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
+          <junitxml>.</junitxml>
           <tagsToExclude>${tagsToExclude}</tagsToExclude>
           <systemProperties>
             <velox.udf.lib.path>${cpp.build.dir}/velox/udf/examples/libmyudf.so</velox.udf.lib.path>

--- a/gluten-ut/spark33/pom.xml
+++ b/gluten-ut/spark33/pom.xml
@@ -156,6 +156,9 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <junitxml>.</junitxml>
+        </configuration>
         <executions>
           <execution>
             <id>test</id>

--- a/gluten-ut/spark34/pom.xml
+++ b/gluten-ut/spark34/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
-      <version>1.13.1</version>
+      <version>1.12.3</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>

--- a/gluten-ut/spark34/pom.xml
+++ b/gluten-ut/spark34/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
-      <version>1.12.3</version>
+      <version>1.13.1</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
@@ -177,6 +177,9 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <junitxml>.</junitxml>
+        </configuration>
         <executions>
           <execution>
             <id>test</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin, it helps CI tools collect UT results.