### PR TITLE
[GLUTEN-10969][FLINK] Set timeout for waiting for task output

### DIFF
--- a/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/common/GlutenStreamingTestBase.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/common/GlutenStreamingTestBase.java
@@ -138,7 +138,11 @@ public class GlutenStreamingTestBase extends StreamingTestBase {
             Thread.sleep(10);
           }
           long fileSize = -1L;
+          startTime = System.currentTimeMillis();
           while (printResultFile.length() > fileSize) {
+            if (System.currentTimeMillis() - startTime > timeoutMS) {
+              break;
+            }
             fileSize = printResultFile.length();
             Thread.sleep(3000);
           }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Flink unit tests wait for the result file in circle, but if some failures happened in velox, the result file keeps empty.
This PR set timeout for waiting for the result file.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->


Related issue: #10969