### PR TITLE
[GLUTEN-10332] Remove unnecessary constructor for PlanNode

### DIFF
--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/plan/PlanBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/plan/PlanBuilder.java
@@ -34,11 +34,6 @@ public class PlanBuilder {
   private PlanBuilder() {}
 
   public static PlanNode makePlan(
-      List<FunctionMappingNode> mappingNodes, List<RelNode> relNodes, List<String> outNames) {
-    return new PlanNode(mappingNodes, relNodes, outNames);
-  }
-
-  public static PlanNode makePlan(
       List<FunctionMappingNode> mappingNodes,
       List<RelNode> relNodes,
       List<String> outNames,
@@ -72,10 +67,7 @@ public class PlanBuilder {
           ExtensionBuilder.makeFunctionMapping(entry.getKey(), entry.getValue());
       mappingNodes.add(mappingNode);
     }
-    if (extension != null || outputSchema != null) {
-      return makePlan(mappingNodes, relNodes, outNames, outputSchema, extension);
-    }
-    return makePlan(mappingNodes, relNodes, outNames);
+    return makePlan(mappingNodes, relNodes, outNames, outputSchema, extension);
   }
 
   public static PlanNode makePlan(SubstraitContext subCtx, ArrayList<RelNode> relNodes) {

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/plan/PlanNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/plan/PlanNode.java
@@ -37,12 +37,6 @@ public class PlanNode implements Serializable {
   private TypeNode outputSchema = null;
   private AdvancedExtensionNode extension = null;
 
-  PlanNode(List<FunctionMappingNode> mappingNodes, List<RelNode> relNodes, List<String> outNames) {
-    this.mappingNodes.addAll(mappingNodes);
-    this.relNodes.addAll(relNodes);
-    this.outNames.addAll(outNames);
-  }
-
   PlanNode(
       List<FunctionMappingNode> mappingNodes,
       List<RelNode> relNodes,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR proposes to remove unnecessary constructor for `PlanNode`.

(Fixes: \#10332)

## How was this patch tested?

unit tests, integration tests, manual tests

