### PR TITLE
[GLUTEN-10903][VL] Install cudf libraries in docker to accelerate build

### DIFF
--- a/dev/docker/cudf/Dockerfile
+++ b/dev/docker/cudf/Dockerfile
@@ -27,7 +27,6 @@ ENV PATH=$SPARK_HOME/bin:$PATH
 ENV CUDA_ARCHITECTURES=70
 
 WORKDIR /opt/gluten
-RUN bash ./dev/buildbundle-veloxbe.sh --run_setup_script=OFF --build_arrow=ON --spark_version=3.4 --enable_gpu=ON && rm -rf /opt/gluten
-
-# You can try the data in folder backends-velox/src/test/resources/tpch-data-parquet
-
+RUN bash ./dev/buildbundle-veloxbe.sh --run_setup_script=OFF --build_arrow=ON --spark_version=3.4 --enable_gpu=ON && \
+    cmake --install ep/build-velox/build/velox_ep/_build/release/_deps/cudf-build --prefix=/usr/local && \
+    rm -rf /opt/gluten


### PR DESCRIPTION
Install /usr/local/include/rapids/cuda, nvtx3, nvcomp and so on. Then we can use system cudf library instead of building it as bundled library



Related issue: #10903