### PR TITLE
[GLUTEN-11296][FLINK] Rename interface getPlanNode to getStatefulPlanNode

### DIFF
--- a/gluten-flink/runtime/src/main/java/org/apache/flink/client/StreamGraphTranslator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/flink/client/StreamGraphTranslator.java
@@ -148,7 +148,7 @@ public class StreamGraphTranslator implements FlinkPipelineTranslator {
     Map<String, RowType> nodeToOutTypes = new HashMap<>(outEdges.size());
     List<StreamEdge> chainedOutputs = new ArrayList<>(outEdges.size());
     List<NonChainedOutput> nonChainedOutputs = new ArrayList<>(outEdges.size());
-    StatefulPlanNode sourceNode = isSourceGluten ? sourceOperator.getPlanNode() : null;
+    StatefulPlanNode sourceNode = isSourceGluten ? sourceOperator.getStatefulPlanNode() : null;
     boolean allGluten = true;
     LOG.debug("Edge size {}, OP {}", outEdges.size(), sourceOperator);
     for (StreamEdge outEdge : outEdges) {
@@ -161,7 +161,7 @@ public class StreamGraphTranslator implements FlinkPipelineTranslator {
       buildGlutenChains(outTask, chainedTasks);
       Optional<GlutenOperator> outOperator = getGlutenOperator(outTask);
       if (isSourceGluten && outOperator.isPresent()) {
-        StatefulPlanNode outNode = outOperator.get().getPlanNode();
+        StatefulPlanNode outNode = outOperator.get().getStatefulPlanNode();
         if (sourceNode != null) {
           sourceNode.addTarget(outNode);
           LOG.debug("Add {} target {}", sourceNode, outNode);

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenOneInputOperatorFactory.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenOneInputOperatorFactory.java
@@ -50,7 +50,7 @@ public class GlutenOneInputOperatorFactory<IN, OUT> extends AbstractStreamOperat
   @Override
   public <T extends StreamOperator<OUT>> T createStreamOperator(
       StreamOperatorParameters<OUT> parameters) {
-    LOG.debug("Build gluten operator {}", Serde.toJson(getOperator().getPlanNode()));
+    LOG.debug("Build gluten operator {}", Serde.toJson(getOperator().getStatefulPlanNode()));
     if (operator instanceof AbstractStreamOperator) {
       ((AbstractStreamOperator) operator).setProcessingTimeService(processingTimeService);
     }

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenOperator.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 /** Interface for all gluten operators. */
 public interface GlutenOperator {
-  public StatefulPlanNode getPlanNode();
+  public StatefulPlanNode getStatefulPlanNode();
 
   public RowType getInputType();
 

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenStreamSource.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenStreamSource.java
@@ -41,8 +41,8 @@ public class GlutenStreamSource extends StreamSource implements GlutenOperator {
   }
 
   @Override
-  public StatefulPlanNode getPlanNode() {
-    return sourceFunction.getPlanNode();
+  public StatefulPlanNode getStatefulPlanNode() {
+    return sourceFunction.getStatefulPlanNode();
   }
 
   @Override

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
@@ -142,7 +142,7 @@ public class GlutenOneInputOperator extends TableStreamOperator<RowData>
   }
 
   @Override
-  public StatefulPlanNode getPlanNode() {
+  public StatefulPlanNode getStatefulPlanNode() {
     return glutenPlan;
   }
 

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
@@ -71,7 +71,7 @@ public class GlutenSourceFunction extends RichParallelSourceFunction<RowData> {
     this.split = split;
   }
 
-  public StatefulPlanNode getPlanNode() {
+  public StatefulPlanNode getStatefulPlanNode() {
     return planNode;
   }
 
@@ -115,7 +115,7 @@ public class GlutenSourceFunction extends RichParallelSourceFunction<RowData> {
       } else if (state == UpIterator.State.BLOCKED) {
         LOG.debug("Get empty row");
       } else {
-        LOG.info("Velox task finished");
+        LOG.info("Velox task finished.");
         break;
       }
     }

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenVectorOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenVectorOneInputOperator.java
@@ -143,7 +143,7 @@ public class GlutenVectorOneInputOperator extends TableStreamOperator<StatefulRe
   }
 
   @Override
-  public StatefulPlanNode getPlanNode() {
+  public StatefulPlanNode getStatefulPlanNode() {
     return glutenPlan;
   }
 

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenVectorSourceFunction.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenVectorSourceFunction.java
@@ -80,7 +80,7 @@ public class GlutenVectorSourceFunction extends RichParallelSourceFunction<State
     this.split = split;
   }
 
-  public StatefulPlanNode getPlanNode() {
+  public StatefulPlanNode getStatefulPlanNode() {
     return planNode;
   }
 

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenVectorTwoInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenVectorTwoInputOperator.java
@@ -181,7 +181,7 @@ public class GlutenVectorTwoInputOperator extends AbstractStreamOperator<Statefu
   }
 
   @Override
-  public StatefulPlanNode getPlanNode() {
+  public StatefulPlanNode getStatefulPlanNode() {
     return glutenPlan;
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Rename interface getPlanNode to getStatefulPlanNode

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

tested by UTs


Related issue: #11296