### PR TITLE
[GLUTEN-4587][VL] Add config to force fallback on scan of complex type

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -85,6 +85,14 @@ object BackendSettings extends BackendSettingsApi {
       }
     }
 
+    val typeValidatorWithComplexTypeFallback: PartialFunction[StructField, String] = {
+      case StructField(_, arrayType: ArrayType, _, _) =>
+        arrayType.simpleString + " is forced to fallback."
+      case StructField(_, mapType: MapType, _, _) =>
+        mapType.simpleString + " is forced to fallback."
+      case StructField(_, structType: StructType, _, _) =>
+        structType.simpleString + " is forced to fallback."
+    }
     format match {
       case ParquetReadFormat =>
         val typeValidator: PartialFunction[StructField, String] = {
@@ -103,7 +111,11 @@ object BackendSettings extends BackendSettingsApi {
               if mapType.valueType.isInstanceOf[ArrayType] =>
             "ArrayType as Value in MapType"
         }
-        validateTypes(typeValidator)
+        if (!GlutenConfig.getConf.forceComplexTypeScanFallbackEnabled) {
+          validateTypes(typeValidator)
+        } else {
+          validateTypes(typeValidatorWithComplexTypeFallback)
+        }
       case DwrfReadFormat => ValidationResult.ok
       case OrcReadFormat =>
         if (!GlutenConfig.getConf.veloxOrcScanEnabled) {
@@ -130,7 +142,11 @@ object BackendSettings extends BackendSettingsApi {
               CharVarcharUtils.getRawTypeString(metadata) + " not support"
             case StructField(_, TimestampType, _, _) => "TimestampType not support"
           }
-          validateTypes(typeValidator)
+          if (!GlutenConfig.getConf.forceComplexTypeScanFallbackEnabled) {
+            validateTypes(typeValidator)
+          } else {
+            validateTypes(typeValidatorWithComplexTypeFallback)
+          }
         }
       case _ => ValidationResult.notOk(s"Unsupported file format for $format.")
     }

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -422,6 +422,18 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
         " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
   }
 
+  test("Force complex type scan fallback") {
+    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "true")) {
+      runQueryAndCompare("select struct from type1") {
+        df =>
+          {
+            val executedPlan = getExecutedPlan(df)
+            assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+          }
+      }
+    }
+  }
+
   test("Decimal type") {
     // Validation: BatchScan Project Aggregate Expand Sort Limit
     runQueryAndCompare(

--- a/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -324,113 +324,115 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
   }
 
   test("Array type") {
-    // Validation: BatchScan.
-    runQueryAndCompare("select array from type1") {
-      checkOperatorMatch[BatchScanExecTransformer]
+    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
+      // Validation: BatchScan.
+      runQueryAndCompare("select array from type1") {
+        checkOperatorMatch[BatchScanExecTransformer]
+      }
+
+      // Validation: BatchScan Project Aggregate Expand Sort Limit
+      runQueryAndCompare(
+        "select int, array from type1 " +
+          " group by grouping sets(int, array) sort by array, int limit 1") {
+        df =>
+          {
+            val executedPlan = getExecutedPlan(df)
+            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+          }
+      }
+
+      // Validation: BroadHashJoin, Filter, Project
+      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+      runQueryAndCompare(
+        "select type1.array from type1," +
+          " type2 where type1.array = type2.array") { _ => }
+
+      // Validation: ShuffledHashJoin, Filter, Project
+      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      runQueryAndCompare(
+        "select type1.array from type1," +
+          " type2 where type1.array = type2.array") { _ => }
     }
-
-    // Validation: BatchScan Project Aggregate Expand Sort Limit
-    runQueryAndCompare(
-      "select int, array from type1 " +
-        " group by grouping sets(int, array) sort by array, int limit 1") {
-      df =>
-        {
-          val executedPlan = getExecutedPlan(df)
-          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-        }
-    }
-
-    // Validation: BroadHashJoin, Filter, Project
-    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-    runQueryAndCompare(
-      "select type1.array from type1," +
-        " type2 where type1.array = type2.array") { _ => }
-
-    // Validation: ShuffledHashJoin, Filter, Project
-    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-    runQueryAndCompare(
-      "select type1.array from type1," +
-        " type2 where type1.array = type2.array") { _ => }
   }
 
   test("Map type") {
-    // Validation: BatchScan Project Limit
-    runQueryAndCompare("select map from type1 limit 1") {
-      df =>
-        {
-          val executedPlan = getExecutedPlan(df)
-          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-        }
-    }
-    // Validation: BatchScan Project Aggregate Sort Limit
-    // TODO validate Expand operator support map type ?
-    runQueryAndCompare(
-      "select map['key'] from type1 group by map['key']" +
-        " sort by map['key'] limit 1") {
-      df =>
-        {
-          val executedPlan = getExecutedPlan(df)
-          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-        }
-    }
+    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
+      // Validation: BatchScan Project Limit
+      runQueryAndCompare("select map from type1 limit 1") {
+        df =>
+          {
+            val executedPlan = getExecutedPlan(df)
+            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+          }
+      }
+      // Validation: BatchScan Project Aggregate Sort Limit
+      // TODO validate Expand operator support map type ?
+      runQueryAndCompare(
+        "select map['key'] from type1 group by map['key']" +
+          " sort by map['key'] limit 1") {
+        df =>
+          {
+            val executedPlan = getExecutedPlan(df)
+            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+          }
+      }
 
-    // Validation: BroadHashJoin, Filter, Project
-    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-    runQueryAndCompare(
-      "select type1.map['key'] from type1," +
-        " type2 where type1.map['key'] = type2.map['key']") { _ => }
+      // Validation: BroadHashJoin, Filter, Project
+      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+      runQueryAndCompare(
+        "select type1.map['key'] from type1," +
+          " type2 where type1.map['key'] = type2.map['key']") { _ => }
 
-    // Validation: ShuffledHashJoin, Filter, Project
-    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-    runQueryAndCompare(
-      "select type1.map['key'] from type1," +
-        " type2 where type1.map['key'] = type2.map['key']") { _ => }
+      // Validation: ShuffledHashJoin, Filter, Project
+      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      runQueryAndCompare(
+        "select type1.map['key'] from type1," +
+          " type2 where type1.map['key'] = type2.map['key']") { _ => }
+    }
   }
 
   test("Struct type") {
-    // Validation: BatchScan Project Limit
-    runQueryAndCompare("select struct from type1") {
-      df =>
-        {
-          val executedPlan = getExecutedPlan(df)
-          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-        }
-    }
-    // Validation: BatchScan Project Aggregate Sort Limit
-    // TODO validate Expand operator support Struct type ?
-    runQueryAndCompare(
-      "select int, struct.struct_1 from type1 " +
-        "sort by struct.struct_1 limit 1") {
-      df =>
-        {
-          val executedPlan = getExecutedPlan(df)
-          assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
-          assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
-        }
-    }
-
-    // Validation: BroadHashJoin, Filter, Project
-    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
-    runQueryAndCompare(
-      "select type1.struct.struct_1 from type1," +
-        " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
-
-    // Validation: ShuffledHashJoin, Filter, Project
-    super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
-    runQueryAndCompare(
-      "select type1.struct.struct_1 from type1," +
-        " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
-  }
-
-  test("Force complex type scan fallback") {
-    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "true")) {
+    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "false")) {
+      // Validation: BatchScan Project Limit
       runQueryAndCompare("select struct from type1") {
         df =>
           {
             val executedPlan = getExecutedPlan(df)
-            assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
           }
       }
+      // Validation: BatchScan Project Aggregate Sort Limit
+      // TODO validate Expand operator support Struct type ?
+      runQueryAndCompare(
+        "select int, struct.struct_1 from type1 " +
+          "sort by struct.struct_1 limit 1") {
+        df =>
+          {
+            val executedPlan = getExecutedPlan(df)
+            assert(executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
+            assert(executedPlan.exists(plan => plan.isInstanceOf[ProjectExecTransformer]))
+          }
+      }
+
+      // Validation: BroadHashJoin, Filter, Project
+      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "10M")
+      runQueryAndCompare(
+        "select type1.struct.struct_1 from type1," +
+          " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
+
+      // Validation: ShuffledHashJoin, Filter, Project
+      super.sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      runQueryAndCompare(
+        "select type1.struct.struct_1 from type1," +
+          " type2 where type1.struct.struct_1 = type2.struct.struct_1") { _ => }
+    }
+  }
+
+  test("Force complex type scan fallback") {
+    withSQLConf(("spark.gluten.sql.complexType.scan.fallback.enabled", "true")) {
+      val df = spark.sql("select struct from type1")
+      val executedPlan = getExecutedPlan(df)
+      assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
     }
   }
 

--- a/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
+++ b/gluten-core/src/test/scala/io/glutenproject/execution/WholeStageTransformerSuite.scala
@@ -251,6 +251,9 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
       val df = spark.sql(sqlStr)
       expected = df.collect()
     }
+    // By default we will fallabck complex type scan but here we should allow
+    // to test support of complex type
+    spark.conf.set("spark.gluten.sql.complexType.scan.fallback.enabled", "false");
     val df = spark.sql(sqlStr)
     if (cache) {
       df.cache()
@@ -275,6 +278,7 @@ abstract class WholeStageTransformerSuite extends GlutenQueryTest with SharedSpa
       compareResult: Boolean = true,
       noFallBack: Boolean = true,
       cache: Boolean = false)(customCheck: DataFrame => Unit): DataFrame = {
+
     compareResultsAgainstVanillaSpark(sqlStr, compareResult, customCheck, noFallBack, cache)
   }
 

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -108,6 +108,7 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "1024MB")
+      .set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
   }
 
   testGluten("hive orc scan") {

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -120,7 +120,9 @@ class GlutenHiveSQLQuerySuite extends GlutenSQLTestsTrait {
   }
 
   testGluten("avoid unnecessary filter binding for subfield during scan") {
-    withSQLConf("spark.sql.hive.convertMetastoreParquet" -> "false") {
+    withSQLConf(
+      "spark.sql.hive.convertMetastoreParquet" -> "false",
+      "spark.gluten.sql.complexType.scan.fallback.enabled" -> "false") {
       sql("DROP TABLE IF EXISTS test_subfield")
       sql(
         "CREATE TABLE test_subfield (name STRING, favorite_color STRING," +

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -97,6 +97,9 @@ class GlutenConfig(conf: SQLConf) extends Logging {
   def veloxOrcScanEnabled: Boolean =
     conf.getConf(VELOX_ORC_SCAN_ENABLED)
 
+  def forceComplexTypeScanFallbackEnabled: Boolean =
+    conf.getConf(VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK)
+
   // whether to use ColumnarShuffleManager
   def isUseColumnarShuffleManager: Boolean =
     conf
@@ -1657,4 +1660,11 @@ object GlutenConfig {
       .doc(" Enable velox orc scan. If disabled, vanilla spark orc scan will be used.")
       .booleanConf
       .createWithDefault(true)
+
+  val VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK =
+    buildStaticConf("spark.gluten.sql.complexType.scan.fallback.enabled")
+      .internal()
+      .doc("Force fallback for complex type scan, including struct, map, array.")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1666,5 +1666,5 @@ object GlutenConfig {
       .internal()
       .doc("Force fallback for complex type scan, including struct, map, array.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 }

--- a/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
+++ b/shims/common/src/main/scala/io/glutenproject/GlutenConfig.scala
@@ -1662,7 +1662,7 @@ object GlutenConfig {
       .createWithDefault(true)
 
   val VELOX_FORCE_COMPLEX_TYPE_SCAN_FALLBACK =
-    buildStaticConf("spark.gluten.sql.complexType.scan.fallback.enabled")
+    buildConf("spark.gluten.sql.complexType.scan.fallback.enabled")
       .internal()
       .doc("Force fallback for complex type scan, including struct, map, array.")
       .booleanConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Complex type support in Parquet Scan still have much issues. Like nested datatype not supported yet. Result mismatch issues listed here: https://github.com/oap-project/gluten/issues/4587

So now let's add a config to fallback all the complex data types until velox support is mature.


## How was this patch tested?

Customer workload

