### PR TITLE
[GLUTEN-11221][VL] Remove JArrayList, JHashMap, JMap from VeloxIteratorApi

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -146,7 +146,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
 
   private def getPartitionColumns(
       schema: StructType,
-      partitionedFiles: Seq[PartitionedFile]): Seq[mutable.Map[String, String]] = {
+      partitionedFiles: Seq[PartitionedFile]): Seq[Map[String, String]] = {
     partitionedFiles.map {
       partitionedFile =>
         val partitionColumn = mutable.Map[String, String]()
@@ -171,7 +171,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
           }
           partitionColumn += (schema.names(i) -> partitionColumnValue)
         }
-        partitionColumn
+        partitionColumn.toMap
     }
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

According to the discussion at https://github.com/apache/incubator-gluten/pull/11183#pullrequestreview-3505241475, I created #11221. This PR proposes to remove `JArrayList`, `JHashMap`, `JMap` from `VeloxIteratorApi`.
Fixes #11221

## How was this patch tested?

GA tests.
