### PR TITLE
[CORE] Add schema validation for broadcast exchange

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ValidatorApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/ValidatorApiImpl.scala
@@ -81,7 +81,7 @@ class ValidatorApiImpl extends ValidatorApi {
       case array: ArrayType =>
         doSchemaValidate(array.elementType)
       case _ =>
-        Some(s"do not support data type: $schema")
+        Some(s"Schema / data type not supported: $schema")
     }
   }
 

--- a/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/execution/RowToVeloxColumnarExec.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.backendsapi.velox.ValidatorApiImpl
+import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.exec.Runtimes
 import io.glutenproject.memory.arrowalloc.ArrowBufferAllocators
@@ -45,7 +45,7 @@ import scala.collection.mutable.ListBuffer
 case class RowToVeloxColumnarExec(child: SparkPlan) extends RowToColumnarExecBase(child = child) {
 
   override def doExecuteColumnarInternal(): RDD[ColumnarBatch] = {
-    new ValidatorApiImpl().doSchemaValidate(schema).foreach {
+    BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema).foreach {
       reason =>
         throw new UnsupportedOperationException(
           s"Input schema contains unsupported type when convert row to columnar for $schema " +

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -50,30 +50,31 @@ case class CachedColumnarBatch(
 // spotless:off
 /**
  * Feature:
- *   1. This serializer supports column pruning 2. TODO: support push down filter 3. Super TODO:
- *      support store offheap object directly
+ * 1. This serializer supports column pruning
+ * 2. TODO: support push down filter
+ * 3. Super TODO: support store offheap object directly
  *
  * The data transformation pipeline:
  *
  *   - Serializer ColumnarBatch -> CachedColumnarBatch
- * -> serialize to byte[]
+ *     -> serialize to byte[]
  *
  *   - Deserializer CachedColumnarBatch -> ColumnarBatch
- * -> deserialize to byte[] to create Velox ColumnarBatch
+ *     -> deserialize to byte[] to create Velox ColumnarBatch
  *
  *   - Serializer InternalRow -> CachedColumnarBatch (support RowToColumnar)
- * -> Convert InternalRow to ColumnarBatch
- * -> Serializer ColumnarBatch -> CachedColumnarBatch
+ *     -> Convert InternalRow to ColumnarBatch
+ *     -> Serializer ColumnarBatch -> CachedColumnarBatch
  *
  *   - Serializer InternalRow -> DefaultCachedBatch (unsupport RowToColumnar)
- * -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
+ *     -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
  *
  *   - Deserializer CachedColumnarBatch -> InternalRow (support ColumnarToRow)
- * -> Deserializer CachedColumnarBatch -> ColumnarBatch
- * -> Convert ColumnarBatch to InternalRow
+ *     -> Deserializer CachedColumnarBatch -> ColumnarBatch
+ *     -> Convert ColumnarBatch to InternalRow
  *
  *   - Deserializer DefaultCachedBatch -> InternalRow (unsupport ColumnarToRow)
- * -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
+ *     -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
  */
 // spotless:on
 class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHelper with Logging {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution
 
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.backendsapi.velox.ValidatorApiImpl
 import io.glutenproject.columnarbatch.ColumnarBatches
 import io.glutenproject.exec.Runtimes
 import io.glutenproject.execution.{RowToVeloxColumnarExec, VeloxColumnarToRowExec}
@@ -51,31 +50,30 @@ case class CachedColumnarBatch(
 // spotless:off
 /**
  * Feature:
- * 1. This serializer supports column pruning
- * 2. TODO: support push down filter
- * 3. Super TODO: support store offheap object directly
+ *   1. This serializer supports column pruning 2. TODO: support push down filter 3. Super TODO:
+ *      support store offheap object directly
  *
  * The data transformation pipeline:
  *
  *   - Serializer ColumnarBatch -> CachedColumnarBatch
- *     -> serialize to byte[]
+ * -> serialize to byte[]
  *
  *   - Deserializer CachedColumnarBatch -> ColumnarBatch
- *     -> deserialize to byte[] to create Velox ColumnarBatch
+ * -> deserialize to byte[] to create Velox ColumnarBatch
  *
  *   - Serializer InternalRow -> CachedColumnarBatch (support RowToColumnar)
- *     -> Convert InternalRow to ColumnarBatch
- *     -> Serializer ColumnarBatch -> CachedColumnarBatch
+ * -> Convert InternalRow to ColumnarBatch
+ * -> Serializer ColumnarBatch -> CachedColumnarBatch
  *
  *   - Serializer InternalRow -> DefaultCachedBatch (unsupport RowToColumnar)
- *     -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
+ * -> Convert InternalRow to DefaultCachedBatch using vanilla Spark serializer
  *
  *   - Deserializer CachedColumnarBatch -> InternalRow (support ColumnarToRow)
- *     -> Deserializer CachedColumnarBatch -> ColumnarBatch
- *     -> Convert ColumnarBatch to InternalRow
+ * -> Deserializer CachedColumnarBatch -> ColumnarBatch
+ * -> Convert ColumnarBatch to InternalRow
  *
  *   - Deserializer DefaultCachedBatch -> InternalRow (unsupport ColumnarToRow)
- *     -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
+ * -> Convert DefaultCachedBatch to InternalRow using vanilla Spark serializer
  */
 // spotless:on
 class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHelper with Logging {
@@ -91,7 +89,7 @@ class ColumnarCachedBatchSerializer extends CachedBatchSerializer with SQLConfHe
   }
 
   private def validateSchema(schema: StructType): Boolean = {
-    val reason = new ValidatorApiImpl().doSchemaValidate(schema)
+    val reason = BackendsApiManager.getValidatorApiInstance.doSchemaValidate(schema)
     if (reason.isDefined) {
       logInfo(s"Columnar cache does not support schema $schema, due to ${reason.get}")
       false

--- a/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -293,7 +293,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataFrameImplicitsSuite]
   enableSuite[GlutenGeneratorFunctionSuite]
   enableSuite[GlutenDataFrameTimeWindowingSuite]
-    .exclude("time window joins") // FIXME hongze
   enableSuite[GlutenDataFrameSessionWindowingSuite]
   enableSuite[GlutenBroadcastExchangeSuite]
   enableSuite[GlutenDataFramePivotSuite]

--- a/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -998,7 +998,6 @@ class VeloxTestSettings extends BackendTestSettings {
       "SPARK-9083: sort with non-deterministic expressions"
     )
   enableSuite[GlutenDataFrameTimeWindowingSuite]
-    .exclude("time window joins") // FIXME hongze
   enableSuite[GlutenDataFrameTungstenSuite]
   enableSuite[GlutenDataFrameWindowFramesSuite]
     // Local window fixes are not added.

--- a/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/io/glutenproject/utils/velox/VeloxTestSettings.scala
@@ -1001,7 +1001,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // test for sort node not present but gluten uses shuffle hash join
     .exclude("SPARK-41048: Improve output partitioning and ordering with AQE cache")
   enableSuite[GlutenDataFrameTimeWindowingSuite]
-    .exclude("time window joins") // FIXME hongze
   enableSuite[GlutenDataFrameTungstenSuite]
   enableSuite[GlutenDataFrameWindowFramesSuite]
     // Local window fixes are not added.


### PR DESCRIPTION
Follows https://github.com/oap-project/gluten/pull/4544#discussion_r1470601260 in https://github.com/oap-project/gluten/pull/4544, fix the following error thrown in Spark UT:

```
Input schema contains unsupported type when convert row to columnar for StructType(StructField(window,StructType(StructField(start,TimestampNTZType,true),StructField(end,TimestampNTZType,true)),false),StructField(othervalue,IntegerType,false)) due to do not support data type: TimestampNTZType
java.lang.UnsupportedOperationException: Input schema contains unsupported type when convert row to columnar for StructType(StructField(window,StructType(StructField(start,TimestampNTZType,true),StructField(end,TimestampNTZType,true)),false),StructField(othervalue,IntegerType,false)) due to do not support data type: TimestampNTZType
	at io.glutenproject.execution.RowToVeloxColumnarExec.$anonfun$doExecuteColumnarInternal$1(RowToVeloxColumnarExec.scala:52)
	at scala.Option.foreach(Option.scala:407)
	at io.glutenproject.execution.RowToVeloxColumnarExec.doExecuteColumnarInternal(RowToVeloxColumnarExec.scala:49)
	at io.glutenproject.execution.RowToColumnarExecBase.doExecuteColumnar(RowToColumnarExecBase.scala:62)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeColumnar$1(SparkPlan.scala:221)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:232)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:229)
	at org.apache.spark.sql.execution.SparkPlan.executeColumnar(SparkPlan.scala:217)
	at io.glutenproject.backendsapi.velox.SparkPlanExecApiImpl.createBroadcastRelation(SparkPlanExecApiImpl.scala:332)
	at org.apache.spark.sql.execution.ColumnarBroadcastExchangeExec.$anonfun$relationFuture$2(ColumnarBroadcastExchangeExec.scala:79)
	at io.glutenproject.utils.Arm$.withResource(Arm.scala:25)
	at io.glutenproject.metrics.GlutenTimeMetric$.millis(GlutenTimeMetric.scala:37)
	at org.apache.spark.sql.execution.ColumnarBroadcastExchangeExec.$anonfun$relationFuture$1(ColumnarBroadcastExchangeExec.scala:69)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withThreadLocalCaptured$1(SQLExecution.scala:191)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```