### PR TITLE
[GLUTEN-11550][UT] Enable GlutenXmlExpressionsSuite for spark4x and exclude 'from_xml- invalid data'

### DIFF
--- a/gluten-ut/spark40/pom.xml
+++ b/gluten-ut/spark40/pom.xml
@@ -85,6 +85,29 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.woodstox</groupId>
+          <artifactId>woodstox-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>stax2-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -243,7 +243,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenUnwrapUDTExpressionSuite]
   enableSuite[GlutenV2ExpressionUtilsSuite]
   enableSuite[GlutenValidateExternalTypeSuite]
-  // TODO: 4.x enableSuite[GlutenXmlExpressionsSuite]  // 7 failures
+  enableSuite[GlutenXmlExpressionsSuite]
+    .exclude("from_xml- invalid data")
   // Generated suites for org.apache.spark.sql.connector
   enableSuite[GlutenDataSourceV2MetricsSuite]
   enableSuite[GlutenDataSourceV2OptionSuite]

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenXmlExpressionsSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenXmlExpressionsSuite.scala
@@ -16,6 +16,6 @@
  */
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.GlutenTestsCommonTrait
+import org.apache.spark.sql.GlutenTestsTrait
 
-class GlutenXmlExpressionsSuite extends XmlExpressionsSuite with GlutenTestsCommonTrait {}
+class GlutenXmlExpressionsSuite extends XmlExpressionsSuite with GlutenTestsTrait {}

--- a/gluten-ut/spark41/pom.xml
+++ b/gluten-ut/spark41/pom.xml
@@ -85,6 +85,30 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>
+
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.woodstox</groupId>
+          <artifactId>woodstox-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>stax2-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -254,7 +254,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenUnwrapUDTExpressionSuite]
   enableSuite[GlutenV2ExpressionUtilsSuite]
   enableSuite[GlutenValidateExternalTypeSuite]
-  // TODO: 4.x enableSuite[GlutenXmlExpressionsSuite]  // 7 failures
+  enableSuite[GlutenXmlExpressionsSuite]
+    .exclude("from_xml- invalid data")
   // Generated suites for org.apache.spark.sql.connector
   enableSuite[GlutenDataSourceV2MetricsSuite]
   enableSuite[GlutenDataSourceV2OptionSuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenXmlExpressionsSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenXmlExpressionsSuite.scala
@@ -16,6 +16,6 @@
  */
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.GlutenTestsCommonTrait
+import org.apache.spark.sql.shim
 
-class GlutenXmlExpressionsSuite extends XmlExpressionsSuite with GlutenTestsCommonTrait {}
+class GlutenXmlExpressionsSuite extends XmlExpressionsSuite with shim.GlutenTestsTrait {}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #11550 (partial)

- **Enable `GlutenXmlExpressionsSuite`** in VeloxTestSettings for both spark40 and spark41 (was TODO disabled for spark41)
- **Fix mixin**: `GlutenTestsCommonTrait` → `GlutenTestsTrait`. The prior PR (#11512) added `GlutenXmlExpressionsSuite` with `GlutenTestsCommonTrait`, which does not enable Gluten execution for the test suite.
- **Exclude `from_xml- invalid data`**: Gluten overrides `checkEvaluation` to execute expressions via DataFrame (`df.select().collect()`), which throws `SparkException` directly instead of wrapping it in `TestFailedException`. Same pattern as `from_json - invalid data`.
- **Fix woodstox classpath conflict**: Exclude `hadoop-common` transitive dependency from `hive-llap-common` in both `gluten-ut/pom.xml` and spark-specific pom files. Hadoop ships a shaded woodstox (`org.apache.hadoop.shaded.com.ctc.wstx.*`) whose property names are incompatible with the non-shaded woodstox used by Spark XML, causing `IllegalArgumentException: Unrecognized property` in `to_xml` tests.

## How was this patch tested?

Ran `GlutenXmlExpressionsSuite` on both spark40 and spark41:
- spark40: 28 passed, 1 ignored (`from_xml- invalid data`) ✅
- spark41: 28 passed, 1 ignored (`from_xml- invalid data`) ✅

Compiled successfully with both `spark-4.0` and `spark-4.1` profiles.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI