### PR TITLE
[VL] Save and load configurations for micro benchmark

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Run micro benchmarks
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh 'cd /opt/gluten/cpp/build/velox/benchmarks && \
-          ./generic_benchmark --with-shuffle --threads 1 --iterations 1'
+          ./generic_benchmark --run-example --with-shuffle --threads 1 --iterations 1'
       - name: Exit docker container
         if: ${{ always() }}
         run: |

--- a/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/benchmarks/NativeBenchmarkPlanGenerator.scala
@@ -19,6 +19,8 @@ package io.glutenproject.benchmarks
 import io.glutenproject.GlutenConfig
 import io.glutenproject.execution.{VeloxWholeStageTransformerSuite, WholeStageTransformer}
 
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -48,6 +50,12 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
     }
     FileUtils.forceMkdir(dir)
     createTPCHNotNullTables()
+  }
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.gluten.sql.debug", "true")
+      .set("spark.gluten.sql.columnar.backend.velox.glogSeverityLevel", "0")
   }
 
   test("Test plan json non-empty - AQE off") {
@@ -98,6 +106,7 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
       SQLConf.SHUFFLE_PARTITIONS.key -> "2",
       GlutenConfig.CACHE_WHOLE_STAGE_TRANSFORMER_CONTEXT.key -> "true"
     ) {
+      logWarning(s"Generating inputs for micro benchmark to $generatedPlanDir")
       val q4_lineitem = spark
         .sql(s"""
                 |select l_orderkey from lineitem where l_commitdate < l_receiptdate
@@ -128,27 +137,29 @@ class NativeBenchmarkPlanGenerator extends VeloxWholeStageTransformerSuite {
         spark.sql("""
                     |select * from q4_orders left semi join q4_lineitem on l_orderkey = o_orderkey
                     |""".stripMargin)
-
-      val executedPlan = df.queryExecution.executedPlan
-      executedPlan.execute()
-
-      val finalPlan =
-        executedPlan match {
-          case aqe: AdaptiveSparkPlanExec =>
-            aqe.executedPlan match {
-              case s: ShuffleQueryStageExec => s.shuffle.child
-              case other => other
-            }
-          case plan => plan
-        }
-      val lastStageTransformer = finalPlan.find(_.isInstanceOf[WholeStageTransformer])
-      assert(lastStageTransformer.nonEmpty)
-      val plan =
-        lastStageTransformer.get.asInstanceOf[WholeStageTransformer].substraitPlanJson.split('\n')
-
-      val exampleJsonFile = Paths.get(generatedPlanDir, "example.json")
-      Files.write(exampleJsonFile, plan.toList.asJava, StandardCharsets.UTF_8)
+      generateSubstraitJson(df, "example.json")
     }
     spark.sparkContext.setLogLevel(logLevel)
+  }
+
+  def generateSubstraitJson(df: DataFrame, file: String): Unit = {
+    val executedPlan = df.queryExecution.executedPlan
+    executedPlan.execute()
+    val finalPlan =
+      executedPlan match {
+        case aqe: AdaptiveSparkPlanExec =>
+          aqe.executedPlan match {
+            case s: ShuffleQueryStageExec => s.shuffle.child
+            case other => other
+          }
+        case plan => plan
+      }
+    val lastStageTransformer = finalPlan.find(_.isInstanceOf[WholeStageTransformer])
+    assert(lastStageTransformer.nonEmpty)
+    val plan =
+      lastStageTransformer.get.asInstanceOf[WholeStageTransformer].substraitPlanJson.split('\n')
+
+    val exampleJsonFile = Paths.get(generatedPlanDir, file)
+    Files.write(exampleJsonFile, plan.toList.asJava, StandardCharsets.UTF_8)
   }
 }

--- a/cpp/core/compute/ProtobufUtils.h
+++ b/cpp/core/compute/ProtobufUtils.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include <google/protobuf/message.h>
-#include <string>
 #include <optional>
+#include <string>
 
 namespace gluten {
 

--- a/cpp/core/compute/ProtobufUtils.h
+++ b/cpp/core/compute/ProtobufUtils.h
@@ -19,6 +19,7 @@
 
 #include <google/protobuf/message.h>
 #include <string>
+#include <optional>
 
 namespace gluten {
 
@@ -26,6 +27,10 @@ bool parseProtobuf(const uint8_t* buf, int bufLen, google::protobuf::Message* ms
 
 std::string substraitFromJsonToPb(std::string_view typeName, std::string_view json);
 
-std::string substraitFromPbToJson(std::string_view typeName, const uint8_t* data, int32_t size);
+std::string substraitFromPbToJson(
+    std::string_view typeName,
+    const uint8_t* data,
+    int32_t size,
+    std::optional<std::string> dumpFile);
 
 } // namespace gluten

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -127,6 +127,8 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
       arrow::MemoryPool* arrowPool,
       struct ArrowSchema* cSchema) = 0;
 
+  virtual void dumpConf(const std::string& path) = 0;
+
   const std::unordered_map<std::string, std::string>& getConfMap() {
     return confMap_;
   }
@@ -146,6 +148,6 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
   std::optional<std::string> writeFilesTempPath_;
   SparkTaskInfo taskInfo_;
   // Session conf map
-  const std::unordered_map<std::string, std::string> confMap_;
+  std::unordered_map<std::string, std::string> confMap_;
 };
 } // namespace gluten

--- a/cpp/core/compute/Runtime.h
+++ b/cpp/core/compute/Runtime.h
@@ -66,13 +66,14 @@ class Runtime : public std::enable_shared_from_this<Runtime> {
 
   /// Parse and cache the plan.
   /// Return true if parsed successfully.
-  virtual void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo) = 0;
+  virtual void
+  parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo, std::optional<std::string> dumpFile) = 0;
 
   virtual std::string planString(bool details, const std::unordered_map<std::string, std::string>& sessionConf) = 0;
 
   virtual void injectWriteFilesTempPath(const std::string& path) = 0;
 
-  virtual void parseSplitInfo(const uint8_t* data, int32_t size) = 0;
+  virtual void parseSplitInfo(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) = 0;
 
   // Just for benchmark
   ::substrait::Plan& getPlan() {

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -28,6 +28,8 @@ const std::string kDebugModeEnabled = "spark.gluten.sql.debug";
 
 const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
+const std::string kDumpConf = "spark.gluten.dumpConf";
+
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
 const std::string kLegacySize = "spark.sql.legacy.sizeOfNull";

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -28,8 +28,6 @@ const std::string kDebugModeEnabled = "spark.gluten.sql.debug";
 
 const std::string kGlutenSaveDir = "spark.gluten.saveDir";
 
-const std::string kDumpConf = "spark.gluten.dumpConf";
-
 const std::string kCaseSensitive = "spark.sql.caseSensitive";
 
 const std::string kLegacySize = "spark.sql.legacy.sizeOfNull";

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -47,7 +47,7 @@ DEFINE_bool(iaa_gzip, false, "Use IAA GZIP as shuffle compression codec");
 DEFINE_int32(shuffle_partitions, 200, "Number of shuffle split (reducer) partitions");
 DEFINE_bool(run_example, false, "Run the example and exit.");
 
-DEFINE_string(json, "", "Path to input json file of the substrait plan.");
+DEFINE_string(plan, "", "Path to input json file of the substrait plan.");
 DEFINE_string(split, "", "Path to input json file of the splits. Only valid for simulating the first stage.");
 DEFINE_string(data, "", "Path to input data files in parquet format. Only valid for simulating the middle stage.");
 
@@ -249,7 +249,7 @@ int main(int argc, char** argv) {
   initVeloxBackend(conf);
 
   // Parse substrait plan, split file and data files.
-  std::string substraitJsonFile = FLAGS_json;
+  std::string substraitJsonFile = FLAGS_plan;
   std::string splitFile = FLAGS_split;
   std::vector<std::string> inputFiles{};
   if (!FLAGS_data.empty()) {
@@ -290,7 +290,7 @@ int main(int argc, char** argv) {
                << "If simulating a middle stage, the usage is:" << std::endl
                << "./generic_benchmark "
                << "--plan /absolute-path/to/substrait_json_file "
-               << "--data-file /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
+               << "--data /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
     LOG(ERROR) << "*** Please check docs/developers/MicroBenchmarks.md for the full usage. ***";
     std::exit(EXIT_FAILURE);
   }

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -332,7 +332,7 @@ int main(int argc, char** argv) {
   LOG(INFO) << "write_file: " << FLAGS_write_file;
   LOG(INFO) << "batch_size: " << FLAGS_batch_size;
 
-  if (splitFile.empty()) {
+  if (!splitFile.empty()) {
     GENERIC_BENCHMARK("SkipInput", FileReaderType::kNone);
   } else {
     GENERIC_BENCHMARK("InputFromBatchVector", FileReaderType::kBuffered);

--- a/cpp/velox/benchmarks/GenericBenchmark.cc
+++ b/cpp/velox/benchmarks/GenericBenchmark.cc
@@ -31,6 +31,7 @@
 #include "config/GlutenConfig.h"
 #include "shuffle/LocalPartitionWriter.h"
 #include "shuffle/VeloxShuffleWriter.h"
+#include "utils/StringUtil.h"
 #include "utils/VeloxArrowUtils.h"
 #include "utils/exception.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -48,7 +49,10 @@ DEFINE_int32(shuffle_partitions, 200, "Number of shuffle split (reducer) partiti
 DEFINE_bool(run_example, false, "Run the example and exit.");
 
 DEFINE_string(plan, "", "Path to input json file of the substrait plan.");
-DEFINE_string(split, "", "Path to input json file of the splits. Only valid for simulating the first stage.");
+DEFINE_string(
+    split,
+    "",
+    "Path to input json file of the splits. Only valid for simulating the first stage. Use comma-separated list for multiple splits.");
 DEFINE_string(data, "", "Path to input data files in parquet format. Only valid for simulating the middle stage.");
 DEFINE_string(conf, "", "Path to the configuration file.");
 
@@ -115,8 +119,8 @@ void populateWriterMetrics(
 
 auto BM_Generic = [](::benchmark::State& state,
                      const std::string& planFile,
-                     const std::string& splitFile,
-                     const std::vector<std::string>& inputFiles,
+                     const std::vector<std::string>& splitFiles,
+                     const std::vector<std::string>& dataFiles,
                      const std::unordered_map<std::string, std::string>& conf,
                      FileReaderType readerType) {
   // Pin each threads to different CPU# starting from 0 or --cpu.
@@ -125,14 +129,13 @@ auto BM_Generic = [](::benchmark::State& state,
   } else {
     setCpu(state.thread_index());
   }
-  bool emptySplit = splitFile.empty();
   memory::MemoryManager::testingSetInstance({});
   auto memoryManager = getDefaultMemoryManager();
   auto runtime = Runtime::create(kVeloxRuntimeKind, conf);
   auto plan = getPlanFromFile("Plan", planFile);
-  std::string split;
-  if (!emptySplit) {
-    split = getPlanFromFile("ReadRel.LocalFiles", splitFile);
+  std::vector<std::string> splits{};
+  for (const auto& splitFile : splitFiles) {
+    splits.push_back(getPlanFromFile("ReadRel.LocalFiles", splitFile));
   }
   auto startTime = std::chrono::steady_clock::now();
   int64_t collectBatchTime = 0;
@@ -141,8 +144,8 @@ auto BM_Generic = [](::benchmark::State& state,
   for (auto _ : state) {
     std::vector<std::shared_ptr<gluten::ResultIterator>> inputIters;
     std::vector<FileReaderIterator*> inputItersRaw;
-    if (!inputFiles.empty()) {
-      for (const auto& input : inputFiles) {
+    if (!dataFiles.empty()) {
+      for (const auto& input : dataFiles) {
         inputIters.push_back(getInputIteratorFromFileReader(input, readerType));
       }
       std::transform(
@@ -154,9 +157,9 @@ auto BM_Generic = [](::benchmark::State& state,
           });
     }
 
-    runtime->parsePlan(reinterpret_cast<uint8_t*>(plan.data()), plan.size(), {});
-    if (!emptySplit) {
-      runtime->parseSplitInfo(reinterpret_cast<uint8_t*>(split.data()), split.size());
+    runtime->parsePlan(reinterpret_cast<uint8_t*>(plan.data()), plan.size(), {}, std::nullopt);
+    for (auto& split : splits) {
+      runtime->parseSplitInfo(reinterpret_cast<uint8_t*>(split.data()), split.size(), std::nullopt);
     }
     auto resultIter =
         runtime->createResultIterator(memoryManager.get(), "/tmp/test-spill", std::move(inputIters), conf);
@@ -244,101 +247,146 @@ int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   // Init Velox backend.
-  std::unordered_map<std::string, std::string> conf;
-  conf.insert({gluten::kSparkBatchSize, std::to_string(FLAGS_batch_size)});
-  conf.insert({kDebugModeEnabled, "true"});
+  std::unordered_map<std::string, std::string> backendConf;
+  std::unordered_map<std::string, std::string> sessionConf;
+  backendConf.insert({gluten::kSparkBatchSize, std::to_string(FLAGS_batch_size)});
+  backendConf.insert({kDebugModeEnabled, "true"});
   if (!FLAGS_conf.empty()) {
     abortIfFileNotExists(FLAGS_conf);
     std::ifstream file(FLAGS_conf);
 
-    if (file.is_open()) {
-      std::string key, value;
-      while (file >> key >> value) {
-        conf[key] = value;
+    if (!file.is_open()) {
+      LOG(ERROR) << "Unable to open configuration file.";
+      ::benchmark::Shutdown();
+      std::exit(EXIT_FAILURE);
+    }
+
+    // Parse the ini file.
+    // Load all key-values under [Backend Conf] to backendConf, under [Session Conf] to sessionConf.
+    // If no [Session Conf] section specified, all key-values are loaded for both backendConf and sessionConf.
+    bool isBackendConf = true;
+    std::string line;
+    while (std::getline(file, line)) {
+      if (line.empty() || line[0] == ';') {
+        continue;
       }
-      file.close();
-    } else {
-      LOG(ERROR) << "Unable to open configuration file";
+      if (line[0] == '[') {
+        if (line == "[Backend Conf]") {
+          isBackendConf = true;
+        } else if (line == "[Session Conf]") {
+          isBackendConf = false;
+        } else {
+          LOG(ERROR) << "Invalid section: " << line;
+          ::benchmark::Shutdown();
+          std::exit(EXIT_FAILURE);
+        }
+        continue;
+      }
+      std::istringstream iss(line);
+      std::string key, value;
+
+      iss >> key;
+
+      // std::ws is used to consume any leading whitespace.
+      std::getline(iss >> std::ws, value);
+
+      if (isBackendConf) {
+        backendConf[key] = value;
+      } else {
+        sessionConf[key] = value;
+      }
+    }
+  }
+  if (sessionConf.empty()) {
+    sessionConf = backendConf;
+  }
+
+  initVeloxBackend(backendConf);
+
+  // Parse substrait plan, split file and data files.
+  std::string substraitJsonFile = FLAGS_plan;
+  std::vector<std::string> splitFiles{};
+  std::vector<std::string> dataFiles{};
+
+  if (FLAGS_run_example) {
+    LOG(INFO) << "Running example...";
+    dataFiles.resize(2);
+    try {
+      substraitJsonFile = getGeneratedFilePath("example.json");
+      dataFiles[0] = getGeneratedFilePath("example_orders");
+      dataFiles[1] = getGeneratedFilePath("example_lineitem");
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to run example. " << e.what();
+      ::benchmark::Shutdown();
+      std::exit(EXIT_FAILURE);
+    }
+  } else {
+    // Validate input args.
+    std::string errorMsg{};
+    if (substraitJsonFile.empty()) {
+      errorMsg = "Missing '--plan' option.";
+    } else if (!checkPathExists(substraitJsonFile)) {
+      errorMsg = "File path does not exist: " + substraitJsonFile;
+    } else if (FLAGS_split.empty() && FLAGS_data.empty()) {
+      errorMsg = "Missing '--split' or '--data' option.";
+    } else if (!FLAGS_split.empty() && !FLAGS_data.empty()) {
+      errorMsg = "Duplicated option '--split' and '--data'.";
+    }
+
+    try {
+      if (!FLAGS_data.empty()) {
+        dataFiles = gluten::splitPaths(FLAGS_data, true);
+      } else {
+        splitFiles = gluten::splitPaths(FLAGS_split, true);
+      }
+    } catch (const std::exception& e) {
+      errorMsg = e.what();
+    }
+
+    if (!errorMsg.empty()) {
+      LOG(ERROR) << "Incorrect usage: " << errorMsg << std::endl
+                 << "If simulating a first stage, the usage is:" << std::endl
+                 << "./generic_benchmark "
+                 << "--plan /absolute-path/to/substrait_json_file "
+                 << "--split /absolute-path/to/split_json_file_1,/abosolute-path/to/split_json_file_2,..." << std::endl
+                 << "If simulating a middle stage, the usage is:" << std::endl
+                 << "./generic_benchmark "
+                 << "--plan /absolute-path/to/substrait_json_file "
+                 << "--data /absolute-path/to/data_file_1,/absolute-path/to/data_file_2,...";
+      LOG(ERROR) << "*** Please check docs/developers/MicroBenchmarks.md for the full usage. ***";
       ::benchmark::Shutdown();
       std::exit(EXIT_FAILURE);
     }
   }
-  initVeloxBackend(conf);
-
-  // Parse substrait plan, split file and data files.
-  std::string substraitJsonFile = FLAGS_plan;
-  std::string splitFile = FLAGS_split;
-  std::vector<std::string> inputFiles{};
-  if (!FLAGS_data.empty()) {
-    inputFiles.emplace_back(FLAGS_data);
-  }
-  // Parse the remaining data files.
-  for (auto i = 1; i < argc; ++i) {
-    inputFiles.emplace_back(std::string(argv[i]));
-  }
-
-  if (FLAGS_run_example) {
-    LOG(INFO) << "Running example...";
-    inputFiles.resize(2);
-    try {
-      substraitJsonFile = getGeneratedFilePath("example.json");
-      inputFiles[0] = getGeneratedFilePath("example_orders");
-      inputFiles[1] = getGeneratedFilePath("example_lineitem");
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to run example. " << e.what();
-    }
-  }
-
-  // Validate input args.
-  std::string errorMsg{};
-  if (substraitJsonFile.empty()) {
-    errorMsg = "Missing '--plan' option.";
-  } else if (splitFile.empty() && inputFiles.empty()) {
-    errorMsg = "Missing '--split' or '--data' option.";
-  } else if (!splitFile.empty() && !inputFiles.empty()) {
-    errorMsg = "Duplicated option '--split' and '--data'.";
-  }
-  if (!errorMsg.empty()) {
-    LOG(ERROR) << "Incorrect usage: " << errorMsg << std::endl
-               << "If simulating a first stage, the usage is:" << std::endl
-               << "./generic_benchmark "
-               << "--plan /absolute-path/to/substrait_json_file "
-               << "--split /absolute-path/to/split_json_file" << std::endl
-               << "If simulating a middle stage, the usage is:" << std::endl
-               << "./generic_benchmark "
-               << "--plan /absolute-path/to/substrait_json_file "
-               << "--data /absolute-path/to/data_file_1 /absolute-path/to/data_file_2 ...";
-    LOG(ERROR) << "*** Please check docs/developers/MicroBenchmarks.md for the full usage. ***";
-    std::exit(EXIT_FAILURE);
-  }
 
   // Check whether input files exist.
   LOG(INFO) << "Using substrait json file: " << std::endl << substraitJsonFile;
-  abortIfFileNotExists(substraitJsonFile);
-  if (!splitFile.empty()) {
-    LOG(INFO) << "Using split json file: " << std::endl << splitFile;
-    abortIfFileNotExists(splitFile);
-  }
-  LOG(INFO) << "Using " << inputFiles.size() << " input data file(s): ";
-  for (const auto& dataFile : inputFiles) {
-    LOG(INFO) << dataFile;
-    abortIfFileNotExists(dataFile);
+  if (!splitFiles.empty()) {
+    LOG(INFO) << "Using " << splitFiles.size() << " input split file(s): ";
+    for (const auto& splitFile : splitFiles) {
+      LOG(INFO) << splitFile;
+    }
+  } else {
+    LOG(INFO) << "Using " << dataFiles.size() << " input data file(s): ";
+    for (const auto& dataFile : dataFiles) {
+      LOG(INFO) << dataFile;
+    }
   }
 
-#define GENERIC_BENCHMARK(NAME, READER_TYPE)                                                                          \
-  do {                                                                                                                \
-    auto* bm =                                                                                                        \
-        ::benchmark::RegisterBenchmark(NAME, BM_Generic, substraitJsonFile, splitFile, inputFiles, conf, READER_TYPE) \
-            ->MeasureProcessCPUTime()                                                                                 \
-            ->UseRealTime();                                                                                          \
-    if (FLAGS_threads > 0) {                                                                                          \
-      bm->Threads(FLAGS_threads);                                                                                     \
-    } else {                                                                                                          \
-      bm->ThreadRange(1, std::thread::hardware_concurrency());                                                        \
-    }                                                                                                                 \
-    if (FLAGS_iterations > 0) {                                                                                       \
-      bm->Iterations(FLAGS_iterations);                                                                               \
-    }                                                                                                                 \
+#define GENERIC_BENCHMARK(NAME, READER_TYPE)                                                             \
+  do {                                                                                                   \
+    auto* bm = ::benchmark::RegisterBenchmark(                                                           \
+                   NAME, BM_Generic, substraitJsonFile, splitFiles, dataFiles, sessionConf, READER_TYPE) \
+                   ->MeasureProcessCPUTime()                                                             \
+                   ->UseRealTime();                                                                      \
+    if (FLAGS_threads > 0) {                                                                             \
+      bm->Threads(FLAGS_threads);                                                                        \
+    } else {                                                                                             \
+      bm->ThreadRange(1, std::thread::hardware_concurrency());                                           \
+    }                                                                                                    \
+    if (FLAGS_iterations > 0) {                                                                          \
+      bm->Iterations(FLAGS_iterations);                                                                  \
+    }                                                                                                    \
   } while (0)
 
   LOG(INFO) << "Using options: ";
@@ -349,7 +397,7 @@ int main(int argc, char** argv) {
   LOG(INFO) << "write_file: " << FLAGS_write_file;
   LOG(INFO) << "batch_size: " << FLAGS_batch_size;
 
-  if (!splitFile.empty()) {
+  if (dataFiles.empty()) {
     GENERIC_BENCHMARK("SkipInput", FileReaderType::kNone);
   } else {
     GENERIC_BENCHMARK("InputFromBatchVector", FileReaderType::kBuffered);

--- a/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0.json
+++ b/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0.json
@@ -138,15 +138,6 @@
                                             }
                                         ]
                                     }
-                                },
-                                "localFiles": {
-                                    "items": [
-                                        {
-                                            "uriFile": "LINEITEM",
-                                            "length": "1863237",
-                                            "parquet": {}
-                                        }
-                                    ]
                                 }
                             }
                         },

--- a/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0_split.json
+++ b/cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0_split.json
@@ -1,0 +1,9 @@
+{
+    "items": [
+        {
+            "uriFile": "LINEITEM",
+            "length": "1863237",
+            "parquet": {}
+        }
+    ]
+}

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -134,10 +134,11 @@ gluten::Runtime* veloxRuntimeFactory(const std::unordered_map<std::string, std::
 } // namespace
 
 void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf) {
+  backendConf_ = conf;
+
   // Register Velox runtime factory
   gluten::Runtime::registerFactory(gluten::kVeloxRuntimeKind, veloxRuntimeFactory);
 
-  // Init glog and log level.
   std::shared_ptr<const facebook::velox::Config> veloxcfg =
       std::make_shared<facebook::velox::core::MemConfigMutable>(conf);
 
@@ -145,6 +146,7 @@ void VeloxBackend::init(const std::unordered_map<std::string, std::string>& conf
     LOG(INFO) << "VeloxBackend config:" << printConfig(veloxcfg->valuesCopy());
   }
 
+  // Init glog and log level.
   if (!veloxcfg->get<bool>(kDebugModeEnabled, false)) {
     uint32_t vlogLevel = veloxcfg->get<uint32_t>(kGlogVerboseLevel, kGlogVerboseLevelDefault);
     FLAGS_v = vlogLevel;
@@ -335,6 +337,10 @@ VeloxBackend* VeloxBackend::get() {
     throw GlutenException("VeloxBackend instance is null.");
   }
   return instance_.get();
+}
+
+const std::unordered_map<std::string, std::string>& VeloxBackend::getBackendConf() const {
+  return backendConf_;
 }
 
 } // namespace gluten

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -53,6 +53,8 @@ class VeloxBackend {
 
   facebook::velox::cache::AsyncDataCache* getAsyncDataCache() const;
 
+  const std::unordered_map<std::string, std::string>& getBackendConf() const;
+
  private:
   explicit VeloxBackend(const std::unordered_map<std::string, std::string>& conf) {
     init(conf);
@@ -80,6 +82,8 @@ class VeloxBackend {
 
   std::string cachePathPrefix_;
   std::string cacheFilePrefix_;
+
+  std::unordered_map<std::string, std::string> backendConf_{};
 };
 
 } // namespace gluten

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -35,7 +35,8 @@ class VeloxRuntime final : public Runtime {
  public:
   explicit VeloxRuntime(const std::unordered_map<std::string, std::string>& confMap);
 
-  void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo, std::optional<std::string> dumpFile) override;
+  void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo, std::optional<std::string> dumpFile)
+      override;
 
   void parseSplitInfo(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) override;
 

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -35,9 +35,9 @@ class VeloxRuntime final : public Runtime {
  public:
   explicit VeloxRuntime(const std::unordered_map<std::string, std::string>& confMap);
 
-  void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo) override;
+  void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo, std::optional<std::string> dumpFile) override;
 
-  void parseSplitInfo(const uint8_t* data, int32_t size) override;
+  void parseSplitInfo(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) override;
 
   static std::shared_ptr<facebook::velox::memory::MemoryPool> getAggregateVeloxPool(MemoryManager* memoryManager) {
     return toVeloxMemoryManager(memoryManager)->getAggregateMemoryPool();

--- a/cpp/velox/compute/VeloxRuntime.h
+++ b/cpp/velox/compute/VeloxRuntime.h
@@ -113,6 +113,8 @@ class VeloxRuntime final : public Runtime {
 
   void injectWriteFilesTempPath(const std::string& path) override;
 
+  void dumpConf(const std::string& path) override;
+
   std::shared_ptr<const facebook::velox::core::PlanNode> getVeloxPlan() {
     return veloxPlan_;
   }

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -94,7 +94,7 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeValidateWithFailu
   auto planSize = env->GetArrayLength(planArray);
   if (gluten::debugModeEnabled(ctx->getConfMap())) {
     try {
-      auto jsonPlan = gluten::substraitFromPbToJson("Plan", planData, planSize);
+      auto jsonPlan = gluten::substraitFromPbToJson("Plan", planData, planSize, std::nullopt);
       LOG(INFO) << std::string(50, '#') << " received substrait::Plan: for validation";
       LOG(INFO) << jsonPlan;
     } catch (const std::exception& e) {

--- a/cpp/velox/tests/RuntimeTest.cc
+++ b/cpp/velox/tests/RuntimeTest.cc
@@ -25,9 +25,10 @@ class DummyRuntime final : public Runtime {
  public:
   DummyRuntime(const std::unordered_map<std::string, std::string>& conf) : Runtime(conf) {}
 
-  void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo) override {}
+  void parsePlan(const uint8_t* data, int32_t size, SparkTaskInfo taskInfo, std::optional<std::string> dumpFile)
+      override {}
 
-  void parseSplitInfo(const uint8_t* data, int32_t size) override {}
+  void parseSplitInfo(const uint8_t* data, int32_t size, std::optional<std::string> dumpFile) override {}
 
   std::shared_ptr<ResultIterator> createResultIterator(
       MemoryManager* memoryManager,

--- a/cpp/velox/tests/RuntimeTest.cc
+++ b/cpp/velox/tests/RuntimeTest.cc
@@ -95,6 +95,10 @@ class DummyRuntime final : public Runtime {
     throw GlutenException("Not yet implemented");
   }
 
+  void dumpConf(const std::string& path) override {
+    throw GlutenException("Not yet implemented");
+  }
+
  private:
   ResourceMap<std::shared_ptr<ResultIterator>> resultIteratorHolder_;
 

--- a/docs/developers/MicroBenchmarks.md
+++ b/docs/developers/MicroBenchmarks.md
@@ -4,25 +4,29 @@ title: Micro Benchmarks for Velox Backend
 nav_order: 3
 parent: Developer Overview
 ---
+
 # Generate Micro Benchmarks for Velox Backend
 
 **This document explains how to use the existing micro benchmark template in Gluten Cpp.**
 
-A micro benchmark for Velox backend is provided in Gluten Cpp to simulate the execution of a first or middle stage in Spark.
+A micro benchmark for Velox backend is provided in Gluten Cpp to simulate the execution of a first or middle stage in
+Spark.
 It serves as a more convenient alternative to debug in Gluten Cpp comparing with directly debugging in a Spark job.
 Developers can use it to create their own workloads, debug in native process, profile the hotspot and do optimizations.
 
-To simulate a first stage, you need to dump the Substrait plan and input split info into two JSON files. The input URIs of the splits should be exising file locations, which can be either local or HDFS paths.
+To simulate a first stage, you need to dump the Substrait plan and input split info into two JSON files. The input URIs
+of the splits should be exising file locations, which can be either local or HDFS paths.
 
-To simulate a middle stage, in addition to the JSON file, you also need to save the input data of this stage into Parquet files.
-The benchmark will load the data into Arrow format, then add Arrow2Velox to feed 
+To simulate a middle stage, in addition to the JSON file, you also need to save the input data of this stage into
+Parquet files.
+The benchmark will load the data into Arrow format, then add Arrow2Velox to feed
 the data into Velox pipeline to reproduce the reducer stage. Shuffle exchange is not included.
 
 Please refer to the sections below to learn how to dump the Substrait plan and create the input data files.
 
 ## Try the example
 
-To run a micro benchmark, user should provide one file that contains the Substrait plan in JSON format, and optional 
+To run a micro benchmark, user should provide one file that contains the Substrait plan in JSON format, and optional
 one or more input data files in parquet format.
 The commands below help to generate example input files:
 
@@ -36,6 +40,7 @@ mvn test -Pspark-3.2 -Pbackends-velox -Prss -pl backends-velox -am \
 ```
 
 The generated example files are placed in gluten/backends-velox:
+
 ```shell
 $ tree gluten/backends-velox/generated-native-benchmark/
 gluten/backends-velox/generated-native-benchmark/
@@ -49,15 +54,18 @@ gluten/backends-velox/generated-native-benchmark/
 ```
 
 Run micro benchmark with the generated files as input. You need to specify the **absolute** path to the input files:
+
 ```shell
 cd /path/to/gluten/cpp/build/velox/benchmarks
 ./generic_benchmark \
 --plan /home/sparkuser/github/oap-project/gluten/backends-velox/generated-native-benchmark/example.json \
---data /home/sparkuser/github/oap-project/gluten/backends-velox/generated-native-benchmark/example_orders/part-00000-1e66fb98-4dd6-47a6-8679-8625dbc437ee-c000.snappy.parquet \
+--data /home/sparkuser/github/oap-project/gluten/backends-velox/generated-native-benchmark/example_orders/part-00000-1e66fb98-4dd6-47a6-8679-8625dbc437ee-c000.snappy.parquet,\
 /home/sparkuser/github/oap-project/gluten/backends-velox/generated-native-benchmark/example_lineitem/part-00000-3ec19189-d20e-4240-85ae-88631d46b612-c000.snappy.parquet \
 --threads 1 --iterations 1 --noprint-result --benchmark_filter=InputFromBatchStream
 ```
+
 The output should be like:
+
 ```shell
 2022-11-18T16:49:56+08:00
 Running ./generic_benchmark
@@ -94,96 +102,83 @@ InputFromBatchVector/iterations:1/process_time/real_time/threads:1   41304520 ns
 
 ## Generate Substrait plan and input for any query
 
-First, rebuild Gluten with build type `RelWithDebInfo`.
+First, build Gluten with `--build_benchmarks=ON`.
 
 ```shell
 cd /path/to/gluten/
-./dev/buildbundle-veloxbe.sh --build_tests=ON --build_benchmarks=ON --build_type=RelWithDebInfo
+./dev/buildbundle-veloxbe.sh --build_benchmarks=ON
 
-```
-Run the query by spark-shell. Be sure to add below configurations to get the Substrait plan from executor's stdout.
-
-```
---conf spark.gluten.sql.debug=true
---conf spark.gluten.sql.columnar.backend.velox.glogSeverityLevel=0
+# For debugging purpose, rebuild Gluten with build type `Debug`.
+./dev/buildbundle-veloxbe.sh --build_benchmarks=ON --build_type=Debug
 ```
 
-Example output:
-```shell
-################################################## received substrait::Plan:
-Task stageId: 2, partitionId: 855, taskId: 857; {"extensions":[{"extensionFunction":{"name":"sum:req_i32"}}],"relations":[{"root":{"input":{"fetch":{"common":{"direct":{}},"input":{"project":{"common":{"direct":{}},"input":{"aggregate":{"common":{"direct":{}},"input":{"read":{"common":{"direct":{}},"baseSchema":{"names":["i_product_name#15","i_brand#16","spark_grouping_id#14","sum#22"],"struct":{"types":[{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"i64":{"nullability":"NULLABILITY_REQUIRED"}},{"i64":{"nullability":"NULLABILITY_NULLABLE"}}]}},"localFiles":{"items":[{"uriFile":"iterator:0"}]}}},"groupings":[{"groupingExpressions":[{"selection":{"directReference":{"structField":{}}}},{"selection":{"directReference":{"structField":{"field":1}}}},{"selection":{"directReference":{"structField":{"field":2}}}}]}],"measures":[{"measure":{"phase":"AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT","outputType":{"i64":{"nullability":"NULLABILITY_NULLABLE"}},"arguments":[{"value":{"selection":{"directReference":{"structField":{"field":3}}}}}]}}]}},"expressions":[{"selection":{"directReference":{"structField":{"field":3}}}}]}},"count":"100"}},"names":["qoh#10"]}}]}
-```
+First, get the Stage Id from spark UI for the stage you want to simulate.
+And then re-run the query with below configurations to dump the inputs to micro benchmark.
 
-Save the Substrait plan to a JSON file, suppose the name is "plan.json".
+| Parameters                                  | Description                                                                                                    | Recommend Setting |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------|-------------------|
+| spark.gluten.sql.benchmark_task.stageId     | Spark task stage id                                                                                            | target stage id   |
+| spark.gluten.sql.benchmark_task.partitionId | Spark task partition id, default value -1 means all the partition of this stage                                | 0                |
+| spark.gluten.sql.benchmark_task.taskId      | If not specify partition id, use spark task attempt id, default value -1 means all the partition of this stage | target task attemp id   |
+| spark.gluten.saveDir                        | Directory to save the inputs to micro benchmark, should exist and be empty.                                    | /path/to/saveDir  |
 
-If you are simulating a first stage, you can find the JSON string of the input splits from exexutor's log. The file location of the split can be either local or HDFS paths.
 
-```shell
-################################################## received substrait::ReadRel.LocalFiles:
-{"items":[{"uriFile":"hdfs://host:9000/user/hadoop/tpch_sf10/lineitem/part-00000-34fbf25c-7909-476d-a63a-b2b56f281c07-c000.snappy.parquet","partitionIndex":"2","start":"302582158","length":"151291079","parquet":{},"schema":{}}]}
-```
+Check the files in `spark.gluten.saveDir`. If the simulated stage is a first stage, you will get 3 types of dumped file: 
 
-Save it to another JSON file. Suppose the name is "split.json".
+- Configuration file: INI formatted, file name `conf_[stageId]_[partitionId].ini`. Contains the configurations to init Velox backend and runtime session.
+- Plan file: JSON formatted, file name `plan_[stageId]_[partitionId].json`. Contains the substrait plan to the stage, without input file splits.
+- Split file: JSON formatted, file name `split_[stageId]_[partitionId]_[splitIndex].json`. There can be more than one split file in a first stage task. Contains the substrait plan piece to the input file splits.
 
-Run benchmark.
-By default, the result will be printed to stdout. You can use `--noprint-result` to suppress this output.
+Run benchmark. By default, the result will be printed to stdout. You can use `--noprint-result` to suppress this output.
+
+Sample command:
 
 ```shell
 cd /path/to/gluten/cpp/build/velox/benchmarks
 ./generic_benchmark \
---plan /path/to/plan.json \
---split /path/to/split.json \
+--conf /absolute_path/to/conf_[stageId]_[partitionId].ini \
+--plan /absolute_path/to/plan_[stageId]_[partitionId].json \
+--split /absolut_path/to/split_[stageId]_[partitionId]_0.parquet,/absolut_path/to/split_[stageId]_[partitionId]_1.parquet \
 --threads 1 --noprint-result
 ```
 
-If you are simulating a middle stage, get the Stage Id from spark UI.
-You need to re-run the query with below configuraions to dump the input data files.
+If the simulated stage is a middle stage, you will get 3 types of dumped file:
 
-| Parameters | Description | Recommend Setting |
-| ---------- | ----------- | --------------- |
-| spark.gluten.sql.debug | Whether open debug mode | true |
-| spark.gluten.sql.benchmark_task.stageId | Spark task stage id | 2 |
-| spark.gluten.sql.benchmark_task.partitionId | Spark task partition id, default value -1 means all the partition of this stage | -1 |
-| spark.gluten.sql.benchmark_task.taskId | If not specify partition id, use spark task attempt id, default value -1 means all the partition of this stage | -1 |
-| spark.gluten.saveDir | Directory should exist and be empty, save the stage input to this directory, parquet name format is input_${taskId}_${iteratorIndex}_${partitionId}.parquet | /path/to/saveDir |
-
-Suppose the dumped input files are /tmp/save/input_34_0_1.parquet and /tmp/save/input_34_0_2.parquet. Please use spark to combine the 2 files to 1 file.
-
-```scala
-val df = spark.read.format("parquet").load("/tmp/save")
-df.repartition(1).write.format("parquet").save("/tmp/new_save")
-```
-
-The input data files of a middle stage will be loaded as iterators to serve as the inputs for the pipeline.
+- Configuration file: INI formatted, file name `conf_[stageId]_[partitionId].ini`. Contains the configurations to init Velox backend and runtime session.
+- Plan file: JSON formatted, file name `plan_[stageId]_[partitionId].json`. Contains the substrait plan to the stage.
+- Data file: Parquet formatted, file name `data_[stageId]_[partitionId]_[iteratorIndex].json`. There can be more than one input data file in a middle stage task. The input data files of a middle stage will be loaded as iterators to serve as the inputs for the pipeline:
 
 ```json
 "localFiles": {
-    "items": [{
-            "uriFile": "iterator:0"
-        }
-    ]
+"items": [
+{
+"uriFile": "iterator:0"
+}
+]
 }
 ```
 
-Run benchmark. The first arg is the absolute path to JSON file, the following args are absolute paths to input data files.
+Sample command:
 
 ```shell
 cd /path/to/gluten/cpp/build/velox/benchmarks
 ./generic_benchmark \
---plan /path/to/plan.json \
---data /tmp/new_save/generate.parquet \
+--conf /absolute_path/to/conf_[stageId]_[partitionId].ini \
+--plan /absolute_path/to/plan_[stageId]_[partitionId].json \
+--data /absolut_path/to/data_[stageId]_[partitionId]_0.parquet,/absolut_path/to/data_[stageId]_[partitionId]_1.parquet \
 --threads 1 --noprint-result
 ```
 
-For some complex queries, stageId may cannot represent the Substrait plan input, please get the taskId from spark UI, and get your target parquet from saveDir.
+For some complex queries, stageId may cannot represent the Substrait plan input, please get the taskId from spark UI,
+and get your target parquet from saveDir.
 
 In this example, only one partition input with partition id 2, taskId is 36, iterator length is 2.
 
 ```shell
 cd /path/to/gluten/cpp/build/velox/benchmarks
 ./generic_benchmark \
---plan /plan/to/complex_plan.json \
---data /tmp/save/input_36_0_2.parquet /tmp/save/input_36_1_2.parquet \
+--plan /absolute_path/to/complex_plan.json \
+--data /absolute_path/to/data_36_2_0.parquet,/absolute_path/to/data_36_2_1.parquet \
 --threads 1 --noprint-result
 ```
 
@@ -194,9 +189,9 @@ You can save the output to a parquet file to analyze.
 ```shell
 cd /path/to/gluten/cpp/build/velox/benchmarks
 ./generic_benchmark \
---plan /plan/to/plan.json \
---data /tmp/save/input_1.parquet /tmp/save/input_2.parquet \
---threads 1 --noprint-result --write-file=/path/to/result.parquet
+--plan /absolute_path/to/plan.json \
+--data /absolute_path/to/data.parquet
+--threads 1 --noprint-result --write-file=/absolute_path/to/result.parquet
 ```
 
 ## Add shuffle write process
@@ -206,25 +201,31 @@ You can add the shuffle write process at the end of this stage. Note that this w
 ```shell
 cd /path/to/gluten/cpp/build/velox/benchmarks
 ./generic_benchmark \
---plan /plan/to/plan.json \
---split /plan/to/split.json \
+--plan /absolute_path/to/plan.json \
+--split /absolute_path/to/split.json \
 --threads 1 --noprint-result --with-shuffle
 ```
 
-By default, the compression codec for shuffle outputs is LZ4. You can switch to other codecs by adding one of the following argument flags to the command:
+By default, the compression codec for shuffle outputs is LZ4. You can switch to other codecs by adding one of the
+following argument flags to the command:
+
 - --zstd: ZSTD codec, compression level 1
 - --qat-gzip: QAT GZIP codec, compression level 1
 - --qat-zstd: QAT ZSTD codec, compression level 1
 - --iaa-gzip: IAA GZIP codec, compression level 1
 
 Note using QAT or IAA codec requires Gluten cpp is built with these features.
-Please check the corresponding section in [Velox document](../get-started/Velox.md) first for how to setup, build and enable these features in Gluten.
-For QAT support, please check [Intel® QuickAssist Technology (QAT) support](../get-started/Velox.md#intel-quickassist-technology-qat-support).
-For IAA support, please check [Intel® In-memory Analytics Accelerator (IAA/IAX) support](../get-started/Velox.md#intel-in-memory-analytics-accelerator-iaaiax-support)
+Please check the corresponding section in [Velox document](../get-started/Velox.md) first for how to setup, build and
+enable these features in Gluten.
+For QAT support, please
+check [Intel® QuickAssist Technology (QAT) support](../get-started/Velox.md#intel-quickassist-technology-qat-support).
+For IAA support, please
+check [Intel® In-memory Analytics Accelerator (IAA/IAX) support](../get-started/Velox.md#intel-in-memory-analytics-accelerator-iaaiax-support)
 
 ## Simulate Spark with multiple processes and threads
 
-You can use below command to launch several processes and threads to simulate parallel execution on Spark. Each thread in the same process will be pinned to the core number starting from `--cpu`.
+You can use below command to launch several processes and threads to simulate parallel execution on Spark. Each thread
+in the same process will be pinned to the core number starting from `--cpu`.
 
 Suppose running on a baremetal machine with 48C, 2-socket, HT-on, launching below command will utilize all vcores.
 
@@ -236,7 +237,10 @@ for ((i=0; i<${processes}; i++)); do
     ./generic_benchmark --plan /path/to/plan.json --split /path/to/split.json --noprint-result --threads $threads --cpu $((i*threads)) &
 done
 ```
-If you want to add the shuffle write process, you can specify multiple direcotries by setting environment variable `GLUTEN_SPARK_LOCAL_DIRS` to a comma-separated string for shuffle write to spread the I/O pressure to multiple disks.
+
+If you want to add the shuffle write process, you can specify multiple direcotries by setting environment
+variable `GLUTEN_SPARK_LOCAL_DIRS` to a comma-separated string for shuffle write to spread the I/O pressure to multiple
+disks.
 
 ```shell
 mkdir -p {/data1,/data2,/data3}/tmp # Make sure each directory has been already created.
@@ -252,9 +256,17 @@ done
 
 ### Run Examples
 
-We also provide some example inputs in [cpp/velox/benchmarks/data](../../cpp/velox/benchmarks/data). E.g. [generic_q5/q5_first_stage_0.json](../../cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0.json) simulates a first-stage in TPCH Q5, which has the the most heaviest table scan. You can follow below steps to run this example.
+We also provide some example inputs in [cpp/velox/benchmarks/data](../../cpp/velox/benchmarks/data).
+E.g. [generic_q5/q5_first_stage_0.json](../../cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0.json) simulates a
+first-stage in TPCH Q5, which has the the most heaviest table scan. You can follow below steps to run this example.
 
-1. Open [generic_q5/q5_first_stage_0.json](../../cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0_split.json) with file editor. Search for `"uriFile": "LINEITEM"` and replace `LINEITEM` with the URI to one partition file in lineitem. In the next line, replace the number in `"length": "..."` with the actual file length. Suppose you are using the provided small TPCH table in [cpp/velox/benchmarks/data/tpch_sf10m](../../cpp/velox/benchmarks/data/tpch_sf10m), the replaced JSON should be like:
+1. Open [generic_q5/q5_first_stage_0.json](../../cpp/velox/benchmarks/data/generic_q5/q5_first_stage_0_split.json) with
+   file editor. Search for `"uriFile": "LINEITEM"` and replace `LINEITEM` with the URI to one partition file in
+   lineitem. In the next line, replace the number in `"length": "..."` with the actual file length. Suppose you are
+   using the provided small TPCH table
+   in [cpp/velox/benchmarks/data/tpch_sf10m](../../cpp/velox/benchmarks/data/tpch_sf10m), the replaced JSON should be
+   like:
+
 ```
 {
     "items": [
@@ -268,6 +280,7 @@ We also provide some example inputs in [cpp/velox/benchmarks/data](../../cpp/vel
 ```
 
 2. Launch multiple processes and multiple threads. Set `GLUTEN_SPARK_LOCAL_DIRS` and add --with-shuffle to the command.
+
 ```
 mkdir -p {/data1,/data2,/data3}/tmp # Make sure each directory has been already created.
 export GLUTEN_SPARK_LOCAL_DIRS=/data1/tmp,/data2/tmp,/data3/tmp
@@ -280,7 +293,8 @@ for ((i=0; i<${processes}; i++)); do
 done >stdout.log 2>stderr.log
 ```
 
-You can find the "elapsed_time" and other metrics in stdout.log. In below output, the "elapsed_time" is ~10.75s. If you run TPCH Q5 with Gluten on Spark, a single task in the same Spark stage should take about the same time.
+You can find the "elapsed_time" and other metrics in stdout.log. In below output, the "elapsed_time" is ~10.75s. If you
+run TPCH Q5 with Gluten on Spark, a single task in the same Spark stage should take about the same time.
 
 ```
 ------------------------------------------------------------------------------------------------------------------
@@ -288,4 +302,5 @@ Benchmark                                                        Time           
 ------------------------------------------------------------------------------------------------------------------
 SkipInput/iterations:1/process_time/real_time/threads:8 1317255379 ns   10061941861 ns            8 collect_batch_time=0 elapsed_time=10.7563G shuffle_compress_time=4.19964G shuffle_spill_time=0 shuffle_split_time=0 shuffle_write_time=1.91651G
 ```
+
 ![TPCH-Q5-first-stage](../image/TPCH-q5-first-stage.png)

--- a/gluten-core/src/main/scala/io/glutenproject/utils/DebugUtil.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/DebugUtil.scala
@@ -21,15 +21,11 @@ import io.glutenproject.GlutenConfig
 import org.apache.spark.TaskContext
 
 object DebugUtil {
-  // if not in debug mode, then do nothing
   // if specify taskId, then only do that task partition
   // if not specify stageId, then do nothing
   // if specify stageId but no partitionId, then do all partitions for that stage
   // if specify stageId and partitionId, then only do that partition for that stage
   def saveInputToFile(): Boolean = {
-    if (!GlutenConfig.getConf.debug) {
-      return false
-    }
     if (TaskContext.get().taskAttemptId() == GlutenConfig.getConf.taskId) {
       return true
     }


### PR DESCRIPTION
Save configurations/substrait plan/input data into the same directory `spark.gluten.saveDir`. User can use the saved files for micro benchmark and no longer need to manually save dumped substrait plan from executor's log. Updated doc for the new usage.