### PR TITLE
[GLUTEN-10774][VL][FOLLOWUP] Strip quotes for osName and osVersion

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoaderUtils.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/utils/SharedLibraryLoaderUtils.scala
@@ -35,6 +35,14 @@ object SharedLibraryLoaderUtils {
     osName.startsWith("Mac OS X") || osName.startsWith("macOS")
   }
 
+  private def stripQuotes(s: String): String = {
+    if (s == null) {
+      null
+    } else {
+      s.stripPrefix("\"").stripSuffix("\"")
+    }
+  }
+
   def load(conf: SparkConf, jni: JniLibLoader): Unit = {
     val shouldLoad = conf.get(GLUTEN_LOAD_LIB_FROM_JAR)
     if (!shouldLoad) {
@@ -57,7 +65,7 @@ object SharedLibraryLoaderUtils {
         val props = new Properties()
         val in = new FileInputStream("/etc/os-release")
         props.load(in)
-        (props.getProperty("NAME"), props.getProperty("VERSION"))
+        (stripQuotes(props.getProperty("NAME")), stripQuotes(props.getProperty("VERSION")))
     }
 
     val loaders = ServiceLoader


### PR DESCRIPTION
## What changes are proposed in this pull request?
Follow-up PR for #10774

The content in `/etc/os-release` is probably in the format of key="value". Previously, when extracting with regular expressions, the double quotes were removed. Currently, using `Properties.load` does not remove the double quotes, causing some `startsWith` logic to return false.

## How was this patch tested?
N/A
