### PR TITLE
[Gluten-11099] Refactor the sameRows for GlutenQueryTest

### DIFF
--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
@@ -685,24 +685,22 @@ object GlutenQueryTest extends Assertions {
       return None
     }
 
-    // if answer is not fully sorted, we should sort the answer first, then compare them
-    val sortedExpected = expected.sortBy(_.toString())
-    val sortedActual = actual.sortBy(_.toString())
-    if (!compare(sortedExpected, sortedActual)) {
-      return Some(genError(sortedExpected, sortedActual))
+    if (sortedColIdxes.nonEmpty) {
+      // if answer is partially sorted, we should compare the sorted part
+      val expectedPart = expected.map(row => sortedColIdxes.map(row.get))
+      val actualPart = actual.map(row => sortedColIdxes.map(row.get))
+      if (!compare(expectedPart, actualPart)) {
+        return Some(genError(expected, actual))
+      }
+    } else {
+      // if answer is not fully sorted, we should sort the answer first, then compare them
+      val sortedExpected = expected.sortBy(_.toString())
+      val sortedActual = actual.sortBy(_.toString())
+      if (!compare(sortedExpected, sortedActual)) {
+        return Some(genError(sortedExpected, sortedActual))
+      }
     }
 
-    // if answer is absolutely not sorted, the compare above is enough
-    if (sortedColIdxes.isEmpty) {
-      return None
-    }
-
-    // if answer is partially sorted, we should compare the sorted part
-    val expectedPart = expected.map(row => sortedColIdxes.map(row.get))
-    val actualPart = actual.map(row => sortedColIdxes.map(row.get))
-    if (!compare(expectedPart, actualPart)) {
-      return Some(genError(expected, actual))
-    }
     None
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR proposes to refactor the `sameRows` for `GlutenQueryTest`.
Currently, the implementation of `sameRows` seems a little unclear and this PR wants simplify it.
Fixes: https://github.com/apache/incubator-gluten/issues/11099

## How was this patch tested?

GA tests.
