### PR TITLE
[GLUTEN-10989][VL] Fix outputPartitioning of BroadcastNestedLoopJoinExecTransformer

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxBroadcastNestedLoopJoinSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxBroadcastNestedLoopJoinSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.sql.catalyst.plans.physical.UnknownPartitioning
+
+class VeloxBroadcastNestedLoopJoinSuite extends VeloxWholeStageTransformerSuite {
+  override protected val resourcePath: String = "/tpch-data-parquet"
+  override protected val fileFormat: String = "parquet"
+
+  test("full outer join without join condition") {
+    withTable("t1", "t2") {
+      spark.range(5).toDF("c1").write.saveAsTable("t1")
+      spark.range(5).toDF("c2").write.saveAsTable("t2")
+      runQueryAndCompare("select * from t1 full outer join t2") {
+        df =>
+          {
+            val executedPlan = getExecutedPlan(df)
+            val bnljs = executedPlan.collect {
+              case bnlj: BroadcastNestedLoopJoinExecTransformer => bnlj
+            }
+            assert(bnljs.head.outputPartitioning == UnknownPartitioning(0))
+          }
+      }
+    }
+  }
+}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BroadcastNestedLoopJoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BroadcastNestedLoopJoinExecTransformer.scala
@@ -86,17 +86,13 @@ abstract class BroadcastNestedLoopJoinExecTransformer(
       joinType match {
         case _: InnerLike => right.outputPartitioning
         case RightOuter => right.outputPartitioning
-        case x =>
-          throw new IllegalArgumentException(
-            s"BroadcastNestedLoopJoin should not take $x as the JoinType with building left side")
+        case _ => super.outputPartitioning
       }
     case BuildRight =>
       joinType match {
         case _: InnerLike => left.outputPartitioning
         case LeftOuter | ExistenceJoin(_) => left.outputPartitioning
-        case x =>
-          throw new IllegalArgumentException(
-            s"BroadcastNestedLoopJoin should not take $x as the JoinType with building right side")
+        case _ => super.outputPartitioning
       }
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Velox supports full out join without join condition , and we should not add exceptions to the `outputPartitioning` because `doValidate` should ensure safety.
Fixes: #10989

## How was this patch tested?

UT
