### PR TITLE
[GLUTEN-9796][VL] Disable CI on ubuntu-20.04

### DIFF
--- a/.github/workflows/velox_backend.yml
+++ b/.github/workflows/velox_backend.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu:20.04", "ubuntu:22.04" ]
+        os: [ "ubuntu:22.04" ]
         spark: [ "spark-3.2", "spark-3.3", "spark-3.4", "spark-3.5" ]
         java: [ "java-8", "java-11", "java-17" ]
         # Spark supports JDK17 since 3.3 and later, see https://issues.apache.org/jira/browse/SPARK-33772


### PR DESCRIPTION
## What changes were proposed in this pull request?

ubuntu20.04 mirror is not stable due to end of life

(Fixes: #9796)

## How was this patch tested?

pass GHA

