### PR TITLE
[CORE] Remove tag TRANSFORM_SUPPORTED and rename transform-hint to fallback-hint: Phase 1

### DIFF
--- a/backends-clickhouse/src/main/java/io/glutenproject/extension/FallbackBroadcaseHashJoinRules.scala
+++ b/backends-clickhouse/src/main/java/io/glutenproject/extension/FallbackBroadcaseHashJoinRules.scala
@@ -61,7 +61,7 @@ case class FallbackBroadcastHashJoinPrepQueryStage(session: SparkSession) extend
                   "columnar broadcast exchange is disabled or " +
                     "columnar broadcast join is disabled")
               } else {
-                if (TransformHints.isAlreadyTagged(bhj) && TransformHints.isNotTransformable(bhj)) {
+                if (TransformHints.isNotTransformable(bhj)) {
                   ValidationResult.notOk("broadcast join is already tagged as not transformable")
                 } else {
                   val bhjTransformer = BackendsApiManager.getSparkPlanExecApiInstance
@@ -146,7 +146,7 @@ case class FallbackBroadcastHashJoin(session: SparkSession) extends Rule[SparkPl
 
                 maybeExchange match {
                   case Some(exchange @ BroadcastExchangeExec(mode, child)) =>
-                    TransformHints.tag(bhj, isBhjTransformable.toTransformHint)
+                    isBhjTransformable.tagOnFallback(bhj)
                     if (!isBhjTransformable.isValid) {
                       TransformHints.tagNotTransformable(exchange, isBhjTransformable)
                     }
@@ -191,7 +191,6 @@ case class FallbackBroadcastHashJoin(session: SparkSession) extends Rule[SparkPl
                               s" transformed to columnar version but BHJ is determined as" +
                               s" non-transformable: ${bhj.toString()}")
                         }
-                        TransformHints.tagTransformable(bhj)
                     }
                 }
               }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -62,12 +62,12 @@ object TransformHints {
   val DEBUG = false
 
   /**
-   * If true, the plan node will be guaranteed fallback to Vanilla plan node
-   * while being implemented.
+   * If true, the plan node will be guaranteed fallback to Vanilla plan node while being
+   * implemented.
    *
-   * If false, the plan still has chance to be turned into "non-transformable"
-   * in any another validation rule. So user should not consider the plan "transformable"
-   * unless all validation rules are passed.
+   * If false, the plan still has chance to be turned into "non-transformable" in any another
+   * validation rule. So user should not consider the plan "transformable" unless all validation
+   * rules are passed.
    */
   def isNotTransformable(plan: SparkPlan): Boolean = {
     getHintOption(plan) match {

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.types.StringType
 
 import org.apache.commons.lang3.exception.ExceptionUtils
 
-trait TransformHint {
+sealed trait TransformHint {
   val stacktrace: Option[String] =
     if (TransformHints.DEBUG) {
       Some(ExceptionUtils.getStackTrace(new Throwable()))

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -61,6 +61,14 @@ object TransformHints {
 
   val DEBUG = false
 
+  /**
+   * If true, the plan node will be guaranteed fallback to Vanilla plan node
+   * while being implemented.
+   *
+   * If false, the plan still has chance to be turned into "non-transformable"
+   * in any another validation rule. So user should not consider the plan "transformable"
+   * unless all validation rules are passed.
+   */
   def isNotTransformable(plan: SparkPlan): Boolean = {
     getHintOption(plan) match {
       case Some(TRANSFORM_UNSUPPORTED(_, _)) => true

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -57,16 +57,16 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
     val validationLogLevel = glutenConfig.validationLogLevel
     plan.foreachUp {
       case _: GlutenPlan => // ignore
-      case plan: SparkPlan if TransformHints.isNotTransformable(plan) =>
-        TransformHints.getHint(plan) match {
+      case p: SparkPlan if TransformHints.isNotTransformable(p) =>
+        TransformHints.getHint(p) match {
           case TRANSFORM_UNSUPPORTED(Some(reason), append) =>
-            logFallbackReason(validationLogLevel, plan.nodeName, reason)
+            logFallbackReason(validationLogLevel, p.nodeName, reason)
             // With in next round stage in AQE, the physical plan would be a new instance that
             // can not preserve the tag, so we need to set the fallback reason to logical plan.
             // Then we can be aware of the fallback reason for the whole plan.
             // If a logical plan mapping to several physical plan, we add all reason into
             // that logical plan to make sure we do not lose any fallback reason.
-            plan.logicalLink.foreach {
+            p.logicalLink.foreach {
               logicalPlan =>
                 val newReason = logicalPlan
                   .getTagValue(FALLBACK_REASON_TAG)
@@ -88,6 +88,7 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
                   .getOrElse(reason)
                 logicalPlan.setTagValue(FALLBACK_REASON_TAG, newReason)
             }
+          case TRANSFORM_UNSUPPORTED(_, _) =>
           case _ =>
             throw new IllegalStateException("Unreachable code")
         }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -90,6 +90,7 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
                   logicalPlan.setTagValue(FALLBACK_REASON_TAG, newReason)
               }
             case _ =>
+              throw new IllegalStateException("Unreachable code")
           }
         }
     }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -57,7 +57,7 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
     val validationLogLevel = glutenConfig.validationLogLevel
     plan.foreachUp {
       case _: GlutenPlan => // ignore
-      case plan: SparkPlan if (TransformHints.isNotTransformable(plan)) =>
+      case plan: SparkPlan if TransformHints.isNotTransformable(plan) =>
         TransformHints.getHint(plan) match {
           case TRANSFORM_UNSUPPORTED(Some(reason), append) =>
             logFallbackReason(validationLogLevel, plan.nodeName, reason)
@@ -91,6 +91,7 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
           case _ =>
             throw new IllegalStateException("Unreachable code")
         }
+      case _ =>
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -57,41 +57,40 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
     val validationLogLevel = glutenConfig.validationLogLevel
     plan.foreachUp {
       case _: GlutenPlan => // ignore
-      case plan: SparkPlan =>
-        if (TransformHints.isNotTransformable(plan))
-          TransformHints.getHint(plan) match {
-            case TRANSFORM_UNSUPPORTED(Some(reason), append) =>
-              logFallbackReason(validationLogLevel, plan.nodeName, reason)
-              // With in next round stage in AQE, the physical plan would be a new instance that
-              // can not preserve the tag, so we need to set the fallback reason to logical plan.
-              // Then we can be aware of the fallback reason for the whole plan.
-              // If a logical plan mapping to several physical plan, we add all reason into
-              // that logical plan to make sure we do not lose any fallback reason.
-              plan.logicalLink.foreach {
-                logicalPlan =>
-                  val newReason = logicalPlan
-                    .getTagValue(FALLBACK_REASON_TAG)
-                    .map {
-                      lastReason =>
-                        if (!append) {
-                          lastReason
-                        } else if (lastReason.contains(reason)) {
-                          // use the last reason, as the reason is redundant
-                          lastReason
-                        } else if (reason.contains(lastReason)) {
-                          // overwrite the reason
-                          reason
-                        } else {
-                          // add the new reason
-                          lastReason + "; " + reason
-                        }
-                    }
-                    .getOrElse(reason)
-                  logicalPlan.setTagValue(FALLBACK_REASON_TAG, newReason)
-              }
-            case _ =>
-              throw new IllegalStateException("Unreachable code")
-          }
+      case plan: SparkPlan if (TransformHints.isNotTransformable(plan)) =>
+        TransformHints.getHint(plan) match {
+          case TRANSFORM_UNSUPPORTED(Some(reason), append) =>
+            logFallbackReason(validationLogLevel, plan.nodeName, reason)
+            // With in next round stage in AQE, the physical plan would be a new instance that
+            // can not preserve the tag, so we need to set the fallback reason to logical plan.
+            // Then we can be aware of the fallback reason for the whole plan.
+            // If a logical plan mapping to several physical plan, we add all reason into
+            // that logical plan to make sure we do not lose any fallback reason.
+            plan.logicalLink.foreach {
+              logicalPlan =>
+                val newReason = logicalPlan
+                  .getTagValue(FALLBACK_REASON_TAG)
+                  .map {
+                    lastReason =>
+                      if (!append) {
+                        lastReason
+                      } else if (lastReason.contains(reason)) {
+                        // use the last reason, as the reason is redundant
+                        lastReason
+                      } else if (reason.contains(lastReason)) {
+                        // overwrite the reason
+                        reason
+                      } else {
+                        // add the new reason
+                        lastReason + "; " + reason
+                      }
+                  }
+                  .getOrElse(reason)
+                logicalPlan.setTagValue(FALLBACK_REASON_TAG, newReason)
+            }
+          case _ =>
+            throw new IllegalStateException("Unreachable code")
+        }
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/GlutenFallbackReporter.scala
@@ -58,7 +58,7 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
     plan.foreachUp {
       case _: GlutenPlan => // ignore
       case plan: SparkPlan =>
-        if (TransformHints.isNotTransformable(plan)) {
+        if (TransformHints.isNotTransformable(plan))
           TransformHints.getHint(plan) match {
             case TRANSFORM_UNSUPPORTED(Some(reason), append) =>
               logFallbackReason(validationLogLevel, plan.nodeName, reason)
@@ -92,7 +92,6 @@ case class GlutenFallbackReporter(glutenConfig: GlutenConfig, spark: SparkSessio
             case _ =>
               throw new IllegalStateException("Unreachable code")
           }
-        }
     }
   }
 

--- a/gluten-delta/src/main/scala/io/glutenproject/extension/DeltaRewriteTransformerRules.scala
+++ b/gluten-delta/src/main/scala/io/glutenproject/extension/DeltaRewriteTransformerRules.scala
@@ -18,7 +18,6 @@ package io.glutenproject.extension
 
 import io.glutenproject.execution.{DeltaScanTransformer, ProjectExecTransformer}
 import io.glutenproject.extension.DeltaRewriteTransformerRules.columnMappingRule
-import io.glutenproject.extension.columnar.TransformHints
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference}
@@ -137,14 +136,12 @@ object DeltaRewriteTransformerRules {
       )
       scanExecTransformer.copyTagsFrom(plan)
       tagColumnMappingRule(scanExecTransformer)
-      TransformHints.tagTransformable(scanExecTransformer)
 
       // alias physicalName into tableName
       val expr = (transformedAttrs, originColumnNames).zipped.map {
         (attr, columnName) => Alias(attr, columnName)(exprId = attr.exprId)
       }
       val projectExecTransformer = ProjectExecTransformer(expr, scanExecTransformer)
-      TransformHints.tagTransformable(projectExecTransformer)
       projectExecTransformer
     case _ => plan
   }


### PR DESCRIPTION
Since we now introduced a set of validation rules and backend-specific validation rules that all tend to add transform-hint tags to plan nodes, it more or less becomes confusing to tag a plan as `TRANSFORM_SUPPORTED`. Before the plan is finally implemented within Gluten transformers, a plan node can be turned from `TRANSFORM_SUPPORTED` to `TRANSFORM_UNSUPPORTED` in any particular validation rule. So if a plan is tagged as `TRANSFORM_SUPPORTED`, it's never guaranteed to be executed natively by Gluten.

To eliminate this confusing state and ease understanding, the PR (and next PR as phase 2) targets to remove tag `TRANSFORM_SUPPORTED` and rename the term `transform-hint` to `fallback-hint`. When a plan is tagged with the hint, then it's considered a plan to be fallback and being run in Vanilla Spark.

Phase 1 (this PR):
Remove tag TRANSFORM_SUPPORTED.

Phase 2 (in next PR):
Rename transform-hint to fallback-hint.