### PR TITLE
[GLUTEN-11251] Follow-up: Enable ut SPARK-47939 for spark 4.1

### DIFF
--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -878,8 +878,6 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-38173: Quoted column cannot be recognized correctly when quotedRegexColumnNames is true")
     // Rewrite with Gluten's explained result.
     .exclude("SPARK-47939: Explain should work with parameterized queries")
-    // TODO: fix on Spark-4.1 based on https://github.com/apache/incubator-gluten/pull/11252
-    .excludeGlutenTest("SPARK-47939: Explain should work with parameterized queries")
   enableSuite[GlutenSQLQueryTestSuite]
   enableSuite[GlutenStatisticsCollectionSuite]
     // The output byte size of Velox is different

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenSQLQuerySuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenSQLQuerySuite.scala
@@ -193,7 +193,7 @@ class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
       spark.sql("explain explain explain select ?", Array(1)),
       """== Physical Plan ==
         |Execute ExplainCommand
-        |   +- ExplainCommand ExplainCommand 'PosParameterizedQuery [1], SimpleMode, SimpleMode
+        |   +- ExplainCommand ExplainCommand 'Project [unresolvedalias(1)], SimpleMode, SimpleMode
 
         |"""
     )
@@ -202,7 +202,7 @@ class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
       // scalastyle:off
       """== Physical Plan ==
         |Execute ExplainCommand
-        |   +- ExplainCommand ExplainCommand 'NameParameterizedQuery [first], [1], SimpleMode, SimpleMode
+        |   +- ExplainCommand ExplainCommand 'Project [unresolvedalias(1)], SimpleMode, SimpleMode
 
         |"""
       // scalastyle:on
@@ -212,7 +212,7 @@ class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
       spark.sql("explain describe select ?", Array(1)),
       """== Physical Plan ==
         |Execute DescribeQueryCommand
-        |   +- DescribeQueryCommand select ?
+        |   +- DescribeQueryCommand select 1
 
         |"""
     )
@@ -220,7 +220,7 @@ class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
       spark.sql("explain describe select :first", Map("first" -> 1)),
       """== Physical Plan ==
         |Execute DescribeQueryCommand
-        |   +- DescribeQueryCommand select :first
+        |   +- DescribeQueryCommand select 1
 
         |"""
     )
@@ -228,10 +228,9 @@ class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
     checkQueryPlan(
       spark.sql("explain extended select * from values (?, ?) t(x, y)", Array(1, "a")),
       """== Parsed Logical Plan ==
-        |'PosParameterizedQuery [1, a]
-        |+- 'Project [*]
-        |   +- 'SubqueryAlias t
-        |      +- 'UnresolvedInlineTable [x, y], [[posparameter(39), posparameter(42)]]
+        |'Project [*]
+        |+- SubqueryAlias t
+        |   +- LocalRelation [x#N, y#N]
 
         |== Analyzed Logical Plan ==
         |x: int, y: string
@@ -252,10 +251,9 @@ class GlutenSQLQuerySuite extends SQLQuerySuite with GlutenSQLTestsTrait {
         Map("first" -> 1, "second" -> "a")
       ),
       """== Parsed Logical Plan ==
-        |'NameParameterizedQuery [first, second], [1, a]
-        |+- 'Project [*]
-        |   +- 'SubqueryAlias t
-        |      +- 'UnresolvedInlineTable [x, y], [[namedparameter(first), namedparameter(second)]]
+        |'Project [*]
+        |+- SubqueryAlias t
+        |   +- LocalRelation [x#N, y#N]
 
         |== Analyzed Logical Plan ==
         |x: int, y: string


### PR DESCRIPTION
Spark 4.1 produces different plan string

Related issue: #11251