### PR TITLE
[VL] Fix decimal arithmetic offload when allowPrecisionLoss=false

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -523,8 +523,6 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
   override def staticPartitionWriteOnly(): Boolean = true
 
-  override def allowDecimalArithmetic: Boolean = true
-
   override def enableNativeWriteFiles(): Boolean = {
     GlutenConfig.get.enableNativeWriter.getOrElse(
       SparkShimLoader.getSparkShims.enableNativeWriteFilesByDefault()

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -105,8 +105,6 @@ trait BackendSettingsApi {
 
   def rescaleDecimalArithmetic: Boolean = false
 
-  def allowDecimalArithmetic: Boolean = true
-
   /**
    * After https://github.com/apache/spark/pull/36698, every arithmetic should report the accurate
    * result decimal type and implement `CheckOverflow` by itself. <p/> Regardless of whether there

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -242,6 +242,8 @@ trait SparkPlanExecApi {
     GenericExpressionTransformer(substraitExprName, Seq(left, right), original)
   }
 
+  def getDecimalArithmeticExprName(exprName: String): String = exprName
+
   /** Transform map_entries to Substrait. */
   def genMapEntriesTransformer(
       substraitExprName: String,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/DecimalArithmeticUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/DecimalArithmeticUtil.scala
@@ -16,9 +16,7 @@
  */
 package org.apache.gluten.utils
 
-import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenNotSupportException
-import org.apache.gluten.expression.ExpressionConverter.conf
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.expressions.{Add, BinaryArithmetic, Cast, Divide, Expression, Literal, Multiply, Pmod, PromotePrecision, Remainder, Subtract}
@@ -220,14 +218,5 @@ object DecimalArithmeticUtil {
       wider: DecimalType): Boolean = {
     val widerType = SparkShimLoader.getSparkShims.widerDecimalType(left, right)
     widerType.equals(wider)
-  }
-
-  def checkAllowDecimalArithmetic(): Unit = {
-    // PrecisionLoss=false: velox not support
-    if (!BackendsApiManager.getSettings.allowDecimalArithmetic) {
-      throw new GlutenNotSupportException(
-        s"Not support ${SQLConf.DECIMAL_OPERATIONS_ALLOW_PREC_LOSS.key} " +
-          s"${conf.decimalOperationsAllowPrecisionLoss} mode")
-    }
   }
 }


### PR DESCRIPTION

## What changes are proposed in this pull request?

Decimal arithmetic is not offload when allowPrecisionLoss is false.

```
 - Native validation failed:
   |- Validation failed due to exception caught at file:SubstraitToVeloxPlanValidator.cc line:1440 function:validate, thrown from file:ExprCompiler.cpp line:393 function:compileCall, reason:Found incompatible return types for 'add' (DECIMAL(38, 10) vs. DECIMAL(38, 11)) for input types (DECIMAL(38, 11), DECIMAL(38, 11)).

```
## How was this patch tested?

UT.
