### PR TITLE
[VL] Fix Iceberg getPartitionValueString

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -25,6 +25,7 @@ on:
       - 'gluten-core/**'
       - 'gluten-data/**'
       - 'gluten-delta/**'
+      - 'gluten-iceberg/**'
       - 'gluten-ut/**'
       - 'shims/**'
       - 'tools/gluten-it/**'

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/TypeUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/TypeUtil.scala
@@ -53,7 +53,7 @@ object TypeUtil {
           .getFractionFormatter(ZoneOffset.UTC)
           .format(partitionValue.asInstanceOf[JLong])
       case _ =>
-        partitionType.toString
+        partitionValue.toString
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The original code had a typo when retrieving the partition value of the iceberg table. The reason why the tpch partitioned table tests did not catch this is mainly because the tpch table's partition column type is primarily date, which did not trigger the `case _` code.

## How was this patch tested?

Add new test case for partition key type of string and integer.

