### PR TITLE
[GLUTEN-3582][CORE][VL][CH] Refactor filter pushdown logic

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -294,8 +294,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
         val adaptiveSparkPlanExec = collectWithSubqueries(df.queryExecution.executedPlan) {
           case adaptive: AdaptiveSparkPlanExec => adaptive
         }
-        assert(adaptiveSparkPlanExec.size == 3)
-        assert(adaptiveSparkPlanExec(1) == adaptiveSparkPlanExec(2))
+        assert(adaptiveSparkPlanExec.size == 2)
     }
   }
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQESuite.scala
@@ -218,8 +218,7 @@ class GlutenClickHouseTPCHParquetAQESuite
         val adaptiveSparkPlanExec = collectWithSubqueries(df.queryExecution.executedPlan) {
           case adaptive: AdaptiveSparkPlanExec => adaptive
         }
-        assert(adaptiveSparkPlanExec.size == 3)
-        assert(adaptiveSparkPlanExec(1) == adaptiveSparkPlanExec(2))
+        assert(adaptiveSparkPlanExec.size == 2)
     }
   }
 

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -480,7 +480,7 @@ QueryPlanPtr SerializedPlanParser::parseOp(const substrait::Rel & rel, std::list
             // Remove this compatiability in later and then only java iter has local files in ReadRel.
             if (read.has_local_files() || (!read.has_extension_table() && !isReadFromMergeTree(read)))
             {
-                assert(rel.has_base_schema());
+                assert(read.has_base_schema());
                 QueryPlanStepPtr step;
                 if (isReadRelFromJava(read))
                     step = parseReadRealWithJavaIter(read);

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -384,30 +384,27 @@ object FilterHandler extends PredicateHelper {
     (ExpressionSet(filters) -- ExpressionSet(scanFilters)).toSeq
 
   // Separate and compare the filter conditions in Scan and Filter.
-  // Push down the remaining conditions in Filter into Scan.
+  // Try push down the remaining conditions in Filter into Scan.
   def applyFilterPushdownToScan(filter: FilterExec, reuseSubquery: Boolean): SparkPlan =
     filter.child match {
       case fileSourceScan: FileSourceScanExec =>
-        val remainingFilters =
-          getRemainingFilters(
-            fileSourceScan.dataFilters,
-            splitConjunctivePredicates(filter.condition))
+        val pushDownFilters =
+          BackendsApiManager.getSparkPlanExecApiInstance.postProcessPushDownFilter(
+            splitConjunctivePredicates(filter.condition),
+            fileSourceScan)
         ScanTransformerFactory.createFileSourceScanTransformer(
           fileSourceScan,
           reuseSubquery,
-          extraFilters = remainingFilters)
+          allPushDownFilters = Some(pushDownFilters))
       case batchScan: BatchScanExec =>
-        val remainingFilters = batchScan.scan match {
-          case fileScan: FileScan =>
-            getRemainingFilters(fileScan.dataFilters, splitConjunctivePredicates(filter.condition))
-          case _ =>
-            // TODO: For data lake format use pushedFilters in SupportsPushDownFilters
-            splitConjunctivePredicates(filter.condition)
-        }
+        val pushDownFilters =
+          BackendsApiManager.getSparkPlanExecApiInstance.postProcessPushDownFilter(
+            splitConjunctivePredicates(filter.condition),
+            batchScan)
         ScanTransformerFactory.createBatchScanTransformer(
           batchScan,
           reuseSubquery,
-          pushdownFilters = remainingFilters)
+          allPushDownFilters = Some(pushDownFilters))
       case other =>
         throw new UnsupportedOperationException(s"${other.getClass.toString} is not supported.")
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -62,7 +62,7 @@ class BatchScanExecTransformer(
   // class. Otherwise, we will encounter an issue where makeCopy cannot find a constructor
   // with the corresponding number of parameters.
   // The workaround is to add a mutable list to pass in pushdownFilters.
-  private var pushdownFilters: Option[Seq[Expression]] = None
+  protected var pushdownFilters: Option[Seq[Expression]] = None
 
   def setPushDownFilters(filters: Seq[Expression]): Unit = {
     pushdownFilters = Some(filters)

--- a/gluten-iceberg/src/main/scala/io/glutenproject/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/io/glutenproject/execution/IcebergScanTransformer.scala
@@ -39,7 +39,7 @@ class IcebergScanTransformer(
     runtimeFilters = runtimeFilters,
     table = table) {
 
-  override def filterExprs(): Seq[Expression] = pushdownFilters
+  override def filterExprs(): Seq[Expression] = pushdownFilters.getOrElse(Seq.empty)
 
   override def getPartitionSchema: StructType = GlutenIcebergSourceUtil.getPartitionSchema(scan)
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer, FilterExecTransformerBase}
+import io.glutenproject.utils.BackendTestUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
@@ -635,8 +636,15 @@ class GlutenDynamicPartitionPruningV1SuiteAEOff
         //
         // See also io.glutenproject.execution.FilterHandler#applyFilterPushdownToScan
         // See also DynamicPartitionPruningSuite.scala:1362
-        assert(subqueryIds.size == 3, "Whole plan subquery reusing not working correctly")
-        assert(reusedSubqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+        if (BackendTestUtils.isCHBackendLoaded()) {
+          assert(subqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+          assert(reusedSubqueryIds.size == 1, "Whole plan subquery reusing not working correctly")
+        } else if (BackendTestUtils.isVeloxBackendLoaded()) {
+          assert(subqueryIds.size == 3, "Whole plan subquery reusing not working correctly")
+          assert(reusedSubqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+        } else {
+          assert(false, "Unknown backend")
+        }
         assert(
           reusedSubqueryIds.forall(subqueryIds.contains(_)),
           "ReusedSubqueryExec should reuse an existing subquery")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDynamicPartitionPruningSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution.{BatchScanExecTransformer, FileSourceScanExecTransformer, FilterExecTransformerBase}
+import io.glutenproject.utils.BackendTestUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.GlutenTestConstants.GLUTEN_TEST
@@ -640,8 +641,15 @@ class GlutenDynamicPartitionPruningV1SuiteAEOff
         //
         // See also io.glutenproject.execution.FilterHandler#applyFilterPushdownToScan
         // See also DynamicPartitionPruningSuite.scala:1362
-        assert(subqueryIds.size == 3, "Whole plan subquery reusing not working correctly")
-        assert(reusedSubqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+        if (BackendTestUtils.isCHBackendLoaded()) {
+          assert(subqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+          assert(reusedSubqueryIds.size == 1, "Whole plan subquery reusing not working correctly")
+        } else if (BackendTestUtils.isVeloxBackendLoaded()) {
+          assert(subqueryIds.size == 3, "Whole plan subquery reusing not working correctly")
+          assert(reusedSubqueryIds.size == 2, "Whole plan subquery reusing not working correctly")
+        } else {
+          assert(false, "Unknown backend")
+        }
         assert(
           reusedSubqueryIds.forall(subqueryIds.contains(_)),
           "ReusedSubqueryExec should reuse an existing subquery")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Vanilla spark just push down part of filter condition into scan, however gluten can push down all filters in some cases, it was done in #4132. But, Clickhouse backend can not do this in parquet file format. we can add this later

This PR add `postProcessPushDownFilter` in `SparkPlanExecApi`,  `CHSparkPlanExecApi` overwrite this funtion to add its own logic.

### Note for CH
Consider TPCH 22 `c_acctbal > (select avg(c_acctbal) from customer where ...)`.   it can be push down before this PR.  I disable it for ch backend, since I want to make push down functionality same as vanilla spark first.

## Update for `ScanTransformerFactory`
Before this PR, `createxxxTransformer` assume pass the extra ilters, after this PR, we pass all push down filters, this is because we may remove unsupported filters  

```scala 
def createFileSourceScanTransformer(
      scanExec: FileSourceScanExec,
      reuseSubquery: Boolean,
      allPushDownFilters: Option[Seq[Expression]] = None,  // extraFilters: Seq[Expression] = Seq.empty,
      validation: Boolean = false): FileSourceScanExecTransformer = {}

  def createBatchScanTransformer(
      batchScan: BatchScanExec,
      reuseSubquery: Boolean,
      allPushDownFilters: Option[Seq[Expression]] = None,  //pushdownFilters: Seq[Expression] = Seq.empty,
      validation: Boolean = false): SparkPlan = {}
```

## How was this patch tested?
Using existed UT