### PR TITLE
[GLUTEN-11062][CORE][FOLLOWUP] Remove unnecessary getSplitInfosFromPartitions

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -56,11 +56,7 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
   def getProperties: Map[String, String] = Map.empty
 
   override def getSplitInfos: Seq[SplitInfo] = {
-    getSplitInfosFromPartitions(getPartitionWithReadFileFormats)
-  }
-
-  def getSplitInfosFromPartitions(partitions: Seq[(Partition, ReadFileFormat)]): Seq[SplitInfo] = {
-    partitions.map {
+    getPartitionWithReadFileFormats.map {
       case (partition, readFileFormat) => partitionToSplitInfo(partition, readFileFormat)
     }
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR follows up https://github.com/apache/incubator-gluten/pull/11113 and remove unnecessary `getSplitInfosFromPartitions`

## How was this patch tested?

GA tests.


Related issue: #11062