### PR TITLE
[VL] Gluten-it: Allow empty configurations in dimension pattern

### DIFF
--- a/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
+++ b/tools/gluten-it/common/src/main/java/org/apache/gluten/integration/command/Parameterized.java
@@ -130,7 +130,7 @@ public class Parameterized implements Callable<Integer> {
 
       final List<Map.Entry<String, String>> options = new ArrayList<>();
       final List<String> splits =
-          Arrays.stream(confText.split(",")).filter(s -> !s.isEmpty()).toList();
+          Arrays.stream(confText.split(",")).filter(s -> !s.isEmpty()).collect(Collectors.toList());
       for (String split : splits) {
         String[] kv = split.split("=");
         if (kv.length != 2) {


### PR DESCRIPTION
This is to allow passing empty configuration in gluten-it under `parameterized` testing mode. For example:

```
...
-d=MIN_PARTITION_NUM:AUTO
-d=MIN_PARTITION_NUM:1,spark.sql.adaptive.coalescePartitions.minPartitionNum=1
...
```

Empty configuration is useful when the configuration key is optional. We don't always know the default value of it so we have to let Spark decide.