### PR TITLE
[GLUTEN-9909][VL] Enable higher-order-functions.sql test

### DIFF
--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -72,7 +72,7 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
       "group-by-ordinal.sql",
       "grouping_set.sql",
       "having.sql",
-//      "higher-order-functions.sql",
+      "higher-order-functions.sql",
       "ignored.sql",
       "inline-table.sql",
       "inner-join.sql",

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -70,7 +70,7 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
     "group-by-ordinal.sql",
     "grouping_set.sql",
     "having.sql",
-//    "higher-order-functions.sql",
+    "higher-order-functions.sql",
     "ignored.sql",
     "ilike-all.sql",
     "ilike-any.sql",

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -70,7 +70,7 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
     "group-by-ordinal.sql",
     "grouping_set.sql",
     "having.sql",
-//    "higher-order-functions.sql",
+    "higher-order-functions.sql",
     "ignored.sql",
     "ilike-all.sql",
     "ilike-any.sql",

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxSQLQueryTestSettings.scala
@@ -68,7 +68,7 @@ object VeloxSQLQueryTestSettings extends SQLQueryTestSettings {
     "group-by-ordinal.sql",
     "grouping_set.sql",
     "having.sql",
-//    "higher-order-functions.sql",
+    "higher-order-functions.sql",
     "identifier-clause.sql",
     "ignored.sql",
     "ilike.sql",


### PR DESCRIPTION
## What changes were proposed in this pull request?

The core dump issue has been fixed in https://github.com/facebookincubator/velox/commit/7d22691c59af9361665d16e2df1fbf60b0ccb2d3.

## How was this patch tested?

UT Verified.
