### PR TITLE
[VL] Allow the use of Gzip codec for shuffle compression

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/spark/shuffle/GlutenShuffleUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/shuffle/GlutenShuffleUtils.scala
@@ -105,6 +105,9 @@ object GlutenShuffleUtils {
       checkAndGetBufferSize(IO_COMPRESSION_LZ4_BLOCKSIZE)
     } else if ("zstd" == codec) {
       checkAndGetBufferSize(IO_COMPRESSION_ZSTD_BUFFERSIZE)
+    } else if ("gzip" == codec) { // QAT supports it only.
+      // Temporarily hard-coded to 32k.
+      32 * 1024
     } else {
       throw new UnsupportedOperationException(s"Unsupported compression codec $codec.")
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

We are testing QAT with Gzip, but found an exception was raised: Unsupported compression codec gzip. It seems a regression from #9356.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Local test with QAT.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
