### PR TITLE
Call getPartitions once in WholeStageTransformer

### DIFF
--- a/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/BasicScanExecTransformer.scala
@@ -28,6 +28,7 @@ import io.glutenproject.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -61,7 +62,11 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
 
   /** Returns the split infos that will be processed by the underlying native engine. */
   def getSplitInfos: Seq[SplitInfo] = {
-    getPartitions.map(
+    getSplitInfosFromPartitions(getPartitions)
+  }
+
+  def getSplitInfosFromPartitions(partitions: Seq[InputPartition]): Seq[SplitInfo] = {
+    partitions.map(
       BackendsApiManager.getIteratorApiInstance
         .genSplitInfo(_, getPartitionSchema, fileFormat))
   }

--- a/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
+++ b/gluten-core/src/main/scala/io/glutenproject/execution/WholeStageTransformer.scala
@@ -34,6 +34,7 @@ import org.apache.spark.softaffinity.SoftAffinity
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -269,7 +270,9 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
        * care of SCAN there won't be any other RDD for SCAN. As a result, genFirstStageIterator
        * rather than genFinalStageIterator will be invoked
        */
-      val allScanSplitInfos = getSplitInfosFromScanTransformer(basicScanExecTransformers)
+      val allScanPartitions = basicScanExecTransformers.map(_.getPartitions)
+      val allScanSplitInfos =
+        getSplitInfosFromPartitions(basicScanExecTransformers, allScanPartitions)
 
       val (wsCtx, inputPartitions) = GlutenTimeMetric.withMillisTime {
         val wsCtx = doWholeStageTransform()
@@ -299,7 +302,6 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
           wsCtx.substraitContext.registeredAggregationParams
         )
       )
-      val allScanPartitions = basicScanExecTransformers.map(_.getPartitions)
       (0 until allScanPartitions.head.size).foreach(
         i => {
           val currentPartitions = allScanPartitions.map(_(i))
@@ -363,8 +365,9 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
   override protected def withNewChildInternal(newChild: SparkPlan): WholeStageTransformer =
     copy(child = newChild, materializeInput = materializeInput)(transformStageId)
 
-  private def getSplitInfosFromScanTransformer(
-      basicScanExecTransformers: Seq[BasicScanExecTransformer]): Seq[Seq[SplitInfo]] = {
+  private def getSplitInfosFromPartitions(
+      basicScanExecTransformers: Seq[BasicScanExecTransformer],
+      allScanPartitions: Seq[Seq[InputPartition]]): Seq[Seq[SplitInfo]] = {
     // If these are two scan transformers, they must have same partitions,
     // otherwise, exchange will be inserted. We should combine the two scan
     // transformers' partitions with same index, and set them together in
@@ -380,7 +383,10 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
     //  p14  |  p24
     //      ...
     //  p1n  |  p2n    => substraitContext.setSplitInfo([p1n, p2n])
-    val allScanSplitInfos = basicScanExecTransformers.map(_.getSplitInfos)
+    val allScanSplitInfos =
+      allScanPartitions.zip(basicScanExecTransformers).map {
+        case (partition, transformer) => transformer.getSplitInfosFromPartitions(partition)
+      }
     val partitionLength = allScanSplitInfos.head.size
     if (allScanSplitInfos.exists(_.size != partitionLength)) {
       throw new GlutenException(


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `WholeStageTransformer` `getPartitions` is called twice - once in `getSplitInfos` and another in `val allScanPartitions = basicScanExecTransformers.map(_.getPartitions)`. This results in a code loop that is executed for twice for the same sequence of partitions including https://github.com/oap-project/gluten/blob/f775d42b5c96709f7beacbd521baebf33337c0d6/gluten-core/src/main/scala/io/glutenproject/utils/InputPartitionsUtil.scala#L37. This PR makes a fix to call `getPartitions` only once and reuse it.

(Fixes: \#4884)

