### PR TITLE
[CORE][VL] Fix protobuf memory leak in JNI_OnUnload

### DIFF
--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -26,6 +26,7 @@
 #include "jni/JniError.h"
 
 #include <arrow/c/bridge.h>
+#include <google/protobuf/stubs/common.h>
 #include <optional>
 #include <string>
 #include "memory/AllocationListener.h"
@@ -304,6 +305,8 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 
   getJniErrorState()->close();
   getJniCommonState()->close();
+
+  google::protobuf::ShutdownProtobufLibrary();
 }
 
 JNIEXPORT jlong JNICALL Java_org_apache_gluten_runtime_RuntimeJniWrapper_createRuntime( // NOLINT


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `google::protobuf::ShutdownProtobufLibrary()` call at the end of `JNI_OnUnload()` to properly clean up protobuf's static internal data structures when the JNI library is unloaded.

## Why are the changes needed?

When running tests with LeakSanitizer enabled, a memory leak is detected:

```
==4790==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 operator new(unsigned long) asan_new_delete.cpp
    #1 gluten::ConfigMap::_InternalParse (libgluten.so+0x9ebd49)
```

Gluten uses protobuf for parsing `ConfigMap` and Substrait plans. When the protobuf library initializes, it creates static internal data structures. According to the [protobuf documentation](https://protobuf.dev/reference/cpp/api-docs/google.protobuf.message_lite/), dynamically-loaded libraries that use protobuf must call `google::protobuf::ShutdownProtobufLibrary()` during cleanup to free these static-duration objects when the library is unloaded.

## Does this PR introduce _any_ user-facing change?

No. This only adds cleanup code that runs during library unload.

## How was this patch tested?

The fix resolves the LeakSanitizer report mentioned above.

Closes #11531