### PR TITLE
[GLUTEN-10621][VL] cuDF: Fix cudf table scan disable mode

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -175,7 +175,8 @@ WholeStageResultIterator::WholeStageResultIterator(
       } else {
         auto connectorId = kHiveConnectorId;
 #ifdef GLUTEN_ENABLE_GPU
-        if (canUseCudfConnector) {
+        if (canUseCudfConnector && enableCudf_ &&
+            veloxCfg_->get<bool>(kCudfEnableTableScan, kCudfEnableTableScanDefault)) {
           connectorId = kCudfHiveConnectorId;
           VELOX_CHECK_EQ(starts[idx], 0, "Not support split file");
           VELOX_CHECK_EQ(lengths[idx], scanInfo->properties[idx]->fileSize, "Not support split file");
@@ -702,7 +703,7 @@ std::shared_ptr<velox::config::ConfigBase> WholeStageResultIterator::createConne
   configs[velox::connector::hive::HiveConfig::kParquetUseColumnNamesSession] =
       std::to_string(veloxCfg_->get<bool>(kParquetUseColumnNames, true));
   configs[velox::connector::hive::HiveConfig::kOrcUseColumnNamesSession] =
-        std::to_string(veloxCfg_->get<bool>(kOrcUseColumnNames, true));
+      std::to_string(veloxCfg_->get<bool>(kOrcUseColumnNames, true));
   return std::make_shared<velox::config::ConfigBase>(std::move(configs));
 }
 


### PR DESCRIPTION
Fix the exception 
```
25/10/15 06:54:43 WARN TaskSetManager: Lost task 0.0 in stage 1.0 (TID 1) (fyse.us-central1-a.c.374602.internal executor driver): org.apache.gluten.exception.GlutenExc
eption: org.apache.gluten.exception.GlutenException: Exception: VeloxRuntimeError                                                                                                             
Error Source: RUNTIME                                                                                                                                                                         
Error Code: INVALID_STATE                                                                                                                                                                     
Reason: (test-hive vs. cudf-hive) Got splits with different connector IDs                                                                                                                     
Retriable: False                                                                                                                                                                              
Expression: connector_->connectorId() == connectorSplit->connectorId                                                                                                                          
Additional Context: Operator: TableScan[0] 0                                                                                                                                                  
Function: getSplit                                                                                                                                                                            
File: /home/fyse/incubator-gluten/ep/build-velox/build/velox_ep/velox/exec/TableScan.cpp                                                                                                      
Line: 335     
```

Related issue: #10621