### PR TITLE
[GLUTEN-3582][CH] Remove Not Support PushDownFilters

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/PushDownUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/utils/PushDownUtil.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.utils
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, SparkToParquetSchemaConverter}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
+import org.apache.spark.sql.sources
+import org.apache.spark.sql.types.StructType
+
+import org.apache.parquet.schema.MessageType
+
+object PushDownUtil {
+  private def createParquetFilters(
+      conf: SQLConf,
+      schema: MessageType,
+      caseSensitive: Option[Boolean] = None,
+      datetimeRebaseSpec: RebaseSpec = RebaseSpec(LegacyBehaviorPolicy.CORRECTED)
+  ): ParquetFilters =
+    new ParquetFilters(
+      schema,
+      conf.parquetFilterPushDownDate,
+      conf.parquetFilterPushDownTimestamp,
+      conf.parquetFilterPushDownDecimal,
+      conf.parquetFilterPushDownStringStartWith,
+      conf.parquetFilterPushDownInFilterThreshold,
+      caseSensitive.getOrElse(conf.caseSensitiveAnalysis),
+      datetimeRebaseSpec
+    )
+
+  def removeNotSupportPushDownFilters(
+      conf: SQLConf,
+      output: Seq[Attribute],
+      dataFilters: Seq[Expression]
+  ): Seq[Expression] = {
+    val schema = new SparkToParquetSchemaConverter(conf).convert(StructType.fromAttributes(output))
+    val parquetFilters = createParquetFilters(conf, schema)
+
+    dataFilters
+      .flatMap {
+        sparkFilter =>
+          DataSourceStrategy.translateFilter(
+            sparkFilter,
+            supportNestedPredicatePushdown = true) match {
+            case Some(sources.StringStartsWith(_, _)) => None
+            case Some(sources.Not(sources.In(_, _) | sources.StringStartsWith(_, _))) => None
+            case Some(sourceFilter) => Some((sparkFilter, sourceFilter))
+            case _ => None
+          }
+      }
+      .flatMap {
+        case (sparkFilter, sourceFilter) =>
+          parquetFilters.createFilter(sourceFilter) match {
+            case Some(_) => Some(sparkFilter)
+            case None => None
+          }
+      }
+  }
+}

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHAbstractSuite.scala
@@ -626,10 +626,11 @@ abstract class GlutenClickHouseTPCHAbstractSuite
       compareResult: Boolean = true,
       noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit = withDataFrame(sqlStr) {
     df =>
-      if (compareResult)
+      if (compareResult) {
         verifyTPCHResult(df, s"q${"%02d".format(queryNum)}", queriesResults)
-      else
+      } else {
         df.collect()
+      }
       checkDataFrame(noFallBack, customCheck, df)
   }
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQEConcurrentSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetAQEConcurrentSuite.scala
@@ -21,14 +21,9 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.types.DoubleType
 
-import java.io.File
 import java.util.concurrent.ForkJoinPool
 
 import scala.collection.parallel.ForkJoinTaskSupport
-import scala.io.Source
-
-// Some sqls' line length exceeds 100
-// scalastyle:off line.size.limit
 
 class GlutenClickHouseTPCHParquetAQEConcurrentSuite
   extends GlutenClickHouseTPCHAbstractSuite
@@ -59,26 +54,26 @@ class GlutenClickHouseTPCHParquetAQEConcurrentSuite
       compareResult: Boolean = true,
       noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit = {
     val sqlNum = "q" + "%02d".format(queryNum)
-    val sqlFile = tpchQueries + "/" + sqlNum + ".sql"
-    val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString
-    val df = spark.sql(sqlStr)
-    val result = df.collect()
-    if (compareResult) {
-      val schema = df.schema
-      if (schema.exists(_.dataType == DoubleType)) {} else {
-        compareResultStr(sqlNum, result, queriesResults)
-      }
-    } else {
-      df.collect()
+    withDataFrame(tpchSQL(queryNum, tpchQueries)) {
+      df =>
+        val result = df.collect()
+        if (compareResult) {
+          val schema = df.schema
+          if (schema.exists(_.dataType == DoubleType)) {} else {
+            compareResultStr(sqlNum, result, queriesResults)
+          }
+        } else {
+          df.collect()
+        }
+        customCheck(df)
     }
-    customCheck(df)
   }
 
   override protected def createTPCHNotNullTables(): Unit = {
     createTPCHParquetTables(tablesPath)
   }
 
-  test("fix race condition at the global variable of isAdaptiveContext in ColumnarOverrideRules") {
+  test("fix race condition at the global variable of ColumnarOverrideRules::isAdaptiveContext") {
 
     val queries = ((1 to 22) ++ (1 to 22) ++ (1 to 22) ++ (1 to 22)).par
     queries.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(22))
@@ -87,4 +82,3 @@ class GlutenClickHouseTPCHParquetAQEConcurrentSuite
   }
 
 }
-// scalastyle:off line.size.limit

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseMetricsUTUtils.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseMetricsUTUtils.scala
@@ -81,13 +81,6 @@ object GlutenClickHouseMetricsUTUtils {
     nativeMetricsList.toSeq
   }
 
-  def getTPCHQueryExecution(spark: SparkSession, queryNum: Int, tpchQueries: String): DataFrame = {
-    val sqlNum = "q" + "%02d".format(queryNum)
-    val sqlFile = tpchQueries + "/" + sqlNum + ".sql"
-    val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString
-    spark.sql(sqlStr)
-  }
-
   def getTPCDSQueryExecution(
       spark: SparkSession,
       queryNum: String,

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/parquet/GlutenParquetFilterSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/parquet/GlutenParquetFilterSuite.scala
@@ -1,0 +1,482 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.gluten.parquet
+
+import io.glutenproject.execution.{FileSourceScanExecTransformer, GlutenClickHouseWholeStageTransformerSuite}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.expressions.{DslExpression, DslSymbol}
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.gluten.test.{GlutenSQLTestUtils, GlutenTPCHBase}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.Decimal
+
+import java.time.LocalDate
+
+class GlutenParquetFilterSuite
+  extends GlutenClickHouseWholeStageTransformerSuite
+  with GlutenSQLTestUtils
+  with GlutenTPCHBase
+  with Logging {
+
+  override protected val fileFormat: String = "parquet"
+  override protected val resourcePath: String = "--- path to tpch-data ---"
+  private val tpchQueriesResourceFolder: String =
+    rootPath + "../../../../gluten-core/src/test/resources/tpch-queries"
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED, false)
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD, -1L) // disable broadcast
+
+  private val result: Array[Map[String, Seq[Predicate]]] = Array(
+    Map( // q1
+      "lineitem0" -> Seq(
+        'l_shipdate.date.isNotNull,
+        'l_shipdate.date <= LocalDate.of(1998, 9, 1)
+      )),
+    Map( // q2
+      "part0" -> Seq(
+        'p_size.int.isNotNull,
+        'p_type.string.isNotNull,
+        'p_size.int === 15,
+        'p_partkey.long.isNotNull
+      ),
+      "partsupp1" -> Seq(
+        'ps_partkey.long.isNotNull,
+        'ps_suppkey.long.isNotNull,
+        'ps_supplycost.decimal(10, 0).isNotNull
+      ),
+      "partsupp2" -> Seq(
+        'ps_partkey.long.isNotNull,
+        'ps_suppkey.long.isNotNull
+      ),
+      "supplier3" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "nation4" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_regionkey.long.isNotNull
+      ),
+      "region5" -> Seq(
+        'r_name.string.isNotNull,
+        'r_name.string === "EUROPE",
+        'r_regionkey.long.isNotNull
+      ),
+      "supplier6" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "nation7" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_regionkey.long.isNotNull
+      )
+    ),
+    Map( // q3
+      "customer0" -> Seq(
+        'c_mktsegment.string.isNotNull,
+        'c_mktsegment.string === "BUILDING",
+        'c_custkey.long.isNotNull
+      ),
+      "orders1" -> Seq(
+        'o_orderkey.long.isNotNull,
+        'o_custkey.long.isNotNull,
+        'o_orderdate.date.isNotNull,
+        'o_orderdate.date < LocalDate.of(1995, 3, 15)
+      ),
+      "lineitem2" -> Seq(
+        'l_orderkey.long.isNotNull,
+        'l_shipdate.date.isNotNull,
+        'l_shipdate.date > LocalDate.of(1995, 3, 15)
+      )
+    ),
+    Map( // q4
+      "orders0" -> Seq(
+        'o_orderdate.date.isNotNull,
+        'o_orderdate.date >= LocalDate.of(1993, 7, 1),
+        'o_orderdate.date < LocalDate.of(1993, 10, 1)
+      ),
+      "lineitem1" -> Seq(
+        'l_commitdate.date.isNotNull,
+        'l_receiptdate.date.isNotNull
+      )
+    ),
+    Map( // q5
+      "customer0" -> Seq(
+        'c_custkey.long.isNotNull,
+        'c_nationkey.long.isNotNull
+      ),
+      "orders1" -> Seq(
+        'o_orderkey.long.isNotNull,
+        'o_custkey.long.isNotNull,
+        'o_orderdate.date.isNotNull,
+        'o_orderdate.date >= LocalDate.of(1994, 1, 1),
+        'o_orderdate.date < LocalDate.of(1995, 1, 1)
+      ),
+      "lineitem2" -> Seq(
+        'l_orderkey.long.isNotNull,
+        'l_suppkey.long.isNotNull
+      ),
+      "supplier3" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "nation4" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_regionkey.long.isNotNull
+      ),
+      "region5" -> Seq(
+        'r_name.string.isNotNull,
+        'r_name.string === "ASIA",
+        'r_regionkey.long.isNotNull
+      )
+    ),
+    Map( // q6
+      "lineitem0" -> Seq(
+        'l_shipdate.date.isNotNull,
+        'l_discount.decimal(10, 2).isNotNull,
+        'l_quantity.decimal(10, 0).isNotNull,
+        'l_shipdate.date >= LocalDate.of(1994, 1, 1),
+        'l_shipdate.date < LocalDate.of(1995, 1, 1),
+        'l_discount.decimal(10, 2) >= Decimal(BigDecimal(0.05), 10, 2),
+        'l_discount.decimal(10, 2) <= Decimal(BigDecimal(0.07), 10, 2),
+        'l_quantity.decimal(10, 0) < Decimal(24)
+      )),
+    Map( // q7
+      "supplier0" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "lineitem1" -> Seq(
+        'l_shipdate.date.isNotNull,
+        'l_shipdate.date >= LocalDate.of(1995, 1, 1),
+        'l_shipdate.date <= LocalDate.of(1996, 12, 31),
+        'l_suppkey.long.isNotNull,
+        'l_orderkey.long.isNotNull
+      ),
+      "orders2" -> Seq(
+        'o_orderkey.long.isNotNull,
+        'o_custkey.long.isNotNull
+      ),
+      "customer3" -> Seq(
+        'c_nationkey.long.isNotNull,
+        'c_custkey.long.isNotNull
+      ),
+      "nation4" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_name.string === "FRANCE" || 'n_name.string === "GERMANY"
+      )
+    ),
+    Map( // q8
+      "part0" -> Seq(
+        'p_partkey.long.isNotNull,
+        'p_type.string.isNotNull,
+        'p_type.string === "ECONOMY ANODIZED STEEL"
+      ),
+      "lineitem1" -> Seq(
+        'l_partkey.long.isNotNull,
+        'l_suppkey.long.isNotNull,
+        'l_orderkey.long.isNotNull
+      ),
+      "supplier2" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "orders3" -> Seq(
+        'o_orderkey.long.isNotNull,
+        'o_custkey.long.isNotNull,
+        'o_orderdate.date.isNotNull,
+        'o_orderdate.date >= LocalDate.of(1995, 1, 1),
+        'o_orderdate.date <= LocalDate.of(1996, 12, 31)
+      ),
+      "customer4" -> Seq(
+        'c_custkey.long.isNotNull,
+        'c_nationkey.long.isNotNull
+      ),
+      "nation5" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_regionkey.long.isNotNull
+      ),
+      "nation6" -> Seq(
+        'n_nationkey.long.isNotNull
+      ),
+      "region7" -> Seq(
+        'r_regionkey.long.isNotNull,
+        'r_name.string.isNotNull,
+        'r_name.string === "AMERICA"
+      )
+    ),
+    Map( // q9
+      "part0" -> Seq(
+        'p_partkey.long.isNotNull,
+        'p_name.string.isNotNull
+      ),
+      "lineitem1" -> Seq(
+        'l_partkey.long.isNotNull,
+        'l_suppkey.long.isNotNull,
+        'l_orderkey.long.isNotNull
+      ),
+      "supplier2" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "partsupp3" -> Seq(
+        'ps_partkey.long.isNotNull,
+        'ps_suppkey.long.isNotNull
+      ),
+      "orders4" -> Seq(
+        'o_orderkey.long.isNotNull
+      ),
+      "nation5" -> Seq(
+        'n_nationkey.long.isNotNull
+      )
+    ),
+    Map( // q10
+      "customer0" -> Seq(
+        'c_custkey.long.isNotNull,
+        'c_nationkey.long.isNotNull
+      ),
+      "orders1" -> Seq(
+        'o_orderkey.long.isNotNull,
+        'o_custkey.long.isNotNull,
+        'o_orderdate.date.isNotNull,
+        'o_orderdate.date >= LocalDate.of(1993, 10, 1),
+        'o_orderdate.date < LocalDate.of(1994, 1, 1)
+      ),
+      "lineitem2" -> Seq(
+        'l_orderkey.long.isNotNull,
+        'l_returnflag.string.isNotNull,
+        'l_returnflag.string === "R"
+      ),
+      "nation3" -> Seq(
+        'n_nationkey.long.isNotNull
+      )
+    ),
+    Map( // q11
+      "partsupp0" -> Seq(
+        'ps_suppkey.long.isNotNull
+      ),
+      "supplier1" -> Seq(
+        's_suppkey.long.isNotNull,
+        's_nationkey.long.isNotNull
+      ),
+      "nation2" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_name.string.isNotNull,
+        'n_name.string === "GERMANY"
+      )
+    ),
+    Map( // q12
+      "orders0" -> Seq(
+        'o_orderkey.long.isNotNull
+      ),
+      "lineitem1" -> Seq(
+        'l_orderkey.long.isNotNull,
+        'l_receiptdate.date.isNotNull,
+        'l_receiptdate.date >= LocalDate.of(1994, 1, 1),
+        'l_receiptdate.date < LocalDate.of(1995, 1, 1),
+        'l_commitdate.date.isNotNull,
+        'l_shipdate.date.isNotNull,
+        'l_shipmode.string.in("MAIL", "SHIP").asInstanceOf[Predicate]
+      )
+    ),
+    Map( // q13
+      "customer0" -> Nil,
+      "orders1" -> Seq(
+        'o_custkey.long.isNotNull,
+        'o_comment.string.isNotNull
+      )),
+    Map( // q14
+      "lineitem0" -> Seq(
+        'l_partkey.long.isNotNull,
+        'l_shipdate.date.isNotNull,
+        'l_shipdate.date >= LocalDate.of(1995, 9, 1),
+        'l_shipdate.date < LocalDate.of(1995, 10, 1)
+      ),
+      "part1" -> Seq(
+        'p_partkey.long.isNotNull
+      )
+    ),
+    Map( // q15
+      "supplier0" -> Seq(
+        's_suppkey.long.isNotNull
+      ),
+      "lineitem1" -> Seq(
+        'l_suppkey.long.isNotNull,
+        'l_shipdate.date.isNotNull,
+        'l_shipdate.date >= LocalDate.of(1996, 1, 1),
+        'l_shipdate.date < LocalDate.of(1996, 4, 1)
+      )
+    ),
+    Map( // q16
+      "partsupp0" -> Seq(
+        'ps_partkey.long.isNotNull
+      ),
+      "supplier1" -> Seq(
+        's_comment.string.isNotNull
+      ),
+      "part2" -> Seq(
+        'p_partkey.long.isNotNull,
+        'p_brand.string.isNotNull,
+        'p_brand.string =!= "Brand#45",
+        'p_type.string.isNotNull,
+        'p_size.int.in(49, 14, 23, 45, 19, 3, 36, 9).asInstanceOf[Predicate]
+      )
+    ),
+    Map( // q17
+      "lineitem0" -> Seq(
+        'l_partkey.long.isNotNull,
+        'l_quantity.decimal(10, 0).isNotNull
+      ),
+      "part1" -> Seq(
+        'p_partkey.long.isNotNull,
+        'p_brand.string.isNotNull,
+        'p_brand.string === "Brand#23",
+        'p_container.string.isNotNull,
+        'p_container.string === "MED BOX"
+      ),
+      "lineitem2" -> Seq(
+        'l_partkey.long.isNotNull
+      )
+    ),
+    Map( // q18
+      "customer0" -> Seq(
+        'c_custkey.long.isNotNull
+      ),
+      "orders1" -> Seq(
+        'o_orderkey.long.isNotNull,
+        'o_custkey.long.isNotNull
+      ),
+      "lineitem2" -> Nil,
+      "lineitem3" -> Seq(
+        'l_orderkey.long.isNotNull
+      )
+    ),
+    Map( // q19
+      "lineitem0" -> Seq(
+        'l_shipinstruct.string.isNotNull,
+        'l_shipmode.string.in("AIR", "AIR REG").asInstanceOf[Predicate],
+        'l_shipinstruct.string === "DELIVER IN PERSON",
+        'l_partkey.long.isNotNull,
+        ('l_quantity.decimal(10, 0) >= Decimal(1) &&
+          'l_quantity.decimal(10, 0) <= Decimal(11)) ||
+          ('l_quantity.decimal(10, 0) >= Decimal(10) &&
+            'l_quantity.decimal(10, 0) <= Decimal(20)) ||
+          ('l_quantity.decimal(10, 0) >= Decimal(20) &&
+            'l_quantity.decimal(10, 0) <= Decimal(30))
+      ),
+      "part1" -> Seq(
+        'p_size.int.isNotNull,
+        'p_size.int >= 1,
+        'p_partkey.long.isNotNull,
+        ('p_brand.string === "Brand#12" &&
+          ('p_container.string in ("SM CASE", "SM BOX", "SM PACK", "SM PKG")) &&
+          'p_size.int <= 5) ||
+          ('p_brand.string === "Brand#23" &&
+            ('p_container.string in ("MED BAG", "MED BOX", "MED PKG", "MED PACK")) &&
+            'p_size.int <= 10) ||
+          ('p_brand.string === "Brand#34" &&
+            ('p_container.string in ("LG CASE", "LG BOX", "LG PACK", "LG PKG")) &&
+            'p_size.int <= 15)
+      )
+    ),
+    Map( // q20
+      "supplier0" -> Seq(
+        's_nationkey.long.isNotNull
+      ),
+      "partsupp1" -> Seq(
+        'ps_suppkey.long.isNotNull,
+        'ps_partkey.long.isNotNull,
+        'ps_availqty.int.isNotNull
+      ),
+      "part2" -> Seq(
+        'p_name.string.isNotNull
+      ),
+      "lineitem3" -> Seq(
+        'l_partkey.long.isNotNull,
+        'l_suppkey.long.isNotNull,
+        'l_shipdate.date.isNotNull,
+        'l_shipdate.date >= LocalDate.of(1994, 1, 1),
+        'l_shipdate.date < LocalDate.of(1995, 1, 1)
+      ),
+      "nation4" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_name.string.isNotNull,
+        'n_name.string === "CANADA"
+      )
+    ),
+    Map( // q21
+      "supplier0" -> Seq(
+        's_nationkey.long.isNotNull,
+        's_suppkey.long.isNotNull
+      ),
+      "lineitem1" -> Seq(
+        'l_orderkey.long.isNotNull,
+        'l_suppkey.long.isNotNull,
+        'l_commitdate.date.isNotNull,
+        'l_receiptdate.date.isNotNull
+      ),
+      "lineitem2" -> Nil,
+      "lineitem3" -> Seq(
+        'l_receiptdate.date.isNotNull,
+        'l_commitdate.date.isNotNull
+      ),
+      "orders4" -> Seq(
+        'o_orderstatus.string.isNotNull,
+        'o_orderstatus.string === "F",
+        'o_orderkey.long.isNotNull
+      ),
+      "nation5" -> Seq(
+        'n_nationkey.long.isNotNull,
+        'n_name.string.isNotNull,
+        'n_name.string === "SAUDI ARABIA"
+      )
+    ),
+    Map( // q22
+      "customer0" -> Seq(
+        'c_acctbal.decimal(10, 0).isNotNull
+      ),
+      "orders1" -> Nil)
+  )
+
+  tpchQueries.zipWithIndex.foreach {
+    case (q, i) =>
+      test(q) {
+        withDataFrame(tpchSQL(i + 1, tpchQueriesResourceFolder)) {
+          df =>
+            val scans = df.queryExecution.executedPlan
+              .collect { case scan: FileSourceScanExecTransformer => scan }
+            assertResult(result(i).size)(scans.size)
+            scans.zipWithIndex
+              .foreach {
+                case (scan, fileIndex) =>
+                  val tableName = scan.tableIdentifier
+                    .map(_.table)
+                    .getOrElse(scan.relation.options("path").split("/").last)
+                  val predicates = scan.filterExprs()
+                  val expected = result(i)(s"$tableName$fileIndex")
+                  assertResult(expected.size)(predicates.size)
+                  if (expected.isEmpty) assert(predicates.isEmpty)
+                  else compareExpressions(expected.reduceLeft(And), predicates.reduceLeft(And))
+              }
+        }
+      }
+  }
+}

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/test/GlutenSQLTestUtils.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/test/GlutenSQLTestUtils.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.gluten.test
+
+import io.glutenproject.GlutenConfig
+import io.glutenproject.utils.UTSystemParameters
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.sql.execution.datasources.v2.clickhouse.{ClickHouseConfig, ClickHouseLog}
+import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+import org.apache.commons.io.FileUtils
+
+import java.io.File
+
+trait GlutenSQLTestUtils extends SparkFunSuite with SharedSparkSession {
+  val backend: String = "ch"
+
+  protected val rootPath: String = getClass.getResource("/").getPath
+  protected val basePath: String = rootPath + "unit-tests-working-home"
+  protected val tablesPath: String = basePath + "/unit-tests-data"
+
+  protected val warehouse: String = basePath + "/spark-warehouse"
+  protected val metaStorePathAbsolute: String = basePath + "/meta"
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set(GlutenConfig.GLUTEN_LIB_PATH, UTSystemParameters.getClickHouseLibPath())
+      .set(
+        "spark.gluten.sql.columnar.backend.ch.use.v2",
+        ClickHouseConfig.DEFAULT_USE_DATASOURCE_V2)
+      .set(GlutenConfig.NATIVE_VALIDATION_ENABLED, false)
+      .set(StaticSQLConf.WAREHOUSE_PATH, warehouse)
+
+  override def beforeAll(): Unit = {
+    // prepare working paths
+    val basePathDir = new File(basePath)
+    if (basePathDir.exists()) {
+      FileUtils.forceDelete(basePathDir)
+    }
+    FileUtils.forceMkdir(basePathDir)
+    FileUtils.forceMkdir(new File(warehouse))
+    FileUtils.forceMkdir(new File(metaStorePathAbsolute))
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    ClickHouseLog.clearCache()
+    super.afterAll()
+    // init GlutenConfig in the next beforeAll
+    GlutenConfig.ins = null
+  }
+}

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/test/GlutenTPCBase.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/test/GlutenTPCBase.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.gluten.test
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+trait GlutenTPCBase extends SharedSparkSession {
+
+  protected def injectStats: Boolean = false
+
+  override protected def sparkConf: SparkConf = {
+    if (injectStats) {
+      super.sparkConf
+        .set(SQLConf.MAX_TO_STRING_FIELDS, Int.MaxValue)
+        .set(SQLConf.CBO_ENABLED, true)
+        .set(SQLConf.PLAN_STATS_ENABLED, true)
+        .set(SQLConf.JOIN_REORDER_ENABLED, true)
+    } else {
+      super.sparkConf.set(SQLConf.MAX_TO_STRING_FIELDS, Int.MaxValue)
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    createTables()
+  }
+
+  override def afterAll(): Unit = {
+    dropTables()
+    super.afterAll()
+  }
+
+  protected def createTables(): Unit
+
+  protected def dropTables(): Unit
+}

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/test/GlutenTPCHBase.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/gluten/test/GlutenTPCHBase.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.gluten.test
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+
+trait GlutenTPCHBase extends GlutenTPCBase {
+
+  val tpchQueries: Seq[String] = Seq(
+    "q1",
+    "q2",
+    "q3",
+    "q4",
+    "q5",
+    "q6",
+    "q7",
+    "q8",
+    "q9",
+    "q10",
+    "q11",
+    "q12",
+    "q13",
+    "q14",
+    "q15",
+    "q16",
+    "q17",
+    "q18",
+    "q19",
+    "q20",
+    "q21",
+    "q22")
+  override def createTables(): Unit = {
+    tpchCreateTable.values.foreach(sql => spark.sql(sql))
+  }
+
+  override def dropTables(): Unit = {
+    tpchCreateTable.keys.foreach {
+      tableName => spark.sessionState.catalog.dropTable(TableIdentifier(tableName), true, true)
+    }
+  }
+
+  private val tpchCreateTable: Map[String, String] = Map(
+    "orders" ->
+      """
+        |CREATE TABLE `orders` (
+        |`o_orderkey` BIGINT, `o_custkey` BIGINT, `o_orderstatus` STRING,
+        |`o_totalprice` DECIMAL(10,0), `o_orderdate` DATE, `o_orderpriority` STRING,
+        |`o_clerk` STRING, `o_shippriority` INT, `o_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "nation" ->
+      """
+        |CREATE TABLE `nation` (
+        |`n_nationkey` BIGINT, `n_name` STRING, `n_regionkey` BIGINT, `n_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "region" ->
+      """
+        |CREATE TABLE `region` (
+        |`r_regionkey` BIGINT, `r_name` STRING, `r_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "part" ->
+      """
+        |CREATE TABLE `part` (`p_partkey` BIGINT, `p_name` STRING, `p_mfgr` STRING,
+        |`p_brand` STRING, `p_type` STRING, `p_size` INT, `p_container` STRING,
+        |`p_retailprice` DECIMAL(10,0), `p_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "partsupp" ->
+      """
+        |CREATE TABLE `partsupp` (`ps_partkey` BIGINT, `ps_suppkey` BIGINT,
+        |`ps_availqty` INT, `ps_supplycost` DECIMAL(10,0), `ps_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "customer" ->
+      """
+        |CREATE TABLE `customer` (`c_custkey` BIGINT, `c_name` STRING, `c_address` STRING,
+        |`c_nationkey` BIGINT, `c_phone` STRING, `c_acctbal` DECIMAL(10,0),
+        |`c_mktsegment` STRING, `c_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "supplier" ->
+      """
+        |CREATE TABLE `supplier` (`s_suppkey` BIGINT, `s_name` STRING, `s_address` STRING,
+        |`s_nationkey` BIGINT, `s_phone` STRING, `s_acctbal` DECIMAL(10,0), `s_comment` STRING)
+        |USING parquet
+      """.stripMargin,
+    "lineitem" ->
+      """
+        |CREATE TABLE `lineitem` (`l_orderkey` BIGINT, `l_partkey` BIGINT, `l_suppkey` BIGINT,
+        |`l_linenumber` INT, `l_quantity` DECIMAL(10,0), `l_extendedprice` DECIMAL(10,0),
+        |`l_discount` DECIMAL(10,2), `l_tax` DECIMAL(10,0), `l_returnflag` STRING,
+        |`l_linestatus` STRING, `l_shipdate` DATE, `l_commitdate` DATE, `l_receiptdate` DATE,
+        |`l_shipinstruct` STRING, `l_shipmode` STRING, `l_comment` STRING)
+        |USING parquet
+      """.stripMargin
+  )
+}

--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -387,7 +387,7 @@ object FilterHandler extends PredicateHelper {
     (ExpressionSet(filters) -- ExpressionSet(scanFilters)).toSeq
 
   // Separate and compare the filter conditions in Scan and Filter.
-  // Try push down the remaining conditions in Filter into Scan.
+  // Try to push down the remaining conditions in Filter into Scan.
   def applyFilterPushdownToScan(filter: FilterExec, reuseSubquery: Boolean): SparkPlan =
     filter.child match {
       case fileSourceScan: FileSourceScanExec =>

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -16,7 +16,7 @@
  */
 package io.glutenproject.execution
 
-import io.glutenproject.utils.FallbackUtil
+import io.glutenproject.utils.{Arm, FallbackUtil}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
@@ -24,7 +24,7 @@ import org.apache.spark.sql.{DataFrame, GlutenQueryTest, Row}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{DoubleType, StructType}
+import org.apache.spark.sql.types.DoubleType
 
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
@@ -41,7 +41,7 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
   protected val fileFormat: String
   protected val logLevel: String = "WARN"
 
-  protected val TPCHTables = Seq(
+  protected val TPCHTables: Seq[Table] = Seq(
     Table("part", partitionColumns = "p_brand" :: Nil),
     Table("supplier", partitionColumns = Nil),
     Table("partsupp", partitionColumns = Nil),
@@ -59,7 +59,7 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
   final protected def disableFallbackCheck: Boolean =
     isFallbackCheckDisabled0.compareAndSet(false, true)
 
-  protected def isFallbackCheckDisabled = isFallbackCheckDisabled0.get()
+  protected def needCheckFallback: Boolean = !isFallbackCheckDisabled0.get()
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -95,96 +95,69 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
       .set("spark.memory.offHeap.size", "1024MB")
   }
 
-  protected def compareResultStr(
-      sqlNum: String,
-      result: Array[Row],
-      queriesResults: String): Unit = {
+  protected def compareResultStr(sqlNum: String, result: Seq[Row], queriesResults: String): Unit = {
     val resultStr = new StringBuffer()
     resultStr.append(result.length).append("\n")
     result.foreach(r => resultStr.append(r.mkString("|-|")).append("\n"))
     val queryResultStr =
-      Source.fromFile(new File(queriesResults + "/" + sqlNum + ".out"), "UTF-8").mkString
+      Arm.withResource(Source.fromFile(new File(queriesResults + "/" + sqlNum + ".out"), "UTF-8"))(
+        _.mkString)
     assert(queryResultStr.equals(resultStr.toString))
   }
 
   protected def compareDoubleResult(
       sqlNum: String,
-      result: Array[Row],
-      schema: StructType,
-      queriesResults: String): Unit = {
-    val queryResults =
-      Source.fromFile(new File(queriesResults + "/" + sqlNum + ".out"), "UTF-8").getLines()
-    var recordCnt = queryResults.next().toInt
-    assert(result.size == recordCnt)
-    for (row <- result) {
-      assert(queryResults.hasNext)
-      val result = queryResults.next().split("\\|-\\|")
-      var i = 0
-      row.schema.foreach(
-        s => {
-          s match {
-            case d if d.dataType == DoubleType =>
-              // handle null value
-              if (row.isNullAt(i)) {
-                assert(result(i).equals("null"))
-              } else {
-                val v1 = row.getDouble(i)
-                assert(!result(i).equals("null"))
-                val v2 = result(i).toDouble
-                assert(Math.abs(v1 - v2) < 0.0005)
+      result: Seq[Row],
+      queriesResults: String): Unit =
+    Arm.withResource(Source.fromFile(new File(queriesResults + "/" + sqlNum + ".out"), "UTF-8")) {
+      resource =>
+        val queryResults = resource.getLines()
+        val recordCnt = queryResults.next().toInt
+        assert(result.length == recordCnt)
+        for (row <- result) {
+          assert(queryResults.hasNext)
+          val result = queryResults.next().split("\\|-\\|")
+          var i = 0
+          row.schema.foreach {
+            s =>
+              val isNull = row.isNullAt(i)
+              val v1 = if (s.dataType == DoubleType) row.getDouble(i) else row.get(i)
+              val v2 = result(i)
+
+              assert(isNull == v2.equals("null"))
+              if (!isNull) {
+                if (s.dataType == DoubleType) {
+                  assert(Math.abs(v1.asInstanceOf[Double] - v2.toDouble) < 0.0005)
+                } else {
+                  assert(v1.toString.equals(v2))
+                }
               }
-            case _ =>
-              // handle null value
-              if (row.isNullAt(i)) {
-                assert(result(i).equals("null"))
-              } else {
-                val v1 = row.get(i)
-                assert(!result(i).equals("null"))
-                val v2 = result(i)
-                assert(v1.toString.equals(v2))
-              }
+              i += 1
           }
-          i += 1
-        })
+        }
     }
-  }
 
   protected def runTPCHQuery(
       queryNum: Int,
       tpchQueries: String,
       queriesResults: String,
       compareResult: Boolean = true,
-      noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit = {
-    val sqlNum = "q" + "%02d".format(queryNum)
-    val sqlFile = tpchQueries + "/" + sqlNum + ".sql"
-    val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString
-    val df = spark.sql(sqlStr)
-    val result = df.collect()
-    if (compareResult) {
-      val schema = df.schema
-      if (schema.exists(_.dataType == DoubleType)) {
-        compareDoubleResult(sqlNum, result, schema, queriesResults)
-      } else {
-        compareResultStr(sqlNum, result, queriesResults)
-      }
-    } else {
-      df.collect()
+      noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit =
+    withDataFrame(tpchSQL(queryNum, tpchQueries)) {
+      df =>
+        if (compareResult)
+          verifyTPCHResult(df, s"q${"%02d".format(queryNum)}", queriesResults)
+        else
+          df.collect()
+        checkDataFrame(noFallBack, customCheck, df)
     }
-    if (!isFallbackCheckDisabled) {
-      WholeStageTransformerSuite.checkFallBack(df, noFallBack)
-    }
-    customCheck(df)
-  }
 
   protected def runSql(sql: String, noFallBack: Boolean = true)(
-      customCheck: DataFrame => Unit): Seq[Row] = {
-    val df = spark.sql(sql)
-    val result = df.collect()
-    if (!isFallbackCheckDisabled) {
-      WholeStageTransformerSuite.checkFallBack(df, noFallBack)
-    }
-    customCheck(df)
-    result
+      customCheck: DataFrame => Unit): Seq[Row] = withDataFrame(sql) {
+    df =>
+      val result = df.collect()
+      checkDataFrame(noFallBack, customCheck, df)
+      result
   }
 
   def checkLengthAndPlan(df: DataFrame, len: Int = 100): Unit = {
@@ -281,10 +254,7 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
         df.unpersist()
       }
     }
-    if (!isFallbackCheckDisabled) {
-      WholeStageTransformerSuite.checkFallBack(df, noFallBack)
-    }
-    customCheck(df)
+    checkDataFrame(noFallBack, customCheck, df)
     df
   }
 
@@ -309,15 +279,40 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
       tpchQueries: String,
       customCheck: DataFrame => Unit,
       noFallBack: Boolean = true,
-      compareResult: Boolean = true): Unit = {
-    val sqlNum = "q" + "%02d".format(queryNum)
-    val sqlFile = tpchQueries + "/" + sqlNum + ".sql"
-    val sqlStr = Source.fromFile(new File(sqlFile), "UTF-8").mkString
-    compareResultsAgainstVanillaSpark(sqlStr, compareResult, customCheck, noFallBack)
-  }
+      compareResult: Boolean = true): Unit =
+    compareResultsAgainstVanillaSpark(
+      tpchSQL(queryNum, tpchQueries),
+      compareResult,
+      customCheck,
+      noFallBack)
 
   protected def vanillaSparkConfs(): Seq[(String, String)] = {
     List(("spark.gluten.enabled", "false"))
+  }
+
+  protected def checkDataFrame(
+      noFallBack: Boolean,
+      customCheck: DataFrame => Unit,
+      df: DataFrame): Unit = {
+    if (needCheckFallback) {
+      WholeStageTransformerSuite.checkFallBack(df, noFallBack)
+    }
+    customCheck(df)
+  }
+  protected def withDataFrame[R](sql: String)(f: DataFrame => R): R = f(spark.sql(sql))
+
+  protected def tpchSQL(queryNum: Int, tpchQueries: String): String =
+    Arm.withResource(
+      Source.fromFile(new File(s"$tpchQueries/q${"%02d".format(queryNum)}.sql"), "UTF-8"))(
+      _.mkString)
+
+  protected def verifyTPCHResult(df: DataFrame, sqlNum: String, queriesResults: String): Unit = {
+    val result = df.collect()
+    if (df.schema.exists(_.dataType == DoubleType)) {
+      compareDoubleResult(sqlNum, result, queriesResults)
+    } else {
+      compareResultStr(sqlNum, result, queriesResults)
+    }
   }
 }
 

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -145,10 +145,11 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
       noFallBack: Boolean = true)(customCheck: DataFrame => Unit): Unit =
     withDataFrame(tpchSQL(queryNum, tpchQueries)) {
       df =>
-        if (compareResult)
+        if (compareResult) {
           verifyTPCHResult(df, s"q${"%02d".format(queryNum)}", queriesResults)
-        else
+        } else {
           df.collect()
+        }
         checkDataFrame(noFallBack, customCheck, df)
     }
 


### PR DESCRIPTION
This is followup of #4582,  this PR removes unsupported  parquet filters for Clickhouse backend. I also refactor `WholeStageTransformerSuite` for adding `GlutenParquetFilterSuite`

1. Introduce `Arm.withResource` to close file for fixing resource leak.
2. Introduce `withDataframe` for dry run sql.
3. Introduce `tpchSQL` to simpilfy getting tpch sql from resources

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#3582)

## How was this patch tested?

Adding new UT.

