### PR TITLE
[VL] Initialize typeConvertor_ in VeloxToSubstraitPlanConvertor

### DIFF
--- a/cpp/velox/substrait/VeloxToSubstraitPlan.h
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.h
@@ -104,7 +104,7 @@ class VeloxToSubstraitPlanConvertor {
 
   /// The Type converter used to conver velox representation into Substrait
   /// type.
-  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
+  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_ = std::make_shared<VeloxToSubstraitTypeConvertor>();
 
   /// The Extension collector storing the relations between the function
   /// signature and the function reference number.

--- a/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
+++ b/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
@@ -37,7 +37,7 @@ class VeloxToSubstraitTypeTest : public ::testing::Test {
         << "Expected: " << type->toString() << ", but got: " << sameType->toString();
   }
 
-  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
+  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_ = std::make_shared<VeloxToSubstraitTypeConvertor>();
 };
 
 TEST_F(VeloxToSubstraitTypeTest, basic) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

When running Gluten CPP tests with ASan/UBSan I see the following failure in `velox_plan_conversion_test`

```
[----------] 3 tests from SubstraitExtensionCollectorTest
  ...
I20260302 13:05:13.832439 18017 Task.cpp:2413] Terminating task test_cursor_3 with state Finished after running for 1ms
/mnt/vss/_work/1/s/Gluten/cpp/velox/substrait/VeloxToSubstraitPlan.cc:200:83: runtime error: member call on null pointer of type 'struct element_type'
    #0 0x155516780544 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::ValuesNode const> const&, substrait::ReadRel*) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24d80544) (BuildId: 3823968b38694acf997dceea565932e47a84025b)
    #1 0x155516787ff2 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::PlanNode const> const&, substrait::Rel*) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24d87ff2) (BuildId: 3823968b38694acf997dceea565932e47a84025b)
    #2 0x15551678b61f in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::ProjectNode const> const&, substrait::ProjectRel*) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24d8b61f) (BuildId: 3823968b38694acf997dceea565932e47a84025b)
    #3 0x155516788760 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::PlanNode const> const&, substrait::Rel*) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24d88760) (BuildId: 3823968b38694acf997dceea565932e47a84025b)
    #4 0x15551678a118 in gluten::VeloxToSubstraitPlanConvertor::toSubstrait(google::protobuf::Arena&, std::shared_ptr<facebook::velox::core::PlanNode const> const&) (/mnt/vss/_work/1/s/Gluten/cpp/build/releases/libvelox.so+0x24d8a118) (BuildId: 3823968b38694acf997dceea565932e47a84025b)
    #5 0x5555620a121b in gluten::VeloxSubstraitRoundTripTest::assertPlanConversion(std::shared_ptr<facebook::velox::core::PlanNode const> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcb4d21b) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #6 0x55556201ff8e in gluten::VeloxSubstraitRoundTripTest_project_Test::TestBody() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcacbf8e) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #7 0x555562105acc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcbb1acc) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #8 0x5555620f4f0d in testing::Test::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcba0f0d) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #9 0x5555620f50c4 in testing::TestInfo::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcba10c4) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #10 0x5555620f51e4 in testing::TestSuite::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcba11e4) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #11 0x5555620fcf2b in testing::internal::UnitTestImpl::RunAllTests() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcba8f2b) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #12 0x5555620f53ac in testing::UnitTest::Run() (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xcba13ac) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #13 0x555561d800c6 in main (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xc82c0c6) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)
    #14 0x1554ec027efa in __libc_start_call_main (/usr/lib/libc.so.6+0x27efa) (BuildId: 770b2da56f3278b92bc9ac4649f450a417ace260)
    #15 0x1554ec027fba in __libc_start_main (/usr/lib/libc.so.6+0x27fba) (BuildId: 770b2da56f3278b92bc9ac4649f450a417ace260)
    #16 0x555561da1514 in _start (/mnt/vss/_work/1/s/Gluten/cpp/build/velox/tests/velox_plan_conversion_test+0xc84d514) (BuildId: 3161011723acf3e0b9f071279f41d6ce7480fd14)

  *** UBSAN ERROR: velox_plan_conversion_test ***
42:/mnt/vss/_work/1/s/Gluten/cpp/velox/substrait/VeloxToSubstraitPlan.cc:200:83: runtime error: member call on null pointer of type 'struct element_type'
```
This is because `typeConvertor_` is declared but never default initialized.

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
