### PR TITLE
[MINOR] Gitignore GitHub Copilot config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ metastore_db/
 
 .ipynb_checkpoints
 .worktrees/
+
+# GitHub Copilot config (allow local customization)
+.github/copilot-instructions.md
+.github/copilot-setup-steps.yml


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add GitHub Copilot config files to `.gitignore` to allow local/per-user customization without affecting the repository.

**Files ignored:**
- `.github/copilot-instructions.md`
- `.github/copilot-setup-steps.yml`

## How was this patch tested?

Not applicable - this is a gitignore change only.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI