### PR TITLE
[GLUTEN-9719][VL] Unify output definitions for Broadcast/Hash/Columnar shuffle joins

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
@@ -71,24 +71,8 @@ trait ColumnarShuffledJoin extends BaseJoinExec {
       throw new IllegalArgumentException(s"ShuffledJoin should not take $x as the JoinType")
   }
 
-  override def output: Seq[Attribute] = {
-    joinType match {
-      case _: InnerLike =>
-        left.output ++ right.output
-      case LeftOuter =>
-        left.output ++ right.output.map(_.withNullability(true))
-      case RightOuter =>
-        left.output.map(_.withNullability(true)) ++ right.output
-      case FullOuter =>
-        (left.output ++ right.output).map(_.withNullability(true))
-      case j: ExistenceJoin =>
-        left.output :+ j.exists
-      case LeftExistence(_) =>
-        left.output
-      case x =>
-        throw new IllegalArgumentException(s"${getClass.getSimpleName} not take $x as the JoinType")
-    }
-  }
+  override def output: Seq[Attribute] =
+    JoinUtils.getDirectJoinOutputSeq(joinType, left.output, right.output, getClass.getSimpleName)
 }
 
 /** Performs a hash join of two child relations by first shuffling the data using the join keys. */
@@ -376,24 +360,8 @@ abstract class BroadcastHashJoinExecTransformerBase(
     isNullAwareAntiJoin: Boolean)
   extends HashJoinLikeExecTransformer {
 
-  override def output: Seq[Attribute] = {
-    joinType match {
-      case _: InnerLike =>
-        left.output ++ right.output
-      case LeftOuter =>
-        left.output ++ right.output.map(_.withNullability(true))
-      case RightOuter =>
-        left.output.map(_.withNullability(true)) ++ right.output
-      case FullOuter =>
-        (left.output ++ right.output).map(_.withNullability(true))
-      case j: ExistenceJoin =>
-        left.output :+ j.exists
-      case LeftExistence(_) =>
-        left.output
-      case x =>
-        throw new IllegalArgumentException(s"${getClass.getSimpleName} not take $x as the JoinType")
-    }
-  }
+  override def output: Seq[Attribute] =
+    JoinUtils.getDirectJoinOutputSeq(joinType, left.output, right.output, getClass.getSimpleName)
 
   override def requiredChildDistribution: Seq[Distribution] = {
     val mode = HashedRelationBroadcastMode(buildKeyExprs, isNullAwareAntiJoin)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinUtils.scala
@@ -133,7 +133,8 @@ object JoinUtils {
   private def getDirectJoinOutput(
       joinType: JoinType,
       leftOutput: Seq[Attribute],
-      rightOutput: Seq[Attribute]): (Seq[Attribute], Seq[Attribute]) = {
+      rightOutput: Seq[Attribute],
+      callerClassName: String = null): (Seq[Attribute], Seq[Attribute]) = {
     joinType match {
       case _: InnerLike =>
         (leftOutput, rightOutput)
@@ -149,15 +150,17 @@ object JoinUtils {
         // LeftSemi | LeftAnti | ExistenceJoin.
         (leftOutput, Nil)
       case x =>
-        throw new IllegalArgumentException(s"${getClass.getSimpleName} not take $x as the JoinType")
+        val joinClass = Option(callerClassName).getOrElse(this.getClass.getSimpleName)
+        throw new IllegalArgumentException(s"$joinClass not take $x as the JoinType")
     }
   }
 
-  private def getDirectJoinOutputSeq(
+  def getDirectJoinOutputSeq(
       joinType: JoinType,
       leftOutput: Seq[Attribute],
-      rightOutput: Seq[Attribute]): Seq[Attribute] = {
-    val (left, right) = getDirectJoinOutput(joinType, leftOutput, rightOutput)
+      rightOutput: Seq[Attribute],
+      joinClassName: String = null): Seq[Attribute] = {
+    val (left, right) = getDirectJoinOutput(joinType, leftOutput, rightOutput, joinClassName)
     left ++ right
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
 - Currently broadcast nested loop join, hash join and columnar shuffle join implement their own output definitions which are all duplicated. Refactor and simplify this code to rely on the function provided through utils.
 - We already have the same definition used in joinutils. Refactored the code to rely on the utils.

## How was this patch tested?
 - Existing unit tests
