### PR TITLE
[CORE] Untangle C2R / R2C transforming code

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCDSSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxTPCDSSuite.scala
@@ -55,7 +55,7 @@ class VeloxTPCDSSuite extends VeloxWholeStageTransformerSuite {
       .set("spark.sql.autoBroadcastJoinThreshold", "10M")
       .set("spark.driver.maxResultSize", "4g")
       .set("spark.sql.sources.useV1SourceList", "avro")
-      .set("park.sql.adaptive.enabled", "true")
+      .set("spark.sql.adaptive.enabled", "true")
       .set("spark.gluten.sql.columnar.maxBatchSize", "4096")
       .set("spark.gluten.shuffleWriter.bufferSize", "4096")
       .set("spark.executor.memory", "4g")

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -593,68 +593,22 @@ case class TransformPreOverrides(isAdaptiveContext: Boolean)
 
 // This rule will try to convert the row-to-columnar and columnar-to-row
 // into native implementations.
-case class TransformPostOverrides(isAdaptiveContext: Boolean) extends Rule[SparkPlan] {
+case class TransformPostOverrides() extends Rule[SparkPlan] {
   val columnarConf: GlutenConfig = GlutenConfig.getConf
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
-  def transformColumnarToRowExec(plan: ColumnarToRowExec): SparkPlan = {
-    if (columnarConf.enableNativeColumnarToRow) {
-      val child = replaceWithTransformerPlan(plan.child)
-
-      if (!PlanUtil.outputNativeColumnarData(child)) {
-        TransformHints.tagNotTransformable(plan, "child is not gluten plan")
-        plan.withNewChildren(plan.children.map(replaceWithTransformerPlan))
-      } else {
-        logDebug(s"ColumnarPostOverrides ColumnarToRowExecBase(${child.nodeName})")
-        val nativeConversion =
-          BackendsApiManager.getSparkPlanExecApiInstance.genColumnarToRowExec(child)
-        val validationResult = nativeConversion.doValidate()
-        if (validationResult.isValid) {
-          nativeConversion
-        } else {
-          TransformHints.tagNotTransformable(plan, validationResult)
-          plan.withNewChildren(plan.children.map(replaceWithTransformerPlan))
-        }
-      }
-    } else {
-      plan.withNewChildren(plan.children.map(replaceWithTransformerPlan))
-    }
-  }
-
-  def replaceWithTransformerPlan(plan: SparkPlan): SparkPlan = plan match {
-    case plan: RowToColumnarExec =>
-      val child = replaceWithTransformerPlan(plan.child)
+  def replaceWithTransformerPlan(plan: SparkPlan): SparkPlan = plan.transformDown {
+    case RowToColumnarExec(child) =>
       logDebug(s"ColumnarPostOverrides RowToColumnarExec(${child.getClass})")
       BackendsApiManager.getSparkPlanExecApiInstance.genRowToColumnarExec(child)
-    // The ColumnarShuffleExchangeExec node may be the top node, so we cannot remove it.
-    // e.g. select /* REPARTITION */ from testData, and the AQE create shuffle stage will check
-    // if the transformed is instance of ShuffleExchangeLike, so we need to remove it in AQE
-    // mode have tested gluten-it TPCH when AQE OFF
-    case ColumnarToRowExec(child: ColumnarShuffleExchangeExec) if isAdaptiveContext =>
-      replaceWithTransformerPlan(child)
-    case ColumnarToRowExec(child: ColumnarBroadcastExchangeExec) =>
-      replaceWithTransformerPlan(child)
-    case ColumnarToRowExec(child: BroadcastQueryStageExec) =>
-      replaceWithTransformerPlan(child)
-    // `InMemoryTableScanExec` internally supports ColumnarToRow
-    case ColumnarToRowExec(child: SparkPlan) if PlanUtil.isGlutenTableCache(child) =>
-      child
-    case plan: ColumnarToRowExec =>
-      transformColumnarToRowExec(plan)
-    case r: SparkPlan
-        if !r.isInstanceOf[QueryStageExec] && !r.supportsColumnar &&
-          r.children.exists(_.isInstanceOf[ColumnarToRowExec]) =>
-      // This is a fix for when DPP and AQE both enabled,
-      // ColumnarExchange maybe child as a Row SparkPlan
-      r.withNewChildren(r.children.map {
-        // `InMemoryTableScanExec` internally supports ColumnarToRow
-        case c: ColumnarToRowExec if !PlanUtil.isGlutenTableCache(c.child) =>
-          transformColumnarToRowExec(c)
-        case other =>
-          replaceWithTransformerPlan(other)
-      })
-    case p =>
-      p.withNewChildren(p.children.map(replaceWithTransformerPlan))
+    case c2r @ ColumnarToRowExec(child) if PlanUtil.outputNativeColumnarData(child) =>
+      logDebug(s"ColumnarPostOverrides ColumnarToRowExec(${child.getClass})")
+      val nativeC2r = BackendsApiManager.getSparkPlanExecApiInstance.genColumnarToRowExec(child)
+      if (nativeC2r.doValidate().isValid) {
+        nativeC2r
+      } else {
+        c2r
+      }
   }
 
   // apply for the physical not final plan
@@ -665,6 +619,52 @@ case class TransformPostOverrides(isAdaptiveContext: Boolean) extends Rule[Spark
   }
 }
 
+// Remove topmost columnar-to-row otherwise AQE throws error.
+// See: org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec#newQueryStage
+//
+// The rule is basically a workaround because of the limited compatibility between Spark's AQE
+// and columnar API.
+case class RemoveTopmostColumnarToRow(session: SparkSession, isAdaptiveContext: Boolean)
+  extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!isAdaptiveContext) {
+      // The rule only applies in AQE. If AQE is off the topmost C2R will be strictly required
+      // by Spark.
+      return plan
+    }
+    plan match {
+      // See: org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec#newQueryStage
+      case ColumnarToRowLike(child: ShuffleExchangeLike) => child
+      case ColumnarToRowLike(child: BroadcastExchangeLike) => child
+      // See: org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec#getFinalPhysicalPlan
+      //  BroadQueryStageExec could be inside a C2R which may cause check failures. E.g.,
+      //  org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec#doExecuteBroadcast
+      // Note: To avoid the similar issue with AQE=off, we don't remove the C2R on
+      //  ShuffleQueryStageExec. Also there is not check like the one for BroadcastQueryStageExec
+      //  so it's safe to keep it.
+      case ColumnarToRowLike(child: BroadcastQueryStageExec) => child
+      case other => other
+    }
+  }
+}
+
+// `InMemoryTableScanExec` internally supports ColumnarToRow.
+case class RemoveGlutenTableCacheColumnarToRow(session: SparkSession) extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = plan.transformDown {
+    case ColumnarToRowLike(child) if PlanUtil.isGlutenTableCache(child) =>
+      child
+  }
+}
+
+private[extension] object ColumnarToRowLike {
+  def unapply(plan: SparkPlan): Option[SparkPlan] = {
+    plan match {
+      case c2r: ColumnarToRowTransition =>
+        Some(c2r.child)
+      case _ => None
+    }
+  }
+}
 // This rule will try to add RowToColumnarExecBase and ColumnarToRowExec
 // to support vanilla columnar operators.
 case class VanillaColumnarPlanOverrides(session: SparkSession) extends Rule[SparkPlan] {
@@ -811,8 +811,9 @@ case class ColumnarOverrideRules(session: SparkSession)
 
   private def postOverrides(): List[SparkSession => Rule[SparkPlan]] =
     List(
-      (_: SparkSession) => TransformPostOverrides(isAdaptiveContext),
-      (s: SparkSession) => VanillaColumnarPlanOverrides(s)
+      (_: SparkSession) => TransformPostOverrides(),
+      (s: SparkSession) => VanillaColumnarPlanOverrides(s),
+      (s: SparkSession) => RemoveTopmostColumnarToRow(s, isAdaptiveContext)
     ) :::
       BackendsApiManager.getSparkPlanExecApiInstance.genExtendedColumnarPostRules() :::
       List((_: SparkSession) => ColumnarCollapseTransformStages(GlutenConfig.getConf)) :::
@@ -820,6 +821,10 @@ case class ColumnarOverrideRules(session: SparkSession)
 
   private def finallyRules(): List[SparkSession => Rule[SparkPlan]] = {
     List(
+      // The rule is required despite whether the stage is fallen back or not. Since
+      // ColumnarCachedBatchSerializer is statically registered to Spark without a columnar rule
+      // when columnar table cache is enabled.
+      (s: SparkSession) => RemoveGlutenTableCacheColumnarToRow(s),
       (s: SparkSession) => GlutenFallbackReporter(GlutenConfig.getConf, s),
       (_: SparkSession) => RemoveTransformHintRule()
     )

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -24,11 +24,14 @@ import io.glutenproject.substrait.SubstraitContext
 import io.glutenproject.substrait.rel.RelBuilder
 
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -40,9 +43,7 @@ import scala.collection.JavaConverters._
  * would be transformed to `ValueStreamNode` at native side.
  */
 case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupport {
-  // `InputAdapter` is a case class, so `ColumnarInputAdapter.withNewChildren()` will return
-  // `InputAdapter`.
-  assert(child.isInstanceOf[InputAdapter])
+  assert(child.isInstanceOf[ColumnarInputAdapter])
 
   @transient
   override lazy val metrics: Map[String, SQLMetric] =
@@ -72,17 +73,6 @@ case class InputIteratorTransformer(child: SparkPlan) extends UnaryTransformSupp
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan = {
     copy(child = newChild)
   }
-}
-
-/**
- * InputAdapter is used to hide a SparkPlan from a subtree that supports transform. Note, if we
- * remove this adaptor, the SQL UI graph would be broken.
- */
-class ColumnarInputAdapter(child: SparkPlan) extends InputAdapter(child) {
-  // this is the most important effect of this class
-  override def supportCodegen: Boolean = false
-
-  override def nodeName: String = s"InputAdapter"
 }
 
 /**
@@ -168,10 +158,27 @@ case class ColumnarCollapseTransformStages(
   }
 }
 
+case class ColumnarInputAdapter(child: SparkPlan) extends UnaryExecNode {
+  override def output: Seq[Attribute] = child.output
+  override def supportsColumnar: Boolean = child.supportsColumnar
+  override protected def doExecute(): RDD[InternalRow] =
+    child.execute()
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child.executeColumnar()
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+  override def vectorTypes: Option[Seq[String]] = child.vectorTypes
+  override protected[sql] def doExecuteBroadcast[T](): Broadcast[T] = child.executeBroadcast()
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+  // Node name's required to be "InputAdapter" to correctly draw UI graph.
+  // See buildSparkPlanGraphNode in SparkPlanGraph.scala of Spark.
+  override def nodeName: String = s"InputAdapter"
+}
+
 object ColumnarCollapseTransformStages {
   val transformStageCounter = new AtomicInteger(0)
 
   def wrapInputIteratorTransformer(plan: SparkPlan): TransformSupport = {
-    InputIteratorTransformer(new ColumnarInputAdapter(plan))
+    InputIteratorTransformer(ColumnarInputAdapter(plan))
   }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -85,6 +85,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
         case _: WholeStageCodegenExec =>
         case _: WholeStageTransformer =>
         case _: InputAdapter =>
+        case _: ColumnarInputAdapter =>
         case _: InputIteratorTransformer =>
         case _: ColumnarToRowTransition =>
         case _: RowToColumnarTransition =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -108,6 +108,7 @@ object GlutenImplicits {
           case _: WholeStageCodegenExec =>
           case _: WholeStageTransformer =>
           case _: InputAdapter =>
+          case _: ColumnarInputAdapter =>
           case _: InputIteratorTransformer =>
           case _: ColumnarToRowTransition =>
           case _: RowToColumnarTransition =>


### PR DESCRIPTION
This patch reworks `TransformPostOverrides` which converts C2R / R2C to native version to simplify code. Will pull out 2 rules from `TransformPostOverrides`:

 * RemoveTopmostColumnarToRow
 * RemoveGlutenTableCacheColumnarToRow

Current UTs should be able to cover the change:
1. GlutenFallbackSuite
2. VeloxAdaptiveQueryExecSuite
3. VeloxColumnarCacheSuite