### PR TITLE
[GLUTEN-10506] Include compression time in the shuffle write metric for Uniffle

### DIFF
--- a/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -245,7 +245,9 @@ public class VeloxUniffleColumnarShuffleWriter<K, V> extends RssShuffleWriter<K,
     // bytesWritten is calculated in uniffle side: WriteBufferManager.createShuffleBlock
     // shuffleWriteMetrics.incBytesWritten(splitResult.getTotalBytesWritten());
     shuffleWriteMetrics.incWriteTime(
-        splitResult.getTotalWriteTime() + splitResult.getTotalPushTime() + splitResult.getTotalCompressTime());
+        splitResult.getTotalWriteTime()
+            + splitResult.getTotalPushTime()
+            + splitResult.getTotalCompressTime());
     // partitionLengths is calculate in uniffle side
 
     long pushMergedDataTime = System.nanoTime();


### PR DESCRIPTION
## What changes are proposed in this pull request?

The compression time of shuffle data should be included into the shuffle write metric.

## How was this patch tested?

Haven't
