### PR TITLE
[VL] Update modify_arrow_dataset_scan_option.patch

### DIFF
--- a/ep/build-velox/src/modify_arrow_dataset_scan_option.patch
+++ b/ep/build-velox/src/modify_arrow_dataset_scan_option.patch
@@ -186,15 +186,18 @@ diff --git a/java/dataset/src/main/cpp/jni_wrapper.cc b/java/dataset/src/main/cp
 index 8d7dafd84..89cdc39fe 100644
 --- a/java/dataset/src/main/cpp/jni_wrapper.cc
 +++ b/java/dataset/src/main/cpp/jni_wrapper.cc
-@@ -25,6 +25,7 @@
- #include "arrow/c/helpers.h"
- #include "arrow/dataset/api.h"
- #include "arrow/dataset/file_base.h"
-+#include "arrow/dataset/file_csv.h"
- #include "arrow/filesystem/localfs.h"
- #include "arrow/filesystem/path_util.h"
- #ifdef ARROW_S3
-@@ -122,6 +123,19 @@ arrow::Result<std::shared_ptr<arrow::dataset::FileFormat>> GetFileFormat(
+@@ -99,8 +99,10 @@
+ arrow::Result<std::shared_ptr<arrow::dataset::FileFormat>> GetFileFormat(
+     jint file_format_id) {
+   switch (file_format_id) {
++#ifdef ARROW_PARQUET
+     case 0:
+       return std::make_shared<arrow::dataset::ParquetFileFormat>();
++#endif
+     case 1:
+       return std::make_shared<arrow::dataset::IpcFileFormat>();
+ #ifdef ARROW_ORC
+@@ -122,6 +124,19 @@
    }
  }
  
@@ -214,7 +217,7 @@ index 8d7dafd84..89cdc39fe 100644
  class ReserveFromJava : public arrow::dataset::jni::ReservationListener {
   public:
    ReserveFromJava(JavaVM* vm, jobject java_reservation_listener)
-@@ -460,12 +474,13 @@ JNIEXPORT void JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_closeDataset
+@@ -460,12 +475,13 @@ JNIEXPORT void JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_closeDataset
  /*
   * Class:     org_apache_arrow_dataset_jni_JniWrapper
   * Method:    createScanner
@@ -231,7 +234,7 @@ index 8d7dafd84..89cdc39fe 100644
    JNI_METHOD_START
    arrow::MemoryPool* pool = reinterpret_cast<arrow::MemoryPool*>(memory_pool_id);
    if (pool == nullptr) {
-@@ -514,6 +529,14 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_createScann
+@@ -514,6 +530,14 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_createScann
      }
      JniAssertOkOrThrow(scanner_builder->Filter(*filter_expr));
    }
@@ -246,7 +249,7 @@ index 8d7dafd84..89cdc39fe 100644
    JniAssertOkOrThrow(scanner_builder->BatchSize(batch_size));
  
    auto scanner = JniGetOrThrow(scanner_builder->Finish());
-@@ -627,14 +650,31 @@ JNIEXPORT void JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_ensureS3Fina
+@@ -627,14 +651,31 @@ JNIEXPORT void JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_ensureS3Fina
  /*
   * Class:     org_apache_arrow_dataset_file_JniWrapper
   * Method:    makeFileSystemDatasetFactory
@@ -281,7 +284,7 @@ index 8d7dafd84..89cdc39fe 100644
    arrow::dataset::FileSystemFactoryOptions options;
    std::shared_ptr<arrow::dataset::DatasetFactory> d =
        JniGetOrThrow(arrow::dataset::FileSystemDatasetFactory::Make(
-@@ -645,16 +685,33 @@ Java_org_apache_arrow_dataset_file_JniWrapper_makeFileSystemDatasetFactory__Ljav
+@@ -645,16 +686,33 @@ Java_org_apache_arrow_dataset_file_JniWrapper_makeFileSystemDatasetFactory__Ljav
  
  /*
   * Class:     org_apache_arrow_dataset_file_JniWrapper


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

When build arrow on my mac, I meet this error

```
[ 54%] Built target arrow_java_jni_dataset_jar                                                                                                                                              
[ 72%] Built target arrow_java_jni_cdata                                                                                                                                                    
[ 81%] Building CXX object dataset/CMakeFiles/arrow_java_jni_dataset.dir/src/main/cpp/jni_wrapper.cc.o                                                                                      
/Users/zxy/project/emr/gluten/ep/_ep/arrow_ep/java/dataset/src/main/cpp/jni_wrapper.cc:103:14: error: no viable conversion from returned value of type 'shared_ptr<ParquetFileFormat>' to fu
nction return type 'arrow::Result<std::shared_ptr<arrow::dataset::FileFormat>>'                                                                                                             
  103 |       return std::make_shared<arrow::dataset::ParquetFileFormat>();                                                                                                                 
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                  
/usr/local/include/arrow/result.h:129:3: note: candidate constructor not viable: no known conversion from 'shared_ptr<ParquetFileFormat>' to 'const Status &' for 1st argument              
  129 |   Result(const Status& status) noexcept  // NOLINT(runtime/explicit)                                                                                                                
      |   ^      ~~~~~~~~~~~~~~~~~~~~                                                                                                                                                       
/usr/local/include/arrow/result.h:177:3: note: candidate constructor not viable: no known conversion from 'shared_ptr<ParquetFileFormat>' to 'std::shared_ptr<arrow::dataset::FileFormat> &&
' for 1st argument                                                                  
```

The reason is that we remove build ARROW_PARQUET in https://github.com/apache/incubator-gluten/issues/9511

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

test build on my own mac
