### PR TITLE
[GLUTEN-11673][CORE] Fix URL-encoded paths in ResourceUtil causing JAR loading failures

### DIFF
--- a/gluten-core/src/test/java/org/apache/gluten/util/ResourceUtilTest.java
+++ b/gluten-core/src/test/java/org/apache/gluten/util/ResourceUtilTest.java
@@ -21,6 +21,7 @@ import org.apache.gluten.utils.ResourceUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.URI;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -42,5 +43,17 @@ public class ResourceUtilTest {
         ResourceUtil.getResources("org", Pattern.compile("apache/spark/SparkContext\\.class"));
     Assert.assertEquals(1, classes.size());
     Assert.assertEquals("apache/spark/SparkContext.class", classes.get(0));
+  }
+
+  /** Verifies URI correctly decodes percent-encoded paths and preserves '+' characters. */
+  @Test
+  public void testUriDecodesPercentEncodedPaths() throws Exception {
+    // %40 should decode to @
+    URI uri1 = new URI("file:///path/user%40domain/file.jar");
+    Assert.assertEquals("/path/user@domain/file.jar", uri1.getPath());
+
+    // + should be preserved (not converted to space like URLDecoder does)
+    URI uri2 = new URI("file:///path/file+name.jar");
+    Assert.assertEquals("/path/file+name.jar", uri2.getPath());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix URL-encoded path handling in `ResourceUtil.getResources()` by using `URL.toURI()` and `URI` for proper path decoding instead of `URL.getPath()`.

Changes:
- Added imports for `java.net.URI` and `java.net.URISyntaxException`
- Fixed the `file:` protocol handler to use `new File(containerUrl.toURI())` instead of `new File(containerUrl.getPath())`
- Fixed the `jar:file:` protocol handler to use `new File(new URI("file://" + jarPath))` for proper decoding
- Added unit test verifying URI decoding behavior

## Why are the changes needed?

When Gluten is loaded from a JAR file located in a directory with special characters in its path (such as `@` or spaces), `ResourceUtil.getResources()` fails because `ClassLoader.getResources()` returns URLs where special characters are percent-encoded (e.g., `@` becomes `%40`). `ResourceUtil` was passing these URL-encoded paths directly to `java.io.File()`, which expects filesystem paths, not URL-encoded strings.

The fix uses `URL.toURI()` and `new File(URI)` which properly decode percent-encoded characters. This also correctly preserves `+` characters (unlike `URLDecoder.decode()` which treats `+` as space).

## Does this PR introduce _any_ user-facing change?

No

## How was this patch tested?

Added unit test `testUriDecodesPercentEncodedPaths` that verifies:
- `URI` correctly decodes `%40` back to `@`
- `URI` preserves `+` characters (unlike `URLDecoder`)

Existing unit tests continue to pass.

Related issue: #11673