### PR TITLE
[GLUTEN-10923][VL] Support shaded netty package for LowCopyNettyJniByteInputStream

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/LowCopyNettyJniByteInputStream.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/LowCopyNettyJniByteInputStream.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This implementation is targeted to optimize against Spark's {@link
@@ -34,12 +36,15 @@ import java.nio.ByteBuffer;
  */
 public class LowCopyNettyJniByteInputStream implements JniByteInputStream {
 
-  private static final Field FIELD_ByteBufInputStream_buffer;
+  // Cache shaded netty ByteBufInputStream_buffer field, <className, field>
+  private static final Map<String, Field> BYTE_BUF_INPUT_STREAM_BUFFER_FIELD_MAP =
+      new ConcurrentHashMap<>();
 
   static {
     try {
-      FIELD_ByteBufInputStream_buffer = ByteBufInputStream.class.getDeclaredField("buffer");
-      FIELD_ByteBufInputStream_buffer.setAccessible(true);
+      Field bufferField = ByteBufInputStream.class.getDeclaredField("buffer");
+      bufferField.setAccessible(true);
+      BYTE_BUF_INPUT_STREAM_BUFFER_FIELD_MAP.put(ByteBufInputStream.class.getName(), bufferField);
     } catch (NoSuchFieldException e) {
       throw new RuntimeException(e);
     }
@@ -54,11 +59,7 @@ public class LowCopyNettyJniByteInputStream implements JniByteInputStream {
   public LowCopyNettyJniByteInputStream(InputStream in) {
     this.in = in; // to prevent underlying netty buffer from being collected by GC
     final InputStream unwrapped = JniByteInputStreams.unwrapSparkInputStream(in);
-    try {
-      this.byteBuf = (ByteBuf) FIELD_ByteBufInputStream_buffer.get(unwrapped);
-    } catch (IllegalAccessException e) {
-      throw new GlutenException(e);
-    }
+    this.byteBuf = getBuffer(unwrapped);
   }
 
   @Override
@@ -76,16 +77,44 @@ public class LowCopyNettyJniByteInputStream implements JniByteInputStream {
   }
 
   public static boolean isSupported(InputStream in) {
-    if (!(in instanceof ByteBufInputStream)) {
+    if (!isByteBufInputStream(in)) {
       return false;
     }
     ByteBufInputStream bbin = (ByteBufInputStream) in;
-    try {
-      final ByteBuf byteBuf = (ByteBuf) FIELD_ByteBufInputStream_buffer.get(bbin);
-      if (!byteBuf.isDirect()) {
-        return false;
-      }
+    final ByteBuf byteBuf = getBuffer(bbin);
+    return byteBuf.isDirect();
+  }
+
+  private static final String BYTE_BUF_INPUT_STREAM_CLASSNAME = ByteBufInputStream.class.getName();
+
+  private static boolean isByteBufInputStream(InputStream bbin) {
+    String className = bbin.getClass().getName();
+    if (BYTE_BUF_INPUT_STREAM_BUFFER_FIELD_MAP.containsKey(className)) {
       return true;
+    }
+    if (!className.endsWith(BYTE_BUF_INPUT_STREAM_CLASSNAME)) {
+      return false;
+    }
+
+    try {
+      Field field = bbin.getClass().getDeclaredField("buffer");
+      field.setAccessible(true);
+      BYTE_BUF_INPUT_STREAM_BUFFER_FIELD_MAP.put(className, field);
+      return true;
+    } catch (NoSuchFieldException e) {
+      return false;
+    }
+  }
+
+  private static ByteBuf getBuffer(Object bbin) {
+    String className = bbin.getClass().getName();
+    Field field = BYTE_BUF_INPUT_STREAM_BUFFER_FIELD_MAP.get(className);
+    if (field == null) {
+      throw new GlutenException(
+          "Field 'buffer' not cached for shaded netty ByteBufInputStream: " + className);
+    }
+    try {
+      return (ByteBuf) field.get(bbin);
     } catch (IllegalAccessException e) {
       throw new GlutenException(e);
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Uniffle spark client shaded netty package results in LowCopyNettyJniByteInputStream not being used as expected.

https://github.com/apache/uniffle/blob/5edf952826aebbbbfaade287e1c39171394d6c43/client-spark/spark3-shaded/pom.xml#L146-L149

This PR supports input stream ending with `io.netty.buffer.ByteBufInputStream` in LowCopyNettyJniByteInputStream to support shaded netty packages like in uniffle shaded client.

## How was this patch tested?

Related issue: #10923