### PR TITLE
[GLUTEN-11550][CORE][UT] Fix GlutenSingleJoinSuite for Spark 4.0+

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.backendsapi
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.ValidationResult
 import org.apache.gluten.extension.columnar.transition.Convention
+import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.LocalFilesNode
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
@@ -91,6 +92,8 @@ trait BackendSettingsApi {
 
   def supportHashBuildJoinTypeOnRight: JoinType => Boolean = {
     case _: InnerLike | LeftOuter | FullOuter | LeftSemi | LeftAnti | _: ExistenceJoin => true
+    // LeftSingle is a Spark 4.0+ join type with same semantics as LeftOuter for build side.
+    case leftSingle if SparkShimLoader.getSparkShims.isLeftSingleJoinType(leftSingle) => true
     case _ => false
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
@@ -63,6 +63,9 @@ trait ColumnarShuffledJoin extends BaseJoinExec {
     case _: InnerLike =>
       PartitioningCollection(Seq(left.outputPartitioning, right.outputPartitioning))
     case LeftOuter => left.outputPartitioning
+    // LeftSingle (Spark 4.0+) has same partitioning as LeftOuter
+    case leftSingle if SparkShimLoader.getSparkShims.isLeftSingleJoinType(leftSingle) =>
+      left.outputPartitioning
     case RightOuter => right.outputPartitioning
     case FullOuter => UnknownPartitioning(left.outputPartitioning.numPartitions)
     case LeftExistence(_) => left.outputPartitioning
@@ -157,6 +160,9 @@ trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
         case _: InnerLike => expandPartitioning(right.outputPartitioning)
         case RightOuter => right.outputPartitioning
         case LeftOuter => left.outputPartitioning
+        // LeftSingle (Spark 4.0+) - same as LeftOuter
+        case leftSingle if SparkShimLoader.getSparkShims.isLeftSingleJoinType(leftSingle) =>
+          left.outputPartitioning
         case FullOuter => UnknownPartitioning(left.outputPartitioning.numPartitions)
         case x =>
           throw new IllegalArgumentException(
@@ -166,6 +172,9 @@ trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
       joinType match {
         case _: InnerLike => expandPartitioning(left.outputPartitioning)
         case LeftOuter | LeftSemi | LeftAnti | _: ExistenceJoin => left.outputPartitioning
+        // LeftSingle (Spark 4.0+) - same as LeftOuter
+        case leftSingle if SparkShimLoader.getSparkShims.isLeftSingleJoinType(leftSingle) =>
+          left.outputPartitioning
         case RightOuter => right.outputPartitioning
         case FullOuter => UnknownPartitioning(right.outputPartitioning.numPartitions)
         case x =>

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/joins/GlutenSingleJoinSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/joins/GlutenSingleJoinSuite.scala
@@ -16,6 +16,6 @@
  */
 package org.apache.spark.sql.execution.joins
 
-import org.apache.spark.sql.GlutenTestsCommonTrait
+import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
-class GlutenSingleJoinSuite extends SingleJoinSuite with GlutenTestsCommonTrait {}
+class GlutenSingleJoinSuite extends SingleJoinSuite with GlutenSQLTestsBaseTrait {}

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/joins/GlutenSingleJoinSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/joins/GlutenSingleJoinSuite.scala
@@ -16,6 +16,6 @@
  */
 package org.apache.spark.sql.execution.joins
 
-import org.apache.spark.sql.GlutenTestsCommonTrait
+import org.apache.spark.sql.GlutenSQLTestsBaseTrait
 
-class GlutenSingleJoinSuite extends SingleJoinSuite with GlutenTestsCommonTrait {}
+class GlutenSingleJoinSuite extends SingleJoinSuite with GlutenSQLTestsBaseTrait {}

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BinaryExpression, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RaiseError, UnBase64}
 import org.apache.spark.sql.catalyst.expressions.aggregate.TypedImperativeAggregate
+import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, Partitioning}
@@ -368,4 +369,10 @@ trait SparkShims {
       plan: LogicalPlan): SparkPlan
 
   def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean
+
+  /**
+   * Checks if the given JoinType is LeftSingle. LeftSingle is a Spark 4.0+ join type, semantically
+   * similar to LeftOuter. Default implementation returns false for Spark 3.x compatibility.
+   */
+  def isLeftSingleJoinType(joinType: JoinType): Boolean = false
 }

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, KeyGroupedPartitioning, KeyGroupedShuffleSpec, Partitioning}
@@ -774,5 +775,9 @@ class Spark40Shims extends SparkShims {
 
   override def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
     p.isFinalPlan
+  }
+
+  override def isLeftSingleJoinType(joinType: JoinType): Boolean = {
+    joinType == LeftSingle
   }
 }

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, KeyGroupedPartitioning, KeyGroupedShuffleSpec, Partitioning}
@@ -773,5 +774,9 @@ class Spark41Shims extends SparkShims {
 
   override def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
     p.isFinalPlan
+  }
+
+  override def isLeftSingleJoinType(joinType: JoinType): Boolean = {
+    joinType == LeftSingle
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for LeftSingle join type to enable proper fallback to Spark execution in Spark 4.0+.

LeftSingle is a new join type introduced in Spark 4.0 for scalar subquery correlation. When Gluten encounters this join type, it should gracefully fall back to Spark execution since Substrait does not support it yet.

This enables `GlutenSingleJoinSuite` to pass for both Spark 4.0 and 4.1.

Fix #11550

## How was this patch tested?

- All 36 tests in GlutenSingleJoinSuite pass for both Spark 4.0 and 4.1
- Verified fallback works correctly with log message:
  "Validation failed for plan: ShuffledHashJoin, due to: Unsupported join type of LeftSingle for substrait: UNRECOGNIZED"

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.5