### PR TITLE
[GLUTEN-11001][CORE] Avoid adding shutdown hook if IllegalStateException is thrown

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkDirectoryUtil.scala
@@ -47,11 +47,11 @@ class SparkDirectoryUtil private (val roots: Array[String]) extends Logging {
               }
             })
         } catch {
-          case _: IllegalStateException =>
+          case ise: IllegalStateException =>
             // Shutdown hooks cannot be modified during shutdown. If the Gluten plugin
             // is being initialized during Spark context shutdown we can safely ignore
             // the hook registration since cleanup is not critical during shutdown.
-            logWarning(s"Cannot register shutdown hook for $localDir")
+            logWarning(s"Cannot register shutdown hook for $localDir: ${ise.getMessage}")
         }
         logInfo(s"Created local directory at $localDir")
         Some(localDir)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes #11001 by catching IllegalStateException from shutdown hook registration during plugin initialization. If Spark is already in shutdown mode, we can safely ignore IllegalStateException thrown during the hook registration since the cleanup isn't critical at that point.
