### PR TITLE
[CORE] Copy tags when new local sort node is added by EnsureLocalSortRequirements rule

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -38,6 +38,7 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
       requiredOrdering: Seq[SortOrder]): SparkPlan = {
     // FIXME: HeuristicTransform is costly. Re-applying it may cause performance issues.
     val newChild = SortExec(requiredOrdering, global = false, child = originalChild)
+    newChild.copyTagsFrom(originalChild)
     transform.apply(newChild)
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
`EnsureLocalSortRequirements` rule in Gluten adds local sort node in certain scenarios. The newly added node was missing tags from original child node.

## How was this patch tested?
Locally, using UTs.
Internally, we add a rule to add some tags when streaming nodes are present. These tags were getting missed and testcases were failing. With this change testcases are passing.

## Was this patch authored or co-authored using generative AI tooling?
No
