### PR TITLE
[GLUTEN-10926][VL] Update Spark mirror to speed up downloading in CI docker image

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -154,6 +154,14 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-vcpkg-centos-8-${{ matrix.os }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   build-vcpkg-centos-8-gcc13:
     if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ${{ matrix.os }}
@@ -508,4 +516,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}
-

--- a/.github/workflows/util/install-spark-resources.sh
+++ b/.github/workflows/util/install-spark-resources.sh
@@ -31,6 +31,7 @@ function install_spark() {
   local scala_suffix=$([ "${scala_version}" == '2.13' ] && echo '-scala-2.13' || echo '')
   local scala_suffix_short=$([ "${scala_version}" == '2.13' ] && echo '-scala2.13' || echo '')
   local mirror_host='https://www.apache.org/dyn/closer.lua/'
+  local mirror_host2='https://mirror.lyrahosting.com/apache/' # Fallback mirror due to closer.lua slowness
   local url_query='?action=download'
   local checksum_suffix='sha512'
   local url_path="spark/spark-${spark_version}/"
@@ -38,9 +39,9 @@ function install_spark() {
   local local_binary_checksum="${local_binary}.${checksum_suffix}"
   local local_source="spark-${spark_version}.tgz"
   local local_source_checksum="${local_source}.${checksum_suffix}"
-  local remote_binary="${mirror_host}${url_path}${local_binary}${url_query}"
+  local remote_binary="${mirror_host2}${url_path}${local_binary}${url_query}"
   local remote_binary_checksum="${mirror_host}${url_path}${local_binary_checksum}${url_query}"
-  local remote_source="${mirror_host}${url_path}${local_source}${url_query}"
+  local remote_source="${mirror_host2}${url_path}${local_source}${url_query}"
   local remote_source_checksum="${mirror_host}${url_path}${local_source_checksum}${url_query}"
   local wget_opts="--no-verbose"
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

The mirror of "https://www.apache.org/dyn/closer.lua" is very slow and the docker image build timeout
This patch adds a new mirror to download Spark binary/source 

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
locally verified

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->


Related issue: #10926