### PR TITLE
[VL] Add Spark randstr function mapping for Velox backend

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
@@ -302,6 +302,13 @@ abstract class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  testWithMinSparkVersion("randstr", "4.0") {
+    // randstr generates random strings, so we only verify native execution, not result equality.
+    runQueryAndCompare("SELECT randstr(5, 0) from lineitem limit 100", compareResult = false) {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+  }
+
   test("rint") {
     withTempPath {
       path =>

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -194,6 +194,7 @@ object ExpressionNames {
   final val REMAINDER = "modulus"
   final val FACTORIAL = "factorial"
   final val RAND = "rand"
+  final val RANDSTR = "randstr"
   final val RINT = "rint"
   final val RIGHT = "right"
 

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -98,7 +98,8 @@ class Spark40Shims extends SparkShims {
       Sig[UrlEncode](ExpressionNames.URL_ENCODE),
       Sig[KnownNotContainsNull](ExpressionNames.KNOWN_NOT_CONTAINS_NULL),
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
-      Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING)
+      Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
+      Sig[RandStr](ExpressionNames.RANDSTR)
     )
   }
 

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -97,7 +97,8 @@ class Spark41Shims extends SparkShims {
       Sig[UrlEncode](ExpressionNames.URL_ENCODE),
       Sig[KnownNotContainsNull](ExpressionNames.KNOWN_NOT_CONTAINS_NULL),
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
-      Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING)
+      Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
+      Sig[RandStr](ExpressionNames.RANDSTR)
     )
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add expression mapping for Spark's `randstr` function (Spark 4.0+) to enable offloading to Velox native execution engine.

The `randstr(length, seed)` function generates a random string of specified length using characters from 0-9, a-z, A-Z. The Velox implementation was merged in facebookincubator/velox#16014.

### Changes:
- Add `RANDSTR` constant to `ExpressionNames.scala`
- Add `Sig[RandStr](ExpressionNames.RANDSTR)` to `Spark40Shims` and `Spark41Shims` scalar expression mappings

## How was this patch tested?

Existing Gluten UT framework. The Velox side has comprehensive tests in `RandStrTest.cpp`.