### PR TITLE
[MINOR] Fix ZipFile resource leak in ResourceUtil

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/utils/ResourceUtil.java
+++ b/gluten-core/src/main/java/org/apache/gluten/utils/ResourceUtil.java
@@ -101,30 +101,23 @@ public class ResourceUtil {
 
   private static void getResourcesFromJarFile(
       final File jarFile, final String dir, final Pattern pattern, final List<String> buffer) {
-    final ZipFile zf;
-    try {
-      zf = new ZipFile(jarFile);
+    try (ZipFile zf = new ZipFile(jarFile)) {
+      final Enumeration<? extends ZipEntry> e = zf.entries();
+      while (e.hasMoreElements()) {
+        final ZipEntry ze = e.nextElement();
+        final String fileName = ze.getName();
+        if (!fileName.startsWith(dir)) {
+          continue;
+        }
+        final String relativeFileName =
+            new File(dir).toURI().relativize(new File(fileName).toURI()).getPath();
+        final boolean accept = pattern.matcher(relativeFileName).matches();
+        if (accept) {
+          buffer.add(relativeFileName);
+        }
+      }
     } catch (final IOException e) {
       throw new GlutenException(e);
-    }
-    final Enumeration<? extends ZipEntry> e = zf.entries();
-    while (e.hasMoreElements()) {
-      final ZipEntry ze = e.nextElement();
-      final String fileName = ze.getName();
-      if (!fileName.startsWith(dir)) {
-        continue;
-      }
-      final String relativeFileName =
-          new File(dir).toURI().relativize(new File(fileName).toURI()).getPath();
-      final boolean accept = pattern.matcher(relativeFileName).matches();
-      if (accept) {
-        buffer.add(relativeFileName);
-      }
-    }
-    try {
-      zf.close();
-    } catch (final IOException e1) {
-      throw new GlutenException(e1);
     }
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR refactors `ResourceUtil.getResourcesFromJarFile()` to use try-with-resources for `ZipFile`, replacing the manual open/close pattern. The existing code opens a file in one try block and closes it in a separate try block at the end of the method. If any unchecked exception is thrown while iterating over the zip entries, `ZipFile.close()` is never called, leaking a file descriptor. 

## How was this patch tested?
Existing unit tests.

## Was this patch authored or co-authored using generative AI tooling?
No.
