### PR TITLE
[BUILD] Upgrade Scala 2.12 version to 2.12.18 to support JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <caffeine.version>2.9.3</caffeine.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.18</scala.version>
     <scala-xml.version>2.1.0</scala-xml.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <spark.major.version>3</spark.major.version>
@@ -998,7 +998,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
       </properties>
     </profile>


### PR DESCRIPTION
## What changes are proposed in this pull request?
Gluten should upgrade the Scala 2.12 version to 2.12.18 to support JDK 21 and align with the Scala version used in Spark 3.5.


