### PR TITLE
[GLUTEN-10772][CH] Fix crash caused by not releasing `QueryContext` resources properly.

### DIFF
--- a/cpp-ch/local-engine/Common/CHUtil.cpp
+++ b/cpp-ch/local-engine/Common/CHUtil.cpp
@@ -1001,6 +1001,7 @@ void BackendFinalizerUtil::finalizeGlobally()
     ReadBufferBuilderFactory::instance().clean();
     StorageMergeTreeFactory::clear_cache_map();
     QueryContext::resetGlobal();
+    QueryContext::instance().reset();
     std::lock_guard lock(paths_mutex);
     std::ranges::for_each(
         paths_need_to_clean,

--- a/cpp-ch/local-engine/Common/QueryContext.cpp
+++ b/cpp-ch/local-engine/Common/QueryContext.cpp
@@ -69,6 +69,11 @@ void QueryContext::resetGlobal()
     Data::shared_context.reset();
 }
 
+void QueryContext::reset()
+{
+    query_map_.clear();
+}
+
 DB::ContextMutablePtr QueryContext::createGlobal()
 {
     assert(Data::shared_context.get() == nullptr);

--- a/cpp-ch/local-engine/Common/QueryContext.h
+++ b/cpp-ch/local-engine/Common/QueryContext.h
@@ -48,6 +48,9 @@ public:
     size_t currentPeakMemory(int64_t id);
     void finalizeQuery(int64_t id);
 
+    // Clear resources held by the QueryContext instance.
+    void reset();
+
 private:
     QueryContext() = default;
     LoggerPtr logger_ = getLogger("QueryContextManager");

--- a/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
@@ -47,14 +47,12 @@
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/wrappers.pb.h>
-#include "Common/Logger.h"
 #include <Common/AggregateUtil.h>
 #include <Common/ArrayJoinHelper.h>
 #include <Common/GlutenConfig.h>
 #include <Common/PlanUtil.h>
 #include <Common/QueryContext.h>
 #include <Common/logger_useful.h>
-#include "cctz/civil_time_detail.h"
 
 namespace DB::ErrorCodes
 {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Fix crash caused by not releasing `QueryContext` resources properly.

This could happen when a query is canceled by YARN, causing the release action for resources in QueryContext::query_map_to not be called as expected."
## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

test manually
