### PR TITLE
[GLUTEN-4855][VL] Fix output ordering of hash join

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/backendsapi/velox/VeloxBackend.scala
@@ -480,4 +480,7 @@ object BackendSettings extends BackendSettingsApi {
     // vanilla Spark, we need to rewrite the aggregate to get the correct data type.
     true
   }
+
+  // The output ordering of hash join can't be guaranteed when spill occured
+  override def hashJoinPreservesOrdering(): Boolean = false
 }

--- a/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/backendsapi/BackendSettingsApi.scala
@@ -132,4 +132,6 @@ trait BackendSettingsApi {
   def mergeTwoPhasesHashBaseAggregateIfNeed(): Boolean = false
 
   def shouldRewriteTypedImperativeAggregate(): Boolean = false
+
+  def hashJoinPreservesOrdering(): Boolean = true
 }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/HashJoinExecTransformer.scala
@@ -190,6 +190,14 @@ trait HashJoinLikeExecTransformer
       }
   }
 
+  override def outputOrdering: Seq[SortOrder] = if (
+    BackendsApiManager.getSettings.hashJoinPreservesOrdering
+  ) {
+    super.outputOrdering
+  } else {
+    Nil
+  }
+
   // https://issues.apache.org/jira/browse/SPARK-31869
   private def expandPartitioning(partitioning: Partitioning): Partitioning = {
     val expandLimit = conf.broadcastHashJoinOutputPartitioningExpandLimit


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there are spilling in hash build side, the output ordering is not guaranteed, since the spilled data is probed at last. 

This affects both *BroadcastHashJoin* and *ShuffledHashJoin*

(Fixes: \#4855)

