### PR TITLE
[VL] Update class duplication list in Maven enforcer

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -325,7 +325,7 @@
                     <!-- hive -->
                     <ignoreClass>org.apache.hadoop.hive.*</ignoreClass>
                     <!-- hawtjni -->
-                    <ignoreClass>org.fusesource.hawtjni.runtime.Library.class</ignoreClass>
+                    <ignoreClass>org.fusesource.hawtjni.runtime.Library</ignoreClass>
                     <!-- The overridden class list by Gluten. Carefully add entries to this list only when you knew exactly what is going to happen -->
                     <ignoreClass>org.apache.spark.sql.hive.execution.HiveFileFormat</ignoreClass>
                     <ignoreClass>org.apache.spark.sql.hive.execution.HiveFileFormat$$$$anon$1</ignoreClass>


### PR DESCRIPTION
This is to address build error:

```
[ERROR] Rule 0: org.codehaus.mojo.extraenforcer.dependencies.BanDuplicateClasses failed with message:
[ERROR] Duplicate classes found:
[ERROR]
[ERROR]   Found in:
[ERROR]     org.openlabtesting.leveldbjni:leveldbjni-all:jar:1.8:provided
[ERROR]     jline:jline:jar:2.12:provided
[ERROR]   Duplicate classes:
[ERROR]     org/fusesource/hawtjni/runtime/Library.class
```

I am still not sure why this message is showing up, but it's definitely not an issue that needs to be addressed by the enforcer rules.