### PR TITLE
[CORE] Get correct fallback reason on nodes without logicalLink

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/utils/GlutenSuiteUtils.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/utils/GlutenSuiteUtils.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.utils
+
+import org.apache.spark.SparkContext
+
+object GlutenSuiteUtils {
+  def waitUntilEmpty(ctx: SparkContext): Unit = ctx.listenerBus.waitUntilEmpty()
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a fallback mechanism to attempt retrieving the fallback reason from a SparkPlan node's tags when its `logicalLink` is unavailable. Some SparkPlan nodes, such as the `SortExec` generated by Spark's `EnsureRequirements` rule, inherently lack a `logicalLink`. Furthermore, some plan conversion rules in Gluten might omit calling `copyTagsFrom`, leading to the loss of the original `logicalLink`.

In such cases, if the node falls back, the fallback reason might be stored within the physical node's tags. This change attempts to retrieve the reason from there as a best-effort approach.

## How was this patch tested?
Add a test case when window sort fallback. Before this change, the fallback reason was a generic "Gluten does not touch it or does not support it". After the change, it can display a more precise reason, such as "[FallbackByUserOptions] Validation failed on node Sort", which is retrieved from the physical node's tags.
