### PR TITLE
[MINOR] Add missing Delta Lake derived file to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -247,6 +247,7 @@
    ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/Snapshot.scala
    ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
    ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
 
     The Velox Project(https://github.com/facebookincubator/velox)
    ./cpp/velox/udf/examples/MyUDAF.cc


### PR DESCRIPTION
## What Changes Were Proposed In This Pull Request?

Add `MergeIntoMaterializeSource.scala` to the Delta Lake section in LICENSE file.

## Why Are The Changes Needed?

During the release validation for Apache Gluten 1.6.0 (RC0), it was found that the file `backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala` is derived from Delta Lake (it carries the Delta Lake copyright header) but was not listed in the LICENSE file under the Delta Lake third-party attribution section.

Other Delta Lake derived files in the same directory tree are properly listed in LICENSE. This PR adds the missing entry for consistency and compliance.

## How Was This Patch Tested?

No code changes - LICENSE file update only.