### PR TITLE
[VL] Fix memory leak caused by hard references on keys of TreeMemoryConsumers#FACTORIES

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/spark/TreeMemoryConsumers.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/spark/TreeMemoryConsumers.java
@@ -21,6 +21,7 @@ import org.apache.gluten.memory.memtarget.Spillers;
 import org.apache.gluten.memory.memtarget.TreeMemoryTarget;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.collections4.map.AbstractReferenceMap;
 import org.apache.commons.collections4.map.ReferenceMap;
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -31,7 +32,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class TreeMemoryConsumers {
-  private static final ReferenceMap<TaskMemoryManager, Factory> FACTORIES = new ReferenceMap<>();
+  private static final ReferenceMap<TaskMemoryManager, Factory> FACTORIES =
+      new ReferenceMap<>(
+          AbstractReferenceMap.ReferenceStrength.WEAK, AbstractReferenceMap.ReferenceStrength.WEAK);
 
   private TreeMemoryConsumers() {}
 


### PR DESCRIPTION
https://github.com/apache/incubator-gluten/pull/4145 was not correctly carried over during the refactor in PR https://github.com/apache/incubator-gluten/pull/8254.

This is to fix the potential memory leak following the solution in #4145.
