### PR TITLE
[VL] Delta: Unify code style with Gluten codebase

### DIFF
--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
@@ -46,48 +46,52 @@ import org.apache.parquet.hadoop.util.ContextUtil
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-// spotless:off
 /**
  * A thin wrapper over the Parquet file format to support
- *  - columns names without restrictions.
- *  - populated a column from the deletion vector of this file (if exists) to indicate
- *    whether the row is deleted or not according to the deletion vector. Consumers
- *    of this scan can use the column values to filter out the deleted rows.
+ *   - columns names without restrictions.
+ *   - populated a column from the deletion vector of this file (if exists) to indicate whether the
+ *     row is deleted or not according to the deletion vector. Consumers of this scan can use the
+ *     column values to filter out the deleted rows.
  */
 case class GlutenDeltaParquetFileFormat(
-                                   protocol: Protocol,
-                                   metadata: Metadata,
-                                   nullableRowTrackingFields: Boolean = false,
-                                   optimizationsEnabled: Boolean = true,
-                                   tablePath: Option[String] = None,
-                                   isCDCRead: Boolean = false)
+    protocol: Protocol,
+    metadata: Metadata,
+    nullableRowTrackingFields: Boolean = false,
+    optimizationsEnabled: Boolean = true,
+    tablePath: Option[String] = None,
+    isCDCRead: Boolean = false)
   extends GlutenParquetFileFormat
-    with LoggingShims {
+  with LoggingShims {
   // Validate either we have all arguments for DV enabled read or none of them.
   if (hasTablePath) {
-    SparkSession.getActiveSession.map { session =>
-      val useMetadataRowIndex =
-        session.sessionState.conf.getConf(DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX)
-      require(useMetadataRowIndex == optimizationsEnabled,
-        "Wrong arguments for Delta table scan with deletion vectors")
+    SparkSession.getActiveSession.map {
+      session =>
+        val useMetadataRowIndex =
+          session.sessionState.conf.getConf(DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX)
+        require(
+          useMetadataRowIndex == optimizationsEnabled,
+          "Wrong arguments for Delta table scan with deletion vectors")
     }
   }
 
-  SparkSession.getActiveSession.ifDefined { session =>
-    TypeWidening.assertTableReadable(session.sessionState.conf, protocol, metadata)
+  SparkSession.getActiveSession.ifDefined {
+    session => TypeWidening.assertTableReadable(session.sessionState.conf, protocol, metadata)
   }
-
 
   val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
   val referenceSchema: StructType = metadata.schema
 
   if (columnMappingMode == IdMapping) {
     val requiredReadConf = SQLConf.PARQUET_FIELD_ID_READ_ENABLED
-    require(SparkSession.getActiveSession.exists(_.sessionState.conf.getConf(requiredReadConf)),
-      s"${requiredReadConf.key} must be enabled to support Delta id column mapping mode")
+    require(
+      SparkSession.getActiveSession.exists(_.sessionState.conf.getConf(requiredReadConf)),
+      s"${requiredReadConf.key} must be enabled to support Delta id column mapping mode"
+    )
     val requiredWriteConf = SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED
-    require(SparkSession.getActiveSession.exists(_.sessionState.conf.getConf(requiredWriteConf)),
-      s"${requiredWriteConf.key} must be enabled to support Delta id column mapping mode")
+    require(
+      SparkSession.getActiveSession.exists(_.sessionState.conf.getConf(requiredWriteConf)),
+      s"${requiredWriteConf.key} must be enabled to support Delta id column mapping mode"
+    )
   }
 
   override def shortName(): String = "parquet"
@@ -95,20 +99,21 @@ case class GlutenDeltaParquetFileFormat(
   override def toString: String = "Parquet"
 
   /**
-   * prepareSchemaForRead must only be used for parquet read.
-   * It removes "PARQUET_FIELD_ID_METADATA_KEY" for name mapping mode which address columns by
-   * physical name instead of id.
+   * prepareSchemaForRead must only be used for parquet read. It removes
+   * "PARQUET_FIELD_ID_METADATA_KEY" for name mapping mode which address columns by physical name
+   * instead of id.
    */
   def prepareSchemaForRead(inputSchema: StructType): StructType = {
-    val schema = DeltaColumnMapping.createPhysicalSchema(
-      inputSchema, referenceSchema, columnMappingMode)
+    val schema =
+      DeltaColumnMapping.createPhysicalSchema(inputSchema, referenceSchema, columnMappingMode)
     if (columnMappingMode == NameMapping) {
-      SchemaMergingUtils.transformColumns(schema) { (_, field, _) =>
-        field.copy(metadata = new MetadataBuilder()
-          .withMetadata(field.metadata)
-          .remove(DeltaColumnMapping.PARQUET_FIELD_ID_METADATA_KEY)
-          .remove(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
-          .build())
+      SchemaMergingUtils.transformColumns(schema) {
+        (_, field, _) =>
+          field.copy(metadata = new MetadataBuilder()
+            .withMetadata(field.metadata)
+            .remove(DeltaColumnMapping.PARQUET_FIELD_ID_METADATA_KEY)
+            .remove(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
+            .build())
       }
     } else schema
   }
@@ -126,7 +131,8 @@ case class GlutenDeltaParquetFileFormat(
       Seq.empty
     } else if (columnMappingMode != NoMapping) {
       import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
-      val physicalNameMap = DeltaColumnMapping.getLogicalNameToPhysicalNameMap(referenceSchema)
+      val physicalNameMap = DeltaColumnMapping
+        .getLogicalNameToPhysicalNameMap(referenceSchema)
         .map { case (logicalName, physicalName) => (logicalName.quoted, physicalName.quoted) }
       filters.flatMap(translateFilterForColumnMapping(_, physicalNameMap))
     } else {
@@ -135,22 +141,22 @@ case class GlutenDeltaParquetFileFormat(
   }
 
   override def isSplitable(
-                            sparkSession: SparkSession,
-                            options: Map[String, String],
-                            path: Path): Boolean = optimizationsEnabled
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = optimizationsEnabled
 
   def hasTablePath: Boolean = tablePath.isDefined
 
   /**
-   * We sometimes need to replace FileFormat within LogicalPlans, so we have to override
-   * `equals` to ensure file format changes are captured
+   * We sometimes need to replace FileFormat within LogicalPlans, so we have to override `equals` to
+   * ensure file format changes are captured
    */
   override def equals(other: Any): Boolean = {
     other match {
       case ff: GlutenDeltaParquetFileFormat =>
         ff.columnMappingMode == columnMappingMode &&
-          ff.referenceSchema == referenceSchema &&
-          ff.optimizationsEnabled == optimizationsEnabled
+        ff.referenceSchema == referenceSchema &&
+        ff.optimizationsEnabled == optimizationsEnabled
       case _ => false
     }
   }
@@ -158,13 +164,13 @@ case class GlutenDeltaParquetFileFormat(
   override def hashCode(): Int = getClass.getCanonicalName.hashCode()
 
   override def buildReaderWithPartitionValues(
-                                               sparkSession: SparkSession,
-                                               dataSchema: StructType,
-                                               partitionSchema: StructType,
-                                               requiredSchema: StructType,
-                                               filters: Seq[Filter],
-                                               options: Map[String, String],
-                                               hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
 
     val useMetadataRowIndexConf = DeltaSQLConf.DELETION_VECTORS_USE_METADATA_ROW_INDEX
     val useMetadataRowIndex = sparkSession.sessionState.conf.getConf(useMetadataRowIndexConf)
@@ -177,7 +183,8 @@ case class GlutenDeltaParquetFileFormat(
         prepareSchemaForRead(requiredSchema),
         prepareFiltersForRead(filters),
         options,
-        hadoopConf)
+        hadoopConf
+      )
 
     val schemaWithIndices = requiredSchema.fields.zipWithIndex
     def findColumn(name: String): Option[ColumnMetadata] = {
@@ -206,7 +213,8 @@ case class GlutenDeltaParquetFileFormat(
 
     // Verify that either predicate pushdown with metadata column is enabled or optimizations
     // are disabled.
-    require(useMetadataRowIndex || !optimizationsEnabled,
+    require(
+      useMetadataRowIndex || !optimizationsEnabled,
       "Cannot generate row index related metadata with file splitting or predicate pushdown")
 
     if (hasTablePath && isRowDeletedColumn.isEmpty) {
@@ -266,15 +274,16 @@ case class GlutenDeltaParquetFileFormat(
   }
 
   override def prepareWrite(
-                             sparkSession: SparkSession,
-                             job: Job,
-                             options: Map[String, String],
-                             dataSchema: StructType): OutputWriterFactory = {
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory = {
     val factory = super.prepareWrite(sparkSession, job, options, dataSchema)
     val conf = ContextUtil.getConfiguration(job)
     // Always write timestamp as TIMESTAMP_MICROS for Iceberg compat based on Iceberg spec
     if (IcebergCompatV1.isEnabled(metadata) || IcebergCompatV2.isEnabled(metadata)) {
-      conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+      conf.set(
+        SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
         SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
     }
     if (IcebergCompatV2.isEnabled(metadata)) {
@@ -287,19 +296,24 @@ case class GlutenDeltaParquetFileFormat(
   }
 
   override def fileConstantMetadataExtractors: Map[String, PartitionedFile => Any] = {
-    val extractBaseRowId: PartitionedFile => Any = { file =>
-      file.otherConstantMetadataColumnValues.getOrElse(RowId.BASE_ROW_ID, {
-        throw new IllegalStateException(
-          s"Missing ${RowId.BASE_ROW_ID} value for file '${file.filePath}'")
-      })
-    }
-    val extractDefaultRowCommitVersion: PartitionedFile => Any = { file =>
-      file.otherConstantMetadataColumnValues
-        .getOrElse(DefaultRowCommitVersion.METADATA_STRUCT_FIELD_NAME, {
+    val extractBaseRowId: PartitionedFile => Any = {
+      file =>
+        file.otherConstantMetadataColumnValues.getOrElse(
+          RowId.BASE_ROW_ID,
           throw new IllegalStateException(
-            s"Missing ${DefaultRowCommitVersion.METADATA_STRUCT_FIELD_NAME} value " +
-              s"for file '${file.filePath}'")
-        })
+            s"Missing ${RowId.BASE_ROW_ID} value for file '${file.filePath}'")
+        )
+    }
+    val extractDefaultRowCommitVersion: PartitionedFile => Any = {
+      file =>
+        file.otherConstantMetadataColumnValues
+          .getOrElse(
+            DefaultRowCommitVersion.METADATA_STRUCT_FIELD_NAME, {
+              throw new IllegalStateException(
+                s"Missing ${DefaultRowCommitVersion.METADATA_STRUCT_FIELD_NAME} value " +
+                  s"for file '${file.filePath}'")
+            }
+          )
     }
     super.fileConstantMetadataExtractors
       .updated(RowId.BASE_ROW_ID, extractBaseRowId)
@@ -307,57 +321,59 @@ case class GlutenDeltaParquetFileFormat(
   }
 
   def copyWithDVInfo(
-                      tablePath: String,
-                      optimizationsEnabled: Boolean): GlutenDeltaParquetFileFormat = {
+      tablePath: String,
+      optimizationsEnabled: Boolean): GlutenDeltaParquetFileFormat = {
     // When predicate pushdown is enabled we allow both splits and predicate pushdown.
-    this.copy(
-      optimizationsEnabled = optimizationsEnabled,
-      tablePath = Some(tablePath))
+    this.copy(optimizationsEnabled = optimizationsEnabled, tablePath = Some(tablePath))
   }
 
   /**
    * Modifies the data read from underlying Parquet reader by populating one or both of the
    * following metadata columns.
-   *   - [[IS_ROW_DELETED_COLUMN_NAME]] - row deleted status from deletion vector corresponding
-   *   to this file
+   *   - [[IS_ROW_DELETED_COLUMN_NAME]] - row deleted status from deletion vector corresponding to
+   *     this file
    *   - [[ROW_INDEX_COLUMN_NAME]] - index of the row within the file. Note, this column is only
    *     populated when we are not using _metadata.row_index column.
    */
   private def iteratorWithAdditionalMetadataColumns(
-                                                     partitionedFile: PartitionedFile,
-                                                     iterator: Iterator[Object],
-                                                     isRowDeletedColumnOpt: Option[ColumnMetadata],
-                                                     rowIndexColumnOpt: Option[ColumnMetadata],
-                                                     useOffHeapBuffers: Boolean,
-                                                     serializableHadoopConf: SerializableConfiguration,
-                                                     useMetadataRowIndex: Boolean): Iterator[Object] = {
-    require(!useMetadataRowIndex || rowIndexColumnOpt.isDefined,
+      partitionedFile: PartitionedFile,
+      iterator: Iterator[Object],
+      isRowDeletedColumnOpt: Option[ColumnMetadata],
+      rowIndexColumnOpt: Option[ColumnMetadata],
+      useOffHeapBuffers: Boolean,
+      serializableHadoopConf: SerializableConfiguration,
+      useMetadataRowIndex: Boolean): Iterator[Object] = {
+    require(
+      !useMetadataRowIndex || rowIndexColumnOpt.isDefined,
       "useMetadataRowIndex is enabled but rowIndexColumn is not defined.")
 
-    val rowIndexFilterOpt = isRowDeletedColumnOpt.map { col =>
-      // Fetch the DV descriptor from the broadcast map and create a row index filter
-      val dvDescriptorOpt = partitionedFile.otherConstantMetadataColumnValues
-        .get(FILE_ROW_INDEX_FILTER_ID_ENCODED)
-      val filterTypeOpt = partitionedFile.otherConstantMetadataColumnValues
-        .get(FILE_ROW_INDEX_FILTER_TYPE)
-      if (dvDescriptorOpt.isDefined && filterTypeOpt.isDefined) {
-        val rowIndexFilter = filterTypeOpt.get match {
-          case RowIndexFilterType.IF_CONTAINED => DropMarkedRowsFilter
-          case RowIndexFilterType.IF_NOT_CONTAINED => KeepMarkedRowsFilter
-          case unexpectedFilterType => throw new IllegalStateException(
-            s"Unexpected row index filter type: ${unexpectedFilterType}")
+    val rowIndexFilterOpt = isRowDeletedColumnOpt.map {
+      col =>
+        // Fetch the DV descriptor from the broadcast map and create a row index filter
+        val dvDescriptorOpt = partitionedFile.otherConstantMetadataColumnValues
+          .get(FILE_ROW_INDEX_FILTER_ID_ENCODED)
+        val filterTypeOpt = partitionedFile.otherConstantMetadataColumnValues
+          .get(FILE_ROW_INDEX_FILTER_TYPE)
+        if (dvDescriptorOpt.isDefined && filterTypeOpt.isDefined) {
+          val rowIndexFilter = filterTypeOpt.get match {
+            case RowIndexFilterType.IF_CONTAINED => DropMarkedRowsFilter
+            case RowIndexFilterType.IF_NOT_CONTAINED => KeepMarkedRowsFilter
+            case unexpectedFilterType =>
+              throw new IllegalStateException(
+                s"Unexpected row index filter type: $unexpectedFilterType")
+          }
+          rowIndexFilter.createInstance(
+            DeletionVectorDescriptor.deserializeFromBase64(
+              dvDescriptorOpt.get.asInstanceOf[String]),
+            serializableHadoopConf.value,
+            tablePath.map(new Path(_)))
+        } else if (dvDescriptorOpt.isDefined || filterTypeOpt.isDefined) {
+          throw new IllegalStateException(
+            s"Both $FILE_ROW_INDEX_FILTER_ID_ENCODED and $FILE_ROW_INDEX_FILTER_TYPE " +
+              "should either both have values or no values at all.")
+        } else {
+          KeepAllRowsFilter
         }
-        rowIndexFilter.createInstance(
-          DeletionVectorDescriptor.deserializeFromBase64(dvDescriptorOpt.get.asInstanceOf[String]),
-          serializableHadoopConf.value,
-          tablePath.map(new Path(_)))
-      } else if (dvDescriptorOpt.isDefined || filterTypeOpt.isDefined) {
-        throw new IllegalStateException(
-          s"Both ${FILE_ROW_INDEX_FILTER_ID_ENCODED} and ${FILE_ROW_INDEX_FILTER_TYPE} " +
-            "should either both have values or no values at all.")
-      } else {
-        KeepAllRowsFilter
-      }
     }
 
     // We only generate the row index column when predicate pushdown is not enabled.
@@ -373,105 +389,117 @@ case class GlutenDeltaParquetFileFormat(
     // Used only when non-column row batches are received from the Parquet reader
     val tempVector = new OnHeapColumnVector(1, ByteType)
 
-    iterator.map { row =>
-      row match {
-        case batch: ColumnarBatch => // When vectorized Parquet reader is enabled.
-          val size = batch.numRows()
-          // Create vectors for all needed metadata columns.
-          // We can't use the one from Parquet reader as it set the
-          // [[WritableColumnVector.isAllNulls]] to true and it can't be reset with using any
-          // public APIs.
-          trySafely(useOffHeapBuffers, size, metadataColumnsToWrite) { writableVectors =>
-            val indexVectorTuples = new ArrayBuffer[(Int, ColumnVector)]
+    iterator.map {
+      row =>
+        row match {
+          case batch: ColumnarBatch => // When vectorized Parquet reader is enabled.
+            val size = batch.numRows()
+            // Create vectors for all needed metadata columns.
+            // We can't use the one from Parquet reader as it set the
+            // [[WritableColumnVector.isAllNulls]] to true and it can't be reset with using any
+            // public APIs.
+            trySafely(useOffHeapBuffers, size, metadataColumnsToWrite) {
+              writableVectors =>
+                val indexVectorTuples = new ArrayBuffer[(Int, ColumnVector)]
 
-            // When predicate pushdown is enabled we use _metadata.row_index. Therefore,
-            // we only need to construct the isRowDeleted column.
-            var index = 0
-            isRowDeletedColumnOpt.foreach { columnMetadata =>
-              val isRowDeletedVector = writableVectors(index)
-              if (useMetadataRowIndex) {
-                rowIndexFilterOpt.get.materializeIntoVectorWithRowIndex(
-                  size, batch.column(rowIndexColumnOpt.get.index), isRowDeletedVector)
-              } else {
-                rowIndexFilterOpt.get
-                  .materializeIntoVector(rowIndex, rowIndex + size, isRowDeletedVector)
-              }
-              indexVectorTuples += (columnMetadata.index -> isRowDeletedVector)
-              index += 1
+                // When predicate pushdown is enabled we use _metadata.row_index. Therefore,
+                // we only need to construct the isRowDeleted column.
+                var index = 0
+                isRowDeletedColumnOpt.foreach {
+                  columnMetadata =>
+                    val isRowDeletedVector = writableVectors(index)
+                    if (useMetadataRowIndex) {
+                      rowIndexFilterOpt.get.materializeIntoVectorWithRowIndex(
+                        size,
+                        batch.column(rowIndexColumnOpt.get.index),
+                        isRowDeletedVector)
+                    } else {
+                      rowIndexFilterOpt.get
+                        .materializeIntoVector(rowIndex, rowIndex + size, isRowDeletedVector)
+                    }
+                    indexVectorTuples += (columnMetadata.index -> isRowDeletedVector)
+                    index += 1
+                }
+
+                rowIndexColumnToWriteOpt.foreach {
+                  columnMetadata =>
+                    val rowIndexVector = writableVectors(index)
+                    // populate the row index column value.
+                    for (i <- 0 until size) {
+                      rowIndexVector.putLong(i, rowIndex + i)
+                    }
+
+                    indexVectorTuples += (columnMetadata.index -> rowIndexVector)
+                    index += 1
+                }
+
+                val newBatch = replaceVectors(batch, indexVectorTuples.toSeq: _*)
+                rowIndex += size
+                newBatch
             }
 
-            rowIndexColumnToWriteOpt.foreach { columnMetadata =>
-              val rowIndexVector = writableVectors(index)
-              // populate the row index column value.
-              for (i <- 0 until size) {
-                rowIndexVector.putLong(i, rowIndex + i)
-              }
-
-              indexVectorTuples += (columnMetadata.index -> rowIndexVector)
-              index += 1
+          case columnarRow: ColumnarBatchRow =>
+            // When vectorized reader is enabled but returns immutable rows instead of
+            // columnar batches [[ColumnarBatchRow]]. So we have to copy the row as a
+            // mutable [[InternalRow]] and set the `row_index` and `is_row_deleted`
+            // column values. This is not efficient. It should affect only the wide
+            // tables. https://github.com/delta-io/delta/issues/2246
+            val newRow = columnarRow.copy();
+            isRowDeletedColumnOpt.foreach {
+              columnMetadata =>
+                val rowIndexForFiltering = if (useMetadataRowIndex) {
+                  columnarRow.getLong(rowIndexColumnOpt.get.index)
+                } else {
+                  rowIndex
+                }
+                rowIndexFilterOpt.get.materializeSingleRowWithRowIndex(
+                  rowIndexForFiltering,
+                  tempVector)
+                newRow.setByte(columnMetadata.index, tempVector.getByte(0))
             }
 
-            val newBatch = replaceVectors(batch, indexVectorTuples.toSeq: _*)
-            rowIndex += size
-            newBatch
-          }
+            rowIndexColumnToWriteOpt
+              .foreach(columnMetadata => newRow.setLong(columnMetadata.index, rowIndex))
+            rowIndex += 1
 
-        case columnarRow: ColumnarBatchRow =>
-          // When vectorized reader is enabled but returns immutable rows instead of
-          // columnar batches [[ColumnarBatchRow]]. So we have to copy the row as a
-          // mutable [[InternalRow]] and set the `row_index` and `is_row_deleted`
-          // column values. This is not efficient. It should affect only the wide
-          // tables. https://github.com/delta-io/delta/issues/2246
-          val newRow = columnarRow.copy();
-          isRowDeletedColumnOpt.foreach { columnMetadata =>
-            val rowIndexForFiltering = if (useMetadataRowIndex) {
-              columnarRow.getLong(rowIndexColumnOpt.get.index)
-            } else {
-              rowIndex
+            newRow
+          case rest: InternalRow => // When vectorized Parquet reader is disabled
+            // Temporary vector variable used to get DV values from RowIndexFilter
+            // Currently the RowIndexFilter only supports writing into a columnar vector
+            // and doesn't have methods to get DV value for a specific row index.
+            // TODO: This is not efficient, but it is ok given the default reader is vectorized
+            isRowDeletedColumnOpt.foreach {
+              columnMetadata =>
+                val rowIndexForFiltering = if (useMetadataRowIndex) {
+                  rest.getLong(rowIndexColumnOpt.get.index)
+                } else {
+                  rowIndex
+                }
+                rowIndexFilterOpt.get.materializeSingleRowWithRowIndex(
+                  rowIndexForFiltering,
+                  tempVector)
+                rest.setByte(columnMetadata.index, tempVector.getByte(0))
             }
-            rowIndexFilterOpt.get.materializeSingleRowWithRowIndex(rowIndexForFiltering, tempVector)
-            newRow.setByte(columnMetadata.index, tempVector.getByte(0))
-          }
 
-          rowIndexColumnToWriteOpt
-            .foreach(columnMetadata => newRow.setLong(columnMetadata.index, rowIndex))
-          rowIndex += 1
-
-          newRow
-        case rest: InternalRow => // When vectorized Parquet reader is disabled
-          // Temporary vector variable used to get DV values from RowIndexFilter
-          // Currently the RowIndexFilter only supports writing into a columnar vector
-          // and doesn't have methods to get DV value for a specific row index.
-          // TODO: This is not efficient, but it is ok given the default reader is vectorized
-          isRowDeletedColumnOpt.foreach { columnMetadata =>
-            val rowIndexForFiltering = if (useMetadataRowIndex) {
-              rest.getLong(rowIndexColumnOpt.get.index)
-            } else {
-              rowIndex
-            }
-            rowIndexFilterOpt.get.materializeSingleRowWithRowIndex(rowIndexForFiltering, tempVector)
-            rest.setByte(columnMetadata.index, tempVector.getByte(0))
-          }
-
-          rowIndexColumnToWriteOpt
-            .foreach(columnMetadata => rest.setLong(columnMetadata.index, rowIndex))
-          rowIndex += 1
-          rest
-        case others =>
-          throw new RuntimeException(
-            s"Parquet reader returned an unknown row type: ${others.getClass.getName}")
-      }
+            rowIndexColumnToWriteOpt
+              .foreach(columnMetadata => rest.setLong(columnMetadata.index, rowIndex))
+            rowIndex += 1
+            rest
+          case others =>
+            throw new RuntimeException(
+              s"Parquet reader returned an unknown row type: ${others.getClass.getName}")
+        }
     }
   }
 
   /**
-   * Translates the filter to use physical column names instead of logical column names.
-   * This is needed when the column mapping mode is set to `NameMapping` or `IdMapping`
-   * to match the requested schema that's passed to the [[ParquetFileFormat]].
+   * Translates the filter to use physical column names instead of logical column names. This is
+   * needed when the column mapping mode is set to `NameMapping` or `IdMapping` to match the
+   * requested schema that's passed to the [[ParquetFileFormat]].
    */
   private def translateFilterForColumnMapping(
-                                               filter: Filter,
-                                               physicalNameMap: Map[String, String]): Option[Filter] = {
+      filter: Filter,
+      physicalNameMap: Map[String, String]): Option[Filter] = {
     object PhysicalAttribute {
       def unapply(attribute: String): Option[String] = {
         physicalNameMap.get(attribute)
@@ -530,9 +558,10 @@ case class GlutenDeltaParquetFileFormat(
 }
 
 object GlutenDeltaParquetFileFormat {
+
   /**
-   * Column name used to identify whether the row read from the parquet file is marked
-   * as deleted according to the Delta table deletion vectors
+   * Column name used to identify whether the row read from the parquet file is marked as deleted
+   * according to the Delta table deletion vectors
    */
   val IS_ROW_DELETED_COLUMN_NAME = "__delta_internal_is_row_deleted"
   val IS_ROW_DELETED_STRUCT_FIELD = StructField(IS_ROW_DELETED_COLUMN_NAME, ByteType)
@@ -541,17 +570,23 @@ object GlutenDeltaParquetFileFormat {
   val ROW_INDEX_COLUMN_NAME = "__delta_internal_row_index"
   val ROW_INDEX_STRUCT_FIELD = StructField(ROW_INDEX_COLUMN_NAME, LongType)
 
-  /** The key to the encoded row index filter identifier value of the
-   * [[PartitionedFile]]'s otherConstantMetadataColumnValues map. */
+  /**
+   * The key to the encoded row index filter identifier value of the [[PartitionedFile]]'s
+   * otherConstantMetadataColumnValues map.
+   */
   val FILE_ROW_INDEX_FILTER_ID_ENCODED = "row_index_filter_id_encoded"
 
-  /** The key to the row index filter type value of the
-   * [[PartitionedFile]]'s otherConstantMetadataColumnValues map. */
+  /**
+   * The key to the row index filter type value of the [[PartitionedFile]]'s
+   * otherConstantMetadataColumnValues map.
+   */
   val FILE_ROW_INDEX_FILTER_TYPE = "row_index_filter_type"
 
   /** Utility method to create a new writable vector */
   private def newVector(
-                         useOffHeapBuffers: Boolean, size: Int, dataType: StructField): WritableColumnVector = {
+      useOffHeapBuffers: Boolean,
+      size: Int,
+      dataType: StructField): WritableColumnVector = {
     if (useOffHeapBuffers) {
       OffHeapColumnVector.allocateColumns(size, Seq(dataType).toArray)(0)
     } else {
@@ -561,9 +596,9 @@ object GlutenDeltaParquetFileFormat {
 
   /** Try the operation, if the operation fails release the created resource */
   private def trySafely[R <: WritableColumnVector, T](
-                                                       useOffHeapBuffers: Boolean,
-                                                       size: Int,
-                                                       columns: Seq[ColumnMetadata])(f: Seq[WritableColumnVector] => T): T = {
+      useOffHeapBuffers: Boolean,
+      size: Int,
+      columns: Seq[ColumnMetadata])(f: Seq[WritableColumnVector] => T): T = {
     val resources = new ArrayBuffer[WritableColumnVector](columns.size)
     try {
       columns.foreach(col => resources.append(newVector(useOffHeapBuffers, size, col.structField)))
@@ -587,12 +622,12 @@ object GlutenDeltaParquetFileFormat {
   }
 
   /**
-   * Helper method to replace the vectors in given [[ColumnarBatch]].
-   * New vectors and its index in the batch are given as tuples.
+   * Helper method to replace the vectors in given [[ColumnarBatch]]. New vectors and its index in
+   * the batch are given as tuples.
    */
   private def replaceVectors(
-                              batch: ColumnarBatch,
-                              indexVectorTuples: (Int, ColumnVector) *): ColumnarBatch = {
+      batch: ColumnarBatch,
+      indexVectorTuples: (Int, ColumnVector)*): ColumnarBatch = {
     val vectors = ArrayBuffer[ColumnVector]()
     for (i <- 0 until batch.numCols()) {
       var replaced: Boolean = false
@@ -616,4 +651,3 @@ object GlutenDeltaParquetFileFormat {
   /** Helper class to encapsulate column info */
   case class ColumnMetadata(index: Int, structField: StructField)
 }
-// spotless:on

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -55,53 +55,48 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 
 import java.util.{Date, UUID}
 
-// spotless:off
 /**
- *  A helper object for writing FileFormat data out to a location.
- *  Logic is copied from FileFormatWriter from Spark 3.5 with added functionality to write partition
- *  values to data files. Specifically L123-126, L132, and L140 where it adds option
- *  WRITE_PARTITION_COLUMNS
+ * A helper object for writing FileFormat data out to a location. Logic is copied from
+ * FileFormatWriter from Spark 3.5 with added functionality to write partition values to data files.
+ * Specifically L123-126, L132, and L140 where it adds option WRITE_PARTITION_COLUMNS
  */
 object GlutenDeltaFileFormatWriter extends LoggingShims {
 
   /**
-   * A variable used in tests to check whether the output ordering of the query matches the
-   * required ordering of the write command.
+   * A variable used in tests to check whether the output ordering of the query matches the required
+   * ordering of the write command.
    */
   private var outputOrderingMatched: Boolean = false
 
-  /**
-   * A variable used in tests to check the final executed plan.
-   */
+  /** A variable used in tests to check the final executed plan. */
   private var executedPlan: Option[SparkPlan] = None
 
   // scalastyle:off argcount
   /**
    * Basic work flow of this command is:
-   * 1. Driver side setup, including output committer initialization and data source specific
-   *    preparation work for the write job to be issued.
-   * 2. Issues a write job consists of one or more executor side tasks, each of which writes all
-   *    rows within an RDD partition.
-   * 3. If no exception is thrown in a task, commits that task, otherwise aborts that task;  If any
-   *    exception is thrown during task commitment, also aborts that task.
-   * 4. If all tasks are committed, commit the job, otherwise aborts the job;  If any exception is
-   *    thrown during job commitment, also aborts the job.
-   * 5. If the job is successfully committed, perform post-commit operations such as
-   *    processing statistics.
-   * @return The set of all partition paths that were updated during this write job.
+   *   1. Driver side setup, including output committer initialization and data source specific
+   *      preparation work for the write job to be issued. 2. Issues a write job consists of one or
+   *      more executor side tasks, each of which writes all rows within an RDD partition. 3. If no
+   *      exception is thrown in a task, commits that task, otherwise aborts that task; If any
+   *      exception is thrown during task commitment, also aborts that task. 4. If all tasks are
+   *      committed, commit the job, otherwise aborts the job; If any exception is thrown during job
+   *      commitment, also aborts the job. 5. If the job is successfully committed, perform
+   *      post-commit operations such as processing statistics.
+   * @return
+   *   The set of all partition paths that were updated during this write job.
    */
   def write(
-             sparkSession: SparkSession,
-             plan: SparkPlan,
-             fileFormat: FileFormat,
-             committer: FileCommitProtocol,
-             outputSpec: OutputSpec,
-             hadoopConf: Configuration,
-             partitionColumns: Seq[Attribute],
-             bucketSpec: Option[BucketSpec],
-             statsTrackers: Seq[WriteJobStatsTracker],
-             options: Map[String, String],
-             numStaticPartitionCols: Int = 0): Set[String] = {
+      sparkSession: SparkSession,
+      plan: SparkPlan,
+      fileFormat: FileFormat,
+      committer: FileCommitProtocol,
+      outputSpec: OutputSpec,
+      hadoopConf: Configuration,
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      statsTrackers: Seq[WriteJobStatsTracker],
+      options: Map[String, String],
+      numStaticPartitionCols: Int = 0): Set[String] = {
     require(partitionColumns.size >= numStaticPartitionCols)
 
     val job = Job.getInstance(hadoopConf)
@@ -237,19 +232,20 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   // scalastyle:on argcount
 
   private def executeWrite(
-                            sparkSession: SparkSession,
-                            plan: SparkPlan,
-                            job: Job,
-                            description: WriteJobDescription,
-                            committer: FileCommitProtocol,
-                            outputSpec: OutputSpec,
-                            requiredOrdering: Seq[Expression],
-                            partitionColumns: Seq[Attribute],
-                            sortColumns: Seq[Attribute],
-                            orderingMatched: Boolean,
-                            writeOffloadable: Boolean): Set[String] = {
+      sparkSession: SparkSession,
+      plan: SparkPlan,
+      job: Job,
+      description: WriteJobDescription,
+      committer: FileCommitProtocol,
+      outputSpec: OutputSpec,
+      requiredOrdering: Seq[Expression],
+      partitionColumns: Seq[Attribute],
+      sortColumns: Seq[Attribute],
+      orderingMatched: Boolean,
+      writeOffloadable: Boolean): Set[String] = {
     val projectList = V1WritesUtils.convertEmptyToNull(plan.output, partitionColumns)
-    val empty2NullPlan = if (projectList.nonEmpty) ProjectExecTransformer(projectList, plan) else plan
+    val empty2NullPlan =
+      if (projectList.nonEmpty) ProjectExecTransformer(projectList, plan) else plan
 
     writeAndCommit(job, description, committer) {
       val (planToExecute, concurrentOutputWriterSpec) = if (orderingMatched) {
@@ -262,9 +258,11 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
           (empty2NullPlan, concurrentOutputWriterSpec)
         } else {
           def addNativeSort(input: SparkPlan): SparkPlan = {
-            val nativeSortPlan = SortExecTransformer(sortPlan.sortOrder, sortPlan.global, child = input)
+            val nativeSortPlan =
+              SortExecTransformer(sortPlan.sortOrder, sortPlan.global, child = input)
             val validationResult = nativeSortPlan.doValidate()
-            assert(validationResult.ok(),
+            assert(
+              validationResult.ok(),
               s"Sort operation for Delta write is not offload-able: ${validationResult.reason()}")
             nativeSortPlan
           }
@@ -274,7 +272,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
             case other if Convention.get(other).batchType == VeloxBatchType =>
               val nativeSortPlan = addNativeSort(other)
               val nativeSortPlanWithWst =
-                GenerateTransformStageId()(ColumnarCollapseTransformStages(new GlutenConfig(sparkSession.sessionState.conf))(nativeSortPlan))
+                GenerateTransformStageId()(ColumnarCollapseTransformStages(
+                  new GlutenConfig(sparkSession.sessionState.conf))(nativeSortPlan))
               nativeSortPlanWithWst
             case other =>
               Transitions.toBatchPlan(sortPlan, VeloxBatchType)
@@ -305,7 +304,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       val jobTrackerID = SparkHadoopWriterUtils.createJobTrackerID(new Date())
       val ret = new Array[WriteTaskResult](rddWithNonEmptyPartitions.partitions.length)
       val partitionColumnToDataType = description.partitionColumns
-        .map(attr => (attr.name, attr.dataType)).toMap
+        .map(attr => (attr.name, attr.dataType))
+        .toMap
       sparkSession.sparkContext.runJob(
         rddWithNonEmptyPartitions,
         (taskContext: TaskContext, iter: Iterator[InternalRow]) => {
@@ -332,9 +332,9 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   }
 
   private def writeAndCommit(
-                              job: Job,
-                              description: WriteJobDescription,
-                              committer: FileCommitProtocol)(f: => Array[WriteTaskResult]): Set[String] = {
+      job: Job,
+      description: WriteJobDescription,
+      committer: FileCommitProtocol)(f: => Array[WriteTaskResult]): Set[String] = {
     // This call shouldn't be put into the `try` block below because it only initializes and
     // prepares the job, any exception thrown from here shouldn't cause abortJob() to be called.
     committer.setupJob(job)
@@ -343,13 +343,15 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       val commitMsgs = ret.map(_.commitMsg)
 
       logInfo(log"Start to commit write Job ${MDC(DeltaLogKeys.JOB_ID, description.uuid)}.")
-      val (_, duration) = Utils.timeTakenMs { committer.commitJob(job, commitMsgs) }
-      logInfo(log"Write Job ${MDC(DeltaLogKeys.JOB_ID, description.uuid)} committed. " +
-        log"Elapsed time: ${MDC(DeltaLogKeys.DURATION, duration)} ms.")
+      val (_, duration) = Utils.timeTakenMs(committer.commitJob(job, commitMsgs))
+      logInfo(
+        log"Write Job ${MDC(DeltaLogKeys.JOB_ID, description.uuid)} committed. " +
+          log"Elapsed time: ${MDC(DeltaLogKeys.DURATION, duration)} ms.")
 
       processStats(description.statsTrackers, ret.map(_.summary.stats), duration)
-      logInfo(log"Finished processing stats for write job " +
-        log"${MDC(DeltaLogKeys.JOB_ID, description.uuid)}.")
+      logInfo(
+        log"Finished processing stats for write job " +
+          log"${MDC(DeltaLogKeys.JOB_ID, description.uuid)}.")
 
       // return a set of all the partition paths that were updated during this job
       ret.map(_.summary.updatedPartitions).reduceOption(_ ++ _).getOrElse(Set.empty)
@@ -361,14 +363,12 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
     }
   }
 
-  /**
-   * Write files using [[SparkPlan.executeWrite]]
-   */
+  /** Write files using [[SparkPlan.executeWrite]] */
   private def executeWrite(
-                            session: SparkSession,
-                            planForWrites: SparkPlan,
-                            writeFilesSpec: WriteFilesSpec,
-                            job: Job): Set[String] = {
+      session: SparkSession,
+      planForWrites: SparkPlan,
+      writeFilesSpec: WriteFilesSpec,
+      job: Job): Set[String] = {
     val committer = writeFilesSpec.committer
     val description = writeFilesSpec.description
 
@@ -399,9 +399,9 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   }
 
   private def createSortPlan(
-                              plan: SparkPlan,
-                              requiredOrdering: Seq[Expression],
-                              outputSpec: OutputSpec): SortExec = {
+      plan: SparkPlan,
+      requiredOrdering: Seq[Expression],
+      outputSpec: OutputSpec): SortExec = {
     // SPARK-21165: the `requiredOrdering` is based on the attributes from analyzed plan, and
     // the physical plan may have different attribute ids due to optimizer removing some
     // aliases. Here we bind the expression ahead to avoid potential attribute ids mismatch.
@@ -411,9 +411,9 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   }
 
   private def createConcurrentOutputWriterSpec(
-                                                sparkSession: SparkSession,
-                                                sortPlan: SortExec,
-                                                sortColumns: Seq[Attribute]): Option[ConcurrentOutputWriterSpec] = {
+      sparkSession: SparkSession,
+      sortPlan: SortExec,
+      sortColumns: Seq[Attribute]): Option[ConcurrentOutputWriterSpec] = {
     val maxWriters = sparkSession.sessionState.conf.maxConcurrentOutputFileWriters
     val concurrentWritersEnabled = maxWriters > 0 && sortColumns.isEmpty
     if (concurrentWritersEnabled) {
@@ -425,15 +425,15 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
 
   /** Writes data out in a single Spark task. */
   private def executeTask(
-                           description: WriteJobDescription,
-                           jobTrackerID: String,
-                           sparkStageId: Int,
-                           sparkPartitionId: Int,
-                           sparkAttemptNumber: Int,
-                           committer: FileCommitProtocol,
-                           iterator: Iterator[InternalRow],
-                           concurrentOutputWriterSpec: Option[ConcurrentOutputWriterSpec],
-                           partitionColumnToDataType: Map[String, DataType]): WriteTaskResult = {
+      description: WriteJobDescription,
+      jobTrackerID: String,
+      sparkStageId: Int,
+      sparkPartitionId: Int,
+      sparkAttemptNumber: Int,
+      committer: FileCommitProtocol,
+      iterator: Iterator[InternalRow],
+      concurrentOutputWriterSpec: Option[ConcurrentOutputWriterSpec],
+      partitionColumnToDataType: Map[String, DataType]): WriteTaskResult = {
 
     val jobId = SparkHadoopWriterUtils.createJobID(jobTrackerID, sparkStageId)
     val taskId = new TaskID(jobId, TaskType.MAP, sparkPartitionId)
@@ -452,7 +452,10 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       if (partitionColumnToDataType.isEmpty) {
         new TaskAttemptContextImpl(hadoopConf, taskAttemptId)
       } else {
-        new DeltaFileFormatWriter.PartitionedTaskAttemptContextImpl(hadoopConf, taskAttemptId, partitionColumnToDataType)
+        new DeltaFileFormatWriter.PartitionedTaskAttemptContextImpl(
+          hadoopConf,
+          taskAttemptId,
+          partitionColumnToDataType)
       }
     }
 
@@ -486,13 +489,16 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
         // Execute the task to write rows out and commit the task.
         dataWriter.writeWithIterator(iterator)
         dataWriter.commit()
-      })(catchBlock = {
-        // If there is an error, abort the task
-        dataWriter.abort()
-        logError(log"Job ${MDC(DeltaLogKeys.JOB_ID, jobId)} aborted.")
-      }, finallyBlock = {
-        dataWriter.close()
-      })
+      })(
+        catchBlock = {
+          // If there is an error, abort the task
+          dataWriter.abort()
+          logError(log"Job ${MDC(DeltaLogKeys.JOB_ID, jobId)} aborted.")
+        },
+        finallyBlock = {
+          dataWriter.close()
+        }
+      )
     } catch {
       case e: FetchFailedException =>
         throw e
@@ -506,13 +512,13 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   }
 
   /**
-   * For every registered [[WriteJobStatsTracker]], call `processStats()` on it, passing it
-   * the corresponding [[WriteTaskStats]] from all executors.
+   * For every registered [[WriteJobStatsTracker]], call `processStats()` on it, passing it the
+   * corresponding [[WriteTaskStats]] from all executors.
    */
   private def processStats(
-                            statsTrackers: Seq[WriteJobStatsTracker],
-                            statsPerTask: Seq[Seq[WriteTaskStats]],
-                            jobCommitDuration: Long): Unit = {
+      statsTrackers: Seq[WriteJobStatsTracker],
+      statsPerTask: Seq[Seq[WriteTaskStats]],
+      jobCommitDuration: Long): Unit = {
 
     val numStatsTrackers = statsTrackers.length
     assert(
@@ -535,10 +541,10 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   }
 
   private class GlutenDynamicPartitionDataSingleWriter(
-                                                          description: WriteJobDescription,
-                                                          taskAttemptContext: TaskAttemptContext,
-                                                          committer: FileCommitProtocol,
-                                                          customMetrics: Map[String, SQLMetric] = Map.empty)
+      description: WriteJobDescription,
+      taskAttemptContext: TaskAttemptContext,
+      committer: FileCommitProtocol,
+      customMetrics: Map[String, SQLMetric] = Map.empty)
     extends BaseDynamicPartitionDataWriter(
       description,
       taskAttemptContext,
@@ -572,8 +578,10 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
 
         fileCounter = 0
         renewCurrentWriter(currentPartitionValues, currentBucketId, closeCurrentWriter = true)
-      } else if (description.maxRecordsPerFile > 0 &&
-        recordsInFile >= description.maxRecordsPerFile) {
+      } else if (
+        description.maxRecordsPerFile > 0 &&
+        recordsInFile >= description.maxRecordsPerFile
+      ) {
         renewCurrentWriterIfTooManyRecords(currentPartitionValues, currentBucketId)
       }
     }
@@ -588,7 +596,9 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
               val numRows = terminalRow.batch().numRows()
               if (numRows > 0) {
                 val blockStripes = GlutenFormatFactory.rowSplitter
-                  .splitBlockByPartitionAndBucket(terminalRow.batch(), partitionColIndice,
+                  .splitBlockByPartitionAndBucket(
+                    terminalRow.batch(),
+                    partitionColIndice,
                     isBucketed)
                 val iter = blockStripes.iterator()
                 while (iter.hasNext) {
@@ -620,4 +630,3 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
     }
   }
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -35,7 +35,6 @@ import java.io.File
 
 import scala.collection.mutable
 
-// spotless:off
 trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   import testImplicits._
@@ -58,20 +57,23 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   protected def columnMappingModeString: String = {
-    spark.conf.getOption(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey)
+    spark.conf
+      .getOption(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey)
       .getOrElse("none")
   }
 
   /**
    * Check if two schemas are equal ignoring column mapping metadata
-   * @param schema1 Schema
-   * @param schema2 Schema
+   * @param schema1
+   *   Schema
+   * @param schema2
+   *   Schema
    */
   protected def assertEqual(schema1: StructType, schema2: StructType): Unit = {
     if (columnMappingEnabled) {
       assert(
         DeltaColumnMapping.dropColumnMappingMetadata(schema1) ==
-        DeltaColumnMapping.dropColumnMappingMetadata(schema2)
+          DeltaColumnMapping.dropColumnMappingMetadata(schema2)
       )
     } else {
       assert(schema1 == schema2)
@@ -80,12 +82,12 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Check if two table configurations are equal ignoring column mapping metadata
-   * @param config1 Table config
-   * @param config2 Table config
+   * @param config1
+   *   Table config
+   * @param config2
+   *   Table config
    */
-  protected def assertEqual(
-      config1: Map[String, String],
-      config2: Map[String, String]): Unit = {
+  protected def assertEqual(config1: Map[String, String], config2: Map[String, String]): Unit = {
     if (columnMappingEnabled) {
       assert(dropColumnMappingConfigurations(config1) == dropColumnMappingConfigurations(config2))
     } else {
@@ -94,11 +96,14 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   /**
-   * Check if a partition with specific values exists.
-   * Handles both column mapped and non-mapped cases
-   * @param partCol Partition column name
-   * @param partValue Partition value
-   * @param deltaLog DeltaLog
+   * Check if a partition with specific values exists. Handles both column mapped and non-mapped
+   * cases
+   * @param partCol
+   *   Partition column name
+   * @param partValue
+   *   Partition value
+   * @param deltaLog
+   *   DeltaLog
    */
   protected def assertPartitionWithValueExists(
       partCol: String,
@@ -109,9 +114,12 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Assert partition exists in an array of set of partition names/paths
-   * @param partCol Partition column name
-   * @param deltaLog Delta log
-   * @param inputFiles Input files to scan for DF
+   * @param partCol
+   *   Partition column name
+   * @param deltaLog
+   *   Delta log
+   * @param inputFiles
+   *   Input files to scan for DF
    */
   protected def assertPartitionExists(
       partCol: String,
@@ -120,23 +128,28 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     val physicalName = partCol.phy(deltaLog)
     val allFiles = deltaLog.update().allFiles.collect()
     // NOTE: inputFiles are *not* URL-encoded.
-    val filesWithPartitions = inputFiles.map { f =>
-      allFiles.filter { af =>
-        f.contains(af.toPath.toString)
-      }.flatMap(_.partitionValues.keys).toSet
+    val filesWithPartitions = inputFiles.map {
+      f =>
+        allFiles
+          .filter(af => f.contains(af.toPath.toString))
+          .flatMap(_.partitionValues.keys)
+          .toSet
     }
     assert(filesWithPartitions.forall(p => p.count(_ == physicalName) > 0))
     // for non-column mapped mode, we can check the file paths as well
     if (!columnMappingEnabled) {
-      assert(inputFiles.forall(path => path.contains(s"$physicalName=")),
-          s"${inputFiles.toSeq.mkString("\n")}\ndidn't contain partition columns $physicalName")
+      assert(
+        inputFiles.forall(path => path.contains(s"$physicalName=")),
+        s"${inputFiles.toSeq.mkString("\n")}\ndidn't contain partition columns $physicalName")
     }
   }
 
   /**
    * Load Deltalog from path
-   * @param pathOrIdentifier Location
-   * @param isIdentifier Whether the previous argument is a metastore identifier
+   * @param pathOrIdentifier
+   *   Location
+   * @param isIdentifier
+   *   Whether the previous argument is a metastore identifier
    * @return
    */
   protected def loadDeltaLog(pathOrIdentifier: String, isIdentifier: Boolean = false): DeltaLog = {
@@ -149,8 +162,10 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Convert a (nested) column string to sequence of name parts
-   * @param col Column string
-   * @return Sequence of parts
+   * @param col
+   *   Column string
+   * @return
+   *   Sequence of parts
    */
   protected def columnNameToParts(col: String): Seq[String] = {
     UnresolvedAttribute.parseAttributeName(col)
@@ -158,10 +173,14 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Get partition file paths for a specific partition value
-   * @param partCol Logical or physical partition name
-   * @param partValue Partition value
-   * @param deltaLog DeltaLog
-   * @return List of paths
+   * @param partCol
+   *   Logical or physical partition name
+   * @param partValue
+   *   Partition value
+   * @param deltaLog
+   *   DeltaLog
+   * @return
+   *   List of paths
    */
   protected def getPartitionFilePathsWithValue(
       partCol: String,
@@ -170,9 +189,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     getPartitionFilePaths(partCol, deltaLog).getOrElse(partValue, Array.empty)
   }
 
-  /**
-   * Get the partition value for null
-   */
+  /** Get the partition value for null */
   protected def nullPartitionValue: String = {
     if (columnMappingEnabled) {
       null
@@ -183,55 +200,77 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Get partition file paths grouped by partition value
-   * @param partCol Logical or physical partition name
-   * @param deltaLog DeltaLog
-   * @return Partition value to paths
+   * @param partCol
+   *   Logical or physical partition name
+   * @param deltaLog
+   *   DeltaLog
+   * @return
+   *   Partition value to paths
    */
   protected def getPartitionFilePaths(
       partCol: String,
       deltaLog: DeltaLog): Map[String, Array[String]] = {
     if (columnMappingEnabled) {
       val colName = partCol.phy(deltaLog)
-      deltaLog.update().allFiles.collect()
+      deltaLog
+        .update()
+        .allFiles
+        .collect()
         .groupBy(_.partitionValues(colName))
-        .mapValues(_.map(deltaLog.dataPath.toUri.getPath + "/" + _.path)).toMap
+        .mapValues(_.map(deltaLog.dataPath.toUri.getPath + "/" + _.path))
+        .toMap
     } else {
       val partColEscaped = s"${ExternalCatalogUtils.escapePathName(partCol)}"
       val dataPath = new File(deltaLog.dataPath.toUri.getPath)
-      dataPath.listFiles().filter(_.getName.startsWith(s"$partColEscaped="))
-        .groupBy(_.getName.split("=").last).mapValues(_.map(_.getPath)).toMap
+      dataPath
+        .listFiles()
+        .filter(_.getName.startsWith(s"$partColEscaped="))
+        .groupBy(_.getName.split("=").last)
+        .mapValues(_.map(_.getPath))
+        .toMap
     }
   }
 
   /**
    * Group a list of input file paths by partition key-value pair w.r.t. delta log
-   * @param inputFiles Input file paths
-   * @param deltaLog Delta log
-   * @return A mapped array each with the corresponding partition keys
+   * @param inputFiles
+   *   Input file paths
+   * @param deltaLog
+   *   Delta log
+   * @return
+   *   A mapped array each with the corresponding partition keys
    */
   protected def groupInputFilesByPartition(
       inputFiles: Array[String],
       deltaLog: DeltaLog): Map[(String, String), Array[String]] = {
     if (columnMappingEnabled) {
       val allFiles = deltaLog.update().allFiles.collect()
-      val grouped = inputFiles.flatMap { f =>
-        allFiles.find {
-          af => f.contains(af.toPath.toString)
-        }.head.partitionValues.map(entry => (f, entry))
-      }.groupBy(_._2)
+      val grouped = inputFiles
+        .flatMap {
+          f =>
+            allFiles
+              .find(af => f.contains(af.toPath.toString))
+              .head
+              .partitionValues
+              .map(entry => (f, entry))
+        }
+        .groupBy(_._2)
       grouped.mapValues(_.map(_._1)).toMap
     } else {
-      inputFiles.groupBy(p => {
-        val nameParts = new Path(p).getParent.getName.split("=")
-        (nameParts(0), nameParts(1))
-      })
+      inputFiles.groupBy(
+        p => {
+          val nameParts = new Path(p).getParent.getName.split("=")
+          (nameParts(0), nameParts(1))
+        })
     }
   }
 
   /**
    * Drop column mapping configurations from Map
-   * @param configuration Table configuration
-   * @return Configuration
+   * @param configuration
+   *   Table configuration
+   * @return
+   *   Configuration
    */
   protected def dropColumnMappingConfigurations(
       configuration: Map[String, String]): Map[String, String] = {
@@ -240,17 +279,22 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Drop column mapping configurations from Dataset (e.g. sql("SHOW TBLPROPERTIES t1")
-   * @param configs Table configuration
-   * @return Configuration Dataset
+   * @param configs
+   *   Table configuration
+   * @return
+   *   Configuration Dataset
    */
   protected def dropColumnMappingConfigurations(
       configs: Dataset[(String, String)]): Dataset[(String, String)] = {
-    spark.createDataset(configs.collect().filter(p =>
-      !Seq(
-        DeltaConfigs.COLUMN_MAPPING_MAX_ID.key,
-        DeltaConfigs.COLUMN_MAPPING_MODE.key
-      ).contains(p._1)
-    ))
+    spark.createDataset(
+      configs
+        .collect()
+        .filter(
+          p =>
+            !Seq(
+              DeltaConfigs.COLUMN_MAPPING_MAX_ID.key,
+              DeltaConfigs.COLUMN_MAPPING_MODE.key
+            ).contains(p._1)))
   }
 
   /** Return KV pairs of Protocol-related stuff for checking the result of DESCRIBE TABLE. */
@@ -259,28 +303,36 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
       DeltaConfigs.mergeGlobalConfigs(spark.sessionState.conf, snapshot.metadata.configuration)
     val metadata = snapshot.metadata.copy(configuration = mergedConf)
     var props = Seq(
-      (Protocol.MIN_READER_VERSION_PROP,
+      (
+        Protocol.MIN_READER_VERSION_PROP,
         Protocol.forNewTable(spark, Some(metadata)).minReaderVersion.toString),
-      (Protocol.MIN_WRITER_VERSION_PROP,
-        Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString))
+      (
+        Protocol.MIN_WRITER_VERSION_PROP,
+        Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString)
+    )
     if (snapshot.protocol.supportsReaderFeatures || snapshot.protocol.supportsWriterFeatures) {
       props ++=
-        Protocol.minProtocolComponentsFromAutomaticallyEnabledFeatures(
-          spark, metadata, snapshot.protocol)
+        Protocol
+          .minProtocolComponentsFromAutomaticallyEnabledFeatures(spark, metadata, snapshot.protocol)
           ._3
-          .map(f => (
-            s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${f.name}",
-            TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))
+          .map(
+            f =>
+              (
+                s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${f.name}",
+                TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))
     }
     props
   }
 
   /**
-   * Convert (nested) column name string into physical name with reference from DeltaLog
-   * If target field does not have physical name, display name is returned
-   * @param col Logical column name
-   * @param deltaLog Reference DeltaLog
-   * @return Physical column name
+   * Convert (nested) column name string into physical name with reference from DeltaLog If target
+   * field does not have physical name, display name is returned
+   * @param col
+   *   Logical column name
+   * @param deltaLog
+   *   Reference DeltaLog
+   * @return
+   *   Physical column name
    */
   protected def getPhysicalName(col: String, deltaLog: DeltaLog): String = {
     val nameParts = UnresolvedAttribute.parseAttributeName(col)
@@ -294,7 +346,8 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   protected def getPhysicalName(nameParts: Seq[String], schema: StructType): String = {
-    SchemaUtils.findNestedFieldIgnoreCase(schema, nameParts, includeCollections = true)
+    SchemaUtils
+      .findNestedFieldIgnoreCase(schema, nameParts, includeCollections = true)
       .map(DeltaColumnMapping.getPhysicalName)
       .get
   }
@@ -312,14 +365,14 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   /**
-   * Gets the physical names of a path. This is used for converting column paths in stats schema,
-   * so it's ok to not support MapType and ArrayType.
+   * Gets the physical names of a path. This is used for converting column paths in stats schema, so
+   * it's ok to not support MapType and ArrayType.
    */
   def getPhysicalPathForStats(path: Seq[String], schema: StructType): Option[Seq[String]] = {
     if (path.isEmpty) return Some(Seq.empty)
     val field = schema.fields.find(_.name.equalsIgnoreCase(path.head))
     field match {
-      case Some(f @ StructField(_, _: AtomicType, _, _ )) =>
+      case Some(f @ StructField(_, _: AtomicType, _, _)) =>
         if (path.size == 1) Some(Seq(DeltaColumnMapping.getPhysicalName(f))) else None
       case Some(f @ StructField(_, st: StructType, _, _)) =>
         val tail = getPhysicalPathForStats(path.tail, st)
@@ -329,15 +382,17 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     }
   }
 
-   /**
-   * Convert (nested) column name string into physical name.
-   * Ignore parts of special paths starting with:
-   *  1. stats columns: minValues, maxValues, numRecords
-   *  2. stats df: stats_parsed
-   *  3. partition values: partitionValues_parsed, partitionValues
-   * @param col Logical column name (e.g. a.b.c)
-   * @param schema Reference schema with metadata
-   * @return Unresolved attribute with physical name paths
+  /**
+   * Convert (nested) column name string into physical name. Ignore parts of special paths starting
+   * with:
+   *   1. stats columns: minValues, maxValues, numRecords 2. stats df: stats_parsed 3. partition
+   *      values: partitionValues_parsed, partitionValues
+   * @param col
+   *   Logical column name (e.g. a.b.c)
+   * @param schema
+   *   Reference schema with metadata
+   * @return
+   *   Unresolved attribute with physical name paths
    */
   protected def convertColumnNameToAttributeWithPhysicalName(
       col: String,
@@ -354,7 +409,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
       parts.head +: getPhysicalPathForStats(parts.tail, schema).getOrElse(parts.tail)
     } else if (shouldIgnoreSecondPart.contains(parts.head)) {
       parts.take(2) ++ getPhysicalPathForStats(parts.slice(2, parts.length), schema)
-          .getOrElse(parts.slice(2, parts.length))
+        .getOrElse(parts.slice(2, parts.length))
     } else {
       getPhysicalPathForStats(parts, schema).getOrElse(parts)
     }
@@ -363,39 +418,42 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Convert a list of (nested) stats columns into physical name with reference from DeltaLog
-   * @param columns Logical columns
-   * @param deltaLog Reference DeltaLog
-   * @return Physical columns
+   * @param columns
+   *   Logical columns
+   * @param deltaLog
+   *   Reference DeltaLog
+   * @return
+   *   Physical columns
    */
-  protected def convertToPhysicalColumns(
-      columns: Seq[Column],
-      deltaLog: DeltaLog): Seq[Column] = {
+  protected def convertToPhysicalColumns(columns: Seq[Column], deltaLog: DeltaLog): Seq[Column] = {
     val schema = deltaLog.update().schema
-    columns.map { col =>
-      val newExpr = col.expr.transform {
-        case a: Attribute =>
-          convertColumnNameToAttributeWithPhysicalName(a.name, schema)
-      }
-      Column(newExpr)
+    columns.map {
+      col =>
+        val newExpr = col.expr.transform {
+          case a: Attribute =>
+            convertColumnNameToAttributeWithPhysicalName(a.name, schema)
+        }
+        Column(newExpr)
     }
   }
 
   /**
    * Standard CONVERT TO DELTA
-   * @param tableOrPath String
+   * @param tableOrPath
+   *   String
    */
   protected def convertToDelta(tableOrPath: String): Unit = {
     sql(s"CONVERT TO DELTA $tableOrPath")
   }
 
   /**
-   * Force enable streaming read (with possible data loss) on column mapping enabled table with
-   * drop / rename schema changes.
+   * Force enable streaming read (with possible data loss) on column mapping enabled table with drop
+   * / rename schema changes.
    */
   protected def withStreamingReadOnColumnMappingTableEnabled(f: => Unit): Unit = {
     if (columnMappingEnabled) {
-      withSQLConf(DeltaSQLConf
-        .DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_COLUMN_MAPPING_SCHEMA_CHANGES.key -> "true") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_COLUMN_MAPPING_SCHEMA_CHANGES.key -> "true") {
         f
       }
     } else {
@@ -407,43 +465,37 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
 trait DeltaColumnMappingTestUtils extends DeltaColumnMappingTestUtilsBase
 
-/**
- * Include this trait to enable Id column mapping mode for a suite
- */
-trait DeltaColumnMappingEnableIdMode extends SharedSparkSession
+/** Include this trait to enable Id column mapping mode for a suite */
+trait DeltaColumnMappingEnableIdMode
+  extends SharedSparkSession
   with DeltaColumnMappingTestUtils
   with DeltaColumnMappingSelectedTestMixin {
 
-  protected override def columnMappingMode: String = IdMapping.name
+  override protected def columnMappingMode: String = IdMapping.name
 
-  protected override def sparkConf: SparkConf =
+  override protected def sparkConf: SparkConf =
     super.sparkConf.set(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey, "id")
 
-  /**
-   * CONVERT TO DELTA blocked in id mode
-   */
-  protected override def convertToDelta(tableOrPath: String): Unit =
+  /** CONVERT TO DELTA blocked in id mode */
+  override protected def convertToDelta(tableOrPath: String): Unit =
     throw DeltaErrors.convertToDeltaWithColumnMappingNotSupported(
       DeltaColumnMappingMode(columnMappingModeString)
     )
 }
 
-/**
- * Include this trait to enable Name column mapping mode for a suite
- */
-trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
+/** Include this trait to enable Name column mapping mode for a suite */
+trait DeltaColumnMappingEnableNameMode
+  extends SharedSparkSession
   with DeltaColumnMappingTestUtils
   with DeltaColumnMappingSelectedTestMixin {
 
-  protected override def columnMappingMode: String = NameMapping.name
+  override protected def columnMappingMode: String = NameMapping.name
 
-  protected override def sparkConf: SparkConf =
+  override protected def sparkConf: SparkConf =
     super.sparkConf.set(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey, columnMappingMode)
 
-  /**
-   * CONVERT TO DELTA can be possible under name mode in tests
-   */
-  protected override def convertToDelta(tableOrPath: String): Unit = {
+  /** CONVERT TO DELTA can be possible under name mode in tests */
+  override protected def convertToDelta(tableOrPath: String): Unit = {
     withColumnMappingConf("none") {
       super.convertToDelta(tableOrPath)
     }
@@ -459,18 +511,22 @@ trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
 
     val tableReaderVersion = deltaLog.unsafeVolatileSnapshot.protocol.minReaderVersion
     val tableWriterVersion = deltaLog.unsafeVolatileSnapshot.protocol.minWriterVersion
-    val requiredReaderVersion = if (tableWriterVersion >=
-      TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION) {
-      // If the writer version of the table supports table features, we need to
-      // bump the reader version to table features to enable column mapping.
-      TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION
-    } else {
-      ColumnMappingTableFeature.minReaderVersion
-    }
-    val readerVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION).max(
-      requiredReaderVersion)
-    val writerVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION).max(
-      ColumnMappingTableFeature.minWriterVersion)
+    val requiredReaderVersion =
+      if (
+        tableWriterVersion >=
+          TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
+      ) {
+        // If the writer version of the table supports table features, we need to
+        // bump the reader version to table features to enable column mapping.
+        TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION
+      } else {
+        ColumnMappingTableFeature.minReaderVersion
+      }
+    val readerVersion =
+      spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION).max(requiredReaderVersion)
+    val writerVersion = spark.conf
+      .get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION)
+      .max(ColumnMappingTableFeature.minWriterVersion)
 
     val properties = mutable.ListBuffer(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name")
     if (tableReaderVersion < readerVersion) {
@@ -484,4 +540,3 @@ trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
   }
 
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -18,16 +18,14 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.QueryTest
 
-// spotless:off
 trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
+
   /**
    * Tests that are meant for Delta compiled against Spark Latest Release only. Executed since this
    * is the Spark Latest Release shim.
    */
-  protected def testSparkLatestOnly(
-      testName: String, testTags: org.scalatest.Tag*)
-      (testFun: => Any)
-      (implicit pos: org.scalactic.source.Position): Unit = {
+  protected def testSparkLatestOnly(testName: String, testTags: org.scalatest.Tag*)(
+      testFun: => Any)(implicit pos: org.scalactic.source.Position): Unit = {
     test(testName, testTags: _*)(testFun)(pos)
   }
 
@@ -35,11 +33,8 @@ trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
    * Tests that are meant for Delta compiled against Spark Master Release only. Ignored since this
    * is the Spark Latest Release shim.
    */
-  protected def testSparkMasterOnly(
-      testName: String, testTags: org.scalatest.Tag*)
-      (testFun: => Any)
-      (implicit pos: org.scalactic.source.Position): Unit = {
+  protected def testSparkMasterOnly(testName: String, testTags: org.scalatest.Tag*)(
+      testFun: => Any)(implicit pos: org.scalactic.source.Position): Unit = {
     ignore(testName, testTags: _*)(testFun)(pos)
   }
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
@@ -26,34 +26,29 @@ import org.scalatest.exceptions.TestFailedException
 
 import scala.collection.mutable
 
-// spotless:off
-/**
- * A trait for selective enabling certain tests to run for column mapping modes
- */
-trait DeltaColumnMappingSelectedTestMixin extends SparkFunSuite
-  with DeltaSQLTestUtils with DeltaColumnMappingTestUtils {
+/** A trait for selective enabling certain tests to run for column mapping modes */
+trait DeltaColumnMappingSelectedTestMixin
+  extends SparkFunSuite
+  with DeltaSQLTestUtils
+  with DeltaColumnMappingTestUtils {
 
   protected def runOnlyTests: Seq[String] = Seq()
 
-  /**
-   * If true, will run all tests.
-   * Requires that `runOnlyTests` is empty.
-   */
+  /** If true, will run all tests. Requires that `runOnlyTests` is empty. */
   protected def runAllTests: Boolean = false
 
   private val testsRun: mutable.Set[String] = mutable.Set.empty
 
-  override protected def test(
-      testName: String,
-      testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
-    require(!runAllTests || runOnlyTests.isEmpty,
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    require(
+      !runAllTests || runOnlyTests.isEmpty,
       "If `runAllTests` is true then `runOnlyTests` must be empty")
 
     if (runAllTests || runOnlyTests.contains(testName)) {
       super.test(s"$testName - column mapping $columnMappingMode mode", testTags: _*) {
         testsRun.add(testName)
-        withSQLConf(
-          DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> columnMappingMode) {
+        withSQLConf(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> columnMappingMode) {
           testFun
         }
       }
@@ -64,13 +59,15 @@ trait DeltaColumnMappingSelectedTestMixin extends SparkFunSuite
 
   override def afterAll(): Unit = {
     super.afterAll()
-    val missingTests = runOnlyTests.toSet diff testsRun
+    val missingTests = runOnlyTests.toSet.diff(testsRun)
     if (missingTests.nonEmpty) {
       throw new TestFailedException(
-        Some("Not all selected column mapping tests were run. Missing: " +
-          missingTests.mkString(", ")), None, 0)
+        Some(
+          "Not all selected column mapping tests were run. Missing: " +
+            missingTests.mkString(", ")),
+        None,
+        0)
     }
   }
 
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaExcludedTestMixin.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaExcludedTestMixin.scala
@@ -21,15 +21,13 @@ import org.apache.spark.sql.QueryTest
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-// spotless:off
 trait DeltaExcludedTestMixin extends QueryTest {
 
   /** Tests to be ignored by the runner. */
   override def excluded: Seq[String] = Seq.empty
 
-  protected override def test(testName: String, testTags: Tag*)
-    (testFun: => Any)
-    (implicit pos: Position): Unit = {
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
     if (excluded.contains(testName)) {
       super.ignore(testName, testTags: _*)(testFun)
     } else {
@@ -37,4 +35,3 @@ trait DeltaExcludedTestMixin extends QueryTest {
     }
   }
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 import io.delta.sql.DeltaSparkSessionExtension
 
-// spotless:off
 /**
  * A trait for tests that are testing a fully set up SparkSession with all of Delta's requirements,
  * such as the configuration of the DeltaCatalog and the addition of all Delta extensions.
@@ -36,13 +35,13 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
     val conf = super.sparkConf
 
     // Delta.
-    conf.set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-        classOf[DeltaSparkSessionExtension].getName)
-      .set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
-        classOf[DeltaCatalog].getName)
+    conf
+      .set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key, classOf[DeltaSparkSessionExtension].getName)
+      .set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
 
     // Gluten.
-    conf.set("spark.plugins", "org.apache.gluten.GlutenPlugin")
+    conf
+      .set("spark.plugins", "org.apache.gluten.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
@@ -54,4 +53,3 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
       .set("spark.gluten.sql.fallbackUnexpectedMetadataParquet", "true")
   }
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -21,13 +21,13 @@ import org.apache.spark.util.Utils
 
 import java.io.File
 
-// spotless:off
 trait DeltaSQLTestUtils extends SQLTestUtils {
+
   /**
    * Override the temp dir/path creation methods from [[SQLTestUtils]] to:
-   * 1. Drop the call to `waitForTasksToFinish` which is a source of flakiness due to timeouts
-   *    without clear benefits.
-   * 2. Allow creating paths with special characters for better test coverage.
+   *   1. Drop the call to `waitForTasksToFinish` which is a source of flakiness due to timeouts
+   *      without clear benefits. 2. Allow creating paths with special characters for better test
+   *      coverage.
    */
 
   protected val defaultTempDirPrefix: String = "spark%dir%prefix"
@@ -50,7 +50,8 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
    */
   def withTempDir(prefix: String)(f: File => Unit): Unit = {
     val path = Utils.createTempDir(namePrefix = prefix)
-    try f(path) finally Utils.deleteRecursively(path)
+    try f(path)
+    finally Utils.deleteRecursively(path)
   }
 
   /**
@@ -60,7 +61,8 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
   def withTempPath(prefix: String)(f: File => Unit): Unit = {
     val path = Utils.createTempDir(namePrefix = prefix)
     path.delete()
-    try f(path) finally Utils.deleteRecursively(path)
+    try f(path)
+    finally Utils.deleteRecursively(path)
   }
 
   /**
@@ -71,9 +73,9 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
     val files =
       Seq.fill[File](numPaths)(Utils.createTempDir(namePrefix = prefix).getCanonicalFile)
     files.foreach(_.delete())
-    try f(files) finally {
+    try f(files)
+    finally {
       files.foreach(Utils.deleteRecursively)
     }
   }
 }
-// spotless:on

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -34,10 +34,7 @@ import org.apache.hadoop.fs.Path
 
 import java.io.File
 
-// spotless:off
-/**
- * Additional method definitions for Delta classes that are intended for use only in testing.
- */
+/** Additional method definitions for Delta classes that are intended for use only in testing. */
 object DeltaTestImplicits {
   implicit class OptimisticTxnTestHelper(txn: OptimisticTransaction) {
 
@@ -103,7 +100,10 @@ object DeltaTestImplicits {
         actions: Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
       tableCommitCoordinatorClient.commit(
-        commitVersion, actions, updatedActions, tableIdentifierOpt = None)
+        commitVersion,
+        actions,
+        updatedActions,
+        tableIdentifierOpt = None)
     }
 
     def getCommits(
@@ -112,14 +112,13 @@ object DeltaTestImplicits {
       tableCommitCoordinatorClient.getCommits(tableIdentifierOpt = None, startVersion, endVersion)
     }
 
-    def backfillToVersion(
-        version: Long,
-        lastKnownBackfilledVersion: Option[Long] = None): Unit = {
+    def backfillToVersion(version: Long, lastKnownBackfilledVersion: Option[Long] = None): Unit = {
       tableCommitCoordinatorClient.backfillToVersion(
-        tableIdentifierOpt = None, version, lastKnownBackfilledVersion)
+        tableIdentifierOpt = None,
+        version,
+        lastKnownBackfilledVersion)
     }
   }
-
 
   /** Helper class for working with [[Snapshot]] */
   implicit class SnapshotTestHelper(snapshot: Snapshot) {
@@ -128,9 +127,7 @@ object DeltaTestImplicits {
     }
   }
 
-  /**
-   * Helper class for working with the most recent snapshot in the deltaLog
-   */
+  /** Helper class for working with the most recent snapshot in the deltaLog */
   implicit class DeltaLogTestHelper(deltaLog: DeltaLog) {
     def snapshot: Snapshot = {
       deltaLog.unsafeVolatileSnapshot
@@ -162,43 +159,41 @@ object DeltaTestImplicits {
   }
 
   implicit class DeltaTableV2ObjectTestHelper(dt: DeltaTableV2.type) {
+
     /** Convenience overload that omits the cmd arg (which is not helpful in tests). */
     def apply(spark: SparkSession, id: TableIdentifier): DeltaTableV2 =
       dt.apply(spark, id, "test")
   }
 
   implicit class DeltaTableV2TestHelper(deltaTable: DeltaTableV2) {
+
     /** For backward compatibility with existing unit tests */
     def snapshot: Snapshot = deltaTable.initialSnapshot
   }
 
   implicit class AutoCompactObjectTestHelper(ac: AutoCompact.type) {
     private[delta] def compact(
-      spark: SparkSession,
-      deltaLog: DeltaLog,
-      partitionPredicates: Seq[Expression] = Nil,
-      opType: String = AutoCompact.OP_TYPE): Seq[OptimizeMetrics] = {
-      AutoCompact.compact(
-        spark, deltaLog, catalogTable = None,
-        partitionPredicates, opType)
+        spark: SparkSession,
+        deltaLog: DeltaLog,
+        partitionPredicates: Seq[Expression] = Nil,
+        opType: String = AutoCompact.OP_TYPE): Seq[OptimizeMetrics] = {
+      AutoCompact.compact(spark, deltaLog, catalogTable = None, partitionPredicates, opType)
     }
   }
 
   implicit class StatisticsCollectionObjectTestHelper(sc: StatisticsCollection.type) {
 
     /**
-     * This is an implicit helper required for backward compatibility with existing
-     * unit tests. It allows to call [[StatisticsCollection.recompute]] without a
-     * catalog table and in the actual call, sets it to [[None]].
+     * This is an implicit helper required for backward compatibility with existing unit tests. It
+     * allows to call [[StatisticsCollection.recompute]] without a catalog table and in the actual
+     * call, sets it to [[None]].
      */
     def recompute(
-      spark: SparkSession,
-      deltaLog: DeltaLog,
-      predicates: Seq[Expression] = Seq(Literal(true)),
-      fileFilter: AddFile => Boolean = af => true): Unit = {
-      StatisticsCollection.recompute(
-        spark, deltaLog, catalogTable = None, predicates, fileFilter)
+        spark: SparkSession,
+        deltaLog: DeltaLog,
+        predicates: Seq[Expression] = Seq(Literal(true)),
+        fileFilter: AddFile => Boolean = af => true): Unit = {
+      StatisticsCollection.recompute(spark, deltaLog, catalogTable = None, predicates, fileFilter)
     }
   }
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -35,7 +35,6 @@ import java.io.File
 
 import scala.collection.mutable
 
-// spotless:off
 trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   import testImplicits._
@@ -58,20 +57,23 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   protected def columnMappingModeString: String = {
-    spark.conf.getOption(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey)
+    spark.conf
+      .getOption(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey)
       .getOrElse("none")
   }
 
   /**
    * Check if two schemas are equal ignoring column mapping metadata
-   * @param schema1 Schema
-   * @param schema2 Schema
+   * @param schema1
+   *   Schema
+   * @param schema2
+   *   Schema
    */
   protected def assertEqual(schema1: StructType, schema2: StructType): Unit = {
     if (columnMappingEnabled) {
       assert(
         DeltaColumnMapping.dropColumnMappingMetadata(schema1) ==
-        DeltaColumnMapping.dropColumnMappingMetadata(schema2)
+          DeltaColumnMapping.dropColumnMappingMetadata(schema2)
       )
     } else {
       assert(schema1 == schema2)
@@ -80,12 +82,12 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Check if two table configurations are equal ignoring column mapping metadata
-   * @param config1 Table config
-   * @param config2 Table config
+   * @param config1
+   *   Table config
+   * @param config2
+   *   Table config
    */
-  protected def assertEqual(
-      config1: Map[String, String],
-      config2: Map[String, String]): Unit = {
+  protected def assertEqual(config1: Map[String, String], config2: Map[String, String]): Unit = {
     if (columnMappingEnabled) {
       assert(dropColumnMappingConfigurations(config1) == dropColumnMappingConfigurations(config2))
     } else {
@@ -94,11 +96,14 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   /**
-   * Check if a partition with specific values exists.
-   * Handles both column mapped and non-mapped cases
-   * @param partCol Partition column name
-   * @param partValue Partition value
-   * @param deltaLog DeltaLog
+   * Check if a partition with specific values exists. Handles both column mapped and non-mapped
+   * cases
+   * @param partCol
+   *   Partition column name
+   * @param partValue
+   *   Partition value
+   * @param deltaLog
+   *   DeltaLog
    */
   protected def assertPartitionWithValueExists(
       partCol: String,
@@ -109,9 +114,12 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Assert partition exists in an array of set of partition names/paths
-   * @param partCol Partition column name
-   * @param deltaLog Delta log
-   * @param inputFiles Input files to scan for DF
+   * @param partCol
+   *   Partition column name
+   * @param deltaLog
+   *   Delta log
+   * @param inputFiles
+   *   Input files to scan for DF
    */
   protected def assertPartitionExists(
       partCol: String,
@@ -120,23 +128,28 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     val physicalName = partCol.phy(deltaLog)
     val allFiles = deltaLog.update().allFiles.collect()
     // NOTE: inputFiles are *not* URL-encoded.
-    val filesWithPartitions = inputFiles.map { f =>
-      allFiles.filter { af =>
-        f.contains(af.toPath.toString)
-      }.flatMap(_.partitionValues.keys).toSet
+    val filesWithPartitions = inputFiles.map {
+      f =>
+        allFiles
+          .filter(af => f.contains(af.toPath.toString))
+          .flatMap(_.partitionValues.keys)
+          .toSet
     }
     assert(filesWithPartitions.forall(p => p.count(_ == physicalName) > 0))
     // for non-column mapped mode, we can check the file paths as well
     if (!columnMappingEnabled) {
-      assert(inputFiles.forall(path => path.contains(s"$physicalName=")),
-          s"${inputFiles.toSeq.mkString("\n")}\ndidn't contain partition columns $physicalName")
+      assert(
+        inputFiles.forall(path => path.contains(s"$physicalName=")),
+        s"${inputFiles.toSeq.mkString("\n")}\ndidn't contain partition columns $physicalName")
     }
   }
 
   /**
    * Load Deltalog from path
-   * @param pathOrIdentifier Location
-   * @param isIdentifier Whether the previous argument is a metastore identifier
+   * @param pathOrIdentifier
+   *   Location
+   * @param isIdentifier
+   *   Whether the previous argument is a metastore identifier
    * @return
    */
   protected def loadDeltaLog(pathOrIdentifier: String, isIdentifier: Boolean = false): DeltaLog = {
@@ -149,8 +162,10 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Convert a (nested) column string to sequence of name parts
-   * @param col Column string
-   * @return Sequence of parts
+   * @param col
+   *   Column string
+   * @return
+   *   Sequence of parts
    */
   protected def columnNameToParts(col: String): Seq[String] = {
     UnresolvedAttribute.parseAttributeName(col)
@@ -158,10 +173,14 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Get partition file paths for a specific partition value
-   * @param partCol Logical or physical partition name
-   * @param partValue Partition value
-   * @param deltaLog DeltaLog
-   * @return List of paths
+   * @param partCol
+   *   Logical or physical partition name
+   * @param partValue
+   *   Partition value
+   * @param deltaLog
+   *   DeltaLog
+   * @return
+   *   List of paths
    */
   protected def getPartitionFilePathsWithValue(
       partCol: String,
@@ -170,9 +189,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     getPartitionFilePaths(partCol, deltaLog).getOrElse(partValue, Array.empty)
   }
 
-  /**
-   * Get the partition value for null
-   */
+  /** Get the partition value for null */
   protected def nullPartitionValue: String = {
     if (columnMappingEnabled) {
       null
@@ -183,55 +200,77 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Get partition file paths grouped by partition value
-   * @param partCol Logical or physical partition name
-   * @param deltaLog DeltaLog
-   * @return Partition value to paths
+   * @param partCol
+   *   Logical or physical partition name
+   * @param deltaLog
+   *   DeltaLog
+   * @return
+   *   Partition value to paths
    */
   protected def getPartitionFilePaths(
       partCol: String,
       deltaLog: DeltaLog): Map[String, Array[String]] = {
     if (columnMappingEnabled) {
       val colName = partCol.phy(deltaLog)
-      deltaLog.update().allFiles.collect()
+      deltaLog
+        .update()
+        .allFiles
+        .collect()
         .groupBy(_.partitionValues(colName))
-        .mapValues(_.map(deltaLog.dataPath.toUri.getPath + "/" + _.path)).toMap
+        .mapValues(_.map(deltaLog.dataPath.toUri.getPath + "/" + _.path))
+        .toMap
     } else {
       val partColEscaped = s"${ExternalCatalogUtils.escapePathName(partCol)}"
       val dataPath = new File(deltaLog.dataPath.toUri.getPath)
-      dataPath.listFiles().filter(_.getName.startsWith(s"$partColEscaped="))
-        .groupBy(_.getName.split("=").last).mapValues(_.map(_.getPath)).toMap
+      dataPath
+        .listFiles()
+        .filter(_.getName.startsWith(s"$partColEscaped="))
+        .groupBy(_.getName.split("=").last)
+        .mapValues(_.map(_.getPath))
+        .toMap
     }
   }
 
   /**
    * Group a list of input file paths by partition key-value pair w.r.t. delta log
-   * @param inputFiles Input file paths
-   * @param deltaLog Delta log
-   * @return A mapped array each with the corresponding partition keys
+   * @param inputFiles
+   *   Input file paths
+   * @param deltaLog
+   *   Delta log
+   * @return
+   *   A mapped array each with the corresponding partition keys
    */
   protected def groupInputFilesByPartition(
       inputFiles: Array[String],
       deltaLog: DeltaLog): Map[(String, String), Array[String]] = {
     if (columnMappingEnabled) {
       val allFiles = deltaLog.update().allFiles.collect()
-      val grouped = inputFiles.flatMap { f =>
-        allFiles.find {
-          af => f.contains(af.toPath.toString)
-        }.head.partitionValues.map(entry => (f, entry))
-      }.groupBy(_._2)
+      val grouped = inputFiles
+        .flatMap {
+          f =>
+            allFiles
+              .find(af => f.contains(af.toPath.toString))
+              .head
+              .partitionValues
+              .map(entry => (f, entry))
+        }
+        .groupBy(_._2)
       grouped.mapValues(_.map(_._1)).toMap
     } else {
-      inputFiles.groupBy(p => {
-        val nameParts = new Path(p).getParent.getName.split("=")
-        (nameParts(0), nameParts(1))
-      })
+      inputFiles.groupBy(
+        p => {
+          val nameParts = new Path(p).getParent.getName.split("=")
+          (nameParts(0), nameParts(1))
+        })
     }
   }
 
   /**
    * Drop column mapping configurations from Map
-   * @param configuration Table configuration
-   * @return Configuration
+   * @param configuration
+   *   Table configuration
+   * @return
+   *   Configuration
    */
   protected def dropColumnMappingConfigurations(
       configuration: Map[String, String]): Map[String, String] = {
@@ -240,17 +279,22 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Drop column mapping configurations from Dataset (e.g. sql("SHOW TBLPROPERTIES t1")
-   * @param configs Table configuration
-   * @return Configuration Dataset
+   * @param configs
+   *   Table configuration
+   * @return
+   *   Configuration Dataset
    */
   protected def dropColumnMappingConfigurations(
       configs: Dataset[(String, String)]): Dataset[(String, String)] = {
-    spark.createDataset(configs.collect().filter(p =>
-      !Seq(
-        DeltaConfigs.COLUMN_MAPPING_MAX_ID.key,
-        DeltaConfigs.COLUMN_MAPPING_MODE.key
-      ).contains(p._1)
-    ))
+    spark.createDataset(
+      configs
+        .collect()
+        .filter(
+          p =>
+            !Seq(
+              DeltaConfigs.COLUMN_MAPPING_MAX_ID.key,
+              DeltaConfigs.COLUMN_MAPPING_MODE.key
+            ).contains(p._1)))
   }
 
   /** Return KV pairs of Protocol-related stuff for checking the result of DESCRIBE TABLE. */
@@ -259,28 +303,36 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
       DeltaConfigs.mergeGlobalConfigs(spark.sessionState.conf, snapshot.metadata.configuration)
     val metadata = snapshot.metadata.copy(configuration = mergedConf)
     var props = Seq(
-      (Protocol.MIN_READER_VERSION_PROP,
+      (
+        Protocol.MIN_READER_VERSION_PROP,
         Protocol.forNewTable(spark, Some(metadata)).minReaderVersion.toString),
-      (Protocol.MIN_WRITER_VERSION_PROP,
-        Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString))
+      (
+        Protocol.MIN_WRITER_VERSION_PROP,
+        Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString)
+    )
     if (snapshot.protocol.supportsReaderFeatures || snapshot.protocol.supportsWriterFeatures) {
       props ++=
-        Protocol.minProtocolComponentsFromAutomaticallyEnabledFeatures(
-          spark, metadata, snapshot.protocol)
+        Protocol
+          .minProtocolComponentsFromAutomaticallyEnabledFeatures(spark, metadata, snapshot.protocol)
           ._3
-          .map(f => (
-            s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${f.name}",
-            TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))
+          .map(
+            f =>
+              (
+                s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${f.name}",
+                TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))
     }
     props
   }
 
   /**
-   * Convert (nested) column name string into physical name with reference from DeltaLog
-   * If target field does not have physical name, display name is returned
-   * @param col Logical column name
-   * @param deltaLog Reference DeltaLog
-   * @return Physical column name
+   * Convert (nested) column name string into physical name with reference from DeltaLog If target
+   * field does not have physical name, display name is returned
+   * @param col
+   *   Logical column name
+   * @param deltaLog
+   *   Reference DeltaLog
+   * @return
+   *   Physical column name
    */
   protected def getPhysicalName(col: String, deltaLog: DeltaLog): String = {
     val nameParts = UnresolvedAttribute.parseAttributeName(col)
@@ -294,7 +346,8 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   protected def getPhysicalName(nameParts: Seq[String], schema: StructType): String = {
-    SchemaUtils.findNestedFieldIgnoreCase(schema, nameParts, includeCollections = true)
+    SchemaUtils
+      .findNestedFieldIgnoreCase(schema, nameParts, includeCollections = true)
       .map(DeltaColumnMapping.getPhysicalName)
       .get
   }
@@ -312,14 +365,14 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
   }
 
   /**
-   * Gets the physical names of a path. This is used for converting column paths in stats schema,
-   * so it's ok to not support MapType and ArrayType.
+   * Gets the physical names of a path. This is used for converting column paths in stats schema, so
+   * it's ok to not support MapType and ArrayType.
    */
   def getPhysicalPathForStats(path: Seq[String], schema: StructType): Option[Seq[String]] = {
     if (path.isEmpty) return Some(Seq.empty)
     val field = schema.fields.find(_.name.equalsIgnoreCase(path.head))
     field match {
-      case Some(f @ StructField(_, _: AtomicType, _, _ )) =>
+      case Some(f @ StructField(_, _: AtomicType, _, _)) =>
         if (path.size == 1) Some(Seq(DeltaColumnMapping.getPhysicalName(f))) else None
       case Some(f @ StructField(_, st: StructType, _, _)) =>
         val tail = getPhysicalPathForStats(path.tail, st)
@@ -329,15 +382,17 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     }
   }
 
-   /**
-   * Convert (nested) column name string into physical name.
-   * Ignore parts of special paths starting with:
-   *  1. stats columns: minValues, maxValues, numRecords
-   *  2. stats df: stats_parsed
-   *  3. partition values: partitionValues_parsed, partitionValues
-   * @param col Logical column name (e.g. a.b.c)
-   * @param schema Reference schema with metadata
-   * @return Unresolved attribute with physical name paths
+  /**
+   * Convert (nested) column name string into physical name. Ignore parts of special paths starting
+   * with:
+   *   1. stats columns: minValues, maxValues, numRecords 2. stats df: stats_parsed 3. partition
+   *      values: partitionValues_parsed, partitionValues
+   * @param col
+   *   Logical column name (e.g. a.b.c)
+   * @param schema
+   *   Reference schema with metadata
+   * @return
+   *   Unresolved attribute with physical name paths
    */
   protected def convertColumnNameToAttributeWithPhysicalName(
       col: String,
@@ -354,7 +409,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
       parts.head +: getPhysicalPathForStats(parts.tail, schema).getOrElse(parts.tail)
     } else if (shouldIgnoreSecondPart.contains(parts.head)) {
       parts.take(2) ++ getPhysicalPathForStats(parts.slice(2, parts.length), schema)
-          .getOrElse(parts.slice(2, parts.length))
+        .getOrElse(parts.slice(2, parts.length))
     } else {
       getPhysicalPathForStats(parts, schema).getOrElse(parts)
     }
@@ -363,39 +418,42 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
   /**
    * Convert a list of (nested) stats columns into physical name with reference from DeltaLog
-   * @param columns Logical columns
-   * @param deltaLog Reference DeltaLog
-   * @return Physical columns
+   * @param columns
+   *   Logical columns
+   * @param deltaLog
+   *   Reference DeltaLog
+   * @return
+   *   Physical columns
    */
-  protected def convertToPhysicalColumns(
-      columns: Seq[Column],
-      deltaLog: DeltaLog): Seq[Column] = {
+  protected def convertToPhysicalColumns(columns: Seq[Column], deltaLog: DeltaLog): Seq[Column] = {
     val schema = deltaLog.update().schema
-    columns.map { col =>
-      val newExpr = col.expr.transform {
-        case a: Attribute =>
-          convertColumnNameToAttributeWithPhysicalName(a.name, schema)
-      }
-      Column(newExpr)
+    columns.map {
+      col =>
+        val newExpr = col.expr.transform {
+          case a: Attribute =>
+            convertColumnNameToAttributeWithPhysicalName(a.name, schema)
+        }
+        Column(newExpr)
     }
   }
 
   /**
    * Standard CONVERT TO DELTA
-   * @param tableOrPath String
+   * @param tableOrPath
+   *   String
    */
   protected def convertToDelta(tableOrPath: String): Unit = {
     sql(s"CONVERT TO DELTA $tableOrPath")
   }
 
   /**
-   * Force enable streaming read (with possible data loss) on column mapping enabled table with
-   * drop / rename schema changes.
+   * Force enable streaming read (with possible data loss) on column mapping enabled table with drop
+   * / rename schema changes.
    */
   protected def withStreamingReadOnColumnMappingTableEnabled(f: => Unit): Unit = {
     if (columnMappingEnabled) {
-      withSQLConf(DeltaSQLConf
-        .DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_COLUMN_MAPPING_SCHEMA_CHANGES.key -> "true") {
+      withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_COLUMN_MAPPING_SCHEMA_CHANGES.key -> "true") {
         f
       }
     } else {
@@ -407,43 +465,37 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
 
 trait DeltaColumnMappingTestUtils extends DeltaColumnMappingTestUtilsBase
 
-/**
- * Include this trait to enable Id column mapping mode for a suite
- */
-trait DeltaColumnMappingEnableIdMode extends SharedSparkSession
+/** Include this trait to enable Id column mapping mode for a suite */
+trait DeltaColumnMappingEnableIdMode
+  extends SharedSparkSession
   with DeltaColumnMappingTestUtils
   with DeltaColumnMappingSelectedTestMixin {
 
-  protected override def columnMappingMode: String = IdMapping.name
+  override protected def columnMappingMode: String = IdMapping.name
 
-  protected override def sparkConf: SparkConf =
+  override protected def sparkConf: SparkConf =
     super.sparkConf.set(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey, "id")
 
-  /**
-   * CONVERT TO DELTA blocked in id mode
-   */
-  protected override def convertToDelta(tableOrPath: String): Unit =
+  /** CONVERT TO DELTA blocked in id mode */
+  override protected def convertToDelta(tableOrPath: String): Unit =
     throw DeltaErrors.convertToDeltaWithColumnMappingNotSupported(
       DeltaColumnMappingMode(columnMappingModeString)
     )
 }
 
-/**
- * Include this trait to enable Name column mapping mode for a suite
- */
-trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
+/** Include this trait to enable Name column mapping mode for a suite */
+trait DeltaColumnMappingEnableNameMode
+  extends SharedSparkSession
   with DeltaColumnMappingTestUtils
   with DeltaColumnMappingSelectedTestMixin {
 
-  protected override def columnMappingMode: String = NameMapping.name
+  override protected def columnMappingMode: String = NameMapping.name
 
-  protected override def sparkConf: SparkConf =
+  override protected def sparkConf: SparkConf =
     super.sparkConf.set(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey, columnMappingMode)
 
-  /**
-   * CONVERT TO DELTA can be possible under name mode in tests
-   */
-  protected override def convertToDelta(tableOrPath: String): Unit = {
+  /** CONVERT TO DELTA can be possible under name mode in tests */
+  override protected def convertToDelta(tableOrPath: String): Unit = {
     withColumnMappingConf("none") {
       super.convertToDelta(tableOrPath)
     }
@@ -459,18 +511,22 @@ trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
 
     val tableReaderVersion = deltaLog.unsafeVolatileSnapshot.protocol.minReaderVersion
     val tableWriterVersion = deltaLog.unsafeVolatileSnapshot.protocol.minWriterVersion
-    val requiredReaderVersion = if (tableWriterVersion >=
-      TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION) {
-      // If the writer version of the table supports table features, we need to
-      // bump the reader version to table features to enable column mapping.
-      TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION
-    } else {
-      ColumnMappingTableFeature.minReaderVersion
-    }
-    val readerVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION).max(
-      requiredReaderVersion)
-    val writerVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION).max(
-      ColumnMappingTableFeature.minWriterVersion)
+    val requiredReaderVersion =
+      if (
+        tableWriterVersion >=
+          TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
+      ) {
+        // If the writer version of the table supports table features, we need to
+        // bump the reader version to table features to enable column mapping.
+        TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION
+      } else {
+        ColumnMappingTableFeature.minReaderVersion
+      }
+    val readerVersion =
+      spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION).max(requiredReaderVersion)
+    val writerVersion = spark.conf
+      .get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION)
+      .max(ColumnMappingTableFeature.minWriterVersion)
 
     val properties = mutable.ListBuffer(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name")
     if (tableReaderVersion < readerVersion) {
@@ -484,4 +540,3 @@ trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
   }
 
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -18,16 +18,14 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.QueryTest
 
-// spotless:off
 trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
+
   /**
    * Tests that are meant for Delta compiled against Spark Latest Release only. Executed since this
    * is the Spark Latest Release shim.
    */
-  protected def testSparkLatestOnly(
-      testName: String, testTags: org.scalatest.Tag*)
-      (testFun: => Any)
-      (implicit pos: org.scalactic.source.Position): Unit = {
+  protected def testSparkLatestOnly(testName: String, testTags: org.scalatest.Tag*)(
+      testFun: => Any)(implicit pos: org.scalactic.source.Position): Unit = {
     test(testName, testTags: _*)(testFun)(pos)
   }
 
@@ -35,11 +33,8 @@ trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
    * Tests that are meant for Delta compiled against Spark Master Release only. Ignored since this
    * is the Spark Latest Release shim.
    */
-  protected def testSparkMasterOnly(
-      testName: String, testTags: org.scalatest.Tag*)
-      (testFun: => Any)
-      (implicit pos: org.scalactic.source.Position): Unit = {
+  protected def testSparkMasterOnly(testName: String, testTags: org.scalatest.Tag*)(
+      testFun: => Any)(implicit pos: org.scalactic.source.Position): Unit = {
     ignore(testName, testTags: _*)(testFun)(pos)
   }
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
@@ -26,34 +26,29 @@ import org.scalatest.exceptions.TestFailedException
 
 import scala.collection.mutable
 
-// spotless:off
-/**
- * A trait for selective enabling certain tests to run for column mapping modes
- */
-trait DeltaColumnMappingSelectedTestMixin extends SparkFunSuite
-  with DeltaSQLTestUtils with DeltaColumnMappingTestUtils {
+/** A trait for selective enabling certain tests to run for column mapping modes */
+trait DeltaColumnMappingSelectedTestMixin
+  extends SparkFunSuite
+  with DeltaSQLTestUtils
+  with DeltaColumnMappingTestUtils {
 
   protected def runOnlyTests: Seq[String] = Seq()
 
-  /**
-   * If true, will run all tests.
-   * Requires that `runOnlyTests` is empty.
-   */
+  /** If true, will run all tests. Requires that `runOnlyTests` is empty. */
   protected def runAllTests: Boolean = false
 
   private val testsRun: mutable.Set[String] = mutable.Set.empty
 
-  override protected def test(
-      testName: String,
-      testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
-    require(!runAllTests || runOnlyTests.isEmpty,
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    require(
+      !runAllTests || runOnlyTests.isEmpty,
       "If `runAllTests` is true then `runOnlyTests` must be empty")
 
     if (runAllTests || runOnlyTests.contains(testName)) {
       super.test(s"$testName - column mapping $columnMappingMode mode", testTags: _*) {
         testsRun.add(testName)
-        withSQLConf(
-          DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> columnMappingMode) {
+        withSQLConf(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> columnMappingMode) {
           testFun
         }
       }
@@ -64,13 +59,15 @@ trait DeltaColumnMappingSelectedTestMixin extends SparkFunSuite
 
   override def afterAll(): Unit = {
     super.afterAll()
-    val missingTests = runOnlyTests.toSet diff testsRun
+    val missingTests = runOnlyTests.toSet.diff(testsRun)
     if (missingTests.nonEmpty) {
       throw new TestFailedException(
-        Some("Not all selected column mapping tests were run. Missing: " +
-          missingTests.mkString(", ")), None, 0)
+        Some(
+          "Not all selected column mapping tests were run. Missing: " +
+            missingTests.mkString(", ")),
+        None,
+        0)
     }
   }
 
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaExcludedTestMixin.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaExcludedTestMixin.scala
@@ -21,15 +21,13 @@ import org.apache.spark.sql.QueryTest
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-// spotless:off
 trait DeltaExcludedTestMixin extends QueryTest {
 
   /** Tests to be ignored by the runner. */
   override def excluded: Seq[String] = Seq.empty
 
-  protected override def test(testName: String, testTags: Tag*)
-    (testFun: => Any)
-    (implicit pos: Position): Unit = {
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
     if (excluded.contains(testName)) {
       super.ignore(testName, testTags: _*)(testFun)
     } else {
@@ -37,4 +35,3 @@ trait DeltaExcludedTestMixin extends QueryTest {
     }
   }
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 import io.delta.sql.DeltaSparkSessionExtension
 
-// spotless:off
 /**
  * A trait for tests that are testing a fully set up SparkSession with all of Delta's requirements,
  * such as the configuration of the DeltaCatalog and the addition of all Delta extensions.
@@ -36,13 +35,13 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
     val conf = super.sparkConf
 
     // Delta.
-    conf.set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-        classOf[DeltaSparkSessionExtension].getName)
-      .set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
-        classOf[DeltaCatalog].getName)
+    conf
+      .set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key, classOf[DeltaSparkSessionExtension].getName)
+      .set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
 
     // Gluten.
-    conf.set("spark.plugins", "org.apache.gluten.GlutenPlugin")
+    conf
+      .set("spark.plugins", "org.apache.gluten.GlutenPlugin")
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
       .set("spark.default.parallelism", "1")
       .set("spark.memory.offHeap.enabled", "true")
@@ -54,4 +53,3 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
       .set("spark.gluten.sql.fallbackUnexpectedMetadataParquet", "true")
   }
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -21,13 +21,13 @@ import org.apache.spark.util.Utils
 
 import java.io.File
 
-// spotless:off
 trait DeltaSQLTestUtils extends SQLTestUtils {
+
   /**
    * Override the temp dir/path creation methods from [[SQLTestUtils]] to:
-   * 1. Drop the call to `waitForTasksToFinish` which is a source of flakiness due to timeouts
-   *    without clear benefits.
-   * 2. Allow creating paths with special characters for better test coverage.
+   *   1. Drop the call to `waitForTasksToFinish` which is a source of flakiness due to timeouts
+   *      without clear benefits. 2. Allow creating paths with special characters for better test
+   *      coverage.
    */
 
   protected val defaultTempDirPrefix: String = "spark%dir%prefix"
@@ -50,7 +50,8 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
    */
   def withTempDir(prefix: String)(f: File => Unit): Unit = {
     val path = Utils.createTempDir(namePrefix = prefix)
-    try f(path) finally Utils.deleteRecursively(path)
+    try f(path)
+    finally Utils.deleteRecursively(path)
   }
 
   /**
@@ -60,7 +61,8 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
   def withTempPath(prefix: String)(f: File => Unit): Unit = {
     val path = Utils.createTempDir(namePrefix = prefix)
     path.delete()
-    try f(path) finally Utils.deleteRecursively(path)
+    try f(path)
+    finally Utils.deleteRecursively(path)
   }
 
   /**
@@ -71,9 +73,9 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
     val files =
       Seq.fill[File](numPaths)(Utils.createTempDir(namePrefix = prefix).getCanonicalFile)
     files.foreach(_.delete())
-    try f(files) finally {
+    try f(files)
+    finally {
       files.foreach(Utils.deleteRecursively)
     }
   }
 }
-// spotless:on

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -34,10 +34,7 @@ import org.apache.hadoop.fs.Path
 
 import java.io.File
 
-// spotless:off
-/**
- * Additional method definitions for Delta classes that are intended for use only in testing.
- */
+/** Additional method definitions for Delta classes that are intended for use only in testing. */
 object DeltaTestImplicits {
   implicit class OptimisticTxnTestHelper(txn: OptimisticTransaction) {
 
@@ -103,7 +100,10 @@ object DeltaTestImplicits {
         actions: Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
       tableCommitCoordinatorClient.commit(
-        commitVersion, actions, updatedActions, tableIdentifierOpt = None)
+        commitVersion,
+        actions,
+        updatedActions,
+        tableIdentifierOpt = None)
     }
 
     def getCommits(
@@ -112,14 +112,13 @@ object DeltaTestImplicits {
       tableCommitCoordinatorClient.getCommits(tableIdentifierOpt = None, startVersion, endVersion)
     }
 
-    def backfillToVersion(
-        version: Long,
-        lastKnownBackfilledVersion: Option[Long] = None): Unit = {
+    def backfillToVersion(version: Long, lastKnownBackfilledVersion: Option[Long] = None): Unit = {
       tableCommitCoordinatorClient.backfillToVersion(
-        tableIdentifierOpt = None, version, lastKnownBackfilledVersion)
+        tableIdentifierOpt = None,
+        version,
+        lastKnownBackfilledVersion)
     }
   }
-
 
   /** Helper class for working with [[Snapshot]] */
   implicit class SnapshotTestHelper(snapshot: Snapshot) {
@@ -128,9 +127,7 @@ object DeltaTestImplicits {
     }
   }
 
-  /**
-   * Helper class for working with the most recent snapshot in the deltaLog
-   */
+  /** Helper class for working with the most recent snapshot in the deltaLog */
   implicit class DeltaLogTestHelper(deltaLog: DeltaLog) {
     def snapshot: Snapshot = {
       deltaLog.unsafeVolatileSnapshot
@@ -162,43 +159,41 @@ object DeltaTestImplicits {
   }
 
   implicit class DeltaTableV2ObjectTestHelper(dt: DeltaTableV2.type) {
+
     /** Convenience overload that omits the cmd arg (which is not helpful in tests). */
     def apply(spark: SparkSession, id: TableIdentifier): DeltaTableV2 =
       dt.apply(spark, id, "test")
   }
 
   implicit class DeltaTableV2TestHelper(deltaTable: DeltaTableV2) {
+
     /** For backward compatibility with existing unit tests */
     def snapshot: Snapshot = deltaTable.initialSnapshot
   }
 
   implicit class AutoCompactObjectTestHelper(ac: AutoCompact.type) {
     private[delta] def compact(
-      spark: SparkSession,
-      deltaLog: DeltaLog,
-      partitionPredicates: Seq[Expression] = Nil,
-      opType: String = AutoCompact.OP_TYPE): Seq[OptimizeMetrics] = {
-      AutoCompact.compact(
-        spark, deltaLog, catalogTable = None,
-        partitionPredicates, opType)
+        spark: SparkSession,
+        deltaLog: DeltaLog,
+        partitionPredicates: Seq[Expression] = Nil,
+        opType: String = AutoCompact.OP_TYPE): Seq[OptimizeMetrics] = {
+      AutoCompact.compact(spark, deltaLog, catalogTable = None, partitionPredicates, opType)
     }
   }
 
   implicit class StatisticsCollectionObjectTestHelper(sc: StatisticsCollection.type) {
 
     /**
-     * This is an implicit helper required for backward compatibility with existing
-     * unit tests. It allows to call [[StatisticsCollection.recompute]] without a
-     * catalog table and in the actual call, sets it to [[None]].
+     * This is an implicit helper required for backward compatibility with existing unit tests. It
+     * allows to call [[StatisticsCollection.recompute]] without a catalog table and in the actual
+     * call, sets it to [[None]].
      */
     def recompute(
-      spark: SparkSession,
-      deltaLog: DeltaLog,
-      predicates: Seq[Expression] = Seq(Literal(true)),
-      fileFilter: AddFile => Boolean = af => true): Unit = {
-      StatisticsCollection.recompute(
-        spark, deltaLog, catalogTable = None, predicates, fileFilter)
+        spark: SparkSession,
+        deltaLog: DeltaLog,
+        predicates: Seq[Expression] = Seq(Literal(true)),
+        fileFilter: AddFile => Boolean = af => true): Unit = {
+      StatisticsCollection.recompute(spark, deltaLog, catalogTable = None, predicates, fileFilter)
     }
   }
 }
-// spotless:on


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously we followed the Delta's original Scala code style for Delta support code that was originated from Delta's codebase, this doesn't suit well for long term maintenance as we had to disable code style checking for these files.

The PR removes the `spotless:off` marks to enable linters for these files. The code will be complying with Gluten's code style then.


## Was this patch authored or co-authored using generative AI tooling?

No.
