### PR TITLE
[GLUTEN-10933][VL]fix: Fix the CudfVector childreSize is not correct

### DIFF
--- a/cpp/velox/memory/VeloxColumnarBatch.h
+++ b/cpp/velox/memory/VeloxColumnarBatch.h
@@ -29,6 +29,13 @@ class VeloxColumnarBatch final : public ColumnarBatch {
   VeloxColumnarBatch(facebook::velox::RowVectorPtr rowVector)
       : ColumnarBatch(rowVector->childrenSize(), rowVector->size()), rowVector_(rowVector) {}
 
+#ifdef GLUTEN_ENABLE_GPU
+  // The batch may be CudfVector, it's childrenSize is not correct, many tests failed if correcting the value
+  // https://github.com/facebookincubator/velox/pull/15629#discussion_r2581655771
+  VeloxColumnarBatch(facebook::velox::RowVectorPtr rowVector, int32_t numColumns)
+      : ColumnarBatch(numColumns, rowVector->size()), rowVector_(rowVector) {}
+#endif
+
   std::string getType() const override {
     return kType;
   }

--- a/cpp/velox/utils/GpuBufferBatchResizer.cc
+++ b/cpp/velox/utils/GpuBufferBatchResizer.cc
@@ -159,7 +159,7 @@ std::shared_ptr<VeloxColumnarBatch> makeCudfTable(
   auto cudfTable = std::make_unique<cudf::table>(std::move(cudfColumns));
   stream.synchronize();
   return std::make_shared<VeloxColumnarBatch>(
-      std::make_shared<cudf_velox::CudfVector>(pool, type, numRows, std::move(cudfTable), stream));
+      std::make_shared<cudf_velox::CudfVector>(pool, type, numRows, std::move(cudfTable), stream), type->size());
 }
 
 } // namespace


### PR DESCRIPTION
After this PR https://github.com/facebookincubator/velox/pull/15629, the CudfVector childrenSize is not correct, if correct it, will cause many unit tests fail as this discussion https://github.com/facebookincubator/velox/pull/15629/files#r2572687025, use a work around in Gluten to fix it.


Related issue: #10933