### PR TITLE
[MINOR][VL] Fix throw-new anti-pattern in FileReaderIterator.cc

### DIFF
--- a/cpp/velox/operators/reader/FileReaderIterator.cc
+++ b/cpp/velox/operators/reader/FileReaderIterator.cc
@@ -41,7 +41,7 @@ std::shared_ptr<gluten::ResultIterator> FileReaderIterator::getInputIteratorFrom
           std::make_unique<ParquetBufferedReaderIterator>(path, batchSize, pool));
     }
   }
-  throw new GlutenException("Unreachable.");
+  throw GlutenException("Unreachable.");
 }
 
 } // namespace gluten


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR replaces `throw new GlutenException(...)` with `throw GlutenException(...)` in `FileReaderIterator::getInputIteratorFromFileReader`.  `throw new` will allocate the exception object on the heap, but standard catch blocks catch by reference (`catch (const std::exception& e)`), so the pointer will never freed causing a memory leak on the exception path.

## How was this patch tested?
Existing tests

## Was this patch authored or co-authored using generative AI tooling?
No
