### PR TITLE
[GLUTEN-10318] Improve the compareMajorMinorVersion for SparkVersionUtil

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkVersionUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkVersionUtil.scala
@@ -19,9 +19,11 @@ package org.apache.spark.util
 object SparkVersionUtil {
   // Returns X. X < 0 if one < other, x == 0 if one == other, x > 0 if one > other.
   def compareMajorMinorVersion(other: (Int, Int)): Int = {
-    val current = VersionUtils.majorMinorVersion(org.apache.spark.SPARK_VERSION)
-    val base = 1000
-    assert(current._2 < base && other._2 < base)
-    current._1 * base + current._2 - (other._1 * base + other._2)
+    val (major, minor) = VersionUtils.majorMinorVersion(org.apache.spark.SPARK_VERSION)
+    if (major == other._1) {
+      minor - other._2
+    } else {
+      major - other._1
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to improve the `compareMajorMinorVersion` for `SparkVersionUtil`.

(Fixes: \#10318)

## How was this patch tested?

unit tests, integration tests, manual tests

