### PR TITLE
[GLUTEN-4650][CORE] Fix BatchScanExecShim otherCopyArgs

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BatchScanExecTransformer.scala
@@ -50,7 +50,7 @@ class BatchScanExecTransformer(
     commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,
     applyPartialClustering: Boolean = false,
     replicatePartitions: Boolean = false)
-  extends BatchScanExecShim(output, scan, runtimeFilters, table)
+  extends BatchScanExecShim(output, scan, runtimeFilters, table = table)
   with BasicScanExecTransformer {
 
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExecShim.scala
@@ -16,25 +16,19 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
-import io.glutenproject.GlutenConfig
-
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
-import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering
-import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
-import com.google.common.base.Objects
 
 class BatchScanExecShim(
     output: Seq[AttributeReference],


### PR DESCRIPTION
## What changes were proposed in this pull request?

it's not correct to override `otherCopyArgs`, it may cause:
```
java.lang.IllegalStateException: Failed to copy node
Is otherCopyArgs specified correctly for BatchScanExecTransformer.
Exception message: wrong number of arguments
ctor: public io.glutenproject.execution.BatchScanExecTransformer(scala.collection.Seq,org.apache.spark.sql.connector.read.Scan,scala.collection.Seq,scala.Option,scala.Option,org.apache.spark.sql.connector.catalog.Table,scala.Option,boolean,boolean)
types: class scala.collection.immutable.$colon$colon, class org.apache.spark.sql.execution.datasources.v2.orc.OrcScan, class scala.collection.immutable.Nil$, class scala.None$
args: List(id#1385304L), OrcScan(org.apache.spark.sql.test.TestSparkSession@3a411bd7,Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml, __spark_hadoop_conf__.xml,org.apache.spark.sql.execution.datasources.InMemoryFileIndex@3eefe389,StructType(StructField(id,LongType,true)),StructType(StructField(id,LongType,true)),StructType(),org.apache.spark.sql.util.CaseInsensitiveStringMap@36431d43,None,[Lorg.apache.spark.sql.sources.Filter;@413dd408,List(),List()), List(), None
  at org.apache.spark.sql.catalyst.trees.TreeNode.makeCopy(TreeNode.scala:978)
```

The `otherCopyArgs` should be `BatchScanExecTransformer.parameters - BatchScanExec.parameters`

## How was this patch tested?

Pass CI
