### PR TITLE
[GLUTEN-11445][CORE] Fix dynamicOffHeapSizingEnabled config not takin…

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemoryTarget.scala
@@ -35,9 +35,13 @@ class GlobalOffHeapMemoryTarget private[memory]
   with Logging {
   private val targetName = MemoryTargetUtil.toUniqueName("GlobalOffHeap")
   private val recorder: MemoryUsageRecorder = new SimpleMemoryUsageRecorder()
-  private val mode: MemoryMode =
-    if (GlutenCoreConfig.get.dynamicOffHeapSizingEnabled) MemoryMode.ON_HEAP
+  private val mode: MemoryMode = {
+    val enabled = Option(SparkEnv.get)
+      .map(_.conf.getBoolean(GlutenCoreConfig.DYNAMIC_OFFHEAP_SIZING_ENABLED.key, false))
+      .getOrElse(false)
+    if (enabled) MemoryMode.ON_HEAP
     else MemoryMode.OFF_HEAP
+  }
 
   private val FIELD_MEMORY_MANAGER: Field = {
     val f =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `SparkEnv.get.conf` instead of `SQLConf.get` to read `dynamicOffHeapSizingEnabled` config in `GlobalOffHeapMemoryTarget`.

### Why are the changes needed?

`GlobalOffHeapMemoryTarget` is initialized during static class loading (via `ArrowBufferAllocators.GLOBAL_INSTANCE`), at which point `SQLConf.get` returns a fallback config without user settings, causing `dynamicOffHeapSizingEnabled` to always be `false`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual testing.

Related issue: #11445