### PR TITLE
[CORE] Use Substrait timestamp_tz for Spark TimestampType to preserve timezone-aware semantics

### DIFF
--- a/cpp-ch/local-engine/Builder/SerializedPlanBuilder.cpp
+++ b/cpp-ch/local-engine/Builder/SerializedPlanBuilder.cpp
@@ -107,7 +107,7 @@ SchemaPtr SerializedSchemaBuilder::build()
         else if (type == "Timestamp")
         {
             auto * t = type_struct->mutable_types()->Add();
-            t->mutable_timestamp()->set_nullability(
+            t->mutable_timestamp_tz()->set_nullability(
                 this->nullability_map[name] ? substrait::Type_Nullability_NULLABILITY_NULLABLE
                                             : substrait::Type_Nullability_NULLABILITY_REQUIRED);
         }
@@ -256,7 +256,7 @@ std::shared_ptr<substrait::Type> SerializedPlanBuilder::buildType(const DB::Data
         const auto * ch_type_datetime64 = checkAndGetDataType<DataTypeDateTime64>(ch_type_without_nullable.get());
         if (ch_type_datetime64->getScale() != 6)
             throw Exception(ErrorCodes::UNKNOWN_TYPE, "Spark doesn't support converting from {}", ch_type->getName());
-        res->mutable_timestamp()->set_nullability(type_nullability);
+        res->mutable_timestamp_tz()->set_nullability(type_nullability);
     }
     else if (which.isDate32())
         res->mutable_date()->set_nullability(type_nullability);
@@ -365,7 +365,7 @@ substrait::Expression * literalTimestamp(int64_t value)
 {
     substrait::Expression * rel = new substrait::Expression();
     auto * literal = rel->mutable_literal();
-    literal->set_timestamp(value);
+    literal->set_timestamp_tz(value);
     return rel;
 }
 

--- a/cpp-ch/local-engine/Parser/ExpressionParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpressionParser.cpp
@@ -112,9 +112,9 @@ std::pair<DB::DataTypePtr, DB::Field> LiteralParser::parse(const substrait::Expr
             field = literal.date();
             break;
         }
-        case substrait::Expression_Literal::kTimestamp: {
+        case substrait::Expression_Literal::kTimestampTz: {
             type = std::make_shared<DB::DataTypeDateTime64>(6);
-            field = DecimalField<DB::DateTime64>(literal.timestamp(), 6);
+            field = DecimalField<DB::DateTime64>(literal.timestamp_tz(), 6);
             break;
         }
         case substrait::Expression_Literal::kDecimal: {

--- a/cpp-ch/local-engine/Parser/TypeParser.cpp
+++ b/cpp-ch/local-engine/Parser/TypeParser.cpp
@@ -153,10 +153,10 @@ DB::DataTypePtr TypeParser::parseType(const substrait::Type & substrait_type, st
         ch_type = std::make_shared<DB::DataTypeFloat64>();
         ch_type = tryWrapNullable(substrait_type.fp64().nullability(), ch_type);
     }
-    else if (substrait_type.has_timestamp())
+    else if (substrait_type.has_timestamp_tz())
     {
         ch_type = std::make_shared<DB::DataTypeDateTime64>(6);
-        ch_type = tryWrapNullable(substrait_type.timestamp().nullability(), ch_type);
+        ch_type = tryWrapNullable(substrait_type.timestamp_tz().nullability(), ch_type);
     }
     else if (substrait_type.has_date())
     {

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -76,7 +76,7 @@ TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType, bool 
       return UNKNOWN();
     case ::substrait::Type::KindCase::kDate:
       return DATE();
-    case ::substrait::Type::KindCase::kTimestamp:
+    case ::substrait::Type::KindCase::kTimestampTz:
       return TIMESTAMP();
     case ::substrait::Type::KindCase::kDecimal: {
       auto precision = substraitType.decimal().precision();
@@ -368,7 +368,7 @@ bool SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& li
 
 template <>
 Timestamp SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal& literal) {
-  return Timestamp::fromMicros(literal.timestamp());
+  return Timestamp::fromMicros(literal.timestamp_tz());
 }
 
 template <>

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -131,7 +131,7 @@ TypePtr getScalarType(const ::substrait::Expression::Literal& literal) {
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
       return DATE();
-    case ::substrait::Expression_Literal::LiteralTypeCase::kTimestamp:
+    case ::substrait::Expression_Literal::LiteralTypeCase::kTimestampTz:
       return TIMESTAMP();
     case ::substrait::Expression_Literal::LiteralTypeCase::kString:
       return VARCHAR();

--- a/cpp/velox/substrait/VeloxToSubstraitExpr.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.cc
@@ -136,7 +136,7 @@ const ::substrait::Expression_Literal& toSubstraitNotNullLiteral(
     case velox::TypeKind::TIMESTAMP: {
       auto vTimeStamp = variantValue.value<TypeKind::TIMESTAMP>();
       auto micros = vTimeStamp.getSeconds() * 1000000 + vTimeStamp.getNanos() / 1000;
-      literalExpr->set_timestamp(micros);
+      literalExpr->set_timestamp_tz(micros);
       break;
     }
     case velox::TypeKind::VARCHAR: {
@@ -250,7 +250,7 @@ const ::substrait::Expression_Literal& toSubstraitNotNullLiteral<TypeKind::TIMES
   ::substrait::Expression_Literal* literalExpr =
       google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(&arena);
   auto micros = value.getSeconds() * 1000000 + value.getNanos() / 1000;
-  literalExpr->set_timestamp(micros);
+  literalExpr->set_timestamp_tz(micros);
   literalExpr->set_nullable(false);
   return *literalExpr;
 }

--- a/cpp/velox/substrait/VeloxToSubstraitType.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitType.cc
@@ -88,9 +88,9 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
       break;
     }
     case velox::TypeKind::TIMESTAMP: {
-      auto substraitTimestamp = google::protobuf::Arena::CreateMessage<::substrait::Type_Timestamp>(&arena);
-      substraitTimestamp->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
-      substraitType->set_allocated_timestamp(substraitTimestamp);
+      auto substraitTimestampTZ = google::protobuf::Arena::CreateMessage<::substrait::Type_TimestampTZ>(&arena);
+      substraitTimestampTZ->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_timestamp_tz(substraitTimestampTZ);
       break;
     }
     case velox::TypeKind::ARRAY: {

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/TimestampLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/TimestampLiteralNode.java
@@ -32,6 +32,6 @@ public class TimestampLiteralNode extends LiteralNodeWithValue<Long> {
 
   @Override
   protected void updateLiteralBuilder(Builder literalBuilder, Long value) {
-    literalBuilder.setTimestamp(value);
+    literalBuilder.setTimestampTz(value);
   }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TimestampTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TimestampTypeNode.java
@@ -26,7 +26,7 @@ public class TimestampTypeNode extends TypeNode {
 
   @Override
   public Type toProtobuf() {
-    Type.Timestamp.Builder timestampBuilder = Type.Timestamp.newBuilder();
+    Type.TimestampTZ.Builder timestampBuilder = Type.TimestampTZ.newBuilder();
     if (nullable) {
       timestampBuilder.setNullability(Type.Nullability.NULLABILITY_NULLABLE);
     } else {
@@ -34,7 +34,7 @@ public class TimestampTypeNode extends TypeNode {
     }
 
     Type.Builder builder = Type.newBuilder();
-    builder.setTimestamp(timestampBuilder.build());
+    builder.setTimestampTz(timestampBuilder.build());
     return builder.build();
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConverterUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConverterUtils.scala
@@ -160,8 +160,8 @@ object ConverterUtils extends Logging {
         (StringType, isNullable(substraitType.getString.getNullability))
       case Type.KindCase.BINARY =>
         (BinaryType, isNullable(substraitType.getBinary.getNullability))
-      case Type.KindCase.TIMESTAMP =>
-        (TimestampType, isNullable(substraitType.getTimestamp.getNullability))
+      case Type.KindCase.TIMESTAMP_TZ =>
+        (TimestampType, isNullable(substraitType.getTimestampTz.getNullability))
       case Type.KindCase.DATE =>
         (DateType, isNullable(substraitType.getDate.getNullability))
       case Type.KindCase.DECIMAL =>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Spark’s TimestampType is timezone-aware: it internally stores timestamps in UTC (by converting input values to UTC based on the session time zone or just read UTC timestamp from parquet file) and represents an absolute point in time. This semantics aligns with Substrait’s timestamp_tz type, which also denotes a timezone-aware timestamp that can be unambiguously mapped to a moment on the timeline.

To maintain semantic consistency between Spark and Substrait, this PR maps Spark’s TimestampType to Substrait’s timestamp_tz.

https://substrait.io/types/type_classes

This approach is consistent with other projects—for example, Apache Iceberg also maps Spark’s TimestampType to TIMESTAMP WITH TIME ZONE and Spark’s TimestampNTZ to TIMESTAMP WITHOUT TIME ZONE.

Note: For future support of Spark’s TimestampNTZType (timezone-naive timestamps), we should map it to Substrait’s timestamp type instead.

## How was this patch tested?

The existing tests already cover this change.
