### PR TITLE
[VL] Fix and use flattenVector

### DIFF
--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -55,6 +55,10 @@ void VeloxColumnarBatch::ensureFlattened() {
       child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
       VELOX_DCHECK_NOT_NULL(child);
     }
+    // In case of output from Limit, RowVector size can be smaller than its children size.
+    if (child->size() > rowVector_->size()) {
+      child->resize(rowVector_->size());
+    }
   }
   flattened_ = true;
 }

--- a/cpp/velox/memory/VeloxColumnarBatch.cc
+++ b/cpp/velox/memory/VeloxColumnarBatch.cc
@@ -16,6 +16,7 @@
  */
 #include "VeloxColumnarBatch.h"
 #include "compute/VeloxRuntime.h"
+#include "utils/Timer.h"
 #include "utils/VeloxArrowUtils.h"
 #include "velox/row/UnsafeRowFast.h"
 #include "velox/type/Type.h"
@@ -44,42 +45,37 @@ RowVectorPtr makeRowVector(
 } // namespace
 
 void VeloxColumnarBatch::ensureFlattened() {
-  if (flattened_ != nullptr) {
+  if (flattened_) {
     return;
   }
-  auto startTime = std::chrono::steady_clock::now();
-  // Make sure to load lazy vector if not loaded already.
+  ScopedTimer timer(&exportNanos_);
   for (auto& child : rowVector_->children()) {
-    child->loadedVector();
+    facebook::velox::BaseVector::flattenVector(child);
+    if (child->isLazy()) {
+      child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
+      VELOX_DCHECK_NOT_NULL(child);
+    }
   }
-
-  // Perform copy to flatten dictionary vectors.
-  velox::RowVectorPtr copy = std::dynamic_pointer_cast<velox::RowVector>(
-      velox::BaseVector::create(rowVector_->type(), rowVector_->size(), rowVector_->pool()));
-  copy->copy(rowVector_.get(), 0, 0, rowVector_->size());
-  flattened_ = copy;
-  auto endTime = std::chrono::steady_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime).count();
-  exportNanos_ += duration;
+  flattened_ = true;
 }
 
 std::shared_ptr<ArrowSchema> VeloxColumnarBatch::exportArrowSchema() {
   auto out = std::make_shared<ArrowSchema>();
   ensureFlattened();
-  velox::exportToArrow(flattened_, *out, ArrowUtils::getBridgeOptions());
+  velox::exportToArrow(rowVector_, *out, ArrowUtils::getBridgeOptions());
   return out;
 }
 
 std::shared_ptr<ArrowArray> VeloxColumnarBatch::exportArrowArray() {
   auto out = std::make_shared<ArrowArray>();
   ensureFlattened();
-  velox::exportToArrow(flattened_, *out, flattened_->pool(), ArrowUtils::getBridgeOptions());
+  velox::exportToArrow(rowVector_, *out, rowVector_->pool(), ArrowUtils::getBridgeOptions());
   return out;
 }
 
 int64_t VeloxColumnarBatch::numBytes() {
   ensureFlattened();
-  return flattened_->estimateFlatSize();
+  return rowVector_->estimateFlatSize();
 }
 
 velox::RowVectorPtr VeloxColumnarBatch::getRowVector() const {
@@ -88,7 +84,7 @@ velox::RowVectorPtr VeloxColumnarBatch::getRowVector() const {
 
 velox::RowVectorPtr VeloxColumnarBatch::getFlattenedRowVector() {
   ensureFlattened();
-  return flattened_;
+  return rowVector_;
 }
 
 std::shared_ptr<VeloxColumnarBatch> VeloxColumnarBatch::from(

--- a/cpp/velox/memory/VeloxColumnarBatch.h
+++ b/cpp/velox/memory/VeloxColumnarBatch.h
@@ -50,7 +50,7 @@ class VeloxColumnarBatch final : public ColumnarBatch {
   void ensureFlattened();
 
   facebook::velox::RowVectorPtr rowVector_ = nullptr;
-  facebook::velox::RowVectorPtr flattened_ = nullptr;
+  bool flattened_ = false;
 };
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -422,8 +422,7 @@ void VeloxColumnarBatchDeserializerFactory::initFromSchema() {
       } break;
       case arrow::StructType::type_id:
       case arrow::MapType::type_id:
-      case arrow::ListType::type_id:
-      case arrow::Decimal128Type::type_id: {
+      case arrow::ListType::type_id: {
         hasComplexType_ = true;
       } break;
       case arrow::BooleanType::type_id: {

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -422,7 +422,8 @@ void VeloxColumnarBatchDeserializerFactory::initFromSchema() {
       } break;
       case arrow::StructType::type_id:
       case arrow::MapType::type_id:
-      case arrow::ListType::type_id: {
+      case arrow::ListType::type_id:
+      case arrow::Decimal128Type::type_id: {
         hasComplexType_ = true;
       } break;
       case arrow::BooleanType::type_id: {

--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -222,6 +222,7 @@ arrow::Status VeloxShuffleWriter::init() {
 
   ARROW_ASSIGN_OR_RAISE(
       partitioner_, Partitioner::make(options_.partitioning, numPartitions_, options_.startPartitionId));
+  DLOG(INFO) << "Create partitioning type: " << std::to_string(options_.partitioning);
 
   // pre-allocated buffer size for each partition, unit is row count
   // when partitioner is SinglePart, partial variables don`t need init


### PR DESCRIPTION
This patch re-enables the flattern vector optimizations.

The flattenVector optimization firstly landed in https://github.com/oap-project/gluten/pull/4415
but partially reverted in https://github.com/oap-project/gluten/pull/4474 due to some bugs on Celeborn code path.


Celeborn integration tests should check the code.
