### PR TITLE
[GLUTEN-4754][CORE] Let PullOutProjectHelper#eliminateProjectList return idempotent results

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/utils/PullOutProjectHelper.scala
@@ -65,7 +65,9 @@ trait PullOutProjectHelper {
   protected def eliminateProjectList(
       childOutput: AttributeSet,
       appendAttributes: Seq[NamedExpression]): Seq[NamedExpression] = {
-    childOutput.toIndexedSeq ++ appendAttributes.filter(attr => !childOutput.contains(attr))
+    childOutput.toIndexedSeq ++ appendAttributes
+      .filter(attr => !childOutput.contains(attr))
+      .sortWith(_.exprId.id < _.exprId.id)
   }
 
   protected def supportedAggregate(agg: BaseAggregateExec): Boolean = agg match {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Spark project expression list always be idempotent, after we do some pull out operation in Gluten, we may add some project expressions in an uncertain order.

You can find this we pass map values to this function cause uncertain order.

https://github.com/oap-project/gluten/blob/9ceade94a061c190bf4f0d5fd6aa7d37d845f29e/gluten-core/src/main/scala/io/glutenproject/extension/columnar/PullOutPreProject.scala#L147-L149

We should make this always return the same order.

Close #4754
## How was this patch tested?

manual tests

In local, run tpc-h test q14:

We can see output(project list) always print in order.
```
(14) ProjectExecTransformer
Output [5]: [l_extendedprice#X, l_discount#X, p_type#X, CASE WHEN StartsWith(p_type#X, PROMO) THEN CheckOverflow((promote_precision(cast(l_extendedprice#X as decimal(13,2))) * promote_precision(CheckOverflow((1.00 - promote_precision(cast(l_discount#X as decimal(13,2)))), DecimalType(13,2), true))), DecimalType(26,4), true) ELSE 0.0000 END AS _pre_184#X, CheckOverflow((promote_precision(cast(l_extendedprice#X as decimal(13,2))) * promote_precision(CheckOverflow((1.00 - promote_precision(cast(l_discount#X as decimal(13,2)))), DecimalType(13,2), true))), DecimalType(26,4), true) AS _pre_185#X]
Input [5]: [l_partkey#X, l_extendedprice#X, l_discount#X, p_partkey#X, p_type#X]

(15) FlushableHashAggregateExecTransformer
Input [5]: [l_extendedprice#X, l_discount#X, p_type#X, _pre_184#X, _pre_185#X]
Keys: []
Functions [2]: [partial_sum(_pre_184#X), partial_sum(_pre_185#X)]
Aggregate Attributes [4]: [sum#X, isEmpty#X, sum#X, isEmpty#X]
Results [4]: [sum#X, isEmpty#X, sum#X, isEmpty#X]
```
