### PR TITLE
[MINOR] Use build/mvn wrapper in CI cache workflow

### DIFF
--- a/.github/workflows/velox_backend_cache.yml
+++ b/.github/workflows/velox_backend_cache.yml
@@ -178,7 +178,7 @@ jobs:
           cd /work
           bash dev/builddeps-veloxbe.sh --run_setup_script=OFF --build_arrow=OFF --build_tests=ON --build_benchmarks=ON --enable_gpu=ON # TODO: re-enable tests with more disk space
           rm -rf ep/build-velox/build/velox_ep
-          mvn clean package -Pbackends-velox -Pspark-3.4 -DskipTests
+          ./build/mvn clean package -Pbackends-velox -Pspark-3.4 -DskipTests
           ccache -s
           "
       - name: Save Ccache


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace bare `mvn` with `./build/mvn` wrapper in `velox_backend_cache.yml` to ensure consistent Maven version and settings in CI.

Follow-up to #11625.

## How was this patch tested?

Single-line CI config change, verified by inspection.