### PR TITLE
[Tools] Add explicit HDFS URI scheme support for qualification-tool

### DIFF
--- a/tools/qualification-tool/src/main/scala/org/apache/gluten/qt/file/HadoopFileSource.scala
+++ b/tools/qualification-tool/src/main/scala/org/apache/gluten/qt/file/HadoopFileSource.scala
@@ -84,6 +84,7 @@ object HadoopFileSource {
       case f if f.startsWith("gs://") => GcsFileSource(conf)
       case f if f.startsWith("file://") => file.LocalFsFileSource(conf)
       case f if f.startsWith("/") => file.LocalFsFileSource(conf)
+      case f if f.startsWith("hdfs://") => file.LocalFsFileSource(conf)
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Fix MatchError when processing event logs from HDFS by adding explicit pattern matching for `hdfs:// `URIs in HadoopFileSource. 

Previously, `hdfs://`paths would cause MatchError crashes. This change enables users to directly specify HDFS paths like: `hdfs://namenode:8020/spark-logs/.`
![20260211135506](https://github.com/user-attachments/assets/40ac2e97-7ef8-44aa-a9ab-41a6e5633663)
