### PR TITLE
[VL] Initialize typeConvertor_ in VeloxToSubstraitExprConvertor

### DIFF
--- a/cpp/velox/substrait/VeloxToSubstraitExpr.h
+++ b/cpp/velox/substrait/VeloxToSubstraitExpr.h
@@ -29,8 +29,7 @@ namespace gluten {
 class VeloxToSubstraitExprConvertor {
  public:
   explicit VeloxToSubstraitExprConvertor(const SubstraitExtensionCollectorPtr& extensionCollector)
-      : extensionCollector_(extensionCollector), 
-        typeConvertor_(std::make_shared<VeloxToSubstraitTypeConvertor>()) {}
+      : typeConvertor_(std::make_shared<VeloxToSubstraitTypeConvertor>()), extensionCollector_(extensionCollector) {}
 
   /// Convert Velox Expression to Substrait Expression.
   /// @param arena Arena to use for allocating Substrait plan objects.


### PR DESCRIPTION
## What changes are proposed in this pull request?

When running Gluten CPP tests with ASan/UBSan I see the following failure in `velox_plan_conversion_test`

```
2026-02-25T11:25:50.0690440Z I20260225 11:25:49.043994 22501 Task.cpp:2413] Terminating task test_cursor_3 with state Finished after running for 2ms
2026-02-25T11:25:50.0691067Z /mnt/vss/_work/1/s/Gluten/cpp/velox/substrait/VeloxToSubstraitExpr.cc:488:81: runtime error: member call on null pointer of type 'struct element_type'
2026-02-25T11:25:50.0694196Z     #0 0x1555166ca7fd in gluten::VeloxToSubstraitExprConvertor::toSubstraitExpr(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::CallTypedExpr const> const&, std::shared_ptr<facebook::velox::RowType const> const&) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24cca7fd) (BuildId: 414873b7abee5e433415f08761f593c79b91c273)
2026-02-25T11:25:50.0694879Z     #1 0x1555166c4e7d in gluten::VeloxToSubstraitExprConvertor::toSubstraitExpr(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::ITypedExpr const> const&, std::shared_ptr<facebook::velox::RowType const> const&) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24cc4e7d) (BuildId: 414873b7abee5e433415f08761f593c79b91c273)
2026-02-25T11:25:50.0695494Z     #2 0x1555166d76f0 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::ProjectNode const> const&, substrait::ProjectRel*) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24cd76f0) (BuildId: 414873b7abee5e433415f08761f593c79b91c273)
2026-02-25T11:25:50.0696064Z     #3 0x1555166d4210 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::PlanNode const> const&, substrait::Rel*) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24cd4210) (BuildId: 414873b7abee5e433415f08761f593c79b91c273)
2026-02-25T11:25:50.0696617Z     #4 0x1555166d5d43 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::PlanNode const> const&) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24cd5d43) (BuildId: 414873b7abee5e433415f08761f593c79b91c273)
2026-02-25T11:25:50.0697381Z     #5 0x55556205e0db in gluten::VeloxSubstraitRoundTripTest::assertPlanConversion(std::shared_ptr<facebook::velox::core::PlanNode const> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb0a0db) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0697922Z     #6 0x555561fdce4e in gluten::VeloxSubstraitRoundTripTest_project_Test::TestBody() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xca88e4e) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0698413Z     #7 0x5555620c20cc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb6e0cc) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0698869Z     #8 0x5555620b150d in testing::Test::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb5d50d) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0699235Z     #9 0x5555620b16c4 in testing::TestInfo::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb5d6c4) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0699608Z     #10 0x5555620b17e4 in testing::TestSuite::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb5d7e4) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0699994Z     #11 0x5555620b952b in testing::internal::UnitTestImpl::RunAllTests() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb6552b) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0700379Z     #12 0x5555620b19ac in testing::UnitTest::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb5d9ac) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0700722Z     #13 0x555561d3cfd6 in main (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xc7e8fd6) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0701103Z     #14 0x1554ec027efa in __libc_start_call_main (/usr/lib/libc.so.6+0x27efa) (BuildId: 770b2da56f3278b92bc9ac4649f450a417ace260)
2026-02-25T11:25:50.0701385Z     #15 0x1554ec027fba in __libc_start_main (/usr/lib/libc.so.6+0x27fba) (BuildId: 770b2da56f3278b92bc9ac4649f450a417ace260)
2026-02-25T11:25:50.0701689Z     #16 0x555561d5e3d4 in _start (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xc80a3d4) (BuildId: f2d821f1c0470c0538998e357104a4352db0635a)
2026-02-25T11:25:50.0701846Z 
2026-02-25T11:25:50.0732222Z   *** UBSAN ERROR: velox_plan_conversion_test ***
2026-02-25T11:25:50.0755090Z 42:/mnt/vss/_work/1/s/Gluten/cpp/velox/substrait/VeloxToSubstraitExpr.cc:488:81: runtime error: member call on null pointer of type 'struct element_type'
```
This is because `typeConvertor_` is declared but never initialized in the constructor. 

Previously `typeConvertor_` was default-constructed as a null shared_ptr. At this line
```
   typeConvertor_->toSubstraitType(arena, callTypeExpr->type())
```
  operator-> on a null shared_ptr dereferences null to get element_type* (element_type is the shared_ptr's
  internal typedef for `VeloxToSubstraitTypeConvertor`), then calls a member function on it and this is the "member call on null pointer of type struct element_type" UBSan reports.

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
