### PR TITLE
[INFRA] Add deletion vector .bin test data files to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -266,4 +266,12 @@
 
    Apache Hive(https://github.com/apache/hive)
    ./backends-clickhouse/src/test/resources/udfs/hive-test-udfs.jar
+
+   This product bundles the following binary test data files, which are
+   self-generated Delta Lake deletion vector fixtures used for testing,
+   under the Apache Software License 2.0.
+
+   ./cpp-ch/local-engine/tests/data/deletion_vector_long_values.bin
+   ./cpp-ch/local-engine/tests/data/deletion_vector_multiple.bin
+   ./cpp-ch/local-engine/tests/data/deletion_vector_only_one.bin
    


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the 3 binary test data files (\deletion_vector_*.bin\) under \cpp-ch/local-engine/tests/data/\ to the LICENSE file.

These files are self-generated Delta Lake deletion vector fixtures used for testing in \gtest_clickhouse_roaring_bitmap.cpp\. They were missing from the LICENSE file, which could be flagged during Apache release validation (e.g., the 1.6.0-rc1 vote).

### Files added to LICENSE:
- \./cpp-ch/local-engine/tests/data/deletion_vector_long_values.bin\
- \./cpp-ch/local-engine/tests/data/deletion_vector_multiple.bin\
- \./cpp-ch/local-engine/tests/data/deletion_vector_only_one.bin\

## How was this patch tested?

This is a LICENSE-only documentation change. No code behavior is affected.