### PR TITLE
[CORE] Support In list option contains non-foldable expression

### DIFF
--- a/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/io/glutenproject/execution/GlutenClickhouseFunctionSuite.scala
@@ -20,17 +20,14 @@ import io.glutenproject.GlutenConfig
 import io.glutenproject.utils.UTSystemParameters
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.v2.clickhouse.ClickHouseLog
 
 import org.apache.commons.io.FileUtils
 
 import java.io.File
 
-class GlutenClickhouseFunctionSuite
-  extends GlutenClickHouseTPCHAbstractSuite
-  with AdaptiveSparkPlanHelper {
+class GlutenClickhouseFunctionSuite extends GlutenClickHouseTPCHAbstractSuite {
 
   override protected val resourcePath: String =
     "../../../../gluten-core/src/test/resources/tpch-data"
@@ -139,17 +136,6 @@ class GlutenClickhouseFunctionSuite
       val diffCount = df.exceptAll(df2).count()
       assert(diffCount == 0)
     }
-  }
-
-  private def checkFallbackOperators(df: DataFrame, num: Int): Unit = {
-    // Decrease one VeloxColumnarToRowExec for the top level node
-    assert(
-      collect(df.queryExecution.executedPlan) {
-        case p if p.isInstanceOf[ColumnarToRowExecBase] => p
-        case p if p.isInstanceOf[RowToColumnarExecBase] => p
-      }.size - 1 == num,
-      df.queryExecution
-    )
   }
 
   test("Support In list option contains non-foldable expression") {

--- a/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
+++ b/backends-velox/src/test/scala/io/glutenproject/execution/TestOperator.scala
@@ -22,14 +22,13 @@ import io.glutenproject.sql.shims.SparkShimLoader
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.execution.{FilterExec, GenerateExec, ProjectExec, RDDScanExec}
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{avg, col, lit, udf}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DecimalType, StringType, StructField, StructType}
 
 import scala.collection.JavaConverters
 
-class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
+class TestOperator extends VeloxWholeStageTransformerSuite {
 
   protected val rootPath: String = getClass.getResource("/").getPath
   override protected val backend: String = "velox"
@@ -943,17 +942,6 @@ class TestOperator extends VeloxWholeStageTransformerSuite with AdaptiveSparkPla
           "SELECT x FROM view WHERE cast(x as timestamp) " +
             "IN ('1970-01-01 08:00:00.001','1970-01-01 08:00:00.2')")(_)
     }
-  }
-
-  private def checkFallbackOperators(df: DataFrame, num: Int): Unit = {
-    // Decrease one VeloxColumnarToRowExec for the top level node
-    assert(
-      collect(df.queryExecution.executedPlan) {
-        case p if p.isInstanceOf[ColumnarToRowExecBase] => p
-        case p if p.isInstanceOf[RowToColumnarExecBase] => p
-      }.size - 1 == num,
-      df.queryExecution
-    )
   }
 
   test("Columnar cartesian product with other join") {

--- a/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/ExpressionConverter.scala
@@ -275,6 +275,10 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           cw
         )
       case i: In =>
+        if (i.list.exists(!_.foldable)) {
+          throw new UnsupportedOperationException(
+            s"In list option does not support non-foldable expression, ${i.list.map(_.sql)}")
+        }
         InTransformer(
           replaceWithExpressionTransformerInternal(i.value, attributeSeq, expressionsMap),
           i.list,

--- a/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/expression/PredicateExpressionTransformer.scala
@@ -34,8 +34,9 @@ case class InTransformer(
     original: Expression)
   extends ExpressionTransformer {
   override def doTransform(args: java.lang.Object): ExpressionNode = {
+    assert(list.forall(_.foldable))
     // Stores the values in a List Literal.
-    val values: Set[Any] = list.map(_.asInstanceOf[Literal].value).toSet
+    val values: Set[Any] = list.map(_.eval()).toSet
     InExpressionTransformer.toTransformer(value.doTransform(args), values, valueType)
   }
 }

--- a/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/ColumnarOverrides.scala
@@ -559,6 +559,7 @@ object ColumnarOverrideRules {
 
   def rewriteSparkPlanRule(): Rule[SparkPlan] = {
     val rewriteRules = Seq(
+      RewriteIn,
       RewriteMultiChildrenCount,
       RewriteTypedImperativeAggregate,
       PullOutPreProject,

--- a/gluten-core/src/main/scala/io/glutenproject/extension/RewriteIn.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/RewriteIn.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.glutenproject.extension
+
+import org.apache.spark.sql.catalyst.expressions.{EqualTo, Expression, In, Or}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, SparkPlan}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * This rule rewrites the [[In]] if the list option contains non-foldable value. A rewrite example:
+ *
+ * {{{
+ *   SELECT * FROM t WHERE c in (1, 2, c2)
+ *   =>
+ *   SELECT * FROM t WHERE c in (1, 2) or c = c2
+ * }}}
+ *
+ * TODO: Remove this rule once Velox support the list option in `In` is not literal.
+ */
+object RewriteIn extends Rule[SparkPlan] {
+
+  private def shouldRewrite(e: Expression): Boolean = {
+    e match {
+      case in: In if !in.value.dataType.isInstanceOf[StructType] && in.list.exists(!_.foldable) =>
+        // `EqualTo` does not allow struct type
+        true
+      case _ => false
+    }
+  }
+
+  private def rewriteIn(condition: Expression): Expression = {
+    condition.transform {
+      case in: In if shouldRewrite(in) =>
+        val (foldableExprs, nonFoldableExprs) = in.list.partition(_.foldable)
+        assert(nonFoldableExprs.nonEmpty)
+        val rewrittenExpr = nonFoldableExprs.map(expr => EqualTo(in.value, expr)).reduce(Or)
+        val newIn = if (foldableExprs.isEmpty) {
+          None
+        } else {
+          Some(in.copy(list = foldableExprs))
+        }
+        (newIn ++ Seq(rewrittenExpr)).reduce(Or)
+    }
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    plan match {
+      // TODO: Support datasource v2
+      case scan: FileSourceScanExec if scan.dataFilters.exists(_.find(shouldRewrite).isDefined) =>
+        val newDataFilters = scan.dataFilters.map(rewriteIn)
+        scan.copy(dataFilters = newDataFilters)
+      case f: FilterExec if f.condition.find(shouldRewrite).isDefined =>
+        val newCondition = rewriteIn(f.condition)
+        f.copy(condition = newCondition)
+      case _ => plan
+    }
+  }
+}

--- a/gluten-core/src/main/scala/io/glutenproject/extension/RewriteSparkPlanRulesManager.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/RewriteSparkPlanRulesManager.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{LeafExecNode, SortExec, SparkPlan, TakeOrderedAndProjectExec}
+import org.apache.spark.sql.execution.{FileSourceScanExec, FilterExec, LeafExecNode, SortExec, SparkPlan, TakeOrderedAndProjectExec}
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.joins.BaseJoinExec
 import org.apache.spark.sql.execution.window.WindowExec
@@ -53,6 +53,8 @@ class RewriteSparkPlanRulesManager(rewriteRules: Seq[Rule[SparkPlan]]) extends R
         case _: BaseAggregateExec => true
         case _: BaseJoinExec => true
         case _: WindowExec => true
+        case _: FilterExec => true
+        case _: FileSourceScanExec => true
         case _ => false
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr adds a rule to rewrite `In` if the list option contain non-foldable value. A rewrite example:

```
SELECT * FROM t WHERE c in (1, 2, c2)
=>
SELECT * FROM t WHERE c in (1, 2) or c = c2
```

## How was this patch tested?

add test
