### PR TITLE
[MINOR][CORE] Fix StaticInvoke fallback reason

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -212,7 +212,7 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       case i: StaticInvoke =>
         throw new GlutenNotSupportException(
           s"Not supported to transform StaticInvoke with object: ${i.staticObject.getName}, " +
-            s"function: $i.functionName")
+            s"function: ${i.functionName}")
       case _ =>
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

The function name in `staticinvoke` fallback reason is not correctly extracted

```
(6) Filter: 
 - Validation failed with exception from: FilterExecTransformer, reason: Not supported to transform StaticInvoke with object: org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils, function: staticinvoke(class org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils, StringType, readSidePadding, cd_gender#59, 1, true, false, true).functionName
```

## How was this patch tested?

minor fix
