### PR TITLE
[GLUTEN-11037][VL] Corrected logic for updating uniffle shuffle metrics

### DIFF
--- a/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
+++ b/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/writer/VeloxUniffleColumnarShuffleWriter.java
@@ -137,7 +137,7 @@ public class VeloxUniffleColumnarShuffleWriter<K, V> extends RssShuffleWriter<K,
         this.codecBackend = codecBackend.get();
       }
     }
-    isSort = SortShuffleWriterType$.MODULE$.name().equals(columnarDep.shuffleWriterType().name());
+    isSort = columnarDep.shuffleWriterType().equals(SortShuffleWriterType$.MODULE$);
   }
 
   @Override
@@ -165,7 +165,7 @@ public class VeloxUniffleColumnarShuffleWriter<K, V> extends RssShuffleWriter<K,
                   bufferSize,
                   partitionPusher);
 
-          if (columnarDep.shuffleWriterType().equals(SortShuffleWriterType$.MODULE$)) {
+          if (isSort) {
             nativeShuffleWriter =
                 shuffleWriterJniWrapper.createSortShuffleWriter(
                     numPartitions,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Corrected logic for updating uniffle shuffle metrics, consistent with `ColumnarShuffleWriter`:

https://github.com/apache/incubator-gluten/blob/903bf543102f9ca5619ffa5ab43585ca28528065/backends-velox/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleWriter.scala#L230-L242

closes #11037

## How was this patch tested?

test sql:

```
select /*+ repartition(10) */ * from range(1, 1000, 1, 10) limit 10;
```

hash shuffle (`spark.gluten.sql.columnar.shuffle.sort.partitions.threshold=4000`):

<img width="459" height="817" alt="image" src="https://github.com/user-attachments/assets/cb162c21-7989-4b5d-9ca0-b119ae38a122" />

sort shuffle (`spark.gluten.sql.columnar.shuffle.sort.partitions.threshold=1`):

<img width="449" height="765" alt="image" src="https://github.com/user-attachments/assets/70fae1e9-fd81-4b81-9c8c-766fbe7e4631" />
