### PR TITLE
[CORE] Move PullOutPreProject after AddTransformHintRule

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -783,13 +783,13 @@ case class ColumnarOverrideRules(session: SparkSession)
       (spark: SparkSession) => FallbackOnANSIMode(spark),
       (spark: SparkSession) => FallbackMultiCodegens(spark),
       (spark: SparkSession) => PlanOneRowRelation(spark),
-      (_: SparkSession) => FallbackEmptySchemaRelation(),
-      (spark: SparkSession) => PullOutPreProject(spark)
+      (_: SparkSession) => FallbackEmptySchemaRelation()
     ) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarValidationRules() :::
       List(
         (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => RewriteMultiChildrenCount,
+        (_: SparkSession) => PullOutPreProject,
         (_: SparkSession) => FallbackBloomFilterAggIfNeeded(),
         (_: SparkSession) => TransformPreOverrides(isAdaptiveContext),
         (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -790,6 +790,8 @@ case class ColumnarOverrideRules(session: SparkSession)
         (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => RewriteMultiChildrenCount,
         (_: SparkSession) => PullOutPreProject,
+        // Apply AddTransformHintRule again for pulled-out project.
+        (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => FallbackBloomFilterAggIfNeeded(),
         (_: SparkSession) => TransformPreOverrides(isAdaptiveContext),
         (_: SparkSession) => RemoveNativeWriteFilesSortAndProject(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala
@@ -80,7 +80,9 @@ object PullOutPreProject extends Rule[SparkPlan] with PullOutProjectHelper {
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
-    AddTransformHintRule().apply(plan.transform(applyLocally))
+    val transformedPlan = plan.transform(applyLocally)
+    TransformHints.untag(transformedPlan)
+    AddTransformHintRule().apply(transformedPlan)
   }
 
   def applyForValidation[T <: SparkPlan](plan: T): T =

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -699,7 +699,8 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               "columnar topK is not enabled in TakeOrderedAndProjectExec")
           } else {
             val rewrittenTopK = PullOutPreProject.applyForValidation(plan)
-            val (limit, offset) = SparkShimLoader.getSparkShims.getLimitAndOffsetFromTopK(rewrittenTopK)
+            val (limit, offset) =
+              SparkShimLoader.getSparkShims.getLimitAndOffsetFromTopK(rewrittenTopK)
             val transformer = TakeOrderedAndProjectExecTransformer(
               limit,
               rewrittenTopK.sortOrder,

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -19,6 +19,7 @@ package io.glutenproject.utils
 import io.glutenproject.extension.columnar.TransformHints
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution.SparkPlan
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -26,6 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 
 trait PullOutProjectHelper {
+
+  // A tag set in post-project, used to prevent the transform method from calling copyTagsFrom.
+  val PULLOUT_PROJECT_TAG = TreeNodeTag[Boolean]("io.glutenproject.pulloutproject")
 
   private val generatedNameIndex = new AtomicInteger(0)
 

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -19,7 +19,6 @@ package io.glutenproject.utils
 import io.glutenproject.extension.columnar.TransformHints
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.execution.SparkPlan
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -27,9 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 
 trait PullOutProjectHelper {
-
-  // A tag set in post-project, used to prevent the transform method from calling copyTagsFrom.
-  val PULLOUT_PROJECT_TAG = TreeNodeTag[Boolean]("io.glutenproject.pulloutproject")
 
   private val generatedNameIndex = new AtomicInteger(0)
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
@@ -44,9 +44,8 @@ trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
       return plan.execute()
     }
 
-    val pulledOutPlan = PullOutPreProject(plan.session)(plan)
-    val transformed =
-      TransformPreOverrides(false).apply(AddTransformHintRule().apply(pulledOutPlan))
+    val transformed = TransformPreOverrides(false).apply(
+      PullOutPreProject.apply(AddTransformHintRule().apply(plan)))
     if (!transformed.isInstanceOf[TransformSupport]) {
       throw new IllegalStateException(
         "Cannot transform the SparkPlans wrapped by FileFormatWriter, " +

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
@@ -44,8 +44,13 @@ trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
       return plan.execute()
     }
 
-    val transformed = TransformPreOverrides(false).apply(
-      PullOutPreProject.apply(AddTransformHintRule().apply(plan)))
+    val rules = List(
+      AddTransformHintRule(),
+      PullOutPreProject,
+      AddTransformHintRule(),
+      TransformPreOverrides(false)
+    )
+    val transformed = rules.foldLeft(plan) { case (latestPlan, rule) => rule.apply(latestPlan) }
     if (!transformed.isInstanceOf[TransformSupport]) {
       throw new IllegalStateException(
         "Cannot transform the SparkPlans wrapped by FileFormatWriter, " +


### PR DESCRIPTION
## What changes were proposed in this pull request?
It is a better choice to modify the `SparkPlan` only when `SparkPlan` itself supports execution by Gluten, so that the fallback `SparkPlan` remains unchanged.

For agg, we found that there are some corner cases that cannot be executed correctly when codegen is enabled after pulling out the project, therefore, we will put the pulling out process after `AddTransformHintRule`, perform the validation process first, and then pull out the `SparkPlan` that has passed validation.

## How was this patch tested?

Exists CI.

