### PR TITLE
[GLUTEN-11432][VL] Bump Maven from 3.9.2 to 3.9.12

### DIFF
--- a/.github/workflows/util/setup-helper.sh
+++ b/.github/workflows/util/setup-helper.sh
@@ -18,7 +18,7 @@ set -e
 
 function install_maven {
   (
-    local maven_version="3.9.2"
+    local maven_version="3.9.12"
     local local_binary="apache-maven-${maven_version}-bin.tar.gz"
     local mirror_host="https://www.apache.org/dyn/closer.lua"
     local url="${mirror_host}/maven/maven-3/${maven_version}/binaries/${local_binary}?action=download"

--- a/dev/docker/Dockerfile.centos8-dynamic-build
+++ b/dev/docker/Dockerfile.centos8-dynamic-build
@@ -32,7 +32,7 @@ RUN set -ex; \
     dnf install -y --setopt=install_weak_deps=False gcc-toolset-11; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-${JAVA_VERSION}-openjdk-devel patch wget git perl; \
-    maven_version=3.9.2; \
+    maven_version=3.9.12; \
     local_binary="apache-maven-${maven_version}-bin.tar.gz"; \
     mirror_host="https://www.apache.org/dyn/closer.lua"; \
     url="${mirror_host}/maven/maven-3/${maven_version}/binaries/${local_binary}?action=download"; \

--- a/dev/docker/Dockerfile.centos9-dynamic-build
+++ b/dev/docker/Dockerfile.centos9-dynamic-build
@@ -30,7 +30,7 @@ RUN set -ex; \
     dnf install -y --setopt=install_weak_deps=False gcc-toolset-12 gcc-toolset-13; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-${JAVA_VERSION}-openjdk-devel patch wget git perl; \
-    maven_version=3.9.2; \
+    maven_version=3.9.12; \
     local_binary="apache-maven-${maven_version}-bin.tar.gz"; \
     mirror_host="https://www.apache.org/dyn/closer.lua"; \
     url="${mirror_host}/maven/maven-3/${maven_version}/binaries/${local_binary}?action=download"; \

--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -25,7 +25,7 @@ function semver {
 
 install_maven_from_source() {
     if [ -z "$(which mvn)" ]; then
-        maven_version=3.9.2
+        maven_version=3.9.12
         maven_install_dir=/opt/maven-$maven_version
         if [ -d /opt/maven-$maven_version ]; then
             echo "Failed to install maven: ${maven_install_dir} is exists" >&2


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
maven 3.9.2 is a little outdated and it is often slow on downloading

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
pass GHA

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->


Related issue: #11432