### PR TITLE
[GLUTEN-4748][VL] Fix JNI array elements memory leak

### DIFF
--- a/cpp/core/config/GlutenConfig.cc
+++ b/cpp/core/config/GlutenConfig.cc
@@ -22,12 +22,11 @@
 #include "jni/JniError.h"
 
 namespace gluten {
-std::unordered_map<std::string, std::string> parseConfMap(JNIEnv* env, jbyteArray configArray) {
+std::unordered_map<std::string, std::string>
+parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength) {
   std::unordered_map<std::string, std::string> sparkConfs;
-  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(configArray, 0));
-  auto planSize = env->GetArrayLength(configArray);
   ConfigMap pConfigMap;
-  gluten::parseProtobuf(planData, planSize, &pConfigMap);
+  gluten::parseProtobuf(planData, planDataLength, &pConfigMap);
   for (const auto& pair : pConfigMap.configs()) {
     sparkConfs.emplace(pair.first, pair.second);
   }

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -61,7 +61,8 @@ const std::string kShuffleCompressionCodecBackend = "spark.gluten.sql.columnar.s
 const std::string kQatBackendName = "qat";
 const std::string kIaaBackendName = "iaa";
 
-std::unordered_map<std::string, std::string> parseConfMap(JNIEnv* env, jbyteArray configArray);
+std::unordered_map<std::string, std::string>
+parseConfMap(JNIEnv* env, const uint8_t* planData, const int32_t planDataLength);
 
 std::string printConfig(const std::unordered_map<std::string, std::string>& conf);
 } // namespace gluten

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -222,7 +222,6 @@ class SafeNativeArray {
   }
 
  private:
-
   SafeNativeArray(JNIEnv* env, JavaArrayType javaArray, NativeArrayType nativeArray)
       : env_(env), javaArray_(javaArray), nativeArray_(nativeArray){};
 

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -210,6 +210,11 @@ class SafeNativeArray {
     PrimitiveArray::release(env_, javaArray_, nativeArray_);
   }
 
+  SafeNativeArray(const SafeNativeArray&) = delete;
+  SafeNativeArray(SafeNativeArray&&) = delete;
+  SafeNativeArray& operator=(const SafeNativeArray&) = delete;
+  SafeNativeArray& operator=(SafeNativeArray&&) = delete;
+
   NativeArrayType elems() const {
     return nativeArray_;
   }

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -203,9 +203,6 @@ class SafeNativeArray {
   using JavaArrayType = typename PrimitiveArray::JavaType;
 
  public:
-  SafeNativeArray(JNIEnv* env, JavaArrayType javaArray, NativeArrayType nativeArray)
-      : env_(env), javaArray_(javaArray), nativeArray_(nativeArray){};
-
   virtual ~SafeNativeArray() {
     PrimitiveArray::release(env_, javaArray_, nativeArray_);
   }
@@ -225,6 +222,10 @@ class SafeNativeArray {
   }
 
  private:
+
+  SafeNativeArray(JNIEnv* env, JavaArrayType javaArray, NativeArrayType nativeArray)
+      : env_(env), javaArray_(javaArray), nativeArray_(nativeArray){};
+
   JNIEnv* env_;
   JavaArrayType javaArray_;
   NativeArrayType nativeArray_;

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -153,7 +153,7 @@ inline JniCommonState* getJniCommonState() {
 Runtime* getRuntime(JNIEnv* env, jobject runtimeAware);
 
 // Safe version of JNI {Get|Release}<PrimitiveType>ArrayElements routines.
-// JniPrimitiveArrayType would release the managed array elements automatically
+// SafeNativeArray would release the managed array elements automatically
 // during destruction.
 
 enum class JniPrimitiveArrayType {

--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -218,7 +218,7 @@ class SafeNativeArray {
     return reinterpret_cast<const NativeArrayType>(nativeArray_);
   }
 
-  jsize length() const {
+  const jsize length() const {
     return env_->GetArrayLength(javaArray_);
   }
 

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -336,7 +336,8 @@ JNIEXPORT jstring JNICALL Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapp
     jboolean details) {
   JNI_METHOD_START
 
-  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
+  auto safeArray = gluten::getByteArrayElementsSafe(env, planArray);
+  auto planData = reinterpret_cast<const uint8_t*>(safeArray.elems());
   auto planSize = env->GetArrayLength(planArray);
   auto ctx = gluten::getRuntime(env, wrapper);
   ctx->parsePlan(planData, planSize, {}, std::nullopt);
@@ -354,11 +355,10 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_
   JNI_METHOD_START
 
   auto len = env->GetArrayLength(path);
-  jbyte* bytes = env->GetByteArrayElements(path, 0);
-  std::string pathStr(reinterpret_cast<char*>(bytes), len);
+  auto safeArray = gluten::getByteArrayElementsSafe(env, path);
+  std::string pathStr(reinterpret_cast<char*>(safeArray.elems()), len);
   auto ctx = gluten::getRuntime(env, wrapper);
   ctx->injectWriteFilesTempPath(pathStr);
-  env->ReleaseByteArrayElements(path, bytes, JNI_ABORT);
 
   JNI_METHOD_END()
 }
@@ -402,7 +402,8 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
   for (jsize i = 0, splitInfoArraySize = env->GetArrayLength(splitInfosArr); i < splitInfoArraySize; i++) {
     jbyteArray splitInfoArray = static_cast<jbyteArray>(env->GetObjectArrayElement(splitInfosArr, i));
     jsize splitInfoSize = env->GetArrayLength(splitInfoArray);
-    auto splitInfoData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(splitInfoArray, nullptr));
+    auto safeArray = gluten::getByteArrayElementsSafe(env, splitInfoArray);
+    auto splitInfoData = reinterpret_cast<const uint8_t*>(safeArray.elems());
     ctx->parseSplitInfo(
         splitInfoData,
         splitInfoSize,
@@ -410,10 +411,10 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeCreateKernelWithI
                   : std::nullopt);
   }
 
-  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArr, nullptr));
+  auto safeArray = gluten::getByteArrayElementsSafe(env, planArr);
   auto planSize = env->GetArrayLength(planArr);
   ctx->parsePlan(
-      planData,
+      reinterpret_cast<const uint8_t*>(safeArray.elems()),
       planSize,
       {stageId, partitionId, taskId},
       saveInput ? std::optional<std::string>(saveDir + "/plan" + fileIdentifier + ".json") : std::nullopt);
@@ -641,12 +642,11 @@ Java_io_glutenproject_vectorized_NativeRowToColumnarJniWrapper_nativeConvertRowT
     throw gluten::GlutenException("Native convert row to columnar: buf_addrs can't be null");
   }
   int numRows = env->GetArrayLength(rowLength);
-  jlong* inRowLength = env->GetLongArrayElements(rowLength, nullptr);
+  auto safeArray = gluten::getLongArrayElementsSafe(env, rowLength);
   uint8_t* address = reinterpret_cast<uint8_t*>(memoryAddress);
 
   auto converter = ctx->objectStore()->retrieve<RowToColumnarConverter>(r2cHandle);
-  auto cb = converter->convert(numRows, reinterpret_cast<int64_t*>(inRowLength), address);
-  env->ReleaseLongArrayElements(rowLength, inRowLength, JNI_ABORT);
+  auto cb = converter->convert(numRows, reinterpret_cast<int64_t*>(safeArray.elems()), address);
   return ctx->objectStore()->save(cb);
   JNI_METHOD_END(kInvalidResourceHandle)
 }
@@ -714,16 +714,15 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
   auto ctx = gluten::getRuntime(env, wrapper);
 
   int handleCount = env->GetArrayLength(batchHandles);
-  jlong* handleArray = env->GetLongArrayElements(batchHandles, nullptr);
+  auto safeArray = gluten::getLongArrayElementsSafe(env, batchHandles);
 
   std::vector<std::shared_ptr<ColumnarBatch>> batches;
   for (int i = 0; i < handleCount; ++i) {
-    jlong handle = handleArray[i];
+    jlong handle = safeArray.elems()[i];
     auto batch = ctx->objectStore()->retrieve<ColumnarBatch>(handle);
     batches.push_back(batch);
   }
   auto newBatch = CompositeColumnarBatch::create(std::move(batches));
-  env->ReleaseLongArrayElements(batchHandles, handleArray, JNI_ABORT);
   return ctx->objectStore()->save(newBatch);
   JNI_METHOD_END(kInvalidResourceHandle)
 }
@@ -784,13 +783,12 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_columnarbatch_ColumnarBatchJniWrap
   auto ctx = gluten::getRuntime(env, wrapper);
   auto memoryManager = jniCastOrThrow<MemoryManager>(memoryManagerHandle);
 
-  int* tmp = env->GetIntArrayElements(jcolumnIndices, nullptr);
+  auto safeArray = gluten::getIntArrayElementsSafe(env, jcolumnIndices);
   int size = env->GetArrayLength(jcolumnIndices);
   std::vector<int32_t> columnIndices;
   for (int32_t i = 0; i < size; i++) {
-    columnIndices.push_back(tmp[i]);
+    columnIndices.push_back(safeArray.elems()[i]);
   }
-  env->ReleaseIntArrayElements(jcolumnIndices, tmp, JNI_ABORT);
 
   return ctx->objectStore()->save(
       ctx->select(memoryManager, ctx->objectStore()->retrieve<ColumnarBatch>(batchHandle), std::move(columnIndices)));
@@ -1029,9 +1027,8 @@ JNIEXPORT void JNICALL Java_io_glutenproject_vectorized_OnHeapJniByteInputStream
     jlong destAddress,
     jint size) {
   JNI_METHOD_START
-  jbyte* bytes = env->GetByteArrayElements(source, nullptr);
-  std::memcpy(reinterpret_cast<void*>(destAddress), reinterpret_cast<const void*>(bytes), size);
-  env->ReleaseByteArrayElements(source, bytes, JNI_ABORT);
+  auto safeArray = gluten::getByteArrayElementsSafe(env, source);
+  std::memcpy(reinterpret_cast<void*>(destAddress), reinterpret_cast<const void*>(safeArray.elems()), size);
   JNI_METHOD_END()
 }
 
@@ -1193,13 +1190,12 @@ Java_io_glutenproject_datasource_DatasourceJniWrapper_splitBlockByPartitionAndBu
   JNI_METHOD_START
   auto ctx = gluten::getRuntime(env, wrapper);
   auto batch = ctx->objectStore()->retrieve<ColumnarBatch>(batchHandle);
-  int* pIndice = env->GetIntArrayElements(partitionColIndice, nullptr);
+  auto safeArray = gluten::getIntArrayElementsSafe(env, partitionColIndice);
   int size = env->GetArrayLength(partitionColIndice);
   std::vector<int32_t> partitionColIndiceVec;
   for (int i = 0; i < size; ++i) {
-    partitionColIndiceVec.push_back(pIndice[i]);
+    partitionColIndiceVec.push_back(safeArray.elems()[i]);
   }
-  env->ReleaseIntArrayElements(partitionColIndice, pIndice, JNI_ABORT);
 
   MemoryManager* memoryManager = reinterpret_cast<MemoryManager*>(memoryManagerId);
   auto result = batch->getRowBytes(0);
@@ -1364,17 +1360,17 @@ JNIEXPORT jobject JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializ
   auto memoryManager = jniCastOrThrow<MemoryManager>(memoryManagerHandle);
 
   int32_t numBatches = env->GetArrayLength(handles);
-  jlong* batchHandles = env->GetLongArrayElements(handles, nullptr);
+  auto safeArray = gluten::getLongArrayElementsSafe(env, handles);
 
   std::vector<std::shared_ptr<ColumnarBatch>> batches;
   int64_t numRows = 0L;
   for (int32_t i = 0; i < numBatches; i++) {
-    auto batch = ctx->objectStore()->retrieve<ColumnarBatch>(batchHandles[i]);
-    GLUTEN_DCHECK(batch != nullptr, "Cannot find the ColumnarBatch with handle " + std::to_string(batchHandles[i]));
+    auto batch = ctx->objectStore()->retrieve<ColumnarBatch>(safeArray.elems()[i]);
+    GLUTEN_DCHECK(
+        batch != nullptr, "Cannot find the ColumnarBatch with handle " + std::to_string(safeArray.elems()[i]));
     numRows += batch->numRows();
     batches.emplace_back(batch);
   }
-  env->ReleaseLongArrayElements(handles, batchHandles, JNI_ABORT);
 
   auto arrowPool = memoryManager->getArrowMemoryPool();
   auto serializer = ctx->createColumnarBatchSerializer(memoryManager, arrowPool, nullptr);
@@ -1415,9 +1411,8 @@ JNIEXPORT jlong JNICALL Java_io_glutenproject_vectorized_ColumnarBatchSerializer
   auto serializer = ctx->objectStore()->retrieve<ColumnarBatchSerializer>(serializerHandle);
   GLUTEN_DCHECK(serializer != nullptr, "ColumnarBatchSerializer cannot be null");
   int32_t size = env->GetArrayLength(data);
-  jbyte* serialized = env->GetByteArrayElements(data, nullptr);
-  auto batch = serializer->deserialize(reinterpret_cast<uint8_t*>(serialized), size);
-  env->ReleaseByteArrayElements(data, serialized, JNI_ABORT);
+  auto safeArray = gluten::getByteArrayElementsSafe(env, data);
+  auto batch = serializer->deserialize(reinterpret_cast<uint8_t*>(safeArray.elems()), size);
   return ctx->objectStore()->save(batch);
   JNI_METHOD_END(kInvalidResourceHandle)
 }

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -90,7 +90,8 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeValidateWithFailu
     jbyteArray planArray) {
   JNI_METHOD_START
   auto ctx = gluten::getRuntime(env, wrapper);
-  auto planData = reinterpret_cast<const uint8_t*>(env->GetByteArrayElements(planArray, 0));
+  auto safeArray = gluten::getByteArrayElementsSafe(env, planArray);
+  auto planData = reinterpret_cast<const uint8_t*>(safeArray.elems());
   auto planSize = env->GetArrayLength(planArray);
   if (gluten::debugModeEnabled(ctx->getConfMap())) {
     try {

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -69,7 +69,8 @@ JNIEXPORT void JNICALL Java_io_glutenproject_init_NativeBackendInitializer_initi
     jclass,
     jbyteArray conf) {
   JNI_METHOD_START
-  auto sparkConf = gluten::parseConfMap(env, conf);
+  auto safeArray = gluten::getByteArrayElementsSafe(env, conf);
+  auto sparkConf = gluten::parseConfMap(env, safeArray.elems(), safeArray.length());
   gluten::VeloxBackend::create(sparkConf);
   JNI_METHOD_END()
 }
@@ -91,7 +92,7 @@ Java_io_glutenproject_vectorized_PlanEvaluatorJniWrapper_nativeValidateWithFailu
   JNI_METHOD_START
   auto ctx = gluten::getRuntime(env, wrapper);
   auto safeArray = gluten::getByteArrayElementsSafe(env, planArray);
-  auto planData = reinterpret_cast<const uint8_t*>(safeArray.elems());
+  auto planData = safeArray.elems();
   auto planSize = env->GetArrayLength(planArray);
   if (gluten::debugModeEnabled(ctx->getConfMap())) {
     try {


### PR DESCRIPTION
This fixes #4748

Introduce a set of `gluten::get<primitive-type>ArrayElementsSafe` functions that would release the gotten array elements while the returned object is destructed. So user would not need to manually release the array elements which can be easily forgotten during programming.