### PR TITLE
[VL] Enable weekday & date_from_unix_date Spark functions

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/utils/CHExpressionUtil.scala
@@ -173,6 +173,7 @@ object CHExpressionUtil {
     DECODE -> EncodeDecodeValidator(),
     ENCODE -> EncodeDecodeValidator(),
     ARRAY_EXCEPT -> DefaultValidator(),
-    ARRAY_REPEAT -> DefaultValidator()
+    ARRAY_REPEAT -> DefaultValidator(),
+    DATE_FROM_UNIX_DATE -> DefaultValidator()
   )
 }

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -590,6 +590,7 @@ std::unordered_map<std::string, std::string> SubstraitVeloxExprConverter::extrac
     {"HOUR", "hour"},
     {"DAY", "day"},
     {"DAY_OF_WEEK", "dayofweek"},
+    {"WEEK_DAY", "weekday"},
     {"DAY_OF_YEAR", "dayofyear"},
     {"MONTH", "month"},
     {"QUARTER", "quarter"},

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionMappings.scala
@@ -176,6 +176,7 @@ object ExpressionMappings {
     Sig[NextDay](NEXT_DAY),
     Sig[LastDay](LAST_DAY),
     Sig[MonthsBetween](MONTHS_BETWEEN),
+    Sig[DateFromUnixDate](DATE_FROM_UNIX_DATE),
     // JSON functions
     Sig[GetJsonObject](GET_JSON_OBJECT),
     Sig[LengthOfJsonArray](JSON_ARRAY_LENGTH),

--- a/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/io/glutenproject/expression/ExpressionNames.scala
@@ -185,6 +185,7 @@ object ExpressionNames {
   final val NEXT_DAY = "next_day"
   final val LAST_DAY = "last_day"
   final val MONTHS_BETWEEN = "months_between"
+  final val DATE_FROM_UNIX_DATE = "date_from_unix_date"
 
   // JSON functions
   final val GET_JSON_OBJECT = "get_json_object"


### PR DESCRIPTION
## What changes were proposed in this pull request?

These two functions have been supported in Velox recently.

## How was this patch tested?

Spark UTs.

