### PR TITLE
[VL][INFRA] Fix docker build error on Centos-7

### DIFF
--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -98,9 +98,10 @@ install_centos_7() {
 
     # Requires git >= 2.7.4
     if [[ "$(git --version)" != "git version 2."* ]]; then
-        [ -f /etc/yum.repos.d/ius.repo ] || yum -y install https://repo.ius.io/ius-release-el7.rpm
         yum -y remove git
-        yum -y install git236
+        # Requires 'centos-release-scl' package to be installed.
+        yum -y install rh-git227
+        source /opt/rh/rh-git227/enable
     fi
 
     # flex>=2.6.0


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Fix docker build error. This PR will install git 2.27.0, which can still meet the minimum version requirement 2.7.4.

```
#6 101.5 Cannot open: https://repo.ius.io/ius-release-el7.rpm. Skipping.
#6 101.5 Error: Nothing to do
```
https://github.com/apache/incubator-gluten/actions/runs/17193209331/job/48789710380
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Local test.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
