### PR TITLE
[VL] Add virtual destructor in RowVectorStream

### DIFF
--- a/cpp/velox/operators/plannodes/RowVectorStream.h
+++ b/cpp/velox/operators/plannodes/RowVectorStream.h
@@ -27,6 +27,8 @@ namespace gluten {
 
 class RowVectorStream {
  public:
+  virtual ~RowVectorStream() = default;
+
   explicit RowVectorStream(
       facebook::velox::exec::DriverCtx* driverCtx,
       facebook::velox::memory::MemoryPool* pool,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Fix the compile error on my mac
```
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:78:5: error: delete called on non-final 'gluten::RowVectorStream' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
   78 |     delete __ptr;
      |     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:300:7: note: in instantiation of member function 'std::default_delete<gluten::RowVectorStream>::operator()' requested here
  300 |       __deleter_(__tmp);
      |       ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:269:71: note: in instantiation of member function 'std::unique_ptr<gluten::RowVectorStream>::reset' requested here
  269 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
      |                                                                       ^
/project/emr/gluten/cpp/velox/operators/plannodes/RowVectorStream.h:92:3: note: in instantiation of member function 'std::unique_ptr<gluten::RowVectorStream>::~unique_ptr' requested here
   92 |   ValueStream(
      |   ^
1 error generated.
make[2]: *** [velox/CMakeFiles/velox.dir/compute/VeloxBackend.cc.o] Error 1
make[1]: *** [velox/CMakeFiles/velox.dir/all] Error 2
make: *** [all] Error 2
```

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
