### PR TITLE
[VL] Cleanup: Remove unused SparkSession arguments in constructors of planner rules

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -80,16 +80,13 @@ object VeloxRuleApi {
     // Legacy: Pre-transform rules.
     injector.injectPreTransform(_ => RemoveTransitions)
     injector.injectPreTransform(_ => PushDownInputFileExpression.PreOffload)
-    injector.injectPreTransform(c => FallbackOnANSIMode.apply(c.session))
-    injector.injectPreTransform(c => FallbackMultiCodegens.apply(c.session))
-    injector.injectPreTransform(c => MergeTwoPhasesHashBaseAggregate(c.session))
+    injector.injectPreTransform(c => FallbackOnANSIMode())
+    injector.injectPreTransform(c => FallbackMultiCodegens())
+    injector.injectPreTransform(c => MergeTwoPhasesHashBaseAggregate())
     injector.injectPreTransform(_ => RewriteSubqueryBroadcast())
     injector.injectPreTransform(
-      c =>
-        BloomFilterMightContainJointRewriteRule.apply(
-          c.session,
-          c.caller.isBloomFilterStatFunction()))
-    injector.injectPreTransform(c => ArrowScanReplaceRule.apply(c.session))
+      c => BloomFilterMightContainJointRewriteRule(c.caller.isBloomFilterStatFunction()))
+    injector.injectPreTransform(c => ArrowScanReplaceRule())
     injector.injectPreTransform(_ => EliminateRedundantGetTimestamp)
 
     // Legacy: The legacy transform rule.
@@ -115,7 +112,7 @@ object VeloxRuleApi {
     injector.injectPostTransform(_ => AppendBatchResizeForShuffleInputAndOutput())
     injector.injectPostTransform(_ => GpuBufferBatchResizeForShuffleInputOutput())
     injector.injectPostTransform(_ => UnionTransformerRule())
-    injector.injectPostTransform(c => PartialProjectRule.apply(c.session))
+    injector.injectPostTransform(c => PartialProjectRule())
     injector.injectPostTransform(_ => PartialGenerateRule())
     injector.injectPostTransform(_ => RemoveNativeWriteFilesSortAndProject())
     injector.injectPostTransform(_ => PushDownFilterToScan)
@@ -124,7 +121,7 @@ object VeloxRuleApi {
     injector.injectPostTransform(_ => EliminateLocalSort)
     injector.injectPostTransform(_ => PullOutDuplicateProject)
     injector.injectPostTransform(_ => CollapseProjectExecTransformer)
-    injector.injectPostTransform(c => FlushableHashAggregateRule.apply(c.session))
+    injector.injectPostTransform(c => FlushableHashAggregateRule())
     injector.injectPostTransform(_ => CollectLimitTransformerRule())
     injector.injectPostTransform(_ => CollectTailTransformerRule())
     injector.injectPostTransform(_ => V2WritePostRule())
@@ -134,7 +131,7 @@ object VeloxRuleApi {
     injector.injectFallbackPolicy(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p))
 
     // Gluten columnar: Post rules.
-    injector.injectPost(c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
+    injector.injectPost(c => RemoveTopmostColumnarToRow(c.caller.isAqe()))
     SparkShimLoader.getSparkShims
       .getExtendedColumnarPostRules()
       .foreach(each => injector.injectPost(c => each(c.session)))
@@ -142,10 +139,10 @@ object VeloxRuleApi {
     injector.injectPost(_ => GenerateTransformStageId())
     injector.injectPost(c => CudfNodeValidationRule(new GlutenConfig(c.sqlConf)))
 
-    injector.injectPost(c => GlutenNoopWriterRule(c.session))
+    injector.injectPost(c => GlutenNoopWriterRule())
 
     // Gluten columnar: Final rules.
-    injector.injectFinal(c => RemoveGlutenTableCacheColumnarToRow(c.session))
+    injector.injectFinal(c => RemoveGlutenTableCacheColumnarToRow())
     injector.injectFinal(
       c => PreventBatchTypeMismatchInTableCache(c.caller.isCache(), Set(VeloxBatchType)))
     injector.injectFinal(
@@ -164,15 +161,12 @@ object VeloxRuleApi {
     // Gluten RAS: Pre rules.
     injector.injectPreTransform(_ => RemoveTransitions)
     injector.injectPreTransform(_ => PushDownInputFileExpression.PreOffload)
-    injector.injectPreTransform(c => FallbackOnANSIMode.apply(c.session))
-    injector.injectPreTransform(c => MergeTwoPhasesHashBaseAggregate(c.session))
+    injector.injectPreTransform(c => FallbackOnANSIMode())
+    injector.injectPreTransform(c => MergeTwoPhasesHashBaseAggregate())
     injector.injectPreTransform(_ => RewriteSubqueryBroadcast())
     injector.injectPreTransform(
-      c =>
-        BloomFilterMightContainJointRewriteRule.apply(
-          c.session,
-          c.caller.isBloomFilterStatFunction()))
-    injector.injectPreTransform(c => ArrowScanReplaceRule.apply(c.session))
+      c => BloomFilterMightContainJointRewriteRule.apply(c.caller.isBloomFilterStatFunction()))
+    injector.injectPreTransform(c => ArrowScanReplaceRule())
     injector.injectPreTransform(_ => EliminateRedundantGetTimestamp)
 
     // Gluten RAS: The RAS rule.
@@ -222,7 +216,7 @@ object VeloxRuleApi {
     injector.injectPostTransform(_ => GpuBufferBatchResizeForShuffleInputOutput())
     injector.injectPostTransform(_ => RemoveTransitions)
     injector.injectPostTransform(_ => UnionTransformerRule())
-    injector.injectPostTransform(c => PartialProjectRule.apply(c.session))
+    injector.injectPostTransform(c => PartialProjectRule())
     injector.injectPostTransform(_ => PartialGenerateRule())
     injector.injectPostTransform(_ => RemoveNativeWriteFilesSortAndProject())
     injector.injectPostTransform(_ => PushDownFilterToScan)
@@ -231,20 +225,20 @@ object VeloxRuleApi {
     injector.injectPostTransform(_ => EliminateLocalSort)
     injector.injectPostTransform(_ => PullOutDuplicateProject)
     injector.injectPostTransform(_ => CollapseProjectExecTransformer)
-    injector.injectPostTransform(c => FlushableHashAggregateRule.apply(c.session))
+    injector.injectPostTransform(c => FlushableHashAggregateRule())
     injector.injectPostTransform(_ => CollectLimitTransformerRule())
     injector.injectPostTransform(_ => CollectTailTransformerRule())
     injector.injectPostTransform(_ => V2WritePostRule())
     injector.injectPostTransform(c => InsertTransitions.create(c.outputsColumnar, VeloxBatchType))
-    injector.injectPostTransform(c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
+    injector.injectPostTransform(c => RemoveTopmostColumnarToRow(c.caller.isAqe()))
     SparkShimLoader.getSparkShims
       .getExtendedColumnarPostRules()
       .foreach(each => injector.injectPostTransform(c => each(c.session)))
     injector.injectPostTransform(c => ColumnarCollapseTransformStages(new GlutenConfig(c.sqlConf)))
     injector.injectPostTransform(_ => GenerateTransformStageId())
     injector.injectPostTransform(c => CudfNodeValidationRule(new GlutenConfig(c.sqlConf)))
-    injector.injectPostTransform(c => GlutenNoopWriterRule(c.session))
-    injector.injectPostTransform(c => RemoveGlutenTableCacheColumnarToRow(c.session))
+    injector.injectPostTransform(c => GlutenNoopWriterRule())
+    injector.injectPostTransform(c => RemoveGlutenTableCacheColumnarToRow())
     injector.injectPostTransform(
       c => PreventBatchTypeMismatchInTableCache(c.caller.isCache(), Set(VeloxBatchType)))
     injector.injectPostTransform(

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/ArrowScanReplaceRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/ArrowScanReplaceRule.scala
@@ -20,12 +20,11 @@ import org.apache.gluten.datasource.ArrowCSVFileFormat
 import org.apache.gluten.datasource.v2.ArrowCSVScan
 import org.apache.gluten.execution.datasource.v2.ArrowBatchScanExec
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ArrowFileSourceScanExec, FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 
-case class ArrowScanReplaceRule(spark: SparkSession) extends Rule[SparkPlan] {
+case class ArrowScanReplaceRule() extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     plan.transformUp {
       case plan: FileSourceScanExec if plan.relation.fileFormat.isInstanceOf[ArrowCSVFileFormat] =>

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/BloomFilterMightContainJointRewriteRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/BloomFilterMightContainJointRewriteRule.scala
@@ -21,13 +21,10 @@ import org.apache.gluten.expression.VeloxBloomFilterMightContain
 import org.apache.gluten.expression.aggregate.VeloxBloomFilterAggregate
 import org.apache.gluten.sql.shims.SparkShimLoader
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 
-case class BloomFilterMightContainJointRewriteRule(
-    spark: SparkSession,
-    isBloomFilterStatFunction: Boolean)
+case class BloomFilterMightContainJointRewriteRule(isBloomFilterStatFunction: Boolean)
   extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     if (isBloomFilterStatFunction || !GlutenConfig.get.enableNativeBloomFilter) {

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
@@ -19,7 +19,6 @@ package org.apache.gluten.extension
 import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.execution._
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.physical.ClusteredDistribution
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -32,7 +31,7 @@ import org.apache.spark.sql.types.{DataType, DoubleType, FloatType}
  * To transform regular aggregation to intermediate aggregation that internally enables
  * optimizations such as flushing and abandoning.
  */
-case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkPlan] {
+case class FlushableHashAggregateRule() extends Rule[SparkPlan] {
   import FlushableHashAggregateRule._
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!VeloxConfig.get.enableVeloxFlushablePartialAggregation) {

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/PartialProjectRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/PartialProjectRule.scala
@@ -20,11 +20,10 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.ColumnarPartialProjectExec
 import org.apache.gluten.utils.PlanUtil
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 
-case class PartialProjectRule(spark: SparkSession) extends Rule[SparkPlan] {
+case class PartialProjectRule() extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!GlutenConfig.get.enableColumnarPartialProject) {
       return plan

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala
@@ -18,14 +18,13 @@ package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.config.GlutenConfig
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, QueryStageExec}
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.joins._
 
-case class FallbackOnANSIMode(session: SparkSession) extends Rule[SparkPlan] {
+case class FallbackOnANSIMode() extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     if (GlutenConfig.get.enableAnsiMode && GlutenConfig.get.enableAnsiFallback) {
       plan.foreach(FallbackTags.add(_, "does not support ansi mode"))
@@ -34,7 +33,7 @@ case class FallbackOnANSIMode(session: SparkSession) extends Rule[SparkPlan] {
   }
 }
 
-case class FallbackMultiCodegens(session: SparkSession) extends Rule[SparkPlan] {
+case class FallbackMultiCodegens() extends Rule[SparkPlan] {
   lazy val glutenConf: GlutenConfig = GlutenConfig.get
   lazy val physicalJoinOptimize = glutenConf.enablePhysicalJoinOptimize
   lazy val optimizeLevel: Integer = glutenConf.physicalJoinOptimizationThrottle

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MergeTwoPhasesHashBaseAggregate.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MergeTwoPhasesHashBaseAggregate.scala
@@ -19,7 +19,6 @@ package org.apache.gluten.extension.columnar
 import org.apache.gluten.config.GlutenConfig
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
@@ -34,9 +33,7 @@ import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregat
  * Note: this rule must be applied before the `PullOutPreProject` rule, because the
  * `PullOutPreProject` rule will modify the attributes in some cases.
  */
-case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
-  extends Rule[SparkPlan]
-  with Logging {
+case class MergeTwoPhasesHashBaseAggregate() extends Rule[SparkPlan] with Logging {
 
   val glutenConf: GlutenConfig = GlutenConfig.get
   val scanOnly: Boolean = glutenConf.enableScanOnly

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
@@ -23,7 +23,6 @@ import org.apache.gluten.utils.PlanUtil
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
@@ -139,8 +138,7 @@ object MiscColumnarRules {
   //
   // The rule is basically a workaround because of the limited compatibility between Spark's AQE
   // and columnar API.
-  case class RemoveTopmostColumnarToRow(session: SparkSession, isAdaptiveContext: Boolean)
-    extends Rule[SparkPlan] {
+  case class RemoveTopmostColumnarToRow(isAdaptiveContext: Boolean) extends Rule[SparkPlan] {
     override def apply(plan: SparkPlan): SparkPlan = {
       if (!isAdaptiveContext) {
         // The rule only applies in AQE. If AQE is off the topmost C2R will be strictly required
@@ -164,7 +162,7 @@ object MiscColumnarRules {
   }
 
   // `InMemoryTableScanExec` internally supports ColumnarToRow.
-  case class RemoveGlutenTableCacheColumnarToRow(session: SparkSession) extends Rule[SparkPlan] {
+  case class RemoveGlutenTableCacheColumnarToRow() extends Rule[SparkPlan] {
     override def apply(plan: SparkPlan): SparkPlan = plan.transformDown {
       case ColumnarToRowLike(child) if PlanUtil.isGlutenTableCache(child) =>
         child

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/datasources/noop/GlutenNoopWriterRule.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/datasources/noop/GlutenNoopWriterRule.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources.noop
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.GlutenWriterColumnarRules.injectFakeRowAdaptor
@@ -31,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.v2.{AppendDataExec, OverwriteB
  * ColumnarToRow operation for NoopWrite. Since NoopWrite does not actually perform any data
  * operations, it can accept input data in either row-based or columnar format.
  */
-case class GlutenNoopWriterRule(session: SparkSession) extends Rule[SparkPlan] {
+case class GlutenNoopWriterRule() extends Rule[SparkPlan] {
   override def apply(p: SparkPlan): SparkPlan = p match {
     case rc @ AppendDataExec(_, _, NoopWrite) =>
       injectFakeRowAdaptor(rc, rc.child)

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -186,7 +186,7 @@ private object FallbackStrategiesSuite {
       transformBuilders,
       List(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p)),
       List(
-        c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()),
+        c => RemoveTopmostColumnarToRow(c.caller.isAqe()),
         _ => ColumnarCollapseTransformStages(GlutenConfig.get)
       ),
       List(_ => RemoveFallbackTagRule()),


### PR DESCRIPTION
As title. A minor refactor to make it clear that which rules in the rule list are accessing the Spark session object internally.
