### PR TITLE
[VL] Enable `SIMDJSON_SKIPUTF8VALIDATION` for simdjson build in setup script

### DIFF
--- a/dev/build-helper-functions.sh
+++ b/dev/build-helper-functions.sh
@@ -156,6 +156,8 @@ function setup_linux {
   local LINUX_VERSION_ID=$(. /etc/os-release && echo ${VERSION_ID})
   CURRENT_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
   GLUTEN_VELOX_SCRIPT_HOME=$CURRENT_DIR/../ep/build-velox/src
+  # Skip UTF-8 validation in JSON parsing. Required for compatibility with Spark.
+  export SIMDJSON_SKIPUTF8VALIDATION=ON
 
   if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" || "$LINUX_DISTRIBUTION" == "pop" ]]; then
     scripts/setup-ubuntu.sh


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
This build option is required to get one Gluten UT passed. It has been enabled in vcpkg build, but not in setup script. If the lib installed by setup script is used in Velox build, that Gluten UT will fail.

With the following Velox patch merged, we can just enable the build option by setting the environment variable .
https://github.com/facebookincubator/velox/commit/868f27959c7ba2243dc446a48401bb7c87d586a4

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Local verification.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
