### PR TITLE
[CORE] Use ArrayList instead of LinkedList in Spillers

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/Spillers.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/Spillers.java
@@ -62,7 +62,7 @@ public final class Spillers {
   }
 
   public static class AppendableSpillerList implements Spiller {
-    private final List<Spiller> spillers = new LinkedList<>();
+    private final List<Spiller> spillers = new ArrayList<>();
 
     private AppendableSpillerList() {}
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR replaces LinkedList with ArrayList in Spillers.AppendableSpillerList. The list is only used for two operations: add() (append) and sequential for-each iteration in `spill()`. ArrayList is more efficient for both: append is amortized O(1) without allocating a Node object per element, and iteration benefits from sequential memory layout (CPU cache locality). LinkedList is faster for frequent mid-list insertions/removals, which this class never does.  

## How was this patch tested?

Existing unit tests.

## Was this patch authored or co-authored using generative AI tooling?

No