### PR TITLE
[GLUTEN-5085] [VL] Fix get_velox.sh on macOS

### DIFF
--- a/ep/build-velox/src/get_velox.sh
+++ b/ep/build-velox/src/get_velox.sh
@@ -320,7 +320,7 @@ function setup_macos {
 
   sed -i '' $'/^  run_and_time install_double_conversion/a\\\n  run_and_time install_folly\\\n' scripts/setup-macos.sh
   # need set BUILD_SHARED_LIBS flag for thrift
-  sed -i  "/facebook\/fbthrift/{n;s/cmake_install -DBUILD_TESTS=OFF/cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF/;}" scripts/setup-macos.sh
+  sed -i '' "/facebook\/fbthrift/{n;s/cmake_install -DBUILD_TESTS=OFF/cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF/;}" scripts/setup-macos.sh
 }
 
 if [ $OS == 'Linux' ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

sed's `-i` param is different on macOS than on Linux, we need to use `-i ''` rather than `-i` to make it work.

Fixes: #5085

## How was this patch tested?

Manual tested on macOS

