### PR TITLE
[VL] No need to increment the fixedWidthIdx variable

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.cc
@@ -1064,7 +1064,6 @@ arrow::Result<std::vector<std::shared_ptr<arrow::Buffer>>> VeloxShuffleWriter::a
       case arrow::ListType::type_id:
         break;
       case arrow::NullType::type_id: {
-        fixedWidthIdx++;
         break;
       }
       default: {


### PR DESCRIPTION
If increase the fixedWidthIdx variable here, it will cause a coredump in the subsequent partitionBuffers_[fixedWidthIdx][partitionId].

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

(Fixes: \#ISSUE-ID)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

