### PR TITLE
[GLUTEN-10920][VL] Allow disabling hash/sort shuffle reader buffer

### DIFF
--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -501,10 +501,14 @@ void VeloxHashShuffleReaderDeserializer::loadNextStream() {
     return;
   }
 
-  GLUTEN_ASSIGN_OR_THROW(
-      in_,
-      arrow::io::BufferedInputStream::Create(
-          readerBufferSize_, memoryManager_->defaultArrowMemoryPool(), std::move(in)));
+  if (readerBufferSize_ > 0) {
+    GLUTEN_ASSIGN_OR_THROW(
+          in_,
+          arrow::io::BufferedInputStream::Create(
+              readerBufferSize_, memoryManager_->defaultArrowMemoryPool(), std::move(in)));
+  } else {
+    in_ = std::move(in);
+  }
 }
 
 std::shared_ptr<ColumnarBatch> VeloxHashShuffleReaderDeserializer::next() {
@@ -656,10 +660,14 @@ void VeloxSortShuffleReaderDeserializer::loadNextStream() {
     GLUTEN_ASSIGN_OR_THROW(
         in_, CompressedInputStream::Make(codec_.get(), std::move(in), memoryManager_->defaultArrowMemoryPool()));
   } else {
-    GLUTEN_ASSIGN_OR_THROW(
-        in_,
-        arrow::io::BufferedInputStream::Create(
-            readerBufferSize_, memoryManager_->defaultArrowMemoryPool(), std::move(in)));
+    if (readerBufferSize_ > 0) {
+      GLUTEN_ASSIGN_OR_THROW(
+          in_,
+          arrow::io::BufferedInputStream::Create(
+              readerBufferSize_, memoryManager_->defaultArrowMemoryPool(), std::move(in)));
+    } else {
+      in_ = std::move(in);
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Add buffer to the shuffle read input stream only if `readerBufferSize` is greater than 0.

## How was this patch tested?

Manually testing internal test case:

add `spark.gluten.sql.columnar.shuffle.readerBufferSize=1MB;` conf:
<img width="1906" height="89" alt="image" src="https://github.com/user-attachments/assets/b9f1f640-27e3-47da-9504-b777cc3a97c5" />

add `spark.gluten.sql.columnar.shuffle.readerBufferSize=0;` conf:

<img width="1885" height="53" alt="image" src="https://github.com/user-attachments/assets/e9221517-c6e2-46df-899f-fc7e37a84a1b" />




Related issue: #10920