### PR TITLE
[GLUTEN-4713][CORE] Fix invalid children caused by std::move in RowVectorStream

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseHiveTableSuite.scala
@@ -1146,7 +1146,7 @@ class GlutenClickHouseHiveTableSuite()
         |if(xxx1 in (39,40),6,
         |if(xxx1 in (38,47),xxx1,-1))))))) as string)
         """.stripMargin
-    runQueryAndCompare(querySql)(df => checkOperatorCount[ProjectExecTransformer](3)(df))
+    runQueryAndCompare(querySql)(df => checkOperatorCount[ProjectExecTransformer](2)(df))
   }
 
   test(

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -61,24 +61,20 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           case scanExec: BasicScanExecTransformer => scanExec
           case hashAggExec: HashAggregateExecBaseTransformer => hashAggExec
           case inputIteratorTransformer: InputIteratorTransformer => inputIteratorTransformer
-          case postProject @ ProjectExecTransformer(_, _: HashAggregateExecBaseTransformer) =>
-            // CH backend only set outputVectors for the last element in metricsDataList for the
-            // final stage, we need to get the final post-project to check outputVectors.
-            postProject
         }
-        assert(plans.size == 6)
+        assert(plans.size == 5)
 
-        assert(plans(5).metrics("numFiles").value === 1)
-        assert(plans(5).metrics("pruningTime").value === -1)
-        assert(plans(5).metrics("filesSize").value === 19230111)
-        assert(plans(5).metrics("outputRows").value === 600572)
+        assert(plans(4).metrics("numFiles").value === 1)
+        assert(plans(4).metrics("pruningTime").value === -1)
+        assert(plans(4).metrics("filesSize").value === 19230111)
+        assert(plans(4).metrics("outputRows").value === 600572)
 
-        assert(plans(4).metrics("inputRows").value === 591673)
-        assert(plans(4).metrics("outputRows").value === 4)
-        assert(plans(4).metrics("outputVectors").value === 1)
+        assert(plans(3).metrics("inputRows").value === 591673)
+        assert(plans(3).metrics("outputRows").value === 4)
+        assert(plans(3).metrics("outputVectors").value === 1)
 
-        assert(plans(3).metrics("inputRows").value === 8)
-        assert(plans(3).metrics("outputRows").value === 8)
+        assert(plans(2).metrics("inputRows").value === 8)
+        assert(plans(2).metrics("outputRows").value === 8)
 
         // Execute Sort operator, it will read the data twice.
         assert(plans(1).metrics("outputRows").value === 8)
@@ -97,20 +93,16 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite
           val plans = collect(df.queryExecution.executedPlan) {
             case scanExec: BasicScanExecTransformer => scanExec
             case hashAggExec: HashAggregateExecBaseTransformer => hashAggExec
-            case postProject @ ProjectExecTransformer(_, _: HashAggregateExecBaseTransformer) =>
-              // CH backend only set outputVectors for the last element in metricsDataList for the
-              // final stage, we need to get the final post-project to check outputVectors.
-              postProject
           }
-          assert(plans.size == 4)
+          assert(plans.size == 3)
 
-          assert(plans(3).metrics("numFiles").value === 1)
-          assert(plans(3).metrics("pruningTime").value === -1)
-          assert(plans(3).metrics("filesSize").value === 19230111)
+          assert(plans(2).metrics("numFiles").value === 1)
+          assert(plans(2).metrics("pruningTime").value === -1)
+          assert(plans(2).metrics("filesSize").value === 19230111)
 
-          assert(plans(2).metrics("inputRows").value === 591673)
-          assert(plans(2).metrics("outputRows").value === 4)
-          assert(plans(2).metrics("outputVectors").value === 1)
+          assert(plans(1).metrics("inputRows").value === 591673)
+          assert(plans(1).metrics("outputRows").value === 4)
+          assert(plans(1).metrics("outputVectors").value === 1)
 
           // Execute Sort operator, it will read the data twice.
           assert(plans(0).metrics("outputRows").value === 8)

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenFunctionValidateSuite.scala
@@ -609,7 +609,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
       runQueryAndCompare(
         "select id % 2, max(hash(id)), min(hash(id)) " +
           "from range(10) group by id % 2") {
-        df => checkOperatorCount[ProjectExecTransformer](2)(df)
+        df => checkOperatorCount[ProjectExecTransformer](1)(df)
       }
       runQueryAndCompare(
         "select id % 10, sum(id +100) + max(id+100) from range(100) group by id % 10") {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -61,19 +61,15 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
         val plans = df.queryExecution.executedPlan.collect {
           case scanExec: BasicScanExecTransformer => scanExec
           case hashAggExec: HashAggregateExecBaseTransformer => hashAggExec
-          case postProject @ ProjectExecTransformer(_, _: HashAggregateExecBaseTransformer) =>
-            // CH backend only set outputVectors for the last element in metricsDataList for the
-            // final stage, we need to get the final post-project to check outputVectors.
-            postProject
         }
-        assert(plans.size == 4)
+        assert(plans.size == 3)
 
-        assert(plans(3).metrics("numFiles").value === 1)
-        assert(plans(3).metrics("pruningTime").value === -1)
-        assert(plans(3).metrics("filesSize").value === 19230111)
+        assert(plans(2).metrics("numFiles").value === 1)
+        assert(plans(2).metrics("pruningTime").value === -1)
+        assert(plans(2).metrics("filesSize").value === 19230111)
 
-        assert(plans(2).metrics("outputRows").value === 4)
-        assert(plans(2).metrics("outputVectors").value === 1)
+        assert(plans(1).metrics("outputRows").value === 4)
+        assert(plans(1).metrics("outputVectors").value === 1)
 
         // Execute Sort operator, it will read the data twice.
         assert(plans(0).metrics("outputRows").value === 4)
@@ -106,19 +102,15 @@ class GlutenClickHouseTPCHMetricsSuite extends GlutenClickHouseTPCHAbstractSuite
           val plans = df.queryExecution.executedPlan.collect {
             case scanExec: BasicScanExecTransformer => scanExec
             case hashAggExec: HashAggregateExecBaseTransformer => hashAggExec
-            case postProject @ ProjectExecTransformer(_, _: HashAggregateExecBaseTransformer) =>
-              // CH backend only set outputVectors for the last element in metricsDataList for the
-              // final stage, we need to get the final post-project to check outputVectors.
-              postProject
           }
-          assert(plans.size == 4)
+          assert(plans.size == 3)
 
-          assert(plans(3).metrics("numFiles").value === 1)
-          assert(plans(3).metrics("pruningTime").value === -1)
-          assert(plans(3).metrics("filesSize").value === 19230111)
+          assert(plans(2).metrics("numFiles").value === 1)
+          assert(plans(2).metrics("pruningTime").value === -1)
+          assert(plans(2).metrics("filesSize").value === 19230111)
 
-          assert(plans(2).metrics("outputRows").value === 4)
-          assert(plans(2).metrics("outputVectors").value === 1)
+          assert(plans(1).metrics("outputRows").value === 4)
+          assert(plans(1).metrics("outputVectors").value === 1)
 
           // Execute Sort operator, it will read the data twice.
           assert(plans(0).metrics("outputRows").value === 4)

--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -41,7 +41,7 @@ class RowVectorStream {
     auto vp = vb->getRowVector();
     VELOX_DCHECK(vp != nullptr);
     return std::make_shared<facebook::velox::RowVector>(
-        vp->pool(), outputType_, facebook::velox::BufferPtr(0), vp->size(), std::move(vp->children()));
+        vp->pool(), outputType_, facebook::velox::BufferPtr(0), vp->size(), vp->children());
   }
 
  private:

--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPostProject.scala
@@ -19,7 +19,7 @@ package io.glutenproject.extension.columnar
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.utils.PullOutProjectHelper
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{AliasHelper, Attribute}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
  * the output of Spark, ensuring that the output data of the native plan can match the Spark plan
  * when a fallback occurs.
  */
-object PullOutPostProject extends Rule[SparkPlan] with PullOutProjectHelper {
+object PullOutPostProject extends Rule[SparkPlan] with PullOutProjectHelper with AliasHelper {
 
   private def needsPostProjection(plan: SparkPlan): Boolean = {
     plan match {
@@ -44,8 +44,9 @@ object PullOutPostProject extends Rule[SparkPlan] with PullOutProjectHelper {
         // If the result expressions has different size with output attribute,
         // post-projection is needed.
         agg.resultExpressions.size != allAggregateResultAttributes.size ||
-        // Compare each item in result expressions and output attributes.
-        agg.resultExpressions.zip(allAggregateResultAttributes).exists {
+        // Compare each item in result expressions and output attributes. Attribute in Alias
+        // should be trimmed before checking.
+        agg.resultExpressions.map(trimAliases).zip(allAggregateResultAttributes).exists {
           case (exprAttr: Attribute, resAttr) =>
             // If the result attribute and result expression has different name or type,
             // post-projection is needed.


### PR DESCRIPTION
## What changes were proposed in this pull request?

In #4713, we discovered that executing q23b on large scale TPCDS dataset would result in a core dump. After investigation, we concluded that an optimization introduced in #4628, which removed some unnecessary post-projects, led to the occurrence of the core dump. However, we believe that this is only a symptom and not the root cause of the problem. In #4726, we restored the post-project and continued to investigate the reason behind the core dump that was triggered by the absence of the post-project.

We ultimately identified the root cause of the issue to be that the `next` method of `RowVectorStream` moves away the children of `RowVector`, leaving the `RowVector`'s children in an indeterminate state. Since the aggregation operation reuses the output `RowVector`, accessing a child that has been moved away during reuse can lead to a core dump.

1. Why doesn't a core dump occur when there is a post-project?
`FilterProject` operator in Velox does not reuse the output `RowVector`, it always creates a new `RowVector` to return.

2. Why doesn't the bug get triggered on small datasets?
The bug is only triggered when there is a reuse scenario occurring with multiple batches being outputted by the aggregation. With small data, the aggregation would only output a single batch, hence no issue arises. However, if the batch size is reduced, this bug can also be triggered.

3. Does the bug occur when the aggregation outputs multiple batches?
The bug is triggered when the downstream of the aggregation is a `RowVectorStream` operator.

After the fix, we can revert the optimization of removing unnecessary post-projects introduced in #4628.

## How was this patch tested?

Testing 1T TPCDS q23b.

