### PR TITLE
[GLUTEN-4213][CORE] Refactoring pull out project in HashAggregateExecTransformer

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -148,6 +148,13 @@ class CHSparkPlanExecApi extends SparkPlanExecApi {
       resultExpressions,
       child)
 
+  /** Generate HashAggregateExecPullOutHelper */
+  override def genHashAggregateExecPullOutHelper(
+      groupingExpressions: Seq[NamedExpression],
+      aggregateExpressions: Seq[AggregateExpression],
+      aggregateAttributes: Seq[Attribute]): HashAggregateExecPullOutBaseHelper =
+    CHHashAggregateExecPullOutHelper(groupingExpressions, aggregateExpressions, aggregateAttributes)
+
   /** Generate ShuffledHashJoinExecTransformer. */
   def genShuffledHashJoinExecTransformer(
       leftKeys: Seq[Expression],

--- a/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
@@ -30,18 +30,8 @@ class HashAggregateMetricsUpdater(val metrics: Map[String, SQLMetric])
       if (opMetrics != null) {
         val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
         if (!operatorMetrics.metricsList.isEmpty && operatorMetrics.aggParams != null) {
-          val aggregationParams = operatorMetrics.aggParams
           var currentIdx = operatorMetrics.metricsList.size() - 1
           var totalTime = 0L
-
-          // pre projection
-          if (aggregationParams.preProjectionNeeded) {
-            metrics("preProjectTime") +=
-              (operatorMetrics.metricsList.get(currentIdx).time / 1000L).toLong
-            metrics("outputVectors") += operatorMetrics.metricsList.get(currentIdx).outputVectors
-            totalTime += operatorMetrics.metricsList.get(currentIdx).time
-            currentIdx -= 1
-          }
 
           // aggregating
           val aggMetricsData = operatorMetrics.metricsList.get(currentIdx)
@@ -71,15 +61,6 @@ class HashAggregateMetricsUpdater(val metrics: Map[String, SQLMetric])
           }
 
           currentIdx -= 1
-
-          // post projection
-          if (aggregationParams.postProjectionNeeded) {
-            metrics("postProjectTime") +=
-              (operatorMetrics.metricsList.get(currentIdx).time / 1000L).toLong
-            metrics("outputVectors") += operatorMetrics.metricsList.get(currentIdx).outputVectors
-            totalTime += operatorMetrics.metricsList.get(currentIdx).time
-            currentIdx -= 1
-          }
           metrics("totalTime") += (totalTime / 1000L).toLong
         }
       }

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -1146,7 +1146,7 @@ class GlutenClickHouseHiveTableSuite()
         |if(xxx1 in (39,40),6,
         |if(xxx1 in (38,47),xxx1,-1))))))) as string)
         """.stripMargin
-    runQueryAndCompare(querySql)(df => checkOperatorCount[ProjectExecTransformer](1)(df))
+    runQueryAndCompare(querySql)(df => checkOperatorCount[ProjectExecTransformer](2)(df))
   }
 
   test(

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -613,7 +613,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       }
       runQueryAndCompare(
         "select id % 10, sum(id +100) + max(id+100) from range(100) group by id % 10") {
-        df => checkOperatorCount[ProjectExecTransformer](1)(df)
+        df => checkOperatorCount[ProjectExecTransformer](2)(df)
       }
 
       // CSE in sort

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
@@ -93,7 +93,7 @@ class GlutenClickHouseTPCDSMetricsSuite extends GlutenClickHouseTPCDSAbstractSui
           case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
         }
 
-        assert(allGlutenPlans.size == 29)
+        assert(allGlutenPlans.size == 30)
 
         val windowPlan0 = allGlutenPlans(3)
         assert(windowPlan0.metrics("totalTime").value == 2)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -263,7 +263,7 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
               case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
             }
 
-            assert(allGlutenPlans.size == 57)
+            assert(allGlutenPlans.size == 58)
 
             val shjPlan = allGlutenPlans(8)
             assert(shjPlan.metrics("totalTime").value == 6)

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/MetricsApiImpl.scala
@@ -219,18 +219,12 @@ class MetricsApiImpl extends MetricsApi with Logging {
         "number of spilled partitions"),
       "aggSpilledFiles" -> SQLMetrics.createMetric(sparkContext, "number of spilled files"),
       "flushRowCount" -> SQLMetrics.createMetric(sparkContext, "number of flushed rows"),
-      "preProjectionCpuCount" -> SQLMetrics.createMetric(
+      "rowConstructionCpuCount" -> SQLMetrics.createMetric(
         sparkContext,
-        "preProjection cpu wall time count"),
-      "preProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
+        "rowConstruction cpu wall time count"),
+      "rowConstructionWallNanos" -> SQLMetrics.createNanoTimingMetric(
         sparkContext,
         "totaltime of preProjection"),
-      "postProjectionCpuCount" -> SQLMetrics.createMetric(
-        sparkContext,
-        "postProjection cpu wall time count"),
-      "postProjectionWallNanos" -> SQLMetrics.createNanoTimingMetric(
-        sparkContext,
-        "totaltime of postProjection"),
       "extractionCpuCount" -> SQLMetrics.createMetric(
         sparkContext,
         "extraction cpu wall time count"),

--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/SparkPlanExecApiImpl.scala
@@ -189,6 +189,13 @@ class SparkPlanExecApiImpl extends SparkPlanExecApi {
       resultExpressions,
       child)
 
+  /** Generate HashAggregateExecPullOutHelper */
+  override def genHashAggregateExecPullOutHelper(
+      groupingExpressions: Seq[NamedExpression],
+      aggregateExpressions: Seq[AggregateExpression],
+      aggregateAttributes: Seq[Attribute]): HashAggregateExecPullOutBaseHelper =
+    HashAggregateExecPullOutHelper(groupingExpressions, aggregateExpressions, aggregateAttributes)
+
   /** Generate ShuffledHashJoinExecTransformer. */
   override def genShuffledHashJoinExecTransformer(
       leftKeys: Seq[Expression],

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/SparkPlanExecApi.scala
@@ -93,6 +93,12 @@ trait SparkPlanExecApi {
       resultExpressions: Seq[NamedExpression],
       child: SparkPlan): HashAggregateExecBaseTransformer
 
+  /** Generate HashAggregateExecPullOutHelper */
+  def genHashAggregateExecPullOutHelper(
+      groupingExpressions: Seq[NamedExpression],
+      aggregateExpressions: Seq[AggregateExpression],
+      aggregateAttributes: Seq[Attribute]): HashAggregateExecPullOutBaseHelper
+
   /** Generate ShuffledHashJoinExecTransformer. */
   def genShuffledHashJoinExecTransformer(
       leftKeys: Seq[Expression],

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -790,6 +790,7 @@ case class ColumnarOverrideRules(session: SparkSession)
         (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => RewriteMultiChildrenCount,
         (_: SparkSession) => PullOutPreProject,
+        (_: SparkSession) => PullOutPostProject,
         // Apply AddTransformHintRule again for pulled-out project.
         (_: SparkSession) => AddTransformHintRule(),
         (_: SparkSession) => FallbackBloomFilterAggIfNeeded(),

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ValidationApplyRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ValidationApplyRule.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension
+
+import org.apache.spark.sql.execution.SparkPlan
+
+/**
+ * Spark Rule that needs to be applied before validation should extends this trait, and implements
+ * the applyForValidation method. This methods should apply the rule locally(There is no need to
+ * recursively traverse the entire plan tree) to the input SparkPlan, and return the transformed
+ * SparkPlan.
+ */
+trait ValidationApplyRule {
+  def applyForValidation[T <: SparkPlan](plan: T): T
+}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension.columnar
+
+import io.glutenproject.backendsapi.BackendsApiManager
+import io.glutenproject.extension.ValidationApplyRule
+import io.glutenproject.utils.PullOutProjectHelper
+
+import org.apache.spark.sql.catalyst.expressions.{AliasHelper, Attribute}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
+import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
+
+/**
+ * The output of the native engine after executing the agg is not completely consistent with Spark.
+ * When the output is inconsistent, it is necessary to use post-project to adjust the output of
+ * native agg to match the output of Spark, ensuring that the data output of the native agg can
+ * match the fallback Spark plan when a fallback occurs.
+ */
+object PullOutPostProject
+  extends Rule[SparkPlan]
+  with PullOutProjectHelper
+  with AliasHelper
+  with ValidationApplyRule {
+
+  private def needsPostProjection(plan: SparkPlan): Boolean = {
+    if (TransformHints.isTaggedAsNotTransformable(plan)) {
+      // We should not pull out post-project for SparkPlan that already been tagged as
+      // not transformable.
+      return false
+    }
+    plan match {
+      case agg: BaseAggregateExec =>
+        val pullOutHelper =
+          BackendsApiManager.getSparkPlanExecApiInstance.genHashAggregateExecPullOutHelper(
+            agg.groupingExpressions,
+            agg.aggregateExpressions,
+            agg.aggregateAttributes)
+        val allAggregateResultAttributes = pullOutHelper.allAggregateResultAttributes
+        // If the result expressions has different size with output attribute,
+        // post-projection is needed.
+        agg.resultExpressions.size != allAggregateResultAttributes.size ||
+        // Compare each item in result expressions and output attributes. Attribute in Alias
+        // should be trimmed before checking.
+        agg.resultExpressions.map(trimAliases).zip(allAggregateResultAttributes).exists {
+          case (exprAttr: Attribute, resAttr) =>
+            // If the result attribute and result expression has different name or type,
+            // post-projection is needed.
+            exprAttr.name != resAttr.name || exprAttr.dataType != resAttr.dataType
+          case _ =>
+            // If result expression is not instance of Attribute,
+            // post-projection is needed.
+            true
+        }
+      case _ => false
+    }
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    val transformedPlan = plan.transform(applyLocally)
+    AddTransformHintRule().apply(transformedPlan)
+  }
+
+  override def applyForValidation[T <: SparkPlan](plan: T): T =
+    applyLocally
+      .lift(plan)
+      .map {
+        case p: ProjectExec => p.child
+        case other => other
+      }
+      .getOrElse(plan)
+      .asInstanceOf[T]
+
+  private val applyLocally: PartialFunction[SparkPlan, SparkPlan] = {
+    case agg: BaseAggregateExec if supportedAggregate(agg) && needsPostProjection(agg) =>
+      val pullOutHelper =
+        BackendsApiManager.getSparkPlanExecApiInstance.genHashAggregateExecPullOutHelper(
+          agg.groupingExpressions,
+          agg.aggregateExpressions,
+          agg.aggregateAttributes)
+      val newResultExpressions = pullOutHelper.allAggregateResultAttributes
+
+      val newAgg = copyBaseAggregateExec(agg, newResultExpressions)
+      newAgg.copyTagsFrom(agg)
+
+      agg.unsetTagValue(TransformHints.TAG)
+      val postProject = ProjectExec(agg.resultExpressions, newAgg)
+      postProject
+  }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -41,13 +41,10 @@ case class JoinParams() {
 
 case class AggregationParams() {
   // Whether preProjection is needed.
-  var preProjectionNeeded = false
+  var rowConstructionNeeded = false
 
   // Whether extraction from intermediate struct is needed.
   var extractionNeeded = false
-
-  // Whether postProjection is needed.
-  var postProjectionNeeded = false
 }
 
 class SubstraitContext extends Serializable {

--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -16,10 +16,9 @@
  */
 package io.glutenproject.utils
 
-import io.glutenproject.extension.columnar.TransformHints
-
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.execution.aggregate._
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -29,12 +28,23 @@ trait PullOutProjectHelper {
 
   private val generatedNameIndex = new AtomicInteger(0)
 
+  protected def generatePreAliasName = s"_pre_${generatedNameIndex.getAndIncrement()}"
+
   /**
    * The majority of Expressions only support Attribute and BoundReference when converting them into
    * native plans.
    */
   protected def isNotAttribute(expression: Expression): Boolean = expression match {
     case _: Attribute | _: BoundReference => false
+    case _ => true
+  }
+
+  /**
+   * Some Expressions support Attribute, BoundReference and Literal when converting them into native
+   * plans, such as the child of AggregateFunction.
+   */
+  protected def isNotAttributeAndLiteral(expression: Expression): Boolean = expression match {
+    case _: Attribute | _: BoundReference | _: Literal => false
     case _ => true
   }
 
@@ -48,9 +58,7 @@ trait PullOutProjectHelper {
       case e: BoundReference => e
       case other =>
         projectExprsMap
-          .getOrElseUpdate(
-            other.canonicalized,
-            Alias(other, s"_pre_${generatedNameIndex.getAndIncrement()}")())
+          .getOrElseUpdate(other.canonicalized, Alias(other, generatePreAliasName)())
           .toAttribute
     }
 
@@ -60,6 +68,56 @@ trait PullOutProjectHelper {
     childOutput.toIndexedSeq ++ appendAttributes.filter(attr => !childOutput.contains(attr))
   }
 
-  protected def notSupportTransform(plan: SparkPlan): Boolean =
-    TransformHints.isAlreadyTagged(plan) && TransformHints.isNotTransformable(plan)
+  protected def supportedAggregate(agg: BaseAggregateExec): Boolean = agg match {
+    case _: HashAggregateExec | _: SortAggregateExec | _: ObjectHashAggregateExec => true
+    case _ => false
+  }
+
+  protected def copyBaseAggregateExec(
+      agg: BaseAggregateExec,
+      newGroupingExpressions: Seq[NamedExpression],
+      newAggregateExpressions: Seq[AggregateExpression]): BaseAggregateExec = {
+    copyBaseAggregateExec(
+      agg,
+      newGroupingExpressions,
+      newAggregateExpressions,
+      agg.resultExpressions)
+  }
+
+  protected def copyBaseAggregateExec(
+      agg: BaseAggregateExec,
+      newResultExpressions: Seq[NamedExpression]): BaseAggregateExec = {
+    copyBaseAggregateExec(
+      agg,
+      agg.groupingExpressions,
+      agg.aggregateExpressions,
+      newResultExpressions)
+  }
+
+  protected def copyBaseAggregateExec(
+      agg: BaseAggregateExec,
+      newGroupingExpressions: Seq[NamedExpression],
+      newAggregateExpressions: Seq[AggregateExpression],
+      newResultExpressions: Seq[NamedExpression]): BaseAggregateExec = agg match {
+    case hash: HashAggregateExec =>
+      hash.copy(
+        groupingExpressions = newGroupingExpressions,
+        aggregateExpressions = newAggregateExpressions,
+        resultExpressions = newResultExpressions
+      )
+    case sort: SortAggregateExec =>
+      sort.copy(
+        groupingExpressions = newGroupingExpressions,
+        aggregateExpressions = newAggregateExpressions,
+        resultExpressions = newResultExpressions
+      )
+    case objectHash: ObjectHashAggregateExec =>
+      objectHash.copy(
+        groupingExpressions = newGroupingExpressions,
+        aggregateExpressions = newAggregateExpressions,
+        resultExpressions = newResultExpressions
+      )
+    case _ =>
+      throw new UnsupportedOperationException(s"Unsupported agg $agg")
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/datasources/GlutenFormatWriterInjectsBase.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 import io.glutenproject.execution.{ProjectExecTransformer, SortExecTransformer, TransformSupport, WholeStageTransformer}
 import io.glutenproject.execution.datasource.GlutenFormatWriterInjects
 import io.glutenproject.extension.TransformPreOverrides
-import io.glutenproject.extension.columnar.{AddTransformHintRule, PullOutPreProject}
+import io.glutenproject.extension.columnar.{AddTransformHintRule, PullOutPostProject, PullOutPreProject}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -47,6 +47,7 @@ trait GlutenFormatWriterInjectsBase extends GlutenFormatWriterInjects {
     val rules = List(
       AddTransformHintRule(),
       PullOutPreProject,
+      PullOutPostProject,
       AddTransformHintRule(),
       TransformPreOverrides(false)
     )

--- a/gluten-data/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
+++ b/gluten-data/src/main/scala/io/glutenproject/metrics/HashAggregateMetricsUpdater.scala
@@ -41,11 +41,8 @@ class HashAggregateMetricsUpdaterImpl(val metrics: Map[String, SQLMetric])
   val aggSpilledFiles: SQLMetric = metrics("aggSpilledFiles")
   val flushRowCount: SQLMetric = metrics("flushRowCount")
 
-  val preProjectionCpuCount: SQLMetric = metrics("preProjectionCpuCount")
-  val preProjectionWallNanos: SQLMetric = metrics("preProjectionWallNanos")
-
-  val postProjectionCpuCount: SQLMetric = metrics("postProjectionCpuCount")
-  val postProjectionWallNanos: SQLMetric = metrics("postProjectionWallNanos")
+  val rowConstructionCpuCount: SQLMetric = metrics("rowConstructionCpuCount")
+  val rowConstructionWallNanos: SQLMetric = metrics("rowConstructionWallNanos")
 
   val extractionCpuCount: SQLMetric = metrics("extractionCpuCount")
   val extractionWallNanos: SQLMetric = metrics("extractionWallNanos")
@@ -57,11 +54,6 @@ class HashAggregateMetricsUpdaterImpl(val metrics: Map[String, SQLMetric])
       aggregationMetrics: java.util.ArrayList[OperatorMetrics],
       aggParams: AggregationParams): Unit = {
     var idx = 0
-    if (aggParams.postProjectionNeeded) {
-      postProjectionCpuCount += aggregationMetrics.get(idx).cpuCount
-      postProjectionWallNanos += aggregationMetrics.get(idx).wallNanos
-      idx += 1
-    }
 
     if (aggParams.extractionNeeded) {
       extractionCpuCount += aggregationMetrics.get(idx).cpuCount
@@ -84,9 +76,9 @@ class HashAggregateMetricsUpdaterImpl(val metrics: Map[String, SQLMetric])
     flushRowCount += aggMetrics.flushRowCount
     idx += 1
 
-    if (aggParams.preProjectionNeeded) {
-      preProjectionCpuCount += aggregationMetrics.get(idx).cpuCount
-      preProjectionWallNanos += aggregationMetrics.get(idx).wallNanos
+    if (aggParams.rowConstructionNeeded) {
+      rowConstructionCpuCount += aggregationMetrics.get(idx).cpuCount
+      rowConstructionWallNanos += aggregationMetrics.get(idx).wallNanos
       idx += 1
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Separating https://github.com/oap-project/gluten/pull/4245 into several smaller PRs. The current PR aims to refactor the process of pre/post-projects in `HashAggregateExecBaseTransformer`.

This PR introduces a new `PullOutPostProject` rule to add post-project to agg, in order to correct the output of aggregate after native execution.

Example: `SELECT sum(c1 + 1) + 1 FROM t GROUP BY c2`
Before this rule:
```
Aggregate(keys=[c2], functions=[sum((c1 + 1))])
   +- Exchange
      +- Aggregate(keys=[c2], functions=[partial_sum((c1 + 1))])
         +- Scan [c1, c2]
```
After this rule:
```
Project [(sum((_pre_1)) + 1) AS (sum((c1 + 1)) + 1)]
   +- Aggregate(keys=[c2], functions=[sum((_pre_1))])
      +- Exchange
         +- Aggregate(keys=[c2], functions=[partial_sum(_pre_1)])
            +- Project [c2, (c1 + 1) AS _pre_1]
               +- Scan [c1, c2]
```

## How was this patch tested?

Exists CI.

