### PR TITLE
Fix window to aggregate conversion with ordering expression validation

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ConvertWindowToAggregate.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/ConvertWindowToAggregate.scala
@@ -54,7 +54,7 @@ case class ConverRowNumbertWindowToAggregateRule(spark: SparkSession)
         if (
           !isSupportedWindowFunction(windowExpressions) || !isTopKLimitFilter(
             condition,
-            windowExpressions(0))
+            windowExpressions(0)) || !hasOrderExpression(partitionSpec, orderSpec)
         ) {
           logDebug(
             s"xxx Not Supported case for converting window to aggregate. is topk limit: " +
@@ -110,6 +110,12 @@ case class ConverRowNumbertWindowToAggregateRule(spark: SparkSession)
     windowFunction match {
       case _: RowNumber => true
       case _ => false
+    }
+  }
+
+  def hasOrderExpression(partitionSpec: Seq[Expression], orderSpec: Seq[SortOrder]): Boolean = {
+    orderSpec.nonEmpty && orderSpec.exists {
+      order => partitionSpec.find(partExpr => partExpr.semanticEquals(order.child)).isEmpty
     }
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -3040,6 +3040,17 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         compareResult = true,
         checkWindowGroupLimit
       )
+
+      compareResultsAgainstVanillaSpark(
+        """
+          |select * from(
+          | select a, b, c, row_number() over (partition by a, b, c order by c) as r
+          |from test_win_top)
+          |where r <= 1
+          |""".stripMargin,
+        compareResult = true,
+        checkWindowGroupLimit
+      )
       spark.sql("drop table if exists test_win_top")
     }
 


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

- Add hasOrderExpression method to validate that ordering expressions are not in partition spec
- Include additional test case for window function with row_number over multiple partition columns
- Prevents incorrect window to aggregate conversion when order expressions don't match partition spec

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

tested by UTs

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No