### PR TITLE
[CORE] Fix limit with offset for Spark3.4

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -22,6 +22,7 @@ import io.glutenproject.execution._
 import io.glutenproject.expression.ExpressionConverter
 import io.glutenproject.extension.columnar._
 import io.glutenproject.metrics.GlutenTimeMetric
+import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.utils.{LogLevelUtil, PhysicalPlanSelector, PlanUtil}
 
 import org.apache.spark.api.python.EvalPythonExecTransformer
@@ -396,7 +397,8 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
       case plan: TakeOrderedAndProjectExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
-        TakeOrderedAndProjectExecTransformer(plan.limit, plan.sortOrder, plan.projectList, child)
+        val (limit, offset) = SparkShimLoader.getSparkShims.getLimitAndOffsetFromTopK(plan)
+        TakeOrderedAndProjectExecTransformer(limit, plan.sortOrder, plan.projectList, child, offset)
       case plan: ShuffleExchangeExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
@@ -502,7 +504,8 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
       case plan: GlobalLimitExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)
-        LimitTransformer(child, 0L, plan.limit)
+        val (limit, offset) = SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)
+        LimitTransformer(child, offset, limit)
       case plan: LocalLimitExec =>
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
         val child = replaceWithTransformerPlan(plan.child)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -27,7 +27,7 @@ import io.glutenproject.utils.PhysicalPlanSelector
 import org.apache.spark.api.python.EvalPythonExecTransformer
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.plans.FullOuter
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
@@ -657,7 +657,9 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar limit is not enabled in GlobalLimitExec")
           } else {
-            val transformer = LimitTransformer(plan.child, 0L, plan.limit)
+            val (limit, offset) =
+              SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)
+            val transformer = LimitTransformer(plan.child, offset, limit)
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
         case plan: LocalLimitExec =>
@@ -694,28 +696,14 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar topK is not enabled in TakeOrderedAndProjectExec")
           } else {
-            var tagged: ValidationResult = null
-            val orderingSatisfies =
-              SortOrder.orderingSatisfies(plan.child.outputOrdering, plan.sortOrder)
-            if (orderingSatisfies) {
-              val limitPlan = LimitTransformer(plan.child, 0, plan.limit)
-              tagged = limitPlan.doValidate()
-            } else {
-              // Here we are validating sort + limit which is a kind of whole stage transformer,
-              // because we would call sort.doTransform in limit.
-              // So, we should add adapter to make it work.
-              val inputTransformer =
-                ColumnarCollapseTransformStages.wrapInputIteratorTransformer(plan.child)
-              val sortPlan = SortExecTransformer(plan.sortOrder, false, inputTransformer)
-              val limitPlan = LimitTransformer(sortPlan, 0, plan.limit)
-              tagged = limitPlan.doValidate()
-            }
-
-            if (tagged.isValid) {
-              val projectPlan = ProjectExecTransformer(plan.projectList, plan.child)
-              tagged = projectPlan.doValidate()
-            }
-            TransformHints.tag(plan, tagged.toTransformHint)
+            val (limit, offset) = SparkShimLoader.getSparkShims.getLimitAndOffsetFromTopK(plan)
+            val transformer = TakeOrderedAndProjectExecTransformer(
+              limit,
+              plan.sortOrder,
+              plan.projectList,
+              plan.child,
+              offset)
+            TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
         case _ =>
           // currently we assume a plan to be transformable by default

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -119,7 +119,7 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
     "subquery/in-subquery/in-group-by.sql",
     "subquery/in-subquery/in-having.sql",
     "subquery/in-subquery/in-joins.sql",
-    // "subquery/in-subquery/in-limit.sql",
+    "subquery/in-subquery/in-limit.sql",
     "subquery/in-subquery/in-multiple-columns.sql",
     "subquery/in-subquery/in-order-by.sql",
     "subquery/in-subquery/in-set-operations.sql",

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -221,7 +221,6 @@ class GlutenSQLQueryTestSuite
     "udf/udf-window.sql", // Local window fixes are not added.
     "window.sql", // Local window fixes are not added.
     "select_having.sql", // 3.4 failed
-    "subquery/in-subquery/in-limit.sql", // 3.4 fail @see line 322
     "mapconcat.sql" // 3.4 failed
   ) ++ otherIgnoreList
 

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Distribution
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
+import org.apache.spark.sql.execution.{FileSourceScanExec, GlobalLimitExec, SparkPlan, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
@@ -88,6 +88,10 @@ trait SparkShims {
       agg: org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec): Boolean
 
   def extractSubPlanFromMightContain(expr: Expression): Option[SparkPlan]
+
+  def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = (plan.limit, 0)
+
+  def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = (plan.limit, 0)
 
   def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should pass the specified offset in global limit to the native operator,  since Spark3.4 supports offset feature. Native topK does not offset, so this pr add fallback if topK offset is not 0.

## How was this patch tested?

Enable some tests

