### PR TITLE
[VL] Reduce triple map lookup to single find in dictionary serialization

### DIFF
--- a/cpp/velox/shuffle/ArrowShuffleDictionaryWriter.cc
+++ b/cpp/velox/shuffle/ArrowShuffleDictionaryWriter.cc
@@ -404,14 +404,14 @@ arrow::Status ArrowShuffleDictionaryWriter::serialize(arrow::io::OutputStream* o
   ARROW_RETURN_NOT_OK(out->Write(bitMap.data(), bitMapSize));
 
   for (auto fieldIdx : dictionaryFields_) {
+    auto it = dictionaries_.find(fieldIdx);
     GLUTEN_DCHECK(
-        dictionaries_.find(fieldIdx) != dictionaries_.end(),
+        it != dictionaries_.end(),
         "Invalid dictionary field index: " + std::to_string(fieldIdx));
 
-    const auto& dictionary = dictionaries_[fieldIdx];
-    ARROW_RETURN_NOT_OK(dictionary->serialize(out));
+    ARROW_RETURN_NOT_OK(it->second->serialize(out));
 
-    dictionaries_.erase(fieldIdx);
+    dictionaries_.erase(it);
   }
 
   return arrow::Status::OK();


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR replaces three separate map look ups on the same key with a single `find()` and iterator reuse in `ArrowShuffleDictionaryWriter::serialize()`

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
