### PR TITLE
[MINOR][VL] Use resize() instead of reserve() in getEmitInfo

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -83,8 +83,8 @@ EmitInfo getEmitInfo(const ::substrait::RelCommon& relCommon, const core::PlanNo
   const auto& emit = relCommon.emit();
   int emitSize = emit.output_mapping_size();
   EmitInfo emitInfo;
-  emitInfo.projectNames.reserve(emitSize);
-  emitInfo.expressions.reserve(emitSize);
+  emitInfo.projectNames.resize(emitSize);
+  emitInfo.expressions.resize(emitSize);
   const auto& outputType = node->outputType();
   for (int i = 0; i < emitSize; i++) {
     int32_t mapId = emit.output_mapping(i);


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR replaces `reserve()` with `resize()` for `projectNames` and `expressions` vectors in `getEmitInfo()`. `std::vector::reserve()` allocates capacity but does not change `size()`. The subsequent loop assigns elements via `operator[]` which accesses indices beyond `size()` and this is undefined behaviour.

## How was this patch tested?

Existing tests.

## Was this patch authored or co-authored using generative AI tooling?

No
