### PR TITLE
[MINOR][VL] Improve temp parquet directory in FunctionsValidateSuite

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/FunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/FunctionsValidateSuite.scala
@@ -51,7 +51,7 @@ class FunctionsValidateSuite extends WholeStageTransformerSuite {
     super.beforeAll()
     createTPCHNotNullTables()
 
-    val lfile = Files.createTempFile("", ".parquet").toFile
+    val lfile = Files.createTempDirectory("temp-parquet").toFile
     lfile.deleteOnExit()
     parquetPath = lfile.getAbsolutePath
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/apache/incubator-gluten/blob/a8f45879d13e193733859bc9174612634df99c58/backends-velox/src/test/scala/org/apache/gluten/functions/FunctionsValidateSuite.scala#L70-L76

Spark writes output to a path. Our internal Spark distribution adds extra validation logic that rejects writes targeting a file path. This change ensures we always provide a directory path, improving compatibility with both upstream and internal Spark builds.
```
  Cause: org.apache.hadoop.fs.ParentNotDirectoryException: Parent path is not a directory: file:/tmp/8263767318181008243.parquet
  at org.apache.hadoop.fs.RawLocalFileSystem.mkdirsWithOptionalPermission(RawLocalFileSystem.java:691)
  at org.apache.hadoop.fs.RawLocalFileSystem.mkdirs(RawLocalFileSystem.java:672)
  at org.apache.hadoop.fs.ChecksumFileSystem.mkdirs(ChecksumFileSystem.java:788)
  at org.apache.spark.sql.InsertOperationLockUtil$.tryLock(InsertOperationLockUtil.scala:111)
  at org.apache.spark.sql.InsertOperationLockUtil$.pickInsertOperationLock(InsertOperationLockUtil.scala:49)
  at org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand.detectConflict(InsertIntoHadoopFsRelationCommand.scala:389)
...
```

## How was this patch tested?

Existing test.