### PR TITLE
[MINOR] Add missing profiles in `format-scala-code.sh`

### DIFF
--- a/dev/format-scala-code.sh
+++ b/dev/format-scala-code.sh
@@ -21,8 +21,8 @@ MVN_CMD="${BASEDIR}/../build/mvn"
 
 # If a new profile is introduced for new modules, please add it here to ensure
 # the new modules are covered.
-PROFILES="-Pbackends-velox -Pceleborn,uniffle -Piceberg,delta,hudi,paimon \
-          -Pspark-3.3,spark-3.4,spark-3.5,spark-4.0,spark-4.1 -Pspark-ut"
+PROFILES="-Pbackends-velox,backends-clickhouse -Pceleborn,uniffle -Piceberg,delta,hudi,paimon \
+          -Pspark-3.3,spark-3.4,spark-3.5,spark-4.0,spark-4.1 -Pspark-ut -Pkafka"
 
 COMMAND=$1
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The scala-format-check CI uses `dev/format-scala-code.sh` to run the spotless check, but it misses the backends-clickhouse and kafka profiles.
