### PR TITLE
[MINOR][VL] Replace C-style casts with C++ casts in shuffle writers

### DIFF
--- a/cpp/velox/shuffle/VeloxGpuShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxGpuShuffleWriter.cc
@@ -26,7 +26,7 @@ void VeloxGpuHashShuffleWriter::splitBoolValueType(const uint8_t* srcAddr, const
     if (dstaddr == nullptr) {
       continue;
     }
-    auto dstPidBase = (uint8_t*)(dstaddr + partitionBufferBase_[pid] * sizeof(uint8_t));
+    auto dstPidBase = reinterpret_cast<uint8_t*>(dstaddr + partitionBufferBase_[pid] * sizeof(uint8_t));
     auto pos = partition2RowOffsetBase_[pid];
     auto end = partition2RowOffsetBase_[pid + 1];
     for (; pos < end; ++pos) {
@@ -42,7 +42,7 @@ void VeloxGpuHashShuffleWriter::splitBoolValueType(const uint8_t* srcAddr, const
 // Split timestamp from int128_t to int64_t, both of them represents the timestamp nanoseconds.
 arrow::Status VeloxGpuHashShuffleWriter::splitTimestamp(const uint8_t* srcAddr, const std::vector<uint8_t*>& dstAddrs) {
    for (auto& pid : partitionUsed_) {
-      auto dstPidBase = (int64_t*)(dstAddrs[pid] + partitionBufferBase_[pid] * sizeof(int64_t));
+      auto dstPidBase = reinterpret_cast<int64_t*>(dstAddrs[pid] + partitionBufferBase_[pid] * sizeof(int64_t));
       auto pos = partition2RowOffsetBase_[pid];
       auto end = partition2RowOffsetBase_[pid + 1];
       for (; pos < end; ++pos) {

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -637,7 +637,7 @@ arrow::Status VeloxHashShuffleWriter::splitBinaryType(
     auto& binaryBuf = dst[pid];
 
     // use 32bit offset
-    auto dstLengthBase = (StringLengthType*)(binaryBuf.lengthPtr) + partitionBufferBase_[pid];
+    auto dstLengthBase = reinterpret_cast<StringLengthType*>(binaryBuf.lengthPtr) + partitionBufferBase_[pid];
 
     auto valueOffset = binaryBuf.valueOffset;
     auto dstValuePtr = binaryBuf.valuePtr + valueOffset;
@@ -661,7 +661,7 @@ arrow::Status VeloxHashShuffleWriter::splitBinaryType(
       if (valueOffset >= capacity) {
         auto oldCapacity = capacity;
         (void)oldCapacity; // suppress warning
-        capacity = capacity + std::max((capacity >> multiply), (uint64_t)stringLen);
+        capacity = capacity + std::max((capacity >> multiply), static_cast<uint64_t>(stringLen));
         multiply = std::min(3, multiply + 1);
 
         const auto& valueBuffer = partitionBuffers_[fixedWidthColumnCount_ + binaryIdx][pid][kBinaryValueBufferIndex];
@@ -675,7 +675,7 @@ arrow::Status VeloxHashShuffleWriter::splitBinaryType(
         binaryBuf.valueCapacity = capacity;
         dstValuePtr = binaryBuf.valuePtr + valueOffset - stringLen;
         // Need to update dstLengthBase because lengthPtr can be updated if Reserve triggers spill.
-        dstLengthBase = (StringLengthType*)(binaryBuf.lengthPtr) + partitionBufferBase_[pid];
+        dstLengthBase = reinterpret_cast<StringLengthType*>(binaryBuf.lengthPtr) + partitionBufferBase_[pid];
       }
 
       // 2. copy value

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.h
@@ -270,7 +270,7 @@ class VeloxHashShuffleWriter : public VeloxShuffleWriter {
   template <typename T>
   arrow::Status splitFixedType(const uint8_t* srcAddr, const std::vector<uint8_t*>& dstAddrs) {
     for (auto& pid : partitionUsed_) {
-      auto dstPidBase = (T*)(dstAddrs[pid] + partitionBufferBase_[pid] * sizeof(T));
+      auto dstPidBase = reinterpret_cast<T*>(dstAddrs[pid] + partitionBufferBase_[pid] * sizeof(T));
       auto pos = partition2RowOffsetBase_[pid];
       auto end = partition2RowOffsetBase_[pid + 1];
       for (; pos < end; ++pos) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR replaces C-style pointer/value casts with C++ casts in `VeloxHashShuffleWriter` and `VeloxGpuShuffleWriter`

## How was this patch tested?

Existing tests since there is no behavioral change and only cast syntax is updated.

## Was this patch authored or co-authored using generative AI tooling?

No
