### PR TITLE
[CORE] Remove a redundant is-adaptive check

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -388,7 +388,7 @@ object FilterHandler extends PredicateHelper {
 
   // Separate and compare the filter conditions in Scan and Filter.
   // Try to push down the remaining conditions in Filter into Scan.
-  def applyFilterPushdownToScan(filter: FilterExec, reuseSubquery: Boolean): SparkPlan =
+  def applyFilterPushdownToScan(filter: FilterExec): SparkPlan =
     filter.child match {
       case fileSourceScan: FileSourceScanExec =>
         val pushDownFilters =
@@ -397,7 +397,6 @@ object FilterHandler extends PredicateHelper {
             fileSourceScan)
         ScanTransformerFactory.createFileSourceScanTransformer(
           fileSourceScan,
-          reuseSubquery,
           allPushDownFilters = Some(pushDownFilters))
       case batchScan: BatchScanExec =>
         val pushDownFilters =
@@ -406,7 +405,6 @@ object FilterHandler extends PredicateHelper {
             batchScan)
         ScanTransformerFactory.createBatchScanTransformer(
           batchScan,
-          reuseSubquery,
           allPushDownFilters = Some(pushDownFilters))
       case other =>
         throw new UnsupportedOperationException(s"${other.getClass.toString} is not supported.")

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
@@ -95,7 +95,6 @@ object ScanTransformerFactory {
 
   def createBatchScanTransformer(
       batchScan: BatchScanExec,
-      reuseSubquery: Boolean,
       allPushDownFilters: Option[Seq[Expression]] = None,
       validation: Boolean = false): SparkPlan = {
     if (supportedBatchScan(batchScan.scan)) {
@@ -104,7 +103,7 @@ object ScanTransformerFactory {
         // during the validation process.
         batchScan.runtimeFilters
       } else {
-        ExpressionConverter.transformDynamicPruningExpr(batchScan.runtimeFilters, reuseSubquery)
+        ExpressionConverter.transformDynamicPruningExpr(batchScan.runtimeFilters)
       }
       val transformer = lookupBatchScanTransformer(batchScan, newPartitionFilters)
       if (!validation && allPushDownFilters.isDefined) {
@@ -128,7 +127,7 @@ object ScanTransformerFactory {
       // If filter expressions aren't empty, we need to transform the inner operators,
       // and fallback the BatchScanExec itself.
       val newSource = batchScan.copy(runtimeFilters = ExpressionConverter
-        .transformDynamicPruningExpr(batchScan.runtimeFilters, reuseSubquery))
+        .transformDynamicPruningExpr(batchScan.runtimeFilters))
       TransformHints.tagNotTransformable(newSource, "The scan in BatchScanExec is not supported.")
       newSource
     }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/ScanTransformerFactory.scala
@@ -36,14 +36,13 @@ object ScanTransformerFactory {
 
   def createFileSourceScanTransformer(
       scanExec: FileSourceScanExec,
-      reuseSubquery: Boolean,
       allPushDownFilters: Option[Seq[Expression]] = None,
       validation: Boolean = false): FileSourceScanExecTransformer = {
     // transform BroadcastExchangeExec to ColumnarBroadcastExchangeExec in partitionFilters
     val newPartitionFilters = if (validation) {
       scanExec.partitionFilters
     } else {
-      ExpressionConverter.transformDynamicPruningExpr(scanExec.partitionFilters, reuseSubquery)
+      ExpressionConverter.transformDynamicPruningExpr(scanExec.partitionFilters)
     }
     val fileFormat = scanExec.relation.fileFormat
     lookupDataSourceScanTransformer(fileFormat.getClass.getName) match {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -527,9 +527,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
    * @return
    *   Transformed partition filter
    */
-  def transformDynamicPruningExpr(
-      partitionFilters: Seq[Expression],
-      reuseSubquery: Boolean): Seq[Expression] = {
+  def transformDynamicPruningExpr(partitionFilters: Seq[Expression]): Seq[Expression] = {
 
     def convertBroadcastExchangeToColumnar(
         exchange: BroadcastExchangeExec): ColumnarBroadcastExchangeExec = {
@@ -588,7 +586,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
                   // the AdaptiveSparkPlanExec.AdaptiveExecutionContext to hold the reused map
                   // for each query.
                   newIn.child match {
-                    case a: AdaptiveSparkPlanExec if reuseSubquery =>
+                    case a: AdaptiveSparkPlanExec if SQLConf.get.subqueryReuseEnabled =>
                       // When AQE is on and reuseSubquery is on.
                       a.context.subqueryCache
                         .update(newIn.canonicalized, transformSubqueryBroadcast)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -547,7 +547,7 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
    */
   def applyScanTransformer(plan: SparkPlan): SparkPlan = plan match {
     case plan: FileSourceScanExec =>
-      val transformer = ScanTransformerFactory.createFileSourceScanTransformer(plan, reuseSubquery)
+      val transformer = ScanTransformerFactory.createFileSourceScanTransformer(plan)
       val validationResult = transformer.doValidate()
       if (validationResult.isValid) {
         logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
@@ -559,13 +559,12 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
         newSource
       }
     case plan: BatchScanExec =>
-      ScanTransformerFactory.createBatchScanTransformer(plan, reuseSubquery)
+      ScanTransformerFactory.createBatchScanTransformer(plan)
 
     case plan if HiveTableScanExecTransformer.isHiveTableScan(plan) =>
       // TODO: Add DynamicPartitionPruningHiveScanSuite.scala
       val newPartitionFilters: Seq[Expression] = ExpressionConverter.transformDynamicPruningExpr(
-        HiveTableScanExecTransformer.getPartitionFilters(plan),
-        reuseSubquery)
+        HiveTableScanExecTransformer.getPartitionFilters(plan))
       val hiveTableScanExecTransformer =
         BackendsApiManager.getSparkPlanExecApiInstance.genHiveTableScanExecTransformer(plan)
       val validateResult = hiveTableScanExecTransformer.doValidate()

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -399,7 +399,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
             } else {
               val transformer =
                 ScanTransformerFactory
-                  .createBatchScanTransformer(plan, reuseSubquery = false, validation = true)
+                  .createBatchScanTransformer(plan, validation = true)
                   .asInstanceOf[BatchScanExecTransformer]
               TransformHints.tag(plan, transformer.doValidate().toTransformHint)
             }
@@ -415,10 +415,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               TransformHints.tagTransformable(plan)
             } else {
               val transformer =
-                ScanTransformerFactory.createFileSourceScanTransformer(
-                  plan,
-                  reuseSubquery = false,
-                  validation = true)
+                ScanTransformerFactory.createFileSourceScanTransformer(plan, validation = true)
               TransformHints.tag(plan, transformer.doValidate().toTransformHint)
             }
           }


### PR DESCRIPTION
We have a check on `isAdaptive` when replacing reusable (broadcast) sub-queries in the case of AQE is on.

```scala
case a: AdaptiveSparkPlanExec if (isAdaptiveContext && conf.subqueryReuseEnabled) =>
  // cache the subquery
```

It's an attempt to replace the code with

```scala
case a: AdaptiveSparkPlanExec if (conf.subqueryReuseEnabled) =>
  // cache the subquery
```

Since ideally `case a: AdaptiveSparkPlanExec` should imply `isAdaptiveContext == true`.


Related to https://github.com/oap-project/gluten/pull/1851