### PR TITLE
[VL] Move RewriteMultiChildrenCount Rule before AddTransformHintRule

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -785,12 +785,12 @@ case class ColumnarOverrideRules(session: SparkSession)
       (spark: SparkSession) => FallbackMultiCodegens(spark),
       (spark: SparkSession) => PlanOneRowRelation(spark),
       (_: SparkSession) => FallbackEmptySchemaRelation(),
+      (_: SparkSession) => RewriteMultiChildrenCount,
       (spark: SparkSession) => PullOutPreProject(spark)
     ) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarValidationRules() :::
       List(
         (_: SparkSession) => AddTransformHintRule(),
-        (_: SparkSession) => RewriteMultiChildrenCount,
         (_: SparkSession) => FallbackBloomFilterAggIfNeeded(),
         (_: SparkSession) => TransformPreOverrides(isAdaptiveContext),
         (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/RewriteMultiChildrenCount.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/RewriteMultiChildrenCount.scala
@@ -18,7 +18,6 @@ package io.glutenproject.extension
 
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution.HashAggregateExecTransformerUtil._
-import io.glutenproject.extension.columnar.TransformHints
 
 import org.apache.spark.sql.catalyst.expressions.{If, IsNull, Literal, Or}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Count, Partial}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension.columnar
 import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.execution._
-import io.glutenproject.extension.{GlutenPlan, RewriteMultiChildrenCount, ValidationResult}
+import io.glutenproject.extension.{GlutenPlan, ValidationResult}
 import io.glutenproject.extension.columnar.TransformHints.EncodeTransformableTagImplicits
 import io.glutenproject.sql.shims.SparkShimLoader
 import io.glutenproject.utils.PhysicalPlanSelector

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -456,16 +456,15 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar HashAggregate is not enabled in HashAggregateExec")
           } else {
-            val rewrittenAgg = RewriteMultiChildrenCount.applyForValidation(plan)
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
-                rewrittenAgg.requiredChildDistributionExpressions,
-                rewrittenAgg.groupingExpressions,
-                rewrittenAgg.aggregateExpressions,
-                rewrittenAgg.aggregateAttributes,
-                rewrittenAgg.initialInputBufferOffset,
-                rewrittenAgg.resultExpressions,
-                rewrittenAgg.child
+                plan.requiredChildDistributionExpressions,
+                plan.groupingExpressions,
+                plan.aggregateExpressions,
+                plan.aggregateAttributes,
+                plan.initialInputBufferOffset,
+                plan.resultExpressions,
+                plan.child
               )
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
@@ -477,16 +476,15 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar HashAgg is not enabled in SortAggregateExec")
           } else {
-            val rewrittenAgg = RewriteMultiChildrenCount.applyForValidation(plan)
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
-                rewrittenAgg.requiredChildDistributionExpressions,
-                rewrittenAgg.groupingExpressions,
-                rewrittenAgg.aggregateExpressions,
-                rewrittenAgg.aggregateAttributes,
-                rewrittenAgg.initialInputBufferOffset,
-                rewrittenAgg.resultExpressions,
-                rewrittenAgg.child
+                plan.requiredChildDistributionExpressions,
+                plan.groupingExpressions,
+                plan.aggregateExpressions,
+                plan.aggregateAttributes,
+                plan.initialInputBufferOffset,
+                plan.resultExpressions,
+                plan.child
               )
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }
@@ -496,16 +494,15 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar HashAgg is not enabled in ObjectHashAggregateExec")
           } else {
-            val rewrittenAgg = RewriteMultiChildrenCount.applyForValidation(plan)
             val transformer = BackendsApiManager.getSparkPlanExecApiInstance
               .genHashAggregateExecTransformer(
-                rewrittenAgg.requiredChildDistributionExpressions,
-                rewrittenAgg.groupingExpressions,
-                rewrittenAgg.aggregateExpressions,
-                rewrittenAgg.aggregateAttributes,
-                rewrittenAgg.initialInputBufferOffset,
-                rewrittenAgg.resultExpressions,
-                rewrittenAgg.child
+                plan.requiredChildDistributionExpressions,
+                plan.groupingExpressions,
+                plan.aggregateExpressions,
+                plan.aggregateAttributes,
+                plan.initialInputBufferOffset,
+                plan.resultExpressions,
+                plan.child
               )
             TransformHints.tag(plan, transformer.doValidate().toTransformHint)
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because `RewriteMultiChildrenCount` Rule will create new `Expression` in aggregation that needs to be pull out, we should move this rule before `AddTransformHintRule`, so that we could pull out pre/post-project before `AddTransformHintRule`.

## How was this patch tested?

Exists CI in `TestOperator`.

