### PR TITLE
[VL][CI] Fix CI failure related to Celeborn 

### DIFF
--- a/.github/workflows/velox_be.yml
+++ b/.github/workflows/velox_be.yml
@@ -437,7 +437,7 @@ jobs:
         run: |
           $PATH_TO_GLUTEN_TE/$OS_IMAGE_NAME/gha/gha-checkout/exec.sh \
           'wget https://archive.apache.org/dist/incubator/celeborn/celeborn-0.3.0-incubating/apache-celeborn-0.3.0-incubating-bin.tgz && \
-          tar xzf apache-celeborn-0.3.0-incubating-bin.tgz && cd apache-celeborn-0.3.0-incubating-bin && \
+          tar xzf apache-celeborn-0.3.0-incubating-bin.tgz -C /opt/ && mv /opt/apache-celeborn-0.3.0-incubating-bin /opt/celeborn && cd /opt/celeborn && \
           mv ./conf/celeborn-env.sh.template ./conf/celeborn-env.sh && \
           echo -e "CELEBORN_MASTER_MEMORY=4g\nCELEBORN_WORKER_MEMORY=4g\nCELEBORN_WORKER_OFFHEAP_MEMORY=8g" > ./conf/celeborn-env.sh && \
           echo -e "celeborn.worker.commitFiles.threads 128\nceleborn.worker.sortPartition.threads 64" > ./conf/celeborn-defaults.conf \
@@ -447,8 +447,8 @@ jobs:
             --local --preset=velox-with-celeborn --benchmark-type=h --error-on-memleak --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 \
           && GLUTEN_IT_JVM_ARGS=-Xmx5G sbin/gluten-it.sh queries-compare \
             --local --preset=velox-with-celeborn --benchmark-type=ds --error-on-memleak --off-heap-size=10g -s=1.0 --threads=16 --iterations=1 && \
-          bash /opt/apache-celeborn-0.3.0-incubating-bin/sbin/stop-worker.sh \
-          && bash /opt/apache-celeborn-0.3.0-incubating-bin/sbin/stop-master.sh'
+          bash /opt/celeborn/sbin/stop-worker.sh \
+          && bash /opt/celeborn/sbin/stop-master.sh'
       - name: Exit docker container
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
## What changes were proposed in this pull request?

The pre-installed celeborn under /opt/ is removed in docker image, which causes CI failure when stopping celeborn master/worker.

