### PR TITLE
[VL] Fix the compilation issue encountered when running micro benchmark

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -20,6 +20,7 @@ import org.apache.gluten.backendsapi.SparkPlanExecApi
 import org.apache.gluten.config.{GlutenConfig, HashShuffleWriterType, ReservedKeys, RssSortShuffleWriterType, ShuffleWriterType, SortShuffleWriterType, VeloxConfig}
 import org.apache.gluten.exception.{GlutenExceptionUtil, GlutenNotSupportException}
 import org.apache.gluten.execution._
+import org.apache.gluten.execution.ColumnarRangeBaseExec
 import org.apache.gluten.expression._
 import org.apache.gluten.expression.aggregate.{HLLAdapter, VeloxBloomFilterAggregate, VeloxCollectList, VeloxCollectSet}
 import org.apache.gluten.extension.columnar.FallbackTags


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
When we were running MicroBenchmarks, we encountered a compile-related issue. The details are as follows. We can solve this problem by clearly defining the package path.
<img width="1492" height="526" alt="image" src="https://github.com/user-attachments/assets/ca5a369d-903e-4ee9-ab32-7ba38f741879" />

## How was this patch tested?
Run `mvn test -Pspark-3.4 -Pbackends-velox -pl backends-velox -am -DtagsToInclude="org.apache.gluten.tags.GenerateExample" -Dtest=none -DfailIfNoTests=false -Dexec.skip`. Refer to [MicroBenchmarks.md](https://github.com/apache/incubator-gluten/blob/main/docs/developers/MicroBenchmarks.md)

## Was this patch authored or co-authored using generative AI tooling?
No.
