### PR TITLE
[VL]Make PartialProject support struct with null fields

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -247,4 +247,28 @@ abstract class UDFPartialProjectSuite extends WholeStageTransformerSuite {
         }
     }
   }
+
+  test("test struct data with null fields") {
+    case class MyStructWithNullValue(a: Option[Long], b: Array[Long])
+    spark.udf.register(
+      "struct_plus_one",
+      udf(
+        (m: MyStructWithNullValue) =>
+          MyStructWithNullValue(if (m.a.isEmpty) None else Some(m.a.get + 1), m.b.map(_ + 1))))
+    runQueryAndCompare("""
+                         |SELECT
+                         |  l_partkey,
+                         |  struct_plus_one(struct_data)
+                         |FROM (
+                         | SELECT l_partkey,
+                         | struct(
+                         |   CASE WHEN l_orderkey % 2 == 0 THEN l_orderkey ELSE null END as a,
+                         |   array(l_orderkey % 2, l_orderkey % 2 + 1, l_orderkey % 2 + 2) as b
+                         | ) as struct_data
+                         | FROM lineitem
+                         |)
+                         |""".stripMargin) {
+      checkGlutenOperatorMatch[ColumnarPartialProjectExec]
+    }
+  }
 }

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
@@ -411,6 +411,16 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     return "vectorCounter is " + vectorCount.get();
   }
 
+  public ArrowColumnarRow getStructInternal(int rowId) {
+    if (isNullAt(rowId)) return null;
+    ArrowWritableColumnVector[] writableColumns =
+        new ArrowWritableColumnVector[childColumns.length];
+    for (int i = 0; i < writableColumns.length; i++) {
+      writableColumns[i] = (ArrowWritableColumnVector) childColumns[i];
+    }
+    return new ArrowColumnarRow(writableColumns);
+  }
+
   @Override
   public boolean hasNull() {
     return accessor.getNullCount() > 0;

--- a/gluten-arrow/src/main/scala/org/apache/gluten/utils/ArrowAbiUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/utils/ArrowAbiUtil.scala
@@ -18,10 +18,10 @@ package org.apache.gluten.utils
 
 import org.apache.gluten.columnarbatch.ColumnarBatches
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.vectorized.ArrowWritableColumnVector
+import org.apache.gluten.vectorized.{ArrowColumnarBatch, ArrowWritableColumnVector}
 
 import org.apache.spark.sql.utils.SparkVectorUtil
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.memory.BufferAllocator
@@ -81,7 +81,7 @@ object ArrowAbiUtil {
 
   private def toSparkColumnarBatch(vsr: VectorSchemaRoot): ColumnarBatch = {
     val rowCount: Int = vsr.getRowCount
-    val vectors: Array[ColumnVector] =
+    val vectors: Array[ArrowWritableColumnVector] =
       ArrowWritableColumnVector
         .loadColumns(rowCount, vsr.getFieldVectors)
         .map(
@@ -89,7 +89,7 @@ object ArrowAbiUtil {
             v.setValueCount(rowCount)
             v
           })
-    new ColumnarBatch(vectors, rowCount)
+    new ArrowColumnarBatch(vectors, rowCount)
   }
 
   private def toVectorSchemaRoot(

--- a/gluten-arrow/src/main/scala/org/apache/gluten/vectorized/ArrowColumnarBatch.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/vectorized/ArrowColumnarBatch.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.vectorized
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class ArrowColumnarBatch(writableColumns: Array[ArrowWritableColumnVector], numRows: Int)
+  extends ColumnarBatch(writableColumns.toArray, numRows) {
+  private val arrowColumnarRow = new ArrowColumnarRow(writableColumns)
+
+  override def getRow(rowId: Int): InternalRow = {
+    assert(rowId >= 0 && rowId < this.numRows)
+    arrowColumnarRow.rowId = rowId
+    arrowColumnarRow
+  }
+}

--- a/gluten-arrow/src/main/scala/org/apache/gluten/vectorized/ArrowColumnarRow.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/vectorized/ArrowColumnarRow.scala
@@ -22,7 +22,7 @@ import org.apache.gluten.execution.InternalRowGetVariantCompatible
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.{ColumnarArray, ColumnarMap, ColumnarRow}
+import org.apache.spark.sql.vectorized.{ColumnarArray, ColumnarMap}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 import java.math.BigDecimal
@@ -109,8 +109,8 @@ final class ArrowColumnarRow(writableColumns: Array[ArrowWritableColumnVector])
   override def getInterval(ordinal: Int): CalendarInterval =
     columns(ordinal).getInterval(rowId)
 
-  override def getStruct(ordinal: Int, numFields: Int): ColumnarRow =
-    columns(ordinal).getStruct(rowId)
+  override def getStruct(ordinal: Int, numFields: Int): ArrowColumnarRow =
+    columns(ordinal).getStructInternal(rowId)
 
   override def getArray(ordinal: Int): ColumnarArray =
     columns(ordinal).getArray(rowId)
@@ -118,23 +118,28 @@ final class ArrowColumnarRow(writableColumns: Array[ArrowWritableColumnVector])
   override def getMap(ordinal: Int): ColumnarMap =
     columns(ordinal).getMap(rowId)
 
-  override def get(ordinal: Int, dataType: DataType): AnyRef = dataType match {
-    case _: BooleanType => java.lang.Boolean.valueOf(getBoolean(ordinal))
-    case _: ByteType => java.lang.Byte.valueOf(getByte(ordinal))
-    case _: ShortType => java.lang.Short.valueOf(getShort(ordinal))
-    case _: IntegerType => java.lang.Integer.valueOf(getInt(ordinal))
-    case _: LongType => java.lang.Long.valueOf(getLong(ordinal))
-    case _: FloatType => java.lang.Float.valueOf(getFloat(ordinal))
-    case _: DoubleType => java.lang.Double.valueOf(getDouble(ordinal))
-    case _: StringType => getUTF8String(ordinal)
-    case _: BinaryType => getBinary(ordinal)
-    case t: DecimalType => getDecimal(ordinal, t.precision, t.scale)
-    case _: DateType => java.lang.Integer.valueOf(getInt(ordinal))
-    case _: TimestampType => java.lang.Long.valueOf(getLong(ordinal))
-    case _: ArrayType => getArray(ordinal)
-    case s: StructType => getStruct(ordinal, s.fields.length)
-    case _: MapType => getMap(ordinal)
-    case _ => throw new UnsupportedOperationException(s"Datatype not supported $dataType")
+  override def get(ordinal: Int, dataType: DataType): AnyRef = {
+    if (isNullAt(ordinal)) {
+      return null
+    }
+    dataType match {
+      case _: BooleanType => java.lang.Boolean.valueOf(getBoolean(ordinal))
+      case _: ByteType => java.lang.Byte.valueOf(getByte(ordinal))
+      case _: ShortType => java.lang.Short.valueOf(getShort(ordinal))
+      case _: IntegerType => java.lang.Integer.valueOf(getInt(ordinal))
+      case _: LongType => java.lang.Long.valueOf(getLong(ordinal))
+      case _: FloatType => java.lang.Float.valueOf(getFloat(ordinal))
+      case _: DoubleType => java.lang.Double.valueOf(getDouble(ordinal))
+      case _: StringType => getUTF8String(ordinal)
+      case _: BinaryType => getBinary(ordinal)
+      case t: DecimalType => getDecimal(ordinal, t.precision, t.scale)
+      case _: DateType => java.lang.Integer.valueOf(getInt(ordinal))
+      case _: TimestampType => java.lang.Long.valueOf(getLong(ordinal))
+      case _: ArrayType => getArray(ordinal)
+      case s: StructType => getStruct(ordinal, s.fields.length)
+      case _: MapType => getMap(ordinal)
+      case _ => throw new UnsupportedOperationException(s"Datatype not supported $dataType")
+    }
   }
 
   override def update(ordinal: Int, value: Any): Unit = {


### PR DESCRIPTION
## What changes are proposed in this pull request?
For now, if `PartialProject` evaluates expressions that accept data whose type is struct and its input has `NULL` values for some fields, the evaluation will throw out exception like follows:
```
Reason: Operator::getOutput failed for [operator: ValueStream, plan node ID: 0]: Error during calling Java code from native code: java.lang.IllegalStateException: Value at index is null
	at org.apache.arrow.vector.BitVector.get(BitVector.java:252)
	at org.apache.gluten.vectorized.ArrowWritableColumnVector$BooleanAccessor.getBoolean(ArrowWritableColumnVector.java:913)
	at org.apache.gluten.vectorized.ArrowWritableColumnVector.getBoolean(ArrowWritableColumnVector.java:471)
	at org.apache.spark.sql.vectorized.ColumnarRow.getBoolean(ColumnarRow.java:104)
	at org.apache.spark.sql.vectorized.ColumnarRow.get(ColumnarRow.java:162)
	at org.apache.spark.sql.catalyst.expressions.GetStructField.nullSafeEval(complexTypeExtractors.scala:128)
```
The reason is that `ColumnarRow` in `Spark` doesn't check whether the field to get is null. This PR fixes this bug.

## How was this patch tested?
Unit tests.