### PR TITLE
[VL] Daily Update Velox Version (2024-02-14)

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -17,7 +17,7 @@
 set -exu
 
 VELOX_REPO=https://github.com/oap-project/velox.git
-VELOX_BRANCH=2024_02_13
+VELOX_BRANCH=2024_02_14
 VELOX_HOME=""
 
 #Set on run gluten on HDFS

--- a/ep/build-velox/src/modify_velox.patch
+++ b/ep/build-velox/src/modify_velox.patch
@@ -36,10 +36,10 @@ index d49115f12..1aaa8e532 100644
 +  endif()
  endif()
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e2ff67fa5..e03b246e3 100644
+index e2099787a..698aa2994 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -243,10 +243,15 @@ if(VELOX_ENABLE_ABFS)
+@@ -248,10 +248,15 @@ if(VELOX_ENABLE_ABFS)
  endif()
  
  if(VELOX_ENABLE_HDFS)
@@ -59,7 +59,7 @@ index e2ff67fa5..e03b246e3 100644
    add_definitions(-DVELOX_ENABLE_HDFS3)
  endif()
  
-@@ -401,7 +406,7 @@ resolve_dependency(Boost 1.66.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+@@ -398,7 +403,7 @@ resolve_dependency(Boost 1.66.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
  # for reference. find_package(range-v3)
  
  set_source(gflags)
@@ -69,7 +69,7 @@ index e2ff67fa5..e03b246e3 100644
    # This is a bit convoluted, but we want to be able to use gflags::gflags as a
    # target even when velox is built as a subproject which uses
 diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
-index c7c4d8557..2715e625c 100644
+index ce4c24dbe..0f1f77ba6 100644
 --- a/third_party/CMakeLists.txt
 +++ b/third_party/CMakeLists.txt
 @@ -26,7 +26,8 @@ if(VELOX_ENABLE_ARROW)
@@ -91,15 +91,27 @@ index c7c4d8557..2715e625c 100644
      SOURCE_SUBDIR cpp
      CMAKE_ARGS ${ARROW_CMAKE_ARGS}
 diff --git a/velox/common/process/tests/CMakeLists.txt b/velox/common/process/tests/CMakeLists.txt
-index d64466568..52927c4a5 100644
+index 2fce354e3..64cfcb2ab 100644
 --- a/velox/common/process/tests/CMakeLists.txt
 +++ b/velox/common/process/tests/CMakeLists.txt
-@@ -17,4 +17,4 @@ add_executable(velox_process_test TraceContextTest.cpp)
+@@ -19,4 +19,4 @@ add_executable(
  add_test(velox_process_test velox_process_test)
  
  target_link_libraries(velox_process_test PRIVATE velox_process fmt::fmt gtest
 -                                                 gtest_main)
 +                                                 gtest_main glog::glog gflags::gflags)
+diff --git a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+index e2a638df6..e383cf205 100644
+--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
++++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+@@ -38,7 +38,6 @@ std::shared_ptr<FileSystem> abfsFileSystemGenerator(
+ 
+ void registerAbfsFileSystem() {
+ #ifdef VELOX_ENABLE_ABFS
+-  LOG(INFO) << "Register ABFS";
+   registerFileSystem(isAbfsFile, std::function(abfsFileSystemGenerator));
+ #endif
+ }
 diff --git a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsMiniCluster.cpp b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsMiniCluster.cpp
 index 10ee508ba..027a58ecc 100644
 --- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsMiniCluster.cpp
@@ -114,11 +126,11 @@ index 10ee508ba..027a58ecc 100644
  }
  
 diff --git a/velox/dwio/common/CMakeLists.txt b/velox/dwio/common/CMakeLists.txt
-index 61264ef8c..293d5683b 100644
+index 25e8bb56a..5b2aa526b 100644
 --- a/velox/dwio/common/CMakeLists.txt
 +++ b/velox/dwio/common/CMakeLists.txt
 @@ -76,4 +76,5 @@ target_link_libraries(
-   velox_exec
+   velox_memory
    Boost::regex
    Folly::folly
 -  glog::glog)
@@ -139,19 +151,3 @@ index 2cabfc29a..54329ce23 100644
  
  add_library(
    velox_dwio_arrow_parquet_writer_test_lib
-
-diff --git a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
-index e2a638df6..e383cf205 100644
---- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
-+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
-@@ -38,7 +38,6 @@ std::shared_ptr<FileSystem> abfsFileSystemGenerator(
-
- void registerAbfsFileSystem() {
- #ifdef VELOX_ENABLE_ABFS
--  LOG(INFO) << "Register ABFS";
-   registerFileSystem(isAbfsFile, std::function(abfsFileSystemGenerator));
- #endif
- }
---
-2.25.1
-


### PR DESCRIPTION
`2024-02-13 17:20:26 -0800 5d1d2a3fa by Ankita Victor, Fix install_conda in setup-ubuntu.sh to consider the CPU architecture `([#8706](https://github.com/facebookincubator/velox/pull/8706))
`2024-02-13 17:18:10 -0800 793222bf5 by Masha Basmanova, Report rawInputPositions stat for MergeExchange `([#8742](https://github.com/facebookincubator/velox/pull/8742))
`2024-02-13 16:18:19 -0800 dec4c446f by Masha Basmanova, Fix 'out of range in dynamic array' error in Task::toJson `([#8735](https://github.com/facebookincubator/velox/pull/8735))
`2024-02-13 15:49:47 -0800 f0583e76b by Pedro Pedreira, Add `VELOX_BUILD_MINIMAL_WITH_DWIO` compilation option` ([#8682](https://github.com/facebookincubator/velox/pull/8682))
`2024-02-13 15:26:54 -0800 76a5fd0ce by Bikramjeet Vig, Add FieldReference benchmark`
`2024-02-13 11:17:59 -0800 b0eeef917 by Schierbeck, Cody, Introduce cappedByteLength to help with indexing `UTF-8 strings ([#8637](https://github.com/facebookincubator/velox/pull/8637))
`2024-02-13 09:16:21 -0800 aba702c05 by Zhenyuan Zhao, Return whether registration succeeded in the custom opaque path `([#8716](https://github.com/facebookincubator/velox/pull/8716))