### PR TITLE
[GLUTEN-11427][CH] Clang 19 or higher is required when build clickhouse

### DIFF
--- a/cpp-ch/local-engine/docker/image/Dockerfile
+++ b/cpp-ch/local-engine/docker/image/Dockerfile
@@ -23,7 +23,7 @@ FROM ubuntu:20.04
 ARG apt_archive="http://mirrors.aliyun.com"
 RUN sed -i "s|http://archive.ubuntu.com|$apt_archive|g" /etc/apt/sources.list
 
-ENV DEBIAN_FRONTEND=noninteractive LLVM_VERSION=17
+ENV DEBIAN_FRONTEND=noninteractive LLVM_VERSION=19
 
 RUN apt-get update \
     && apt-get install \

--- a/cpp-ch/local-engine/docker/image/build.sh
+++ b/cpp-ch/local-engine/docker/image/build.sh
@@ -35,6 +35,7 @@ cmake -G Ninja  "-DCMAKE_C_COMPILER=$CC" "-DCMAKE_CXX_COMPILER=$CXX" \
           "-DENABLE_GWP_ASAN=OFF" \
           "-DENABLE_EXTERN_LOCAL_ENGINE=ON" \
           "-DENABLE_THINLTO=false" \
+          "-DENABLE_NUMACTL=OFF" \
           /clickhouse
 ninja
 


### PR DESCRIPTION
Clang 19 or higher is required for build clickhouse

Related issue: #11427