### PR TITLE
[MINOR] Use build/mvn wrapper in release scripts

### DIFF
--- a/dev/release/build-release.sh
+++ b/dev/release/build-release.sh
@@ -40,7 +40,7 @@ fi
 # Build Gluten for Spark 3.3 with Java 8. All feature modules are enabled.
 for spark_version in 3.3
 do
-  mvn clean install -Pbackends-velox -Pspark-${spark_version} -Pceleborn,uniffle \
+  ${GLUTEN_HOME}/build/mvn clean install -Pbackends-velox -Pspark-${spark_version} -Pceleborn,uniffle \
                     -Piceberg,delta,hudi,paimon -DskipTests
 done
 
@@ -61,6 +61,6 @@ fi
 # All feature modules are enabled.
 for spark_version in 3.4 3.5
 do
-  mvn clean install -Pjava-17 -Pbackends-velox -Pspark-${spark_version} -Pceleborn,uniffle \
+  ${GLUTEN_HOME}/build/mvn clean install -Pjava-17 -Pbackends-velox -Pspark-${spark_version} -Pceleborn,uniffle \
                     -Piceberg,delta,hudi,paimon -DskipTests
 done

--- a/dev/release/bump-version.sh
+++ b/dev/release/bump-version.sh
@@ -27,7 +27,7 @@ NEW_VERSION="${1:-}"; [[ -n "$NEW_VERSION" ]] || usage
 # Resolve script dir
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 GLUTEN_HOME="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
-MVN_BIN="${MVN:-mvn}"
+MVN_BIN="${MVN:-${GLUTEN_HOME}/build/mvn}"
 
 bump() {
   local dir="$1"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace bare `mvn` with `./build/mvn` wrapper in release scripts to ensure consistent Maven version and settings across environments.

### Changes:
- `dev/release/build-release.sh`: Use `${GLUTEN_HOME}/build/mvn` for both Java 8 and Java 17 builds
- `dev/release/bump-version.sh`: Default `MVN_BIN` to `${GLUTEN_HOME}/build/mvn` instead of bare `mvn`

## How was this patch tested?

Script-only change, verified by inspection. The `GLUTEN_HOME` variable is already resolved in both scripts before the mvn invocations.