### PR TITLE
[GLUTEN-10950][VL][FOLLOWUP] Fix missing time unit in hadoop-aws time configuration (pre-3.4 versions)

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
@@ -85,7 +85,7 @@ class VeloxTransformerApi extends TransformerApi with Logging {
     s3aTimeConfigs.foreach {
       case (configKey, defaultUnit) =>
         val configValue = nativeConfMap.get(configKey)
-        if (configValue != null && NumberUtils.isCreatable(configValue)) {
+        if (NumberUtils.isCreatable(configValue)) {
           // Config is numeric (no unit), append the default unit for backward compatibility
           nativeConfMap.put(configKey, s"$configValue$defaultUnit")
         }


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

FOLLOWUP Fix: https://github.com/apache/incubator-gluten/issues/10950

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
No need

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
