### PR TITLE
[VL] Add waitForPreloadSplitNanos in metric

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -54,6 +54,7 @@ const std::string kRamReadBytes = "ramReadBytes";
 const std::string kPreloadSplits = "readyPreloadedSplits";
 const std::string kPageLoadTime = "pageLoadTimeNs";
 const std::string kDataSourceAddSplitWallNanos = "dataSourceAddSplitWallNanos";
+const std::string kWaitForPreloadSplitNanos = "waitForPreloadSplitNanos";
 const std::string kDataSourceReadWallNanos = "dataSourceReadWallNanos";
 const std::string kNumWrittenFiles = "numWrittenFiles";
 const std::string kWriteIOTime = "writeIOWallNanos";
@@ -478,7 +479,8 @@ void WholeStageResultIterator::collectMetrics() {
           runtimeMetric("sum", entry.second->customStats, kPreloadSplits);
       metrics_->get(Metrics::kPageLoadTime)[metricIndex] = runtimeMetric("sum", second->customStats, kPageLoadTime);
       metrics_->get(Metrics::kDataSourceAddSplitWallNanos)[metricIndex] =
-          runtimeMetric("sum", second->customStats, kDataSourceAddSplitWallNanos);
+          runtimeMetric("sum", second->customStats, kDataSourceAddSplitWallNanos) +
+          runtimeMetric("sum", second->customStats, kWaitForPreloadSplitNanos);
       metrics_->get(Metrics::kDataSourceReadWallNanos)[metricIndex] =
           runtimeMetric("sum", second->customStats, kDataSourceReadWallNanos);
       metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =


### PR DESCRIPTION

## What changes are proposed in this pull request?

Add `waitForPreloadSplitNanos` in the metric `data source add split time`.

`dataSourceAddSplitWallNanos` counts the time when the split isn't prefetched.
`waitForPreloadSplitNanos` counts the time when the split is prefetched but not finished when table scan read it.

Both metrics count time in table scan thread(main task thread) only.

`preloadSplitPrepareTimeNanos` counts the accumulated time of all prefetched split. It may count time in I/O thread

## How was this patch tested?

under test
