### PR TITLE
[GLUTEN-8851][VL] Set kCudfEnabledDefault to true if Gluten GPU is enabled

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -94,7 +94,7 @@ const std::string kSparkJsonIgnoreNullFields = "spark.sql.jsonGenerator.ignoreNu
 // cudf
 #ifdef GLUTEN_ENABLE_GPU
 const std::string kCudfEnabled = "spark.gluten.sql.columnar.cudf";
-const bool kCudfEnabledDefault = "false";
+const bool kCudfEnabledDefault = "true";
 const std::string kDebugCudf = "spark.gluten.sql.debug.cudf";
 const bool kDebugCudfDefault = "false";
 #endif


### PR DESCRIPTION
Then the microbenchmark can run gpu path if compiled with `--enable_cudf=ON`
