### PR TITLE
[GLUTEN-11088][VL] Mark test case `SPARK-47289: extended explain info` as non-fixable

### DIFF
--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -947,7 +947,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("Logging plan changes for execution")
     // Rewrite for transformed plan
     .exclude("dumping query execution info to a file - explainMode=formatted")
-    // The case doesn't need to be fixed in Gluten since it's verifying against
+    // The case doesn't need to be run in Gluten since it's verifying against
     // vanilla Spark's query plan.
     .exclude("SPARK-47289: extended explain info")
 


### PR DESCRIPTION
The Spark 4.0 test case `GlutenQueryExecutionSuite.SPARK-47289: extended explain info` is not necessarily to be run in Gluten code because it aims to test against vanilla Spark's query plan. The PR corrects the code comment.


Related issue: #11088