### PR TITLE
[GLUTEN-4741][CORE] Align the ProjectExecTransformer#verboseStringWithOperatorId of Gluten with the ProjectExec of Spark

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicPhysicalOperatorTransformer.scala
@@ -235,6 +235,14 @@ case class ProjectExecTransformer private (projectList: Seq[NamedExpression], ch
     }
   }
 
+  override def verboseStringWithOperatorId(): String = {
+    s"""
+       |$formattedNodeName
+       |${ExplainUtils.generateFieldString("Output", projectList)}
+       |${ExplainUtils.generateFieldString("Input", child.output)}
+       |""".stripMargin
+  }
+
   override protected def withNewChildInternal(newChild: SparkPlan): ProjectExecTransformer =
     copy(child = newChild)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Keep `ProjectExecTransformer` print the same verbose schema with Spark [`ProjectExec`](https://github.com/apache/spark/blob/a87015efb5cf36103bc4eb82ae8613874e2eb408/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala#L109-L115)

```diff
 $formattedNodeName
+Output: $projectList
 Input: $child.output
-Arguments: $argumentString
```

Close #4741

## How was this patch tested?

Local manual
