### PR TITLE
[VL] Support multi-children count with row construct

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -991,14 +991,13 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
     )(df => checkFallbackOperators(df, 0))
   }
 
-  test("Do not support multi-children count with row construct") {
-    // TODO: Remove this test when Velox support multi-children Count
+  test("Support multi-children count with row construct") {
     runQueryAndCompare(
       """
         |select l_orderkey, count(distinct l_partkey, l_comment), corr(l_partkey, l_partkey+1)
         |from lineitem group by l_orderkey
         |""".stripMargin
-    )(df => checkFallbackOperators(df, 1))
+    )(df => checkFallbackOperators(df, 0))
   }
 
   test("Remainder with non-foldable right side") {

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashAggregateExecBaseTransformer.scala
@@ -180,21 +180,6 @@ abstract class HashAggregateExecBaseTransformer(
       validation: Boolean = false): RelNode
 }
 
-object HashAggregateExecTransformerUtil {
-  // Return whether the outputs partial aggregation should be combined for Velox computing.
-  // When the partial outputs are multiple-column, row construct is needed.
-  def rowConstructNeeded(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
-    aggregateExpressions.exists {
-      aggExpr =>
-        aggExpr.mode match {
-          case PartialMerge | Final =>
-            aggExpr.aggregateFunction.inputAggBufferAttributes.size > 1
-          case _ => false
-        }
-    }
-  }
-}
-
 abstract class HashAggregateExecPullOutBaseHelper(
     groupingExpressions: Seq[NamedExpression],
     aggregateExpressions: Seq[AggregateExpression],

--- a/gluten-core/src/main/scala/io/glutenproject/extension/RewriteMultiChildrenCount.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/RewriteMultiChildrenCount.scala
@@ -17,7 +17,6 @@
 package io.glutenproject.extension
 
 import io.glutenproject.backendsapi.BackendsApiManager
-import io.glutenproject.execution.HashAggregateExecTransformerUtil._
 import io.glutenproject.utils.PullOutProjectHelper
 
 import org.apache.spark.sql.catalyst.expressions.{If, IsNull, Literal, Or}
@@ -31,7 +30,6 @@ import org.apache.spark.sql.types.IntegerType
  * This Rule is used to rewrite the count for aggregates if:
  *   - the count is partial
  *   - the count has more than one child
- *   - the aggregate expressions do not need row construct
  *
  * A rewrite count multi-children example:
  * {{{
@@ -66,8 +64,6 @@ object RewriteMultiChildrenCount extends Rule[SparkPlan] with PullOutProjectHelp
   }
 
   private def shouldRewrite(aggregateExpressions: Seq[AggregateExpression]): Boolean = {
-    // There is a conflict if we would also add a pre-project for row construct
-    !rowConstructNeeded(aggregateExpressions) &&
     aggregateExpressions.exists(extractCountForRewrite(_).isDefined)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since we have pulled out pre-project, the conflict of pre-project and row constrcut is resolved. This pr enables rewrite multi-children count even if aggregate has row construct.

## How was this patch tested?

add test
