### PR TITLE
[GLUTEN-11088][VL] Follow-up: Spark 4.0: Fix remaining error in ArrowEvalPythonExecSuite

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/python/ArrowEvalPythonExecSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/python/ArrowEvalPythonExecSuite.scala
@@ -88,7 +88,7 @@ class ArrowEvalPythonExecSuite extends WholeStageTransformerSuite {
   }
 
   // TODO: fix on spark-4.1
-  testWithMaxSparkVersion("arrow_udf test: with unrelated projection", "4.0") {
+  testWithMaxSparkVersion("arrow_udf test: with preprojection", "4.0") {
     lazy val base =
       Seq(("1", 1), ("1", 2), ("2", 1), ("2", 2), ("3", 1), ("3", 2), ("0", 1), ("3", 0))
         .toDF("a", "b")


### PR DESCRIPTION
Following https://github.com/apache/incubator-gluten/pull/11288:

Fix error in case "arrow_udf test: with preprojection" due to Spark 4.0 change in https://github.com/apache/spark/pull/42864.


Related issue: #11088