### PR TITLE
[VL] Suppress "uninitialized" warnings treated as errors in GCC 13 builds

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -100,6 +100,7 @@ set(KNOWN_WARNINGS
        -Wno-error=unused-variable \
        -Wno-error=uninitialized \
        -Wno-error=maybe-uninitialized \
+       -Wno-unknown-warning-option \
        -Wno-strict-aliasing \
        -Wno-ignored-qualifiers \
        -Wno-deprecated-declarations \

--- a/ep/build-velox/src/build-velox.sh
+++ b/ep/build-velox/src/build-velox.sh
@@ -98,16 +98,11 @@ for arg in "$@"; do
 done
 
 function compile {
-  CXX_FLAGS='-Wno-error=cpp -Wno-missing-field-initializers -Wno-error=uninitialized'
-  # Set compiler-specific flags.
-  local compiler="${CXX:-c++}"
-  local compiler_specific_flags="-Wno-error=stringop-overflow -Wno-unknown-warning-option"
-  for flag in $compiler_specific_flags; do
-    # Validate if a flag is accepted by the compiler.
-    if $compiler $flag -E - </dev/null >/dev/null 2>&1; then
-      CXX_FLAGS="$CXX_FLAGS $flag"
-    fi
-  done
+  # -Wno-unknown-warning-option is a Clang-originated flag. GCC ignores unrecognized -Wno- flags to
+  # maintain compatibility, but it prints a diagnostic note about the unknown flag if a true warning
+  # or error occurs.
+  CXX_FLAGS='-Wno-error=stringop-overflow -Wno-error=cpp -Wno-missing-field-initializers \
+    -Wno-error=uninitialized -Wno-unknown-warning-option'
 
   COMPILE_OPTION="-DCMAKE_CXX_FLAGS=\"$CXX_FLAGS\" -DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=OFF \
       -DVELOX_MONO_LIBRARY=ON -DVELOX_BUILD_RUNNER=OFF -DVELOX_SIMDJSON_SKIPUTF8VALIDATION=ON \


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

- ~GCC 13 will fail the compilation due to the unrecognized flag `-Wno-unknown-warning-option` is used. This flag is for Clang to allow the use of Clang unrecognized flag `-Wno-error=stringop-overflow`. We should set the latter by checking if compiler accepts it. And then, the former can be removed.~
- GCC 13 has stricter check for using uninitialized variables. Currently, these errors reported by compiler are related to some folly headers. We set two flags to suppress such warnings treated as errors.
- Due to the above uninitialized variable errors, the compiler also reported the error below, which is easily misleading: 
`cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics`. 
This `-Wno-unknown-warning-option` flag is not belonging to GCC. But when facing such unrecognized flags in `-Wno-xxx` pattern, the GCC compiler normally ignore them. Only when there are real errors, the compiler will report error about this unrecognized flag in case the real warning or error is somehow related to the use of an unknown flag.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
CI.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
