### PR TITLE
[VL] Adapting the bind reference of agg that contains subquery in agg expressions

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
@@ -706,6 +706,12 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
                          |from values (5), (-10), (15) AS tab(c);
                          |""".stripMargin)(
       df => assert(getExecutedPlan(df).count(_.isInstanceOf[HashAggregateExecTransformer]) == 2))
+
+    runQueryAndCompare("""
+                         |select sum(if(c > (select sum(a) from values (1), (-1) AS tab(a)), 1, -1))
+                         |from values (1L, 5), (1L, -10), (2L, 15) AS tab(sum, c) group by sum;
+                         |""".stripMargin)(
+      df => assert(getExecutedPlan(df).count(_.isInstanceOf[HashAggregateExecTransformer]) == 2))
   }
 }
 

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxAggregateFunctionsSuite.scala
@@ -699,6 +699,14 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
           getExecutedPlan(df).count(plan => plan.isInstanceOf[HashAggregateExecTransformer]) >= 2)
     }
   }
+
+  test("bind reference failed when subquery in agg expressions") {
+    runQueryAndCompare("""
+                         |select sum(if(c > (select sum(a) from values (1), (-1) AS tab(a)), 1, -1))
+                         |from values (5), (-10), (15) AS tab(c);
+                         |""".stripMargin)(
+      df => assert(getExecutedPlan(df).count(_.isInstanceOf[HashAggregateExecTransformer]) == 2))
+  }
 }
 
 class VeloxAggregateFunctionsDefaultSuite extends VeloxAggregateFunctionsSuite {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -257,9 +257,10 @@ abstract class HashAggregateExecBaseTransformer(
                   // to this situation; when encountering a failure to bind, it is necessary to
                   // allow the binding of inputAggBufferAttribute with the same name but different
                   // exprId.
-                  val attrsWithSameName = originalInputAttributes.collect {
-                    case a if a.name == attr.name => a
-                  }
+                  val attrsWithSameName =
+                    originalInputAttributes.drop(groupingExpressions.size).collect {
+                      case a if a.name == attr.name => a
+                    }
                   val aggBufferAttrsWithSameName = aggregateExpressions.toIndexedSeq
                     .flatMap(_.aggregateFunction.inputAggBufferAttributes)
                     .filter(_.name == attr.name)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `aggregateExpressions` includes a subquery, Spark's `PlanAdaptiveSubqueries` Rule will transform the subquery within the final aggregation. The `aggregateFunction` in the `aggregateExpressions` of the final aggregation will be cloned, resulting in creating new `aggregateFunction` objects. The `inputAggBufferAttributes` will also generate new `AttributeReference` instances with larger `exprId`, which leads to a failure in binding with the output of the partial aggregation. We need to adapt to this situation; when encountering a failure to bind, it is necessary to allow the binding of `inputAggBufferAttribute` with the same name but different `exprId`.

## How was this patch tested?

Add a test case in `VeloxAggregateFunctionsSuite`.

