### PR TITLE
[GLUTEN-4772][VL] Support empty map/array literal

### DIFF
--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -1086,4 +1086,29 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
     }
   }
 
+  test("test array literal") {
+    withTable("array_table") {
+      sql("create table array_table(a array<bigint>) using parquet")
+      sql("insert into table array_table select array(1)")
+      runQueryAndCompare("select size(coalesce(a, array())) from array_table") {
+        df =>
+          {
+            assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
+          }
+      }
+    }
+  }
+
+  test("test map literal") {
+    withTable("map_table") {
+      sql("create table map_table(a map<bigint, string>) using parquet")
+      sql("insert into table map_table select map(1, 'hello')")
+      runQueryAndCompare("select size(coalesce(a, map())) from map_table") {
+        df =>
+          {
+            assert(getExecutedPlan(df).count(_.isInstanceOf[ProjectExecTransformer]) == 1)
+          }
+      }
+    }
+  }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
@@ -73,6 +73,7 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
   }
 
   test("Array Literal") {
+    validateOffloadResult("SELECT array()")
     validateOffloadResult("SELECT array('Spark', '5')")
     validateOffloadResult("SELECT array(5, 1, -1)")
     validateOffloadResult("SELECT array(5S, 1S, -1S)")
@@ -93,6 +94,7 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
   }
 
   test("Map Literal") {
+    validateOffloadResult("SELECT map()")
     validateOffloadResult("SELECT map('b', 'a', 'e', 'e')")
     validateOffloadResult("SELECT map(1D, 'a', 2D, 'e')")
     validateOffloadResult("SELECT map(1.0, map(1, 2, 3, 4))")
@@ -134,10 +136,5 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
     validateFallbackResult("SELECT array(cast(null as int))")
     validateFallbackResult("SELECT map(1, null)")
     validateFallbackResult("SELECT struct(cast(null as struct<a: string>))")
-  }
-
-  test("Literal Offload") {
-    validateOffloadResult("SELECT array()")
-    validateOffloadResult("SELECT map()")
   }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
@@ -126,15 +126,18 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
   }
 
   test("Literal Fallback") {
-    validateFallbackResult("SELECT array()")
     validateFallbackResult("SELECT array(array())")
     validateFallbackResult("SELECT array(map())")
-    validateFallbackResult("SELECT map()")
     validateFallbackResult("SELECT map(1, array())")
     validateFallbackResult("SELECT map(1, map())")
     validateFallbackResult("SELECT array(null)")
     validateFallbackResult("SELECT array(cast(null as int))")
     validateFallbackResult("SELECT map(1, null)")
     validateFallbackResult("SELECT struct(cast(null as struct<a: string>))")
+  }
+
+  test("Literal Offload") {
+    validateOffloadResult("SELECT array()")
+    validateOffloadResult("SELECT map()")
   }
 }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxLiteralSuite.scala
@@ -74,6 +74,8 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
 
   test("Array Literal") {
     validateOffloadResult("SELECT array()")
+    validateOffloadResult("SELECT array(array())")
+    validateOffloadResult("SELECT array(map())")
     validateOffloadResult("SELECT array('Spark', '5')")
     validateOffloadResult("SELECT array(5, 1, -1)")
     validateOffloadResult("SELECT array(5S, 1S, -1S)")
@@ -95,6 +97,8 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
 
   test("Map Literal") {
     validateOffloadResult("SELECT map()")
+    validateOffloadResult("SELECT map(1, array())")
+    validateOffloadResult("SELECT map(1, map())")
     validateOffloadResult("SELECT map('b', 'a', 'e', 'e')")
     validateOffloadResult("SELECT map(1D, 'a', 2D, 'e')")
     validateOffloadResult("SELECT map(1.0, map(1, 2, 3, 4))")
@@ -128,10 +132,6 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
   }
 
   test("Literal Fallback") {
-    validateFallbackResult("SELECT array(array())")
-    validateFallbackResult("SELECT array(map())")
-    validateFallbackResult("SELECT map(1, array())")
-    validateFallbackResult("SELECT map(1, map())")
     validateFallbackResult("SELECT array(null)")
     validateFallbackResult("SELECT array(cast(null as int))")
     validateFallbackResult("SELECT map(1, null)")

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1464,7 +1464,7 @@ std::pair<DataTypePtr, Field> SerializedPlanParser::parseLiteral(const substrait
             break;
         }
         case substrait::Expression_Literal::kEmptyList: {
-            type = TypeParser::parseType(literal.empty_list().type());
+            type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeNothing>());
             field = Array();
             break;
         }
@@ -1514,9 +1514,7 @@ std::pair<DataTypePtr, Field> SerializedPlanParser::parseLiteral(const substrait
             break;
         }
         case substrait::Expression_Literal::kEmptyMap: {
-            DataTypePtr keyType = TypeParser::parseType(literal.empty_map().key());
-            DataTypePtr valueType = TypeParser::parseType(literal.empty_map().value());
-            type = std::make_shared<DataTypeMap>(keyType, valueType);
+            type = std::make_shared<DataTypeMap>(std::make_shared<DataTypeNothing>(), std::make_shared<DataTypeNothing>());
             field = Map();
             break;
         }

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -1463,6 +1463,11 @@ std::pair<DataTypePtr, Field> SerializedPlanParser::parseLiteral(const substrait
             field = std::move(array);
             break;
         }
+        case substrait::Expression_Literal::kEmptyList: {
+            type = TypeParser::parseType(literal.empty_list().type());
+            field = Array();
+            break;
+        }
         case substrait::Expression_Literal::kMap: {
             const auto & key_values = literal.map().key_values();
             if (key_values.empty())
@@ -1506,6 +1511,13 @@ std::pair<DataTypePtr, Field> SerializedPlanParser::parseLiteral(const substrait
 
             type = std::make_shared<DataTypeMap>(common_key_type, common_value_type);
             field = std::move(map);
+            break;
+        }
+        case substrait::Expression_Literal::kEmptyMap: {
+            DataTypePtr keyType = TypeParser::parseType(literal.empty_map().key());
+            DataTypePtr valueType = TypeParser::parseType(literal.empty_map().value());
+            type = std::make_shared<DataTypeMap>(keyType, valueType);
+            field = Map();
             break;
         }
         case substrait::Expression_Literal::kStruct: {

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -510,7 +510,6 @@ RowVectorPtr SubstraitVeloxExprConverter::literalsToRowVector(const ::substrait:
         vectors.emplace_back(literalsToMapVector(child));
         break;
       }
-
       case ::substrait::Expression_Literal::LiteralTypeCase::kStruct: {
         vectors.emplace_back(literalsToRowVector(child));
         break;

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -392,10 +392,7 @@ std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::toVe
 
 ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substrait::Expression::Literal& literal) {
   auto childSize = literal.list().values().size();
-  if (childSize == 0) {
-    // childSize == 0 should not happend here but just for integrity check
-    return makeEmptyArrayVector(pool_, UNKNOWN());
-  }
+  VELOX_USER_CHECK_GT(childSize, 0, "Expect a non-empty array literal");
   auto childTypeCase = literal.list().values(0).literal_type_case();
   auto elementAtFunc = [&](vector_size_t idx) { return literal.list().values(idx); };
   auto childVector = literalsToVector(childTypeCase, childSize, literal, elementAtFunc);
@@ -404,10 +401,7 @@ ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substr
 
 MapVectorPtr SubstraitVeloxExprConverter::literalsToMapVector(const ::substrait::Expression::Literal& literal) {
   auto childSize = literal.map().key_values().size();
-  if (childSize == 0) {
-    // childSize == 0 should not happend here but just for integrity check
-    return makeEmptyMapVector(pool_, UNKNOWN(), UNKNOWN());
-  }
+  VELOX_USER_CHECK_GT(childSize, 0, "Expect a non-empty map literal");
   auto keyTypeCase = literal.map().key_values(0).key().literal_type_case();
   auto valueTypeCase = literal.map().key_values(0).value().literal_type_case();
   auto keyAtFunc = [&](vector_size_t idx) { return literal.map().key_values(idx).key(); };

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -351,8 +351,19 @@ std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::toVe
       auto constantVector = BaseVector::wrapInConstant(1, 0, literalsToArrayVector(substraitLit));
       return std::make_shared<const core::ConstantTypedExpr>(constantVector);
     }
+    case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyList: {
+      auto elementType = SubstraitParser::parseType(substraitLit.empty_list().type());
+      auto constantVector = BaseVector::wrapInConstant(1, 0, makeEmptyArrayVector(pool_, elementType));
+      return std::make_shared<const core::ConstantTypedExpr>(constantVector);
+    }
     case ::substrait::Expression_Literal::LiteralTypeCase::kMap: {
       auto constantVector = BaseVector::wrapInConstant(1, 0, literalsToMapVector(substraitLit));
+      return std::make_shared<const core::ConstantTypedExpr>(constantVector);
+    }
+    case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyMap: {
+      auto keyType = SubstraitParser::parseType(substraitLit.empty_map().key());
+      auto valueType = SubstraitParser::parseType(substraitLit.empty_map().value());
+      auto constantVector = BaseVector::wrapInConstant(1, 0, makeEmptyMapVector(pool_, keyType, valueType));
       return std::make_shared<const core::ConstantTypedExpr>(constantVector);
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kStruct: {
@@ -495,21 +506,11 @@ RowVectorPtr SubstraitVeloxExprConverter::literalsToRowVector(const ::substrait:
         vectors.emplace_back(literalsToArrayVector(child));
         break;
       }
-      case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyList: {
-        auto elementType = SubstraitParser::parseType(substraitLit.empty_list().type());
-        auto constantVector = BaseVector::wrapInConstant(1, 0, makeEmptyArrayVector(pool_, elementType));
-        return std::make_shared<const core::ConstantTypedExpr>(constantVector);
-      }
       case ::substrait::Expression_Literal::LiteralTypeCase::kMap: {
         vectors.emplace_back(literalsToMapVector(child));
         break;
       }
-      case ::substrait::Expression_Literal::LiteralTypeCase::kEmptyMap: {
-        auto keyType = SubstraitParser::parseType(substraitLit.empty_map().key());
-        auto valueType = SubstraitParser::parseType(substraitLit.empty_map().value());
-        auto constantVector = BaseVector::wrapInConstant(1, 0, makeEmptyMapVector(pool_, keyType, valueType));
-        return std::make_shared<const core::ConstantTypedExpr>(constantVector);
-      }
+
       case ::substrait::Expression_Literal::LiteralTypeCase::kStruct: {
         vectors.emplace_back(literalsToRowVector(child));
         break;

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -392,9 +392,7 @@ std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::toVe
 
 ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substrait::Expression::Literal& literal) {
   auto childSize = literal.list().values().size();
-  if (childSize == 0) {
-    return makeEmptyArrayVector(pool_, UNKNOWN());
-  }
+  VELOX_CHECK_GT(childSize, 0, "there should be at least 1 value in list literal.");
   auto childLiteral = literal.list().values(0);
   auto elementAtFunc = [&](vector_size_t idx) { return literal.list().values(idx); };
   auto childVector = literalsToVector(childLiteral, childSize, literal, elementAtFunc);
@@ -403,9 +401,7 @@ ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substr
 
 MapVectorPtr SubstraitVeloxExprConverter::literalsToMapVector(const ::substrait::Expression::Literal& literal) {
   auto childSize = literal.map().key_values().size();
-  if (childSize == 0) {
-    return makeEmptyMapVector(pool_, UNKNOWN(), UNKNOWN());
-  }
+  VELOX_CHECK_GT(childSize, 0, "there should be at least 1 value in map literal.");
   auto& keyLiteral = literal.map().key_values(0).key();
   auto& valueLiteral = literal.map().key_values(0).value();
   auto keyAtFunc = [&](vector_size_t idx) { return literal.map().key_values(idx).key(); };

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -392,7 +392,9 @@ std::shared_ptr<const core::ConstantTypedExpr> SubstraitVeloxExprConverter::toVe
 
 ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substrait::Expression::Literal& literal) {
   auto childSize = literal.list().values().size();
-  VELOX_USER_CHECK_GT(childSize, 0, "Expect a non-empty array literal");
+  if (childSize == 0) {
+    return makeEmptyArrayVector(pool_, UNKNOWN());
+  }
   auto childTypeCase = literal.list().values(0).literal_type_case();
   auto elementAtFunc = [&](vector_size_t idx) { return literal.list().values(idx); };
   auto childVector = literalsToVector(childTypeCase, childSize, literal, elementAtFunc);
@@ -401,7 +403,9 @@ ArrayVectorPtr SubstraitVeloxExprConverter::literalsToArrayVector(const ::substr
 
 MapVectorPtr SubstraitVeloxExprConverter::literalsToMapVector(const ::substrait::Expression::Literal& literal) {
   auto childSize = literal.map().key_values().size();
-  VELOX_USER_CHECK_GT(childSize, 0, "Expect a non-empty map literal");
+  if (childSize == 0) {
+    return makeEmptyMapVector(pool_, UNKNOWN(), UNKNOWN());
+  }
   auto keyTypeCase = literal.map().key_values(0).key().literal_type_case();
   auto valueTypeCase = literal.map().key_values(0).value().literal_type_case();
   auto keyAtFunc = [&](vector_size_t idx) { return literal.map().key_values(idx).key(); };

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.h
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.h
@@ -91,7 +91,7 @@ class SubstraitVeloxExprConverter {
   /// Convert map literal to MapVector.
   MapVectorPtr literalsToMapVector(const ::substrait::Expression::Literal& literal);
   VectorPtr literalsToVector(
-      ::substrait::Expression_Literal::LiteralTypeCase childTypeCase,
+      const ::substrait::Expression::Literal& childLiteral,
       vector_size_t childSize,
       const ::substrait::Expression::Literal& literal,
       std::function<::substrait::Expression::Literal(vector_size_t /* idx */)> elementAtFunc);

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -243,29 +243,19 @@ bool SubstraitToVeloxPlanValidator::validateLiteral(
     const ::substrait::Expression_Literal& literal,
     const RowTypePtr& inputType) {
   if (literal.has_list()) {
-    if (literal.list().values_size() == 0) {
-      LOG_VALIDATION_MSG("Literal is a list but has no value.");
-      return false;
-    } else {
-      for (auto child : literal.list().values()) {
-        if (!validateLiteral(child, inputType)) {
-          // the error msg has been set, so do not need to set it again.
-          return false;
-        }
+    for (auto child : literal.list().values()) {
+      if (!validateLiteral(child, inputType)) {
+        // the error msg has been set, so do not need to set it again.
+        return false;
       }
     }
-  } else if (literal.has_map()) {
-    if (literal.map().key_values().empty()) {
-      LOG_VALIDATION_MSG("Literal is a map but has no value.");
-      return false;
-    } else {
-      for (auto child : literal.map().key_values()) {
+   } else if (literal.has_map()) {
+     for (auto child : literal.map().key_values()) {
         if (!validateLiteral(child.key(), inputType) || !validateLiteral(child.value(), inputType)) {
           // the error msg has been set, so do not need to set it again.
           return false;
         }
-      }
-    }
+     }
   }
   return true;
 }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -249,13 +249,13 @@ bool SubstraitToVeloxPlanValidator::validateLiteral(
         return false;
       }
     }
-   } else if (literal.has_map()) {
-     for (auto child : literal.map().key_values()) {
-        if (!validateLiteral(child.key(), inputType) || !validateLiteral(child.value(), inputType)) {
-          // the error msg has been set, so do not need to set it again.
-          return false;
-        }
-     }
+  } else if (literal.has_map()) {
+    for (auto child : literal.map().key_values()) {
+      if (!validateLiteral(child.key(), inputType) || !validateLiteral(child.value(), inputType)) {
+        // the error msg has been set, so do not need to set it again.
+        return false;
+      }
+    }
   }
   return true;
 }

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.cc
@@ -541,9 +541,6 @@ const ::substrait::Expression_Literal_List& VeloxToSubstraitExprConvertor::toSub
   ::substrait::Expression_Literal_List* listLiteral =
       google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal_List>(&arena);
   auto size = arrayVector->sizeAt(row);
-  if (size == 0) {
-    return *listLiteral;
-  }
   auto offset = arrayVector->offsetAt(row);
   if (arrayVector->elements()->isScalar()) {
     VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
@@ -581,7 +578,14 @@ const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstrai
     auto encoding = constantVector->valueVector()->encoding();
     if (encoding == VectorEncoding::Simple::ARRAY) {
       auto arrayVector = constantVector->valueVector()->as<ArrayVector>();
-      substraitField->mutable_list()->MergeFrom(toSubstraitLiteralList(arena, arrayVector, constantVector->index()));
+      auto row = constantVector->index();
+      auto size = arrayVector->sizeAt(row);
+      if (size == 0) {
+        substraitField->mutable_empty_list()->MergeFrom(
+          toSubstraitLiteralEmptyList(arena, arrayVector->elements()->type()));
+      } else {
+        substraitField->mutable_list()->MergeFrom(toSubstraitLiteralList(arena, arrayVector, row));
+      }
       return *substraitField;
     }
   }
@@ -604,6 +608,15 @@ const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstrai
     return toSubstraitLiteralComplex(arena, constantVector);
   }
   return *substraitField;
+}
+
+const ::substrait::Type_List& VeloxToSubstraitExprConvertor::toSubstraitLiteralEmptyList(
+    google::protobuf::Arena& arena,
+    const velox::TypePtr& type) {
+  ::substrait::Type_List* emptyListLiteral =
+      google::protobuf::Arena::CreateMessage<::substrait::Type_List>(&arena);
+  emptyListLiteral->mutable_type()->MergeFrom(typeConvertor_->toSubstraitType(arena, type));
+  return *emptyListLiteral;
 }
 
 } // namespace gluten

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.cc
@@ -582,7 +582,7 @@ const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstrai
       auto size = arrayVector->sizeAt(row);
       if (size == 0) {
         substraitField->mutable_empty_list()->MergeFrom(
-          toSubstraitLiteralEmptyList(arena, arrayVector->elements()->type()));
+            toSubstraitLiteralEmptyList(arena, arrayVector->elements()->type()));
       } else {
         substraitField->mutable_list()->MergeFrom(toSubstraitLiteralList(arena, arrayVector, row));
       }
@@ -613,8 +613,7 @@ const ::substrait::Expression_Literal& VeloxToSubstraitExprConvertor::toSubstrai
 const ::substrait::Type_List& VeloxToSubstraitExprConvertor::toSubstraitLiteralEmptyList(
     google::protobuf::Arena& arena,
     const velox::TypePtr& type) {
-  ::substrait::Type_List* emptyListLiteral =
-      google::protobuf::Arena::CreateMessage<::substrait::Type_List>(&arena);
+  ::substrait::Type_List* emptyListLiteral = google::protobuf::Arena::CreateMessage<::substrait::Type_List>(&arena);
   emptyListLiteral->mutable_type()->MergeFrom(typeConvertor_->toSubstraitType(arena, type));
   return *emptyListLiteral;
 }

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.h
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.h
@@ -93,8 +93,7 @@ class VeloxToSubstraitExprConvertor {
   toSubstraitLiteralList(google::protobuf::Arena& arena, const ArrayVector* arrayVector, vector_size_t row);
 
   /// Convert an empty Velox array vector to Substrait Literal Empty List.
-  const ::substrait::Type_List&
-  toSubstraitLiteralEmptyList(google::protobuf::Arena& arena, const velox::TypePtr& type);
+  const ::substrait::Type_List& toSubstraitLiteralEmptyList(google::protobuf::Arena& arena, const velox::TypePtr& type);
 
   /// Convert values in Velox complex vector to Substrait Literal.
   const ::substrait::Expression_Literal& toSubstraitLiteralComplex(

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.h
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.h
@@ -92,6 +92,10 @@ class VeloxToSubstraitExprConvertor {
   const ::substrait::Expression_Literal_List&
   toSubstraitLiteralList(google::protobuf::Arena& arena, const ArrayVector* arrayVector, vector_size_t row);
 
+  /// Convert an empty Velox array vector to Substrait Literal Empty List.
+  const ::substrait::Type_List&
+  toSubstraitLiteralEmptyList(google::protobuf::Arena& arena, const velox::TypePtr& type);
+
   /// Convert values in Velox complex vector to Substrait Literal.
   const ::substrait::Expression_Literal& toSubstraitLiteralComplex(
       google::protobuf::Arena& arena,

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/ListLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/ListLiteralNode.java
@@ -21,6 +21,7 @@ import io.glutenproject.substrait.type.TypeNode;
 
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
+import io.substrait.proto.Type;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 
 public class ListLiteralNode extends LiteralNodeWithValue<ArrayData> {
@@ -33,13 +34,18 @@ public class ListLiteralNode extends LiteralNodeWithValue<ArrayData> {
     Object[] elements = array.array();
     TypeNode elementType = ((ListNode) getTypeNode()).getNestedType();
 
-    Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
-    for (Object element : elements) {
-      LiteralNode elementNode = ExpressionBuilder.makeLiteral(element, elementType);
-      Expression.Literal elementExpr = elementNode.getLiteral();
-      listBuilder.addValues(elementExpr);
+    if (elements.length > 0) {
+      Expression.Literal.List.Builder listBuilder = Expression.Literal.List.newBuilder();
+      for (Object element : elements) {
+        LiteralNode elementNode = ExpressionBuilder.makeLiteral(element, elementType);
+        Expression.Literal elementExpr = elementNode.getLiteral();
+        listBuilder.addValues(elementExpr);
+      }
+      literalBuilder.setList(listBuilder.build());
+    } else {
+      Type.List.Builder listTypeBuilder = Type.List.newBuilder();
+      listTypeBuilder.setType(elementType.toProtobuf());
+      literalBuilder.setEmptyList(listTypeBuilder.build());
     }
-
-    literalBuilder.setList(listBuilder.build());
   }
 }

--- a/gluten-core/src/main/java/io/glutenproject/substrait/expression/MapLiteralNode.java
+++ b/gluten-core/src/main/java/io/glutenproject/substrait/expression/MapLiteralNode.java
@@ -21,6 +21,7 @@ import io.glutenproject.substrait.type.TypeNode;
 
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Literal.Builder;
+import io.substrait.proto.Type;
 import org.apache.spark.sql.catalyst.util.MapData;
 
 public class MapLiteralNode extends LiteralNodeWithValue<MapData> {
@@ -32,21 +33,28 @@ public class MapLiteralNode extends LiteralNodeWithValue<MapData> {
   protected void updateLiteralBuilder(Builder literalBuilder, MapData map) {
     Object[] keys = map.keyArray().array();
     Object[] values = map.valueArray().array();
+    TypeNode mapType = ((MapNode) getTypeNode()).getKeyType();
+    TypeNode valueType = ((MapNode) getTypeNode()).getValueType();
 
-    Expression.Literal.Map.Builder mapBuilder = Expression.Literal.Map.newBuilder();
-    for (int i = 0; i < keys.length; ++i) {
-      LiteralNode keyNode =
-          ExpressionBuilder.makeLiteral(keys[i], ((MapNode) getTypeNode()).getKeyType());
-      LiteralNode valueNode =
-          ExpressionBuilder.makeLiteral(values[i], ((MapNode) getTypeNode()).getValueType());
+    if (keys.length > 0) {
+      Expression.Literal.Map.Builder mapBuilder = Expression.Literal.Map.newBuilder();
+      for (int i = 0; i < keys.length; ++i) {
+        LiteralNode keyNode = ExpressionBuilder.makeLiteral(keys[i], mapType);
+        LiteralNode valueNode = ExpressionBuilder.makeLiteral(values[i], valueType);
 
-      Expression.Literal.Map.KeyValue.Builder kvBuilder =
-          Expression.Literal.Map.KeyValue.newBuilder();
-      kvBuilder.setKey(keyNode.getLiteral());
-      kvBuilder.setValue(valueNode.getLiteral());
-      mapBuilder.addKeyValues(kvBuilder.build());
+        Expression.Literal.Map.KeyValue.Builder kvBuilder =
+            Expression.Literal.Map.KeyValue.newBuilder();
+        kvBuilder.setKey(keyNode.getLiteral());
+        kvBuilder.setValue(valueNode.getLiteral());
+        mapBuilder.addKeyValues(kvBuilder.build());
+      }
+
+      literalBuilder.setMap(mapBuilder.build());
+    } else {
+      Type.Map.Builder mapTypeBuilder = Type.Map.newBuilder();
+      mapTypeBuilder.setKey(mapType.toProtobuf());
+      mapTypeBuilder.setValue(valueType.toProtobuf());
+      literalBuilder.setEmptyMap(mapTypeBuilder.build());
     }
-
-    literalBuilder.setMap(mapBuilder.build());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support array or map literal without value.
For example
```
create table map_table(a map<bigint, string>) using parquet;
insert into table map_table select map(1, 'hello');
select size(coalesce(a, map())) from map_table;
```

## How was this patch tested?

Added UT

