### PR TITLE
[CORE] ColumnarShuffleExchangeExec should respect advisoryPartitionSize for Spark3.5

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/extension/columnar/TransformHintRule.scala
@@ -568,11 +568,7 @@ case class AddTransformHintRule() extends Rule[SparkPlan] {
               plan,
               "columnar Shuffle is not enabled in ShuffleExchangeExec")
           } else {
-            val transformer = ColumnarShuffleExchangeExec(
-              plan.outputPartitioning,
-              plan.child,
-              plan.shuffleOrigin,
-              plan.child.output)
+            val transformer = ColumnarShuffleExchangeExec(plan, plan.child, plan.child.output)
             transformer.doValidate().tagOnFallback(plan)
           }
         case plan: ShuffledHashJoinExec =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/ColumnarShuffleExchangeExec.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
 import io.glutenproject.backendsapi.BackendsApiManager
 import io.glutenproject.extension.GlutenPlan
 import io.glutenproject.extension.ValidationResult
+import io.glutenproject.sql.shims.SparkShimLoader
 
 import org.apache.spark._
 import org.apache.spark.internal.Logging
@@ -176,7 +177,9 @@ object ColumnarShuffleExchangeExec extends Logging {
       plan.outputPartitioning,
       child,
       plan.shuffleOrigin,
-      shuffleOutputAttributes)
+      shuffleOutputAttributes,
+      advisoryPartitionSize = SparkShimLoader.getSparkShims.getShuffleAdvisoryPartitionSize(plan)
+    )
   }
 
   // scalastyle:off argcount

--- a/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/io/glutenproject/sql/shims/SparkShims.scala
@@ -21,7 +21,7 @@ import io.glutenproject.expression.Sig
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.scheduler.TaskInfo
-import org.apache.spark.shuffle.{ShuffleHandle, ShuffleReader, ShuffleReadMetricsReporter}
+import org.apache.spark.shuffle.ShuffleHandle
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -34,6 +34,7 @@ import org.apache.spark.sql.execution.{FileSourceScanExec, GlobalLimitExec, Spar
 import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionDirectory, PartitionedFile, PartitioningAwareFileIndex, WriteJobDescription, WriteTaskResult}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
@@ -122,6 +123,9 @@ trait SparkShims {
       startPartition: Int,
       endPartition: Int)
       : Tuple2[Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])], Boolean]
+
+  // Compatible with Spark-3.5 and later
+  def getShuffleAdvisoryPartitionSize(shuffle: ShuffleExchangeLike): Option[Long] = None
 
   // Partition id in TaskInfo is only available after spark 3.3.
   def getPartitionId(taskInfo: TaskInfo): Int

--- a/shims/spark35/src/main/scala/io/glutenproject/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/io/glutenproject/sql/shims/spark35/Spark35Shims.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.execution.datasources.{BucketingUtils, FilePartition
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.text.TextScan
 import org.apache.spark.sql.execution.datasources.v2.utils.CatalogUtil
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.storage.{BlockId, BlockManagerId}
@@ -212,6 +213,9 @@ class Spark35Shims extends SparkShims {
       : Tuple2[Iterator[(BlockManagerId, collection.Seq[(BlockId, Long, Int)])], Boolean] = {
     ShuffleUtils.getReaderParam(handle, startMapIndex, endMapIndex, startPartition, endPartition)
   }
+
+  override def getShuffleAdvisoryPartitionSize(shuffle: ShuffleExchangeLike): Option[Long] =
+    shuffle.advisoryPartitionSize
 
   override def getPartitionId(taskInfo: TaskInfo): Int = {
     taskInfo.partitionId


### PR DESCRIPTION

## What changes were proposed in this pull request?

Add `def getShuffleAdvisoryPartitionSize(shuffle: ShuffleExchangeLike): Option[Long] = None` in Spark shim to be compatible with Spark 3.5.

## How was this patch tested?

Pass CI and in coming 3.5 tests
