### PR TITLE
[GLUTEN-10903][VL] Build cudf always

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -419,6 +419,7 @@ if(BUILD_EXAMPLES)
 endif()
 
 if(ENABLE_GPU)
+  set(cudf_DIR "${VELOX_BUILD_PATH}/_deps/cudf-build")
   find_package(cudf CONFIG REQUIRED)
 
   import_library(

--- a/ep/build-velox/src/build-velox.sh
+++ b/ep/build-velox/src/build-velox.sh
@@ -173,12 +173,6 @@ function compile {
         sudo cmake --install xsimd-build/
       fi
     fi
-    if [ -d cudf-build ]; then
-      echo "INSTALL cudf."
-      if [ $OS == 'Linux' ]; then
-        sudo cmake --install cudf-build/
-      fi
-    fi
     if [ -d googletest-build ]; then
       echo "INSTALL gtest."
       if [ $OS == 'Linux' ]; then


### PR DESCRIPTION
Because the base image `apache/gluten:centos-9-jdk8-cudf` is updated every week while cudf maybe updated in place, so we need to build cudf every time to avoid API compatibility.

Related issue: #10903

Fixes: https://github.com/apache/incubator-gluten/issues/11693