### PR TITLE
[GLUTEN-4749][CH] Support to purge mergetree data for CH backend

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/table/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/table/ClickHouseTableV2.scala
@@ -97,7 +97,7 @@ case class ClickHouseTableV2(
 
   protected def metadata: Metadata = if (snapshot == null) Metadata() else snapshot.metadata
 
-  private lazy val (rootPath, partitionFilters, timeTravelByPath) = {
+  lazy val (rootPath, partitionFilters, timeTravelByPath) = {
     if (catalogTable.isDefined) {
       // Fast path for reducing path munging overhead
       (new Path(catalogTable.get.location), Nil, None)
@@ -380,6 +380,8 @@ object ClickHouseTableV2 extends Logging {
     .build[Path, Seq[AddMergeTreeParts]](fileStatusCacheLoader)
 
   def clearAllFileStatusCache: Unit = fileStatusCache.invalidateAll()
+
+  def clearFileStatusCacheByPath(p: Path): Unit = fileStatusCache.invalidate(p)
 
   protected val stalenessLimit: Long = SparkSession.active.sessionState.conf
     .getConf(DeltaSQLConf.DELTA_ASYNC_UPDATE_STALENESS_TIME_LIMIT)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now when executing drop table command, it can not delete mergetree data from a external table, so support command `drop table xxx purge` to delete mergetree data from the external table when dropping table.

Close #4749.

(Fixes: #4749)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

