### PR TITLE
[GLUTEN-4807][CH] Fix 'Unsupported phase for state function' error when merging hash aggregate with the bloom filter agg

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHBucketSuite.scala
@@ -343,6 +343,23 @@ class GlutenClickHouseTPCHBucketSuite
         assert(plans(3).metrics("numFiles").value === 2)
         assert(plans(3).metrics("outputRows").value === 72678)
       })
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      runTPCHQuery(3)(
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 8)
+          }
+        })
+    }
   }
 
   test("TPCH Q4") {
@@ -372,6 +389,23 @@ class GlutenClickHouseTPCHBucketSuite
         assert(plans(2).metrics("numFiles").value === 2)
         assert(plans(2).metrics("outputRows").value === 379809)
       })
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      runTPCHQuery(4)(
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 4)
+          }
+        })
+    }
   }
 
   test("TPCH Q6") {
@@ -414,6 +448,23 @@ class GlutenClickHouseTPCHBucketSuite
         assert(plans(2).metrics("numFiles").value === 2)
         assert(plans(2).metrics("outputRows").value === 3155)
       })
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      runTPCHQuery(12)(
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 4)
+          }
+        })
+    }
   }
 
   test("TPCH Q18") {
@@ -494,6 +545,23 @@ class GlutenClickHouseTPCHBucketSuite
             .right
             .isInstanceOf[ProjectExecTransformer])
       })
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      runTPCHQuery(20)(
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 6)
+          }
+        })
+    }
   }
 
   test("GLUTEN-4668: Merge two phase hash-based aggregate into one aggregate") {

--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickHouseTPCHParquetBucketSuite.scala
@@ -376,6 +376,26 @@ class GlutenClickHouseTPCHParquetBucketSuite
         assert(plans(3).metrics("outputRows").value === 150000)
       }
     )
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      compareTPCHQueryAgainstVanillaSpark(
+        3,
+        tpchQueries,
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 4)
+          }
+        }
+      )
+    }
   }
 
   test("TPCH Q4") {
@@ -408,6 +428,26 @@ class GlutenClickHouseTPCHParquetBucketSuite
         assert(plans(2).metrics("outputRows").value === 600572)
       }
     )
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      compareTPCHQueryAgainstVanillaSpark(
+        4,
+        tpchQueries,
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 2)
+          }
+        }
+      )
+    }
   }
 
   test("TPCH Q6") {
@@ -456,6 +496,26 @@ class GlutenClickHouseTPCHParquetBucketSuite
         assert(plans(2).metrics("outputRows").value === 600572)
       }
     )
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      compareTPCHQueryAgainstVanillaSpark(
+        12,
+        tpchQueries,
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 2)
+          }
+        }
+      )
+    }
   }
 
   test("TPCH Q18") {
@@ -542,6 +602,26 @@ class GlutenClickHouseTPCHParquetBucketSuite
             .isInstanceOf[ProjectExecTransformer])
       }
     )
+
+    withSQLConf(
+      ("spark.sql.optimizer.runtime.bloomFilter.applicationSideScanSizeThreshold", "1KB"),
+      ("spark.sql.optimizer.runtime.bloomFilter.enabled", "true")) {
+      compareTPCHQueryAgainstVanillaSpark(
+        20,
+        tpchQueries,
+        df => {
+          if (sparkVersion.equals("3.3")) {
+            val plans = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case aggExec: HashAggregateExecBaseTransformer
+                  if aggExec.aggregateExpressions.exists(
+                    _.aggregateFunction.getClass.getSimpleName.equals("BloomFilterAggregate")) =>
+                aggExec
+            }
+            assert(plans.size == 3)
+          }
+        }
+      )
+    }
   }
 
   test("GLUTEN-3922: Fix incorrect shuffle hash id value when executing modulo") {

--- a/cpp-ch/local-engine/Parser/AggregateFunctionParser.cpp
+++ b/cpp-ch/local-engine/Parser/AggregateFunctionParser.cpp
@@ -49,8 +49,8 @@ DB::ActionsDAG::NodeRawConstPtrs AggregateFunctionParser::parseFunctionArguments
 
         // If the aggregate result is required to be nullable, make all inputs be nullable at the first stage.
         auto required_output_type = DB::WhichDataType(TypeParser::parseType(func_info.output_type));
-        if (required_output_type.isNullable() && func_info.phase == substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE
-            && !arg_node->result_type->isNullable())
+        if (required_output_type.isNullable() && (func_info.phase == substrait::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE
+            || func_info.phase == substrait::AGGREGATION_PHASE_INITIAL_TO_RESULT) && !arg_node->result_type->isNullable())
         {
             DB::ActionsDAG::NodeRawConstPtrs args;
             args.emplace_back(arg_node);

--- a/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/AggregateRelParser.cpp
@@ -223,9 +223,9 @@ void AggregateRelParser::buildAggregateDescriptions(AggregateDescriptions & desc
         else
         {
             // If the function is a state function, we don't need to apply `PartialMerge`.
-            // In INITIAL_TO_INTERMEDIATE phase, we do arguments -> xxState.
+            // In INITIAL_TO_INTERMEDIATE or INITIAL_TO_RESULT phase, we do arguments -> xxState.
             // In INTERMEDIATE_TO_RESULT phase, we do xxState -> xxState.
-            if (agg_info.parser_func_info.phase == substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE)
+            if (agg_info.parser_func_info.phase == substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE || agg_info.parser_func_info.phase == substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_RESULT)
             {
                 description.function = getAggregateFunction(agg_info.function_name, agg_info.arg_column_types, properties, agg_info.params);
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When merging hash aggregate with the bloom filter agg, there is the 'Unsupported phase for state function' error throwing.

Close #4807.

(Fixes: #4807)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

