### PR TITLE
[VL] Restrict `-Wno-class-memaccess` flag to GNU compiler

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -147,8 +147,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_compile_definitions(_GNU_SOURCE)
 endif()
 
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND "${CMAKE_CXX_COMPILER_ID}"
-                                                    STREQUAL "GNU")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-memaccess")
 endif()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Only GNU GCC supports this flag; using Clang to compile will result in an error.

## How was this patch tested?

N/A
