### PR TITLE
[MINOR] Add bundled test JAR to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -259,4 +259,10 @@
    ClickHouse(https://github.com/ClickHouse/ClickHouse)
    ./cpp-ch/local-engine/AggregateFunctions/AggregateFunctionPartialMerge.h
    ./cpp-ch/local-engine/Functions/SparkFunctionArrayDistinct.cpp
+
+   This product bundles the following compiled test binary under the
+   Apache Software License 2.0.
+
+   Apache Hive(https://github.com/apache/hive)
+   ./backends-clickhouse/src/test/resources/udfs/hive-test-udfs.jar
    


### PR DESCRIPTION
## What Changes Were Proposed In This Pull Request?

Document `hive-test-udfs.jar` in the LICENSE file as a bundled compiled test binary under the Apache Software License 2.0.

## Why Are The Changes Needed?

During the release validation for Apache Gluten 1.6.0 (RC0), it was found that the compiled binary `backends-clickhouse/src/test/resources/udfs/hive-test-udfs.jar` is bundled in the source archive but not documented in LICENSE or NOTICE.

Per ASF release policy, all compiled archives bundled in the source archive should be properly attributed. This JAR is a test binary derived from Apache Hive and is licensed under the Apache Software License 2.0.

## How Was This Patch Tested?

No code changes - LICENSE file update only.