### PR TITLE
[GLUTEN-11401][DOC] Fix doc percentile/percentile_approx not support on velox backend

### DIFF
--- a/docs/velox-backend-aggregate-function-support.md
+++ b/docs/velox-backend-aggregate-function-support.md
@@ -9,7 +9,7 @@
 | any                   | BoolOr                             | S        |                |
 | any_value             | AnyValue                           | S        |                |
 | approx_count_distinct | HyperLogLogPlusPlus                | S        |                |
-| approx_percentile     | ApproximatePercentile              | S        |                |
+| approx_percentile     | ApproximatePercentile              |          |                |
 | array_agg             | CollectList                        | S        |                |
 | avg                   | Average                            | S        |                |
 | bit_and               | BitAndAgg                          | S        |                |
@@ -45,8 +45,8 @@
 | min                   | Min                                | S        |                |
 | min_by                | MinBy                              | S        |                |
 | mode                  | Mode                               |          |                |
-| percentile            | Percentile                         | S        |                |
-| percentile_approx     | ApproximatePercentile              | S        |                |
+| percentile            | Percentile                         |          |                |
+| percentile_approx     | ApproximatePercentile              |          |                |
 | regr_avgx             | RegrAvgX                           | S        |                |
 | regr_avgy             | RegrAvgY                           | S        |                |
 | regr_count            | RegrCount                          | S        |                |


### PR DESCRIPTION
### What changes are proposed in this pull request?
Fix document.

Related issue: #11401