### PR TITLE
[GLUTEN-11550][UT] Enable GlutenXmlFunctionsSuite for Spark 4.0 and 4.1

### DIFF
--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -857,7 +857,7 @@ class VeloxTestSettings extends BackendTestSettings {
   // TODO: 4.x enableSuite[GlutenVariantShreddingSuite]  // 8 failures
   enableSuite[GlutenVariantSuite]
   enableSuite[GlutenVariantWriteShreddingSuite]
-  // TODO: 4.x enableSuite[GlutenXmlFunctionsSuite]  // 10 failures
+  enableSuite[GlutenXmlFunctionsSuite]
   enableSuite[GlutenApproxCountDistinctForIntervalsQuerySuite]
   enableSuite[GlutenApproximatePercentileQuerySuite]
   enableSuite[GlutenCachedTableSuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -822,7 +822,7 @@ class VeloxTestSettings extends BackendTestSettings {
   // TODO: 4.x enableSuite[GlutenVariantShreddingSuite]  // 8 failures
   enableSuite[GlutenVariantSuite]
   enableSuite[GlutenVariantWriteShreddingSuite]
-  // TODO: 4.x enableSuite[GlutenXmlFunctionsSuite]  // 10 failures
+  enableSuite[GlutenXmlFunctionsSuite]
   enableSuite[GlutenApproxCountDistinctForIntervalsQuerySuite]
   enableSuite[GlutenAddMetadataColumnsSuite]
   enableSuite[GlutenAlwaysPersistedConfigsSuite]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #11550 (partial)

- **Enable `GlutenXmlFunctionsSuite`** in VeloxTestSettings for both spark40 and spark41.
- The woodstox classpath conflict that previously caused 10 failures was already fixed by PR #11580. All 31 tests now pass on both spark40 and spark41 without any exclusions.

## How was this patch tested?

Ran `GlutenXmlFunctionsSuite` on both spark40 and spark41:
- spark40: 31 passed, 0 failed ✅
- spark41: 31 passed, 0 failed ✅

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI