### PR TITLE
[VL] Fix broken JAVA_HOME for gluten-it

### DIFF
--- a/tools/gluten-it/sbin/gluten-it.sh
+++ b/tools/gluten-it/sbin/gluten-it.sh
@@ -30,7 +30,7 @@ SPARK_JVM_OPTIONS=$($JAVA_HOME/bin/java -cp $JAR_PATH org.apache.gluten.integrat
 
 EMBEDDED_SPARK_HOME=$BASEDIR/../spark-home
 
-mkdir $EMBEDDED_SPARK_HOME && ln -snf $BASEDIR/../package/target/lib $EMBEDDED_SPARK_HOME/jars
+mkdir -p $EMBEDDED_SPARK_HOME && ln -snf ../package/target/lib $EMBEDDED_SPARK_HOME/jars
 
 # We temporarily disallow setting these two variables by caller.
 SPARK_HOME=""
@@ -49,4 +49,4 @@ $JAVA_HOME/bin/java \
     -XX:ErrorFile=/var/log/java/hs_err_pid%p.log \
     -Dio.netty.tryReflectionSetAccessible=true \
     -cp $JAR_PATH \
-    org.apache.gluten.integration.Cli $@
+    org.apache.gluten.integration.Cli "$@"


### PR DESCRIPTION
This fixes the following error when running gluten-it with parameter `--local-cluster`:

```
ava.lang.IllegalStateException: Library directory '/opt/code/incubator-gluten/tools/gluten-it/sbin/../spark-home/assembly/target/scala-2.12/jars' does not exist; make sure Spark is built.
	at org.apache.spark.launcher.CommandBuilderUtils.checkState(CommandBuilderUtils.java:228)
	at org.apache.spark.launcher.CommandBuilderUtils.findJarsDir(CommandBuilderUtils.java:322)
	at org.apache.spark.launcher.AbstractCommandBuilder.buildClassPath(AbstractCommandBuilder.java:195)
	at org.apache.spark.launcher.AbstractCommandBuilder.buildJavaCommand(AbstractCommandBuilder.java:118)
	at org.apache.spark.launcher.WorkerCommandBuilder.buildCommand(WorkerCommandBuilder.scala:39)
	at org.apache.spark.launcher.WorkerCommandBuilder.buildCommand(WorkerCommandBuilder.scala:45)
	at org.apache.spark.deploy.worker.CommandUtils$.buildCommandSeq(CommandUtils.scala:63)
	at org.apache.spark.deploy.worker.CommandUtils$.buildProcessBuilder(CommandUtils.scala:51)
	at org.apache.spark.deploy.worker.ExecutorRunner.org$apache$spark$deploy$worker$ExecutorRunner$$fetchAndRunExecutor(ExecutorRunner.scala:160)
	at org.apache.spark.deploy.worker.ExecutorRunner$$anon$1.run(ExecutorRunner.scala:80)
[ExecutorRunner for app-20250721105932-0000/0] ERROR org.apache.spark.deploy.worker.ExecutorRunner - Error running executor
```

Related to https://github.com/apache/incubator-gluten/pull/9851