### PR TITLE
[VL] Fix oom when plan is large

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackTag.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackTag.scala
@@ -105,7 +105,7 @@ object FallbackTags {
 
   def get(plan: TreeNode[_]): FallbackTag = {
     getOption(plan).getOrElse(
-      throw new IllegalStateException("Transform hint tag not set in plan: " + plan.toString()))
+      throw new IllegalStateException("Transform hint tag not set in plan: " + plan.nodeName))
   }
 
   def getOption(plan: TreeNode[_]): Option[FallbackTag] = {

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/property/Conv.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/enumerated/planner/property/Conv.scala
@@ -41,7 +41,8 @@ object Conv {
   }
 
   def findTransition(from: Prop, to: Req): Transition = {
-    val out = Transition.factory.findTransition(from.prop, to.req, new IllegalStateException())
+    val out =
+      Transition.factory.findTransitionOrThrow(from.prop, to.req)(new IllegalStateException())
     out
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/Transitions.scala
@@ -49,7 +49,7 @@ case class InsertTransitions(convReq: ConventionReq) extends Rule[SparkPlan] {
           child
         } else {
           val transition =
-            Transition.factory.findTransition(from, convReq, Transition.notFound(node))
+            Transition.factory.findTransitionOrThrow(from, convReq)(Transition.notFound(node))
           val newChild = transition.apply(child)
           newChild
         }
@@ -98,7 +98,7 @@ object Transitions {
     val convFunc = ConventionFunc.create()
     val removed = RemoveTransitions.removeForNode(plan)
     val transition = Transition.factory
-      .findTransition(convFunc.conventionOf(removed), req, Transition.notFound(removed, req))
+      .findTransitionOrThrow(convFunc.conventionOf(removed), req)(Transition.notFound(removed, req))
     val out = transition.apply(removed)
     out
   }


### PR DESCRIPTION
This PR fixes an OOM issue in transition error handling by making `Transition.Factory.findTransition(..., otherwise)` lazy and by avoiding full-plan stringification in `Transition.notFound`.

`otherwise` was passed by value (otherwise: Exception), so `Transition.notFound(...)` was constructed eagerly at call sites.
`notFound` previously interpolated `$plan`, which triggers full `SparkPlan.toString()` and can allocate huge strings for large plans, causing:

```
 java.lang.OutOfMemoryError
 	at java.lang.AbstractStringBuilder.hugeCapacity(AbstractStringBuilder.java:161)
 	at java.lang.AbstractStringBuilder.newCapacity(AbstractStringBuilder.java:155)
 	at java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:125)
 	at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:448)
 	at java.lang.StringBuilder.append(StringBuilder.java:136)
 	at java.lang.StringBuilder.append(StringBuilder.java:131)
 	at org.apache.gluten.extension.columnar.transition.Transition$.notFound(Transition.scala:59)
 	at org.apache.gluten.extension.columnar.transition.Transitions$.enforceReq(Transitions.scala:105)
 	at org.apache.gluten.extension.columnar.transition.InsertTransitions.apply(Transitions.scala:33)
 	at org.apache.gluten.extension.columnar.transition.Transitions$.insert(Transitions.scala:89)
 	at org.apache.gluten.extension.GlutenColumnarRule.org$apache$gluten$extension$GlutenColumnarRule$$$anonfun$postColumnarTransitions$1(GlutenColumnarRule.scala:100)
 	at org.apache.gluten.extension.GlutenColumnarRule$$anonfun$postColumnarTransitions$2.apply(GlutenColumnarRule.scala:85)
 	at org.apache.gluten.extension.GlutenColumnarRule$$anonfun$postColumnarTransitions$2.apply(GlutenColumnarRule.scala:85)
```