### PR TITLE
INFRA: Open rebase for large commit

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,7 +34,7 @@ github:
   enabled_merge_buttons:
     squash: true
     merge: false
-    rebase: false
+    rebase: true
   protected_branches:
     main:
       required_pull_request_reviews:


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR implements the proposal outlined in https://github.com/apache/incubator-gluten/discussions/11352

Here are guidelines:

1. We normally **squash** PRs when merging.
2. **Rebase** is only used for very large PRs—specifically, when adding support for a new Spark version, which must be split into **three commits**.

## How was this patch tested?
Pass GHA
