### PR TITLE
[Fix] Update artifact download path for velox-native-lib for spark 41

### DIFF
--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -1508,7 +1508,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/releases
+          path: ./cpp/build/
       - name: Download Arrow Jars
         uses: actions/download-artifact@v4
         with:
@@ -1565,7 +1565,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/releases
+          path: ./cpp/build/
       - name: Download Arrow Jars
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This PR fix broken ut due to  https://github.com/apache/incubator-gluten/pull/11120

## How was this patch tested?

Existing UTs