### PR TITLE
[VL] Refactor: move arenas_ from VeloxShuffleWriter to VeloxHashShuffleWriter

### DIFF
--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.h
@@ -196,7 +196,9 @@ class VeloxHashShuffleWriter : public VeloxShuffleWriter {
       MemoryManager* memoryManager)
       : VeloxShuffleWriter(numPartitions, partitionWriter, options, memoryManager),
         splitBufferSize_(options->splitBufferSize),
-        splitBufferReallocThreshold_(options->splitBufferReallocThreshold) {}
+        splitBufferReallocThreshold_(options->splitBufferReallocThreshold) {
+    arenas_.resize(numPartitions);
+  }
 
   arrow::Status init();
 
@@ -412,6 +414,8 @@ class VeloxHashShuffleWriter : public VeloxShuffleWriter {
   SplitState splitState_{kInit};
 
   std::optional<uint32_t> partitionBufferInUse_{std::nullopt};
+
+  std::vector<std::unique_ptr<facebook::velox::StreamArena>> arenas_;
 }; // class VeloxHashBasedShuffleWriter
 
 } // namespace gluten

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -124,7 +124,6 @@ class VeloxShuffleWriter : public ShuffleWriter {
         veloxPool_(dynamic_cast<VeloxMemoryManager*>(memoryManager)->getLeafMemoryPool()),
         partitionWriter_(partitionWriter) {
     partitioner_ = Partitioner::make(options->partitioning, numPartitions_, options->startPartitionId);
-    arenas_.resize(numPartitions);
     serdeOptions_.useLosslessTimestamp = true;
   }
 
@@ -141,8 +140,6 @@ class VeloxShuffleWriter : public ShuffleWriter {
   std::shared_ptr<PartitionWriter> partitionWriter_;
 
   std::shared_ptr<Partitioner> partitioner_;
-
-  std::vector<std::unique_ptr<facebook::velox::StreamArena>> arenas_;
 
   facebook::velox::serializer::presto::PrestoVectorSerde::PrestoOptions serdeOptions_;
 


### PR DESCRIPTION

## What changes are proposed in this pull request?

`arenas_` is only used in VeloxHashShuffleWriter, move it to VeloxHashShuffleWriter.
## How was this patch tested?

