### PR TITLE
[GLUTEN-11402][VL] Fix decimal partition key serialization to preserve scale

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -161,7 +161,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
               case _: DateType =>
                 DateFormatter.apply().format(pv.asInstanceOf[Integer])
               case _: DecimalType =>
-                pv.asInstanceOf[Decimal].toJavaBigInteger.toString
+                pv.asInstanceOf[Decimal].toJavaBigDecimal.unscaledValue().toString
               case _: TimestampType =>
                 TimestampFormatter
                   .getFractionFormatter(ZoneOffset.UTC)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -27,7 +27,6 @@ import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.types.DecimalType
 
 import com.google.protobuf.StringValue
 import io.substrait.proto.NamedStruct
@@ -137,10 +136,6 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
       )
     if (!validationResult.ok()) {
       return validationResult
-    }
-
-    if (getPartitionSchema.fields.exists(_.dataType.isInstanceOf[DecimalType])) {
-      return ValidationResult.failed(s"Unsupported decimal partition column in native scan.")
     }
 
     val substraitContext = new SubstraitContext


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR fixes decimal partition value serialization by replacing `toJavaBigInteger.toString` with `toJavaBigDecimal.unscaledValue().toString`, removes fallback guard that was added by #11518 and adds additional test cases to SQLQuerySuite covering small decimals, zero-scale decimals, negative values, and multi-partition pruning.

## How was this patch tested?
Existing UTs added in #11518 + extended `Incorrect decimal casting for partition read` test

## Was this patch authored or co-authored using generative AI tooling?
No


Related issue: #11402