### PR TITLE
[VL] Add mirror for ftp.gnu.org

### DIFF
--- a/dev/vcpkg/CONTRIBUTING.md
+++ b/dev/vcpkg/CONTRIBUTING.md
@@ -161,7 +161,7 @@ vcpkg_from_github(
 
 # Download from source archive
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz"
     FILENAME "gsasl-2.2.0.tar.gz"
     SHA512 0ae318a8616fe675e9718a3f04f33731034f9a7ba03d83ccb1a72954ded54ced35dc7c7e173fdcb6fa0f0813f8891c6cbcedf8bf70b37d00b8ec512eb9f07f5f
 )

--- a/dev/vcpkg/ports/gsasl/portfile.cmake
+++ b/dev/vcpkg/ports/gsasl/portfile.cmake
@@ -1,5 +1,5 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz"
     FILENAME "gsasl-2.2.0.tar.gz"
     SHA512 0ae318a8616fe675e9718a3f04f33731034f9a7ba03d83ccb1a72954ded54ced35dc7c7e173fdcb6fa0f0813f8891c6cbcedf8bf70b37d00b8ec512eb9f07f5f
 )

--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -49,6 +49,9 @@ install_gcc11_from_source() {
             cd /tmp
             if [ ! -d $gcc_version ]; then
                 wget https://ftp.gnu.org/gnu/gcc/${gcc_version}/${gcc_version}.tar.gz
+                if [ $? -ne 0 ]; then
+                    wget https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/${gcc_version}/${gcc_version}.tar.gz
+                fi
                 tar -xvf ${gcc_version}.tar.gz
             fi
             cd ${gcc_version}
@@ -116,7 +119,12 @@ install_centos_7() {
     installed_automake_version="$(aclocal --version | sed -En "1s/^.* ([1-9\.]*)$/\1/p")"
     if [ "$(semver "$installed_automake_version")" -lt "$(semver 1.14)" ]; then
         mkdir -p /tmp/automake
-        wget -O - http://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz | tar -x --xz -C /tmp/automake --strip-components=1
+        AUTOMAKE_URL1="https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz"
+        AUTOMAKE_URL2="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz"
+        wget -O - "$AUTOMAKE_URL1" | tar -x --xz -C /tmp/automake --strip-components=1
+        if [ $? -ne 0 ]; then
+            wget -O - "$AUTOMAKE_URL2" | tar -x --xz -C /tmp/automake --strip-components=1
+        fi
         cd /tmp/automake
         ./configure
         make install -j

--- a/tools/gluten-te/centos/centos-7-deps.sh
+++ b/tools/gluten-te/centos/centos-7-deps.sh
@@ -72,7 +72,12 @@ fi
 installed_automake_version="$(aclocal --version | sed -En "1s/^.* ([1-9\.]*)$/\1/p")"
 if [ "$(semver "$installed_automake_version")" -lt "$(semver 1.14)" ]; then
   mkdir -p /tmp/automake
-  wget -O - http://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz | tar -x --xz -C /tmp/automake --strip-components=1
+  AUTOMAKE_URL1="https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz"
+  AUTOMAKE_URL2="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz"
+  wget -O - "$AUTOMAKE_URL1" | tar -x --xz -C /tmp/automake --strip-components=1
+  if [ $? -ne 0 ]; then
+    wget -O - "$AUTOMAKE_URL2" | tar -x --xz -C /tmp/automake --strip-components=1
+  fi
   cd /tmp/automake
   ./configure
   make install -j


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since the normal ftp.gnu.org site was not accessible for all users to acquire several GNU libraries, such as Huawei Cloud overseas machines.
I added mirror https://www.mirrorservice.org/sites to some GNU libraries to fix this issue.
Reference https://github.com/microsoft/vcpkg/pull/9123

## How was this patch tested?


