### PR TITLE
[INFRA] Minor follow-up for PR #11482, remove SPARK_HOME setting from cudf docker build

### DIFF
--- a/dev/docker/cudf/Dockerfile
+++ b/dev/docker/cudf/Dockerfile
@@ -23,10 +23,10 @@ ENV LD_LIBRARY_PATH=/opt/gluten/ep/build-velox/build/velox_ep/_build/release/_de
 RUN yum install -y sudo patch maven perl && \
     dnf remove -y cuda-toolkit-12* && dnf install -y cuda-toolkit-13-1; \
     dnf autoremove -y && dnf clean all; \
+    rm -rf /opt/rh/gcc-toolset-12 && ln -s /opt/rh/gcc-toolset-14 /opt/rh/gcc-toolset-12; \
     ln -sf /usr/local/bin/cmake /usr/bin && \
     git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten && \
     cd /opt/gluten/.github/workflows/util/ && \
-    ./install-spark-resources.sh 3.4 && \
     cd /opt/gluten && \
     source /opt/rh/gcc-toolset-14/enable && \
     bash ./dev/buildbundle-veloxbe.sh --run_setup_script=OFF --build_arrow=ON --spark_version=3.4 --build_tests=ON --build_benchmarks=ON --enable_gpu=ON && \


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->
The SPARK_HOME was set with nonexistent directory. It seems not really used.

Follow-up for #11482.

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
