### PR TITLE
[GLUTEN-10833][VL] Reduce memcpy in ColumnToRow

### DIFF
--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -58,8 +58,11 @@ void VeloxColumnarToRowConverter::refreshStates(facebook::velox::RowVectorPtr ro
   }
 
   if (nullptr == veloxBuffers_ || veloxBuffers_->capacity() < totalMemorySize) {
-    veloxBuffers_ = velox::AlignedBuffer::allocate<uint8_t>(totalMemorySize, veloxPool_.get(), 0);
+    veloxBuffers_ = velox::AlignedBuffer::allocate<uint8_t>(totalMemorySize, veloxPool_.get());
   }
+
+  bufferAddress_ = veloxBuffers_->asMutable<uint8_t>();
+  memset(bufferAddress_, 0, sizeof(int8_t) * totalMemorySize);
 }
 
 void VeloxColumnarToRowConverter::convert(std::shared_ptr<ColumnarBatch> cb, int64_t startRow) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

We always fill the buffer with `0` so it's no necessary to keep the old content when doing allocation in C2R

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Fixes #10833

## How was this patch tested?
pass GHA

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
