### PR TITLE
[GLUTEN-11157][CORE] Replace NullPointerException with IllegalStateException for WholeStageTransformer

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -236,7 +236,7 @@ case class WholeStageTransformer(child: SparkPlan, materializeInput: Boolean = f
       .asInstanceOf[TransformSupport]
       .transform(substraitContext)
     if (childCtx == null) {
-      throw new NullPointerException(s"WholeStageTransformer can't do Transform on $child")
+      throw new IllegalStateException(s"WholeStageTransformer can't do Transform on $child")
     }
 
     val outNames = childCtx.outputAttributes.map(ConverterUtils.genColumnNameWithExprId).asJava


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR proposes to replace `NullPointerException` with `IllegalStateException` for `WholeStageTransformer`.
Fixes #11157

## How was this patch tested?

GA tests.
