### PR TITLE
[GLUTEN-11088][VL] Fix GlutenDeltaBasedMergeIntoTableSuite in Spark-4.0

### DIFF
--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -1000,10 +1000,10 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenRuntimeNullChecksV2Writes]
   enableSuite[GlutenTableOptionsConstantFoldingSuite]
   enableSuite[GlutenDeltaBasedMergeIntoTableSuite]
-    // TODO: fix in Spark-4.0
+    // Replaced by Gluten versions that handle wrapped exceptions
     .excludeByPrefix("merge cardinality check with")
   enableSuite[GlutenDeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite]
-    // TODO: fix in Spark-4.0
+    // Replaced by Gluten versions that handle wrapped exceptions
     .excludeByPrefix("merge cardinality check with")
   enableSuite[GlutenDeltaBasedUpdateAsDeleteAndInsertTableSuite]
     // FIXME: complex type result mismatch
@@ -1011,7 +1011,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("update char/varchar columns")
   enableSuite[GlutenDeltaBasedUpdateTableSuite]
   enableSuite[GlutenGroupBasedMergeIntoTableSuite]
-    // TODO: fix in Spark-4.0
+    // Replaced by Gluten versions that handle wrapped exceptions
     .excludeByPrefix("merge cardinality check with")
   enableSuite[GlutenFileSourceCustomMetadataStructSuite]
   enableSuite[GlutenParquetFileMetadataStructRowIndexSuite]

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenDeltaBasedMergeIntoTableSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenDeltaBasedMergeIntoTableSuite.scala
@@ -20,4 +20,5 @@ import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
 class GlutenDeltaBasedMergeIntoTableSuite
   extends DeltaBasedMergeIntoTableSuite
-  with GlutenSQLTestsBaseTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenMergeIntoTableSuiteBase {}

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenDeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenDeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite.scala
@@ -20,4 +20,5 @@ import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
 class GlutenDeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite
   extends DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite
-  with GlutenSQLTestsBaseTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenMergeIntoTableSuiteBase {}

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenGroupBasedMergeIntoTableSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenGroupBasedMergeIntoTableSuite.scala
@@ -20,4 +20,5 @@ import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
 class GlutenGroupBasedMergeIntoTableSuite
   extends GroupBasedMergeIntoTableSuite
-  with GlutenSQLTestsBaseTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenMergeIntoTableSuiteBase {}

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenMergeIntoTableSuiteBase.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenMergeIntoTableSuiteBase.scala
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.GlutenSQLTestsTrait
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * A trait that provides Gluten-compatible cardinality error assertion for merge operations.
+ *
+ * In Gluten, SparkRuntimeException is wrapped inside GlutenException, so we need to check the
+ * exception chain for the expected error message instead of matching the exact exception type.
+ */
+trait GlutenMergeIntoTableSuiteBase extends MergeIntoTableSuiteBase with GlutenSQLTestsTrait {
+
+  import testImplicits._
+
+  /** Helper method to find if any exception in the chain contains the expected message. */
+  private def findInExceptionChain(e: Throwable, expectedMessage: String): Boolean = {
+    var current: Throwable = e
+    while (current != null) {
+      if (current.getMessage != null && current.getMessage.contains(expectedMessage)) {
+        return true
+      }
+      current = current.getCause
+    }
+    false
+  }
+
+  /**
+   * Gluten-compatible version of assertCardinalityError. The original method expects
+   * SparkRuntimeException directly, but Gluten wraps it in GlutenException.
+   */
+  protected def assertGlutenCardinalityError(query: String): Unit = {
+    val e = intercept[Exception] {
+      sql(query)
+    }
+    assert(
+      findInExceptionChain(e, "ON search condition of the MERGE statement"),
+      s"Expected cardinality violation error but got: ${e.getMessage}")
+  }
+
+  testGluten("merge cardinality check with conditional MATCHED clause (delete)") {
+    withTempView("source") {
+      createAndInitTable(
+        "pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 6, "salary": 600, "dep": "software" }
+          |""".stripMargin
+      )
+
+      val sourceRows = Seq((1, 101, "support"), (1, 102, "support"), (2, 201, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      assertGlutenCardinalityError(
+        s"""MERGE INTO $tableNameAsString AS t
+           |USING source AS s
+           |ON t.pk = s.pk
+           |WHEN MATCHED AND s.salary = 101 THEN
+           | DELETE
+           |""".stripMargin
+      )
+    }
+  }
+
+  testGluten("merge cardinality check with small target and large source (broadcast enabled)") {
+    withTempView("source") {
+      createAndInitTable(
+        "pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin
+      )
+
+      val sourceRows = (1 to 1000).map(pk => (pk, pk * 100, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
+        assertGlutenCardinalityError(
+          s"""MERGE INTO $tableNameAsString AS t
+             |USING (SELECT * FROM source UNION ALL SELECT * FROM source) AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |""".stripMargin
+        )
+
+        assert(sql(s"SELECT * FROM $tableNameAsString").count() == 2)
+      }
+    }
+  }
+
+  testGluten("merge cardinality check with small target and large source (broadcast disabled)") {
+    withTempView("source") {
+      createAndInitTable(
+        "pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin
+      )
+
+      val sourceRows = (1 to 1000).map(pk => (pk, pk * 100, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        assertGlutenCardinalityError(
+          s"""MERGE INTO $tableNameAsString AS t
+             |USING (SELECT * FROM source UNION ALL SELECT * FROM source) AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |""".stripMargin
+        )
+
+        assert(sql(s"SELECT * FROM $tableNameAsString").count() == 2)
+      }
+    }
+  }
+
+  testGluten("merge cardinality check with small target and large source (shuffle hash enabled)") {
+    withTempView("source") {
+      createAndInitTable(
+        "pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin
+      )
+
+      val sourceRows = (1 to 1000).map(pk => (pk, pk * 100, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSQLConf(
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.PREFER_SORTMERGEJOIN.key -> "false") {
+        assertGlutenCardinalityError(
+          s"""MERGE INTO $tableNameAsString AS t
+             |USING (SELECT * FROM source UNION ALL SELECT * FROM source) AS s
+             |ON t.pk = s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |""".stripMargin
+        )
+
+        assert(sql(s"SELECT * FROM $tableNameAsString").count() == 2)
+      }
+    }
+  }
+
+  testGluten("merge cardinality check without equality condition and only MATCHED clauses") {
+    withTempView("source") {
+      createAndInitTable(
+        "pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin
+      )
+
+      val sourceRows = (1 to 1000).map(pk => (pk, pk * 100, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        assertGlutenCardinalityError(
+          s"""MERGE INTO $tableNameAsString AS t
+             |USING (SELECT * FROM source UNION ALL SELECT * FROM source) AS s
+             |ON t.pk > s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |""".stripMargin
+        )
+
+        assert(sql(s"SELECT * FROM $tableNameAsString").count() == 2)
+      }
+    }
+  }
+
+  testGluten("merge cardinality check without equality condition") {
+    withTempView("source") {
+      createAndInitTable(
+        "pk INT NOT NULL, salary INT, dep STRING",
+        """{ "pk": 1, "salary": 100, "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "dep": "software" }
+          |""".stripMargin
+      )
+
+      val sourceRows = (1 to 1000).map(pk => (pk, pk * 100, "support"))
+      sourceRows.toDF("pk", "salary", "dep").createOrReplaceTempView("source")
+
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        assertGlutenCardinalityError(
+          s"""MERGE INTO $tableNameAsString AS t
+             |USING (SELECT * FROM source UNION ALL SELECT * FROM source) AS s
+             |ON t.pk > s.pk
+             |WHEN MATCHED THEN
+             | UPDATE SET *
+             |WHEN NOT MATCHED THEN
+             | INSERT *
+             |""".stripMargin
+        )
+
+        assert(sql(s"SELECT * FROM $tableNameAsString").count() == 2)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

In Gluten, SparkRuntimeException is wrapped inside GlutenException, so we need to check the exception chain for the expected error message instead of matching the exact exception type.
 
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->


Related issue: #11088