### PR TITLE
[GLUTEN-10878][INFRA] Maturity CS50: Synchronize GitHub discussions to the dev mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,4 +52,4 @@ notifications:
   commits: commits@gluten.apache.org
   issues: commits@gluten.apache.org
   pullrequests: commits@gluten.apache.org
-  discussions: commits@gluten.apache.org
+  discussions: dev@gluten.apache.org


### PR DESCRIPTION
The GitHub discussions were previously synchronized to commit@github.apache.org.

This PR redirect them to dev@github.apache.org. Which will make more discussions show up on dev list and possibly attract more attentions, for the compliance with The Apache Way.



Related issue: #10878