### PR TITLE
[GLUTEN-4713][CORE] Not trim the Alias from resultExpressions when determining whether a post-project is needed

### DIFF
--- a/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
+++ b/backends-clickhouse/src/main/scala/io/glutenproject/backendsapi/clickhouse/CHMetricsApi.scala
@@ -176,12 +176,8 @@ class CHMetricsApi extends MetricsApi with Logging with LogLevelUtil {
       "outputWaitTime" -> SQLMetrics.createTimingMetric(sparkContext, "time of waiting for output"),
       "resizeInputRows" -> SQLMetrics.createMetric(sparkContext, "number of resize input rows"),
       "resizeOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of resize output rows"),
-      "preProjectTime" ->
-        SQLMetrics.createTimingMetric(sparkContext, "time of preProjection"),
       "aggregatingTime" ->
         SQLMetrics.createTimingMetric(sparkContext, "time of aggregating"),
-      "postProjectTime" ->
-        SQLMetrics.createTimingMetric(sparkContext, "time of postProjection"),
       "totalTime" -> SQLMetrics.createTimingMetric(sparkContext, "total time")
     )
 

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -1146,7 +1146,7 @@ class GlutenClickHouseHiveTableSuite()
         |if(xxx1 in (39,40),6,
         |if(xxx1 in (38,47),xxx1,-1))))))) as string)
         """.stripMargin
-    runQueryAndCompare(querySql)(df => checkOperatorCount[ProjectExecTransformer](2)(df))
+    runQueryAndCompare(querySql)(df => checkOperatorCount[ProjectExecTransformer](3)(df))
   }
 
   test(

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -609,7 +609,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       runQueryAndCompare(
         "select id % 2, max(hash(id)), min(hash(id)) " +
           "from range(10) group by id % 2") {
-        df => checkOperatorCount[ProjectExecTransformer](1)(df)
+        df => checkOperatorCount[ProjectExecTransformer](2)(df)
       }
       runQueryAndCompare(
         "select id % 10, sum(id +100) + max(id+100) from range(100) group by id % 10") {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -61,15 +61,19 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         val plans = df.queryExecution.executedPlan.collect {
           case scanExec: BasicScanExecTransformer => scanExec
           case hashAggExec: HashAggregateExecBaseTransformer => hashAggExec
+          case postProject @ ProjectExecTransformer(_, _: HashAggregateExecBaseTransformer) =>
+            // CH backend only set outputVectors for the last element in metricsDataList for the
+            // final stage, we need to get the final post-project to check outputVectors.
+            postProject
         }
-        assert(plans.size == 3)
+        assert(plans.size == 4)
 
-        assert(plans(2).metrics("numFiles").value === 1)
-        assert(plans(2).metrics("pruningTime").value === -1)
-        assert(plans(2).metrics("filesSize").value === 19230111)
+        assert(plans(3).metrics("numFiles").value === 1)
+        assert(plans(3).metrics("pruningTime").value === -1)
+        assert(plans(3).metrics("filesSize").value === 19230111)
 
-        assert(plans(1).metrics("outputRows").value === 4)
-        assert(plans(1).metrics("outputVectors").value === 1)
+        assert(plans(2).metrics("outputRows").value === 4)
+        assert(plans(2).metrics("outputVectors").value === 1)
 
         // Execute Sort operator, it will read the data twice.
         assert(plans(0).metrics("outputRows").value === 4)
@@ -102,15 +106,19 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
           val plans = df.queryExecution.executedPlan.collect {
             case scanExec: BasicScanExecTransformer => scanExec
             case hashAggExec: HashAggregateExecBaseTransformer => hashAggExec
+            case postProject @ ProjectExecTransformer(_, _: HashAggregateExecBaseTransformer) =>
+              // CH backend only set outputVectors for the last element in metricsDataList for the
+              // final stage, we need to get the final post-project to check outputVectors.
+              postProject
           }
-          assert(plans.size == 3)
+          assert(plans.size == 4)
 
-          assert(plans(2).metrics("numFiles").value === 1)
-          assert(plans(2).metrics("pruningTime").value === -1)
-          assert(plans(2).metrics("filesSize").value === 19230111)
+          assert(plans(3).metrics("numFiles").value === 1)
+          assert(plans(3).metrics("pruningTime").value === -1)
+          assert(plans(3).metrics("filesSize").value === 19230111)
 
-          assert(plans(1).metrics("outputRows").value === 4)
-          assert(plans(1).metrics("outputVectors").value === 1)
+          assert(plans(2).metrics("outputRows").value === 4)
+          assert(plans(2).metrics("outputVectors").value === 1)
 
           // Execute Sort operator, it will read the data twice.
           assert(plans(0).metrics("outputRows").value === 4)

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension.columnar
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.utils.PullOutProjectHelper
 
-import org.apache.spark.sql.catalyst.expressions.{AliasHelper, Attribute}
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
  * the output of Spark, ensuring that the output data of the native plan can match the Spark plan
  * when a fallback occurs.
  */
-object PullOutPostProject extends Rule[SparkPlan] with PullOutProjectHelper with AliasHelper {
+object PullOutPostProject extends Rule[SparkPlan] with PullOutProjectHelper {
 
   private def needsPostProjection(plan: SparkPlan): Boolean = {
     plan match {

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
@@ -44,9 +44,8 @@ object PullOutPostProject extends Rule[SparkPlan] with PullOutProjectHelper with
         // If the result expressions has different size with output attribute,
         // post-projection is needed.
         agg.resultExpressions.size != allAggregateResultAttributes.size ||
-        // Compare each item in result expressions and output attributes. Attribute in Alias
-        // should be trimmed before checking.
-        agg.resultExpressions.map(trimAliases).zip(allAggregateResultAttributes).exists {
+        // Compare each item in result expressions and output attributes.
+        agg.resultExpressions.zip(allAggregateResultAttributes).exists {
           case (exprAttr: Attribute, resAttr) =>
             // If the result attribute and result expression has different name or type,
             // post-projection is needed.

--- a/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/substrait/SubstraitContext.scala
@@ -40,7 +40,7 @@ case class JoinParams() {
 }
 
 case class AggregationParams() {
-  // Whether preProjection is needed.
+  // Whether rowConstruction is needed.
   var rowConstructionNeeded = false
 
   // Whether extraction from intermediate struct is needed.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #4713.

## How was this patch tested?

Exists CI. Test 1T TPCDS q23b.

