### PR TITLE
[VL] Check VELOX_HOME variable in build_arrow to allow custom Velox path

### DIFF
--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -206,7 +206,7 @@ fi
 concat_velox_param
 
 function build_arrow {
-  if [ ! -d "$GLUTEN_DIR/ep/build-velox/build/velox_ep" ]; then
+  if [ ! -d "$VELOX_HOME" ]; then
     get_velox && setup_dependencies
   fi
   cd $GLUTEN_DIR/dev


### PR DESCRIPTION
## What changes are proposed in this pull request?
The build_arrow function should check the value of `VELOX_HOME` to determine whether it needs to execute `get_velox && setup_dependencies`.

Currently, if the user provides a custom `VELOX_HOME` path (pointing to an external Velox installation), the script still unconditionally runs `get_velox && setup_dependencies`, which is redundant and inefficient.

The default value of `VELOX_HOME` is `$GLUTEN_DIR/ep/build-velox/build/velox_ep`

## How was this patch tested?
N/A
