### PR TITLE
[GLUTEN-8611][VL] Set VELOX_GFLAGS_TYPE by  checking GLUTEN_VCPKG_ENABLED in build_velox.sh

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -187,7 +187,7 @@ function build_velox {
   cd $GLUTEN_DIR/ep/build-velox/src
   # When BUILD_TESTS is on for gluten cpp, we need turn on VELOX_BUILD_TEST_UTILS via build_test_utils.
   ./build_velox.sh --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
-                   --enable_abfs=$ENABLE_ABFS --enable_vcpkg=$ENABLE_VCPKG --build_test_utils=$BUILD_TESTS \
+                   --enable_abfs=$ENABLE_ABFS --build_test_utils=$BUILD_TESTS \
                    --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS --num_threads=$NUM_THREADS \
                    --velox_home=$VELOX_HOME
 }

--- a/ep/build-velox/src/build_velox.sh
+++ b/ep/build-velox/src/build_velox.sh
@@ -34,8 +34,6 @@ ENABLE_BENCHMARK=OFF
 ENABLE_TESTS=OFF
 # Set to ON for gluten cpp test build.
 BUILD_TEST_UTILS=OFF
-# Enable vcpkg for Gluten can affect Velox cmake build options such as gflags library type.
-ENABLE_VCPKG=OFF
 # Number of threads to use for building.
 NUM_THREADS=""
 
@@ -82,10 +80,6 @@ for arg in "$@"; do
     ENABLE_BENCHMARK=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
-  --enable_vcpkg=*)
-    ENABLE_VCPKG=("${arg#*=}")
-    shift # Remove argument name from processing
-    ;;
   --num_threads=*)
     NUM_THREADS=("${arg#*=}")
     shift # Remove argument name from processing
@@ -127,7 +121,7 @@ function compile {
     echo "ENABLE_BENCHMARK is ON. Disabling Tests, GCS and ABFS connectors if enabled."
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_BENCHMARKS=ON"
   fi
-  if [ $ENABLE_VCPKG == "ON" ]; then
+  if [ -n "${GLUTEN_VCPKG_ENABLED:-}" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_GFLAGS_TYPE=static"
   fi
 


### PR DESCRIPTION
With this patch we can remove https://github.com/oap-project/velox/commit/885fbc654c1c20d4ef987144d39a35734d89dee6#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a