### PR TITLE
[GLUTEN-11390][VL] Align aarch64 compiler flags with Velox to fix xsimd initialization errors

### DIFF
--- a/dev/build-helper-functions.sh
+++ b/dev/build-helper-functions.sh
@@ -75,8 +75,8 @@ function get_cxx_flags {
 
     "aarch64")
       # Follow Velox's ARM CPU detection logic to ensure consistent compiler flags
-      # between Gluten and Velox, preventing xsimd initialization issues.
-      # See: ep/build-velox/build/velox_ep/scripts/setup-helper-functions.sh:142-180
+      # between Gluten and Velox, preventing xsimd initialization issues, see GLUTEN-11390.
+      # Reference: function get_cxx_flags in Velox's setup-helper-functions.sh.
 
       # Read Arm MIDR_EL1 register to detect Arm cpu.
       # https://developer.arm.com/documentation/100616/0301/register-descriptions/aarch64-system-registers/midr-el1--main-id-register--el1


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

fix: https://github.com/apache/incubator-gluten/issues/11390

Follow Velox's ARM CPU detection logic to ensure consistent compiler flags, between Gluten and Velox, preventing xsimd initialization issues.See: ep/build-velox/build/velox_ep/scripts/setup-helper-functions.sh:142-180

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
build test

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
