### PR TITLE
[GLUTEN-10215][VL] Delta: Support update command in write

### DIFF
--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v2/OffloadDeltaCommand.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v2/OffloadDeltaCommand.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.gluten.config.VeloxDeltaConfig
 import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
+
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.{DeleteCommand, UpdateCommand}
 import org.apache.spark.sql.delta.sources.DeltaDataSource


### PR DESCRIPTION
Adds support for `UPDATE` DML statement for Delta 3.3 / Spark 3.5.

PR is tested by existing suite `UpdateSQLSuite`.

Related issue: #10215