### PR TITLE
[GLUTEN-9994][VL] Log velox memory usage stats when VeloxMemoryManager is shrinking

### DIFF
--- a/cpp/velox/memory/VeloxMemoryManager.cc
+++ b/cpp/velox/memory/VeloxMemoryManager.cc
@@ -296,8 +296,8 @@ MemoryUsageStats collectGlutenAllocatorMemoryUsageStats(
 
 void logMemoryUsageStats(MemoryUsageStats stats, const std::string& name, const std::string& logPrefix) {
   VLOG(2) << logPrefix << "+- " << name
-          << " (usedBytes: " << velox::succinctBytes(stats.current())
-          << ",peakBytes: " <<  velox::succinctBytes(stats.peak()) << ")";
+          << " (used: " << velox::succinctBytes(stats.current())
+          << ", peak: " <<  velox::succinctBytes(stats.peak()) << ")";
   if (stats.children_size() > 0) {
     for (auto it = stats.children().begin(); it != stats.children().end(); ++it) {
       logMemoryUsageStats(it->second, it->first, logPrefix + "   ");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Log velox memory usage stats when VeloxMemoryManager is shrinking

Fixes: #9994

## How was this patch tested?

after this:

```
I20250618 13:28:43.308105 39027 VeloxMemoryManager.cc:266] Shrink[root/root]: Trying to shrink 92274688 bytes of data...
I20250618 13:28:43.308111 39027 VeloxMemoryManager.cc:267] Shrink[root/root]: Pool has reserved 1668143424/1700790272/1700790272/9223372036854775807 bytes.
I20250618 13:28:43.308116 39027 VeloxMemoryManager.cc:269] Shrink[root/root]: Velox memory usage stats...
I20250618 13:28:43.308132 39027 VeloxMemoryManager.cc:253] Shrink[root/root]: +- root/root (used: 1.55GB, peak: 1.63GB)
I20250618 13:28:43.308140 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:    +- default_leaf (used: 0B, peak: 0B)
I20250618 13:28:43.308151 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:    +- task.Gluten_Stage_5_TID_9713_VTID_5 (used: 1.55GB, peak: 1.63GB)
I20250618 13:28:43.308158 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.6 (used: 24.00KB, peak: 1.00MB)
I20250618 13:28:43.308166 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.6.0.0.FilterProject (used: 24.00KB, peak: 24.00KB)
I20250618 13:28:43.308173 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.3 (used: 1.52GB, peak: 1.59GB)
I20250618 13:28:43.308182 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.3.1.0.HashBuild (used: 1.52GB, peak: 1.58GB)
I20250618 13:28:43.308188 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.3.0.0.HashProbe (used: 4.15MB, peak: 13.08MB)
I20250618 13:28:43.308197 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.5 (used: 256B, peak: 2.00MB)
I20250618 13:28:43.308204 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.5.0.0.FilterProject (used: 256B, peak: 1.52MB)
I20250618 13:28:43.308212 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.4 (used: 0B, peak: 0B)
I20250618 13:28:43.308219 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.4.0.0.FilterProject (used: 0B, peak: 0B)
I20250618 13:28:43.308228 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.2 (used: 0B, peak: 0B)
I20250618 13:28:43.308234 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.2.1.0.ValueStream (used: 0B, peak: 0B)
I20250618 13:28:43.308241 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.7 (used: 0B, peak: 40.00MB)
I20250618 13:28:43.308249 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.7.0.0.OrderBy (used: 0B, peak: 32.50MB)
I20250618 13:28:43.308257 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.8 (used: 0B, peak: 0B)
I20250618 13:28:43.308264 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.8.0.0.FilterProject (used: 0B, peak: 0B)
I20250618 13:28:43.308271 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.0 (used: 0B, peak: 0B)
I20250618 13:28:43.308279 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.0.0.0.ValueStream (used: 0B, peak: 0B)
I20250618 13:28:43.308286 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:       +- node.1 (used: 32.19MB, peak: 128.00MB)
I20250618 13:28:43.308295 39027 VeloxMemoryManager.cc:253] Shrink[root/root]:          +- op.1.0.0.Aggregation (used: 32.19MB, peak: 98.69MB)
I20250618 13:28:43.308303 39027 VeloxMemoryManager.cc:273] Shrink[root/root]: Shrinking...
I20250618 13:28:43.308310 39027 VeloxMemoryManager.cc:278] Shrink[root/root]: 0 bytes released from shrinking.
```
