### PR TITLE
[CORE] Add metadata exclusion list for native write

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
@@ -134,12 +134,12 @@ case class WriteFilesExecTransformer(
   }
 
   private def getFinalChildOutput(): Seq[Attribute] = {
-    val metadataWhiteList = conf
-      .getConf(GlutenConfig.NATIVE_WRITE_FILES_COLUMN_METADATA_WHITE_LIST)
+    val metadataExclusionList = conf
+      .getConf(GlutenConfig.NATIVE_WRITE_FILES_COLUMN_METADATA_EXCLUSION_LIST)
       .split(",")
       .map(_.trim)
       .toSeq
-    child.output.map(attr => WriteFilesExecTransformer.removeMetadata(attr, metadataWhiteList))
+    child.output.map(attr => WriteFilesExecTransformer.removeMetadata(attr, metadataExclusionList))
   }
 
   override protected def doValidateInternal(): ValidationResult = {
@@ -196,8 +196,8 @@ object WriteFilesExecTransformer {
     "__file_source_generated_metadata_col"
   )
 
-  def removeMetadata(attr: Attribute, whiteList: Seq[String]): Attribute = {
-    val metadataKeys = INTERNAL_METADATA_KEYS ++ whiteList
+  def removeMetadata(attr: Attribute, metadataExclusionList: Seq[String]): Attribute = {
+    val metadataKeys = INTERNAL_METADATA_KEYS ++ metadataExclusionList
     attr.withMetadata {
       var builder = new MetadataBuilder().withMetadata(attr.metadata)
       metadataKeys.foreach(key => builder = builder.remove(key))

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WriteFilesExecTransformer.scala
@@ -16,6 +16,7 @@
  */
 package io.glutenproject.execution
 
+import io.glutenproject.GlutenConfig
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.expression.ConverterUtils
 import io.glutenproject.extension.ValidationResult
@@ -133,7 +134,12 @@ case class WriteFilesExecTransformer(
   }
 
   private def getFinalChildOutput(): Seq[Attribute] = {
-    child.output.map(WriteFilesExecTransformer.removeInternalMetadata)
+    val metadataWhiteList = conf
+      .getConf(GlutenConfig.NATIVE_WRITE_FILES_COLUMN_METADATA_WHITE_LIST)
+      .split(",")
+      .map(_.trim)
+      .toSeq
+    child.output.map(attr => WriteFilesExecTransformer.removeMetadata(attr, metadataWhiteList))
   }
 
   override protected def doValidateInternal(): ValidationResult = {
@@ -190,10 +196,11 @@ object WriteFilesExecTransformer {
     "__file_source_generated_metadata_col"
   )
 
-  def removeInternalMetadata(attr: Attribute): Attribute = {
+  def removeMetadata(attr: Attribute, whiteList: Seq[String]): Attribute = {
+    val metadataKeys = INTERNAL_METADATA_KEYS ++ whiteList
     attr.withMetadata {
       var builder = new MetadataBuilder().withMetadata(attr.metadata)
-      INTERNAL_METADATA_KEYS.foreach(key => builder = builder.remove(key))
+      metadataKeys.foreach(key => builder = builder.remove(key))
       builder.build()
     }
   }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/sources/GlutenInsertSuite.scala
@@ -246,6 +246,19 @@ class GlutenInsertSuite
       checkAndGetWriteFiles(df)
     }
   }
+
+  testGluten("Add metadata white list to allow native write files") {
+    withTable("t1", "t2") {
+      spark.sql("""
+                  |CREATE TABLE t1 (c1 long comment 'data column1', c2 long comment 'data column2')
+                  |USING PARQUET
+                  |""".stripMargin)
+      spark.sql("INSERT INTO TABLE t1 VALUES(1, 1),(2, 2)")
+      spark.sql("CREATE TABLE t2 (c1 long, c2 long) USING PARQUET")
+      val df = spark.sql("INSERT INTO TABLE t2 SELECT * FROM t1")
+      checkAndGetWriteFiles(df)
+    }
+  }
 }
 
 class GlutenRenameFromSparkStagingToFinalDirAlwaysTurnsFalseFilesystem extends RawLocalFileSystem {

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1326,6 +1326,14 @@ object GlutenConfig {
       .booleanConf
       .createOptional
 
+  val NATIVE_WRITE_FILES_COLUMN_METADATA_WHITE_LIST =
+    buildConf("spark.gluten.sql.native.writeFilesColumnMetadataWhiteList")
+      .doc(
+        "Native write files does not support column metadata. Metadata in white list would be" +
+          "removed to support native write files. Multiple values separated by commas.")
+      .stringConf
+      .createWithDefault("comment")
+
   val REMOVE_NATIVE_WRITE_FILES_SORT_AND_PROJECT =
     buildConf("spark.gluten.sql.removeNativeWriteFilesSortAndProject")
       .internal()

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1326,10 +1326,10 @@ object GlutenConfig {
       .booleanConf
       .createOptional
 
-  val NATIVE_WRITE_FILES_COLUMN_METADATA_WHITE_LIST =
-    buildConf("spark.gluten.sql.native.writeFilesColumnMetadataWhiteList")
+  val NATIVE_WRITE_FILES_COLUMN_METADATA_EXCLUSION_LIST =
+    buildConf("spark.gluten.sql.native.writeColumnMetadataExclusionList")
       .doc(
-        "Native write files does not support column metadata. Metadata in white list would be" +
+        "Native write files does not support column metadata. Metadata in list would be " +
           "removed to support native write files. Multiple values separated by commas.")
       .stringConf
       .createWithDefault("comment")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds a new config `spark.gluten.sql.native.writeFilesColumnMetadataWhiteList` to allow native write files even if there are some metadata. By default, set with `comment` which is quite common if the source table column has comment and the write files column reference it directly. 

## How was this patch tested?

add test
