### PR TITLE
[MINOR] Fix run-scala-test.sh to always use build/mvn for JVM args extraction

### DIFF
--- a/dev/run-scala-test.sh
+++ b/dev/run-scala-test.sh
@@ -557,7 +557,8 @@ log_step "Step 2: Getting JVM arguments from pom.xml..."
 
 TIMER_STEP2_START=$(timer_now)
 
-JVM_ARGS_RAW=$(${MVN_CMD} help:evaluate \
+# Always use build/mvn for help:evaluate (mvnd returns empty output for this goal)
+JVM_ARGS_RAW=$(./build/mvn help:evaluate \
   -Dexpression=extraJavaTestArgs \
   -q -DforceStdout \
   -P"${PROFILES}" 2>/dev/null || echo "")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Quick fix for https://github.com/apache/incubator-gluten/pull/11560.

`mvnd` returns empty output for `help:evaluate` goal, causing `--add-opens` JVM flags to be missing when using `--mvnd` flag. This broke Arrow memory initialization in tests like `GlutenParquetTypeWideningSuite`.

**Fix**: Always use `./build/mvn` (not `${MVN_CMD}`) for the `help:evaluate` step, since this step only extracts JVM arguments and does not benefit from mvnd acceleration.

## How was this patch tested?

Ran `dev/run-scala-test.sh --mvnd` and verified JVM args are correctly extracted.

## Was this patch authored or co-authored using generative AI tooling?

Yes, GitHub Copilot.