### PR TITLE
[VL] Add libsodium.so to thirdparty lib for CentOS8

### DIFF
--- a/backends-velox/src/main/scala/io/glutenproject/utils/SharedLibraryLoaderCentos8.scala
+++ b/backends-velox/src/main/scala/io/glutenproject/utils/SharedLibraryLoaderCentos8.scala
@@ -42,6 +42,7 @@ class SharedLibraryLoaderCentos8 extends SharedLibraryLoader {
       .loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so", false)
       .loadAndCreateLink("libhdfs3.so.1", "libhdfs3.so", false)
       .loadAndCreateLink("libre2.so.0", "libre2.so", false)
+      .loadAndCreateLink("libsodium.so", "libsodium.so", false)
       .commit()
   }
 }

--- a/dev/package.sh
+++ b/dev/package.sh
@@ -27,7 +27,7 @@ function process_setup_ubuntu_2204 {
 }
 
 function process_setup_centos_8 {
-  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libgflags.so.2.2,libglog.so.0,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0} $THIRDPARTY_LIB/
+  cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libgflags.so.2.2,libglog.so.0,libevent-2.1.so.6,libdwarf.so.1,libgsasl.so.7,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libidn.so.11,libntlm.so.0,libsodium.so} $THIRDPARTY_LIB/
   cp /usr/local/lib/{libhdfs3.so.1,libboost_context.so.1.72.0,libboost_filesystem.so.1.72.0,libboost_program_options.so.1.72.0,libboost_regex.so.1.72.0,libboost_system.so.1.72.0,libboost_thread.so.1.72.0,libprotobuf.so.32} $THIRDPARTY_LIB/
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following exception will occur when testing a CentOS8 cluster that does not contain libsodium.so.
```
Exception in thread "main" java.lang.UnsatisfiedLinkError:/libvelox.so: libsodium.so.23: cannot open shared object file: No such file or directory
        at java.lang.ClassLoader$NativeLibrary.load(Native Method)
        at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1934)
        at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1817)
        at java.lang.Runtime.load0(Runtime.java:782)
        at java.lang.System.load(System.java:1100)
        at io.glutenproject.vectorized.JniLibLoader.loadFromPath0(JniLibLoader.java:89)
        at io.glutenproject.vectorized.JniLibLoader.access$300(JniLibLoader.java:57)
        at io.glutenproject.vectorized.JniLibLoader$JniLoadTransaction.loadWithLink(JniLibLoader.java:311)
        at io.glutenproject.vectorized.JniLibLoader$JniLoadTransaction.lambda$commit$1(JniLibLoader.java:261)
        at java.util.ArrayList.forEach(ArrayList.java:1259)
        at io.glutenproject.vectorized.JniLibLoader$JniLoadTransaction.commit(JniLibLoader.java:257)
        at io.glutenproject.vectorized.JniLibLoader.mapAndLoad(JniLibLoader.java:107)
        at io.glutenproject.backendsapi.velox.ListenerApiImpl.initialize(ListenerApiImpl.scala:166)
        at io.glutenproject.backendsapi.velox.ListenerApiImpl.onDriverStart(ListenerApiImpl.scala:49)
        at io.glutenproject.GlutenDriverPlugin.init(GlutenPlugin.scala:74)
        at org.apache.spark.internal.plugin.DriverPluginContainer.$anonfun$driverPlugins$1(PluginContainer.scala:53)
```



## How was this patch tested?
CI

