### PR TITLE
[GLUTEN-11088][CORE] Fix Spark 4.0 GlutenDynamicPartitionPruningV1SuiteAEOn

### DIFF
--- a/gluten-delta/src/main/scala/org/apache/gluten/extension/DeltaPostTransformRules.scala
+++ b/gluten-delta/src/main/scala/org/apache/gluten/extension/DeltaPostTransformRules.scala
@@ -153,6 +153,7 @@ object DeltaPostTransformRules {
       // replace tableName in schema with physicalName
       val scanExecTransformer = new DeltaScanTransformer(
         newFsRelation,
+        plan.stream,
         newOutput,
         DeltaColumnMapping.createPhysicalSchema(
           plan.requiredSchema,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicPhysicalOperatorTransformer.scala
@@ -313,7 +313,8 @@ object FilterHandler extends PredicateHelper {
   }
 
   def subtractFilters(left: Seq[Expression], right: Seq[Expression]): Seq[Expression] = {
-    (left.toSet -- right.toSet).toSeq
+    val scanSet = right.map(_.canonicalized).toSet
+    left.filter(f => !scanSet.contains(f.canonicalized))
   }
 
   def combineFilters(left: Seq[Expression], right: Seq[Expression]): Seq[Expression] = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
@@ -27,6 +27,7 @@ object ScanTransformerFactory {
       scanExec: FileSourceScanExec): FileSourceScanExecTransformerBase = {
     FileSourceScanExecTransformer(
       scanExec.relation,
+      SparkShimLoader.getSparkShims.getFileSourceScanStream(scanExec),
       scanExec.output,
       scanExec.requiredSchema,
       scanExec.partitionFilters,

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.extension
 
+import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -26,6 +28,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
     case fileSourceScan: FileSourceScanExec =>
       val transformer = new TestFileSourceScanExecTransformer(
         fileSourceScan.relation,
+        SparkShimLoader.getSparkShims.getFileSourceScanStream(fileSourceScan),
         fileSourceScan.output,
         fileSourceScan.requiredSchema,
         fileSourceScan.partitionFilters,

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -24,6 +24,7 @@ import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
@@ -31,6 +32,7 @@ import org.apache.spark.util.collection.BitSet
 /** Test for customer column rules */
 case class TestFileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
+    @transient stream: Option[SparkDataStream],
     override val output: Seq[Attribute],
     override val requiredSchema: StructType,
     override val partitionFilters: Seq[Expression],
@@ -42,6 +44,7 @@ case class TestFileSourceScanExecTransformer(
     override val pushDownFilters: Option[Seq[Expression]] = None)
   extends FileSourceScanExecTransformerBase(
     relation,
+    stream,
     output,
     requiredSchema,
     partitionFilters,
@@ -71,6 +74,7 @@ case class TestFileSourceScanExecTransformer(
   override def doCanonicalize(): TestFileSourceScanExecTransformer = {
     TestFileSourceScanExecTransformer(
       relation,
+      None,
       output.map(QueryPlan.normalizeExpressions(_, output)),
       requiredSchema,
       QueryPlan.normalizePredicates(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.extension
 
+import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -26,6 +28,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
     case fileSourceScan: FileSourceScanExec =>
       val transformer = new TestFileSourceScanExecTransformer(
         fileSourceScan.relation,
+        SparkShimLoader.getSparkShims.getFileSourceScanStream(fileSourceScan),
         fileSourceScan.output,
         fileSourceScan.requiredSchema,
         fileSourceScan.partitionFilters,

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
@@ -30,6 +31,7 @@ import org.apache.spark.util.collection.BitSet
 /** Test for customer column rules */
 case class TestFileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
+    @transient stream: Option[SparkDataStream],
     override val output: Seq[Attribute],
     override val requiredSchema: StructType,
     override val partitionFilters: Seq[Expression],
@@ -41,6 +43,7 @@ case class TestFileSourceScanExecTransformer(
     override val pushDownFilters: Option[Seq[Expression]] = None)
   extends FileSourceScanExecTransformerBase(
     relation,
+    stream,
     output,
     requiredSchema,
     partitionFilters,

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.extension
 
+import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -26,6 +28,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
     case fileSourceScan: FileSourceScanExec =>
       val transformer = new TestFileSourceScanExecTransformer(
         fileSourceScan.relation,
+        SparkShimLoader.getSparkShims.getFileSourceScanStream(fileSourceScan),
         fileSourceScan.output,
         fileSourceScan.requiredSchema,
         fileSourceScan.partitionFilters,

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
@@ -30,6 +31,7 @@ import org.apache.spark.util.collection.BitSet
 /** Test for customer column rules */
 case class TestFileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
+    @transient stream: Option[SparkDataStream],
     override val output: Seq[Attribute],
     override val requiredSchema: StructType,
     override val partitionFilters: Seq[Expression],
@@ -41,6 +43,7 @@ case class TestFileSourceScanExecTransformer(
     override val pushDownFilters: Option[Seq[Expression]] = None)
   extends FileSourceScanExecTransformerBase(
     relation,
+    stream,
     output,
     requiredSchema,
     partitionFilters,

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.extension
 
+import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -26,6 +28,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
     case fileSourceScan: FileSourceScanExec =>
       val transformer = new TestFileSourceScanExecTransformer(
         fileSourceScan.relation,
+        SparkShimLoader.getSparkShims.getFileSourceScanStream(fileSourceScan),
         fileSourceScan.output,
         fileSourceScan.requiredSchema,
         fileSourceScan.partitionFilters,

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
@@ -30,6 +31,7 @@ import org.apache.spark.util.collection.BitSet
 /** Test for customer column rules */
 case class TestFileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
+    @transient stream: Option[SparkDataStream],
     override val output: Seq[Attribute],
     override val requiredSchema: StructType,
     override val partitionFilters: Seq[Expression],
@@ -41,6 +43,7 @@ case class TestFileSourceScanExecTransformer(
     override val pushDownFilters: Option[Seq[Expression]] = None)
   extends FileSourceScanExecTransformerBase(
     relation,
+    stream,
     output,
     requiredSchema,
     partitionFilters,

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -853,8 +853,6 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDeprecatedAPISuite]
   enableSuite[GlutenDynamicPartitionPruningV1SuiteAEOff]
   enableSuite[GlutenDynamicPartitionPruningV1SuiteAEOn]
-    // TODO: fix in Spark-4.0
-    .exclude("join key with multiple references on the filtering plan")
   enableSuite[GlutenDynamicPartitionPruningV1SuiteAEOnDisableScan]
   enableSuite[GlutenDynamicPartitionPruningV1SuiteAEOffDisableScan]
   enableSuite[GlutenDynamicPartitionPruningV2SuiteAEOff]

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/extension/CustomerColumnarPreRules.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.extension
 
+import org.apache.gluten.sql.shims.SparkShimLoader
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
@@ -26,6 +28,7 @@ case class CustomerColumnarPreRules(session: SparkSession) extends Rule[SparkPla
     case fileSourceScan: FileSourceScanExec =>
       val transformer = new TestFileSourceScanExecTransformer(
         fileSourceScan.relation,
+        SparkShimLoader.getSparkShims.getFileSourceScanStream(fileSourceScan),
         fileSourceScan.output,
         fileSourceScan.requiredSchema,
         fileSourceScan.partitionFilters,

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/extension/TestFileSourceScanExecTransformer.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.collection.BitSet
@@ -30,6 +31,7 @@ import org.apache.spark.util.collection.BitSet
 /** Test for customer column rules */
 case class TestFileSourceScanExecTransformer(
     @transient override val relation: HadoopFsRelation,
+    @transient val stream: Option[SparkDataStream],
     override val output: Seq[Attribute],
     override val requiredSchema: StructType,
     override val partitionFilters: Seq[Expression],
@@ -41,6 +43,7 @@ case class TestFileSourceScanExecTransformer(
     override val pushDownFilters: Option[Seq[Expression]] = None)
   extends FileSourceScanExecTransformerBase(
     relation,
+    stream,
     output,
     requiredSchema,
     partitionFilters,

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
@@ -340,5 +341,9 @@ trait SparkShims {
       s"Task failed while writing rows to staging path: $writePath, " +
         s"output path: $descriptionPath",
       t)
+  }
+
+  def getFileSourceScanStream(scan: FileSourceScanExec): Option[SparkDataStream] = {
+    None
   }
 }

--- a/shims/spark32/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark32/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
 
+import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, Expression, PlanExpression, Predicate}
@@ -153,6 +154,10 @@ abstract class FileSourceScanExecShim(
 
   def getPartitionArray: Array[PartitionDirectory] = {
     dynamicallySelectedPartitions
+  }
+
+  def getPartitionsSeq(): Seq[Partition] = {
+    Seq()
   }
 }
 

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
 
+import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, Expression, FileSourceMetadataAttribute, PlanExpression, Predicate}
@@ -162,6 +163,10 @@ abstract class FileSourceScanExecShim(
 
   def getPartitionArray: Array[PartitionDirectory] = {
     dynamicallySelectedPartitions
+  }
+
+  def getPartitionsSeq(): Seq[Partition] = {
+    Seq()
   }
 }
 

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.sql.shims.SparkShimLoader
 
+import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, Expression, FileSourceConstantMetadataAttribute, FileSourceGeneratedMetadataAttribute, PlanExpression, Predicate}
@@ -122,6 +123,10 @@ abstract class FileSourceScanExecShim(
 
   def getPartitionArray: Array[PartitionDirectory] = {
     dynamicallySelectedPartitions
+  }
+
+  def getPartitionsSeq(): Seq[Partition] = {
+    Seq()
   }
 }
 

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.metrics.GlutenTimeMetric
 
+import org.apache.spark.Partition
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, BoundReference, Expression, FileSourceConstantMetadataAttribute, FileSourceGeneratedMetadataAttribute, PlanExpression, Predicate}
@@ -119,6 +120,10 @@ abstract class FileSourceScanExecShim(
 
   def getPartitionArray: Array[PartitionDirectory] = {
     dynamicallySelectedPartitions
+  }
+
+  def getPartitionsSeq(): Seq[Partition] = {
+    Seq()
   }
 }
 

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
+import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters}
@@ -767,5 +768,9 @@ class Spark40Shims extends SparkShims {
       writePath: String,
       descriptionPath: String): Unit = {
     throw t
+  }
+
+  override def getFileSourceScanStream(scan: FileSourceScanExec): Option[SparkDataStream] = {
+    scan.stream
   }
 }


### PR DESCRIPTION
Support FileSourceScanExecTransformer stream.

FileSourceScanExecTransformer is not equal because dataFilters is not equal, `(cast(x#688 as double) = ReusedSubquery Subquery subquery#683, [id=#2324])` and  `(cast(x#688 as double) = Subquery subquery#683, [id=#2324])` should be same, must use canonicalized expression to deduplicate.

Fix dynamic pruning FileSourceScanExec getPartitions because add new class ScanFileListing and other refactor for inputRDD

Related issue: #11088