### PR TITLE
Update repository references from incubator-gluten to gluten after TLP graduation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,5 +16,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Gluten Discussions
-    url: https://github.com/apache/incubator-gluten/discussions
+    url: https://github.com/apache/gluten/discussions
     about: Ask questions or discuss new feature ideas here.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 Thank you for submitting a pull request! Here are some tips:
 
 1. For first-time contributors, please read our contributing guide:
-   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
+   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
 2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
 3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
    Velox or ClickHouse backend, respectively.

--- a/.github/workflows/dev_cron/pr_issue_linker.js
+++ b/.github/workflows/dev_cron/pr_issue_linker.js
@@ -29,7 +29,7 @@ function detectIssueID(title) {
 }
 
 async function appendToPRDescription(github, context, pullRequestNumber, issuesID) {
-  const issueURL = `https://github.com/apache/incubator-gluten/issues/${issuesID}`;
+  const issueURL = `https://github.com/apache/gluten/issues/${issuesID}`;
   const issueReference = `#${issuesID}`
 
   // Fetch the current PR description.

--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -62,7 +62,7 @@ jobs:
           export PATH=$JAVA_HOME/bin:$PATH
           
           # action/checkout does not work centos7 anymore, so we clone the branch instead.
-          git clone -b main --depth=1 https://github.com/apache/incubator-gluten.git && cd incubator-gluten/
+          git clone -b main --depth=1 https://github.com/apache/gluten.git && cd gluten/
           if [ ${{ github.event_name }} = "pull_request" ]; then
             git fetch origin ${{ github.ref }}:pr_branch && git checkout pr_branch
           fi

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -25,7 +25,7 @@
             GitHub share the sequence number of issues and pull requests, and it will redirect to
             the right place when the the sequence number not match kind.
            -->
-          <option name="linkRegexp" value="https://github.com/apache/incubator-gluten/issues/$1" />
+          <option name="linkRegexp" value="https://github.com/apache/gluten/issues/$1" />
         </IssueNavigationLink>
       </list>
     </option>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,15 +44,15 @@ please add at least one UT to ensure code quality and reduce regression issues f
 
 Please update document for your proposed code change if necessary.
 
-If a new config property is being introduced, please update [Configuration.md](https://github.com/apache/incubator-gluten/blob/main/docs/Configuration.md).
+If a new config property is being introduced, please update [Configuration.md](https://github.com/apache/gluten/blob/main/docs/Configuration.md).
 
 ### Code Style
 
 ##### Java/Scala code style
-Developer can import the code style setting to IDE and format Java/Scala code with spotless maven plugin. See [Java/Scala code style](https://github.com/apache/incubator-gluten/blob/main/docs/developers/NewToGluten.md#javascala-code-style).
+Developer can import the code style setting to IDE and format Java/Scala code with spotless maven plugin. See [Java/Scala code style](https://github.com/apache/gluten/blob/main/docs/developers/NewToGluten.md#javascala-code-style).
 
 ##### C/C++ code style
-There are some code style conventions need to comply. See [CppCodingStyle.md](https://github.com/apache/incubator-gluten/blob/main/docs/developers/CppCodingStyle.md).
+There are some code style conventions need to comply. See [CppCodingStyle.md](https://github.com/apache/gluten/blob/main/docs/developers/CppCodingStyle.md).
 
 For Velox backend, developer can just execute `dev/formatcppcode.sh` to format C/C++ code. It requires `clang-format-15`
 installed in your development env.
@@ -68,7 +68,7 @@ You can execute a script to fix license header issue, as the following shows.
 ### Gluten CI
 
 ##### ClickHouse Backend CI
-To check CI failure for CH backend, please log in with the public account/password provided [here](https://github.com/apache/incubator-gluten/blob/main/docs/get-started/ClickHouse.md#new-ci-system).
+To check CI failure for CH backend, please log in with the public account/password provided [here](https://github.com/apache/gluten/blob/main/docs/get-started/ClickHouse.md#new-ci-system).
 To re-trigger CH CI, please post the below comment on PR page:
 
 `Run Gluten Clickhouse CI`
@@ -79,7 +79,7 @@ To check CI failure for Velox backend, please go into the GitHub action page fro
 To see the perf. impact on Velox backend, you can comment `/Benchmark Velox` on PR page to trigger a pretest. The benchmark
 (currently TPC-H) result will be posted after completed.
 
-If some new dependency is required to be installed, you may need to do some change for CI docker at [this folder](https://github.com/apache/incubator-gluten/tree/main/tools/gluten-te).
+If some new dependency is required to be installed, you may need to do some change for CI docker at [this folder](https://github.com/apache/gluten/tree/main/tools/gluten-te).
 
 ### Code Review
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ to view past discussions, or [subscribe to the mailing list](mailto:dev-subscrib
 
 ### Slack Channel (English)
 
-Request an invitation to the ASF Slack workspace via [this page](https://github.com/apache/incubator-gluten/discussions/8429). Once invited, you can join the **incubator-gluten** channel.
+Request an invitation to the ASF Slack workspace via [this page](https://github.com/apache/gluten/discussions/8429). Once invited, you can join the **gluten** channel.
 
 The ASF Slack login entry: https://the-asf.slack.com/.
 
@@ -166,6 +166,6 @@ Gluten is licensed under [Apache License Version 2.0](https://www.apache.org/lic
 
 Gluten was initiated by Intel and Kyligence in 2022. Several other companies are also actively contributing to its development, including BIGO, Meituan, Alibaba Cloud, NetEase, Baidu, Microsoft, IBM, Google, etc.
 
-<a href="https://github.com/apache/incubator-gluten/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=apache/incubator-gluten&columns=25" />
+<a href="https://github.com/apache/gluten/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=apache/gluten&columns=25" />
 </a>

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -164,7 +164,23 @@ object CHRuleApi {
   }
 
   /**
-   * Since https://github.com/apache/incubator-gluten/pull/883.
+   * Registers Gluten's columnar rules. These rules will be executed only when RAS (relational
+   * algebra selector) is enabled by spark.gluten.ras.enabled=true.
+   *
+   * These rules are covered by CI test job spark-test-spark35-ras.
+   */
+  private def injectRas(injector: RasInjector): Unit = {
+    // CH backend doesn't work with RAS at the moment. Inject a rule that aborts any
+    // execution calls.
+    injector.injectPreTransform(
+      _ =>
+        new SparkPlanRules.AbortRule(
+          "Clickhouse backend doesn't yet have RAS support, please try disabling RAS and" +
+            " rerunning the application"))
+  }
+
+  /**
+   * Since https://github.com/apache/gluten/pull/883.
    *
    * TODO: Remove this since tricky to maintain.
    */

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHValidatorApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHValidatorApi.scala
@@ -114,7 +114,7 @@ object CHValidatorApi {
    * and make it into a new column which the shuffle will refer to. But we need to remove it from
    * the result columns from the shuffle.
    *
-   * Since https://github.com/apache/incubator-gluten/pull/1071.
+   * Since https://github.com/apache/gluten/pull/1071.
    */
   def supportShuffleWithProject(outputPartitioning: Partitioning, child: SparkPlan): Boolean = {
     child match {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHColumnarToCarrierRowExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHColumnarToCarrierRowExec.scala
@@ -29,7 +29,7 @@ case class CHColumnarToCarrierRowExec(override val child: SparkPlan)
   override def rowType(): Convention.RowType = CHCarrierRowType
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     copy(child = newChild)
-  // Since https://github.com/apache/incubator-gluten/pull/1595.
+  // Since https://github.com/apache/gluten/pull/1595.
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
     if (child.supportsColumnar) {
       child.executeColumnar()

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressions.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/expression/CHExpressions.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 
 // Static helper object for handling expressions that are specifically used in CH backend.
 object CHExpressions {
-  // Since https://github.com/apache/incubator-gluten/pull/1937.
+  // Since https://github.com/apache/gluten/pull/1937.
   def createAggregateFunction(context: SubstraitContext, aggregateFunc: AggregateFunction): Long = {
     val expressionExtensionTransformer =
       ExpressionExtensionTrait.findExpressionExtension(aggregateFunc.getClass)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -861,7 +861,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
   }
 
   test("test parse string with blank to integer") {
-    // issue https://github.com/apache/incubator-gluten/issues/4956
+    // issue https://github.com/apache/gluten/issues/4956
     val sql = "select  cast(concat(' ', cast(id as string)) as bigint) from range(10)"
     runQueryAndCompare(sql)(checkGlutenPlan[ProjectExecTransformer])
   }
@@ -915,7 +915,7 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     }
   }
 
-  test("test issue: https://github.com/apache/incubator-gluten/issues/6561") {
+  test("test issue: https://github.com/apache/gluten/issues/6561") {
     val sql =
       """
         |select

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/compatibility/GlutenClickhouseFunctionSuite.scala
@@ -72,7 +72,7 @@ class GlutenClickhouseFunctionSuite extends ParquetSuite {
     }
   }
 
-  test("https://github.com/apache/incubator-gluten/issues/6938") {
+  test("https://github.com/apache/gluten/issues/6938") {
     val testSQL =
       s"""
          |select * from (
@@ -372,7 +372,7 @@ class GlutenClickhouseFunctionSuite extends ParquetSuite {
     }
   }
 
-  test("GLUTEN-7545: https://github.com/apache/incubator-gluten/issues/7545") {
+  test("GLUTEN-7545: https://github.com/apache/gluten/issues/7545") {
     withTable("regexp_test") {
       sql("create table if not exists regexp_test (id string) using parquet")
       sql("insert into regexp_test values('1999-6-1')")

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseNativeWriteTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseNativeWriteTableSuite.scala
@@ -514,7 +514,7 @@ class GlutenClickHouseNativeWriteTableSuite
       ("decimal_field", "decimal(23,12)"),
       ("date_field", "date")
       // ("timestamp_field", "timestamp")
-      // FIXME https://github.com/apache/incubator-gluten/issues/8053
+      // FIXME https://github.com/apache/gluten/issues/8053
     )
     val origin_table = "origin_table"
     withSource(genTestData(), origin_table) {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHColumnarShuffleParquetAQESuite.scala
@@ -319,7 +319,7 @@ class GlutenClickHouseTPCHColumnarShuffleParquetAQESuite extends ParquetTPCHSuit
     }
   }
 
-  ignore("https://github.com/apache/incubator-gluten/issues/7726") {
+  ignore("https://github.com/apache/gluten/issues/7726") {
     runQueryAndCompare(Arm.withResource(
       Source.fromFile(new File(s"$queryPath/tpch-schema-related/7726.sql"), "UTF-8"))(_.mkString)) {
       df =>

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -325,7 +325,7 @@ class VeloxIcebergSuite extends IcebergSuite {
       val lastExecId = statusStore.executionsList().last.executionId
       val executionMetrics = statusStore.executionMetrics(lastExecId)
 
-      // TODO: fix https://github.com/apache/incubator-gluten/issues/11510
+      // TODO: fix https://github.com/apache/gluten/issues/11510
       assert(executionMetrics(metrics("numWrittenFiles").id).toLong == 0)
     }
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -154,7 +154,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
         case ParquetReadFormat =>
           val parquetOptions = new ParquetOptions(CaseInsensitiveMap(properties), SQLConf.get)
           if (parquetOptions.mergeSchema) {
-            // https://github.com/apache/incubator-gluten/issues/7174
+            // https://github.com/apache/gluten/issues/7174
             Some(s"not support when merge schema is true")
           } else {
             None

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -315,7 +315,7 @@ object VeloxListenerApi {
 
     var parsed: Map[String, String] = GlutenConfigUtil.parseConfig(conf.getAll.toMap)
 
-    // Workaround for https://github.com/apache/incubator-gluten/issues/7837
+    // Workaround for https://github.com/apache/gluten/issues/7837
     if (isDriver && !inLocalMode(conf)) {
       parsed += (COLUMNAR_VELOX_CACHE_ENABLED.key -> "false")
     }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
@@ -90,11 +90,11 @@ class VeloxValidatorApi extends ValidatorApi {
       child: SparkPlan): Option[String] = {
     if (!BackendsApiManager.getSettings.supportEmptySchemaColumnarShuffle()) {
       if (outputAttributes.isEmpty) {
-        // See: https://github.com/apache/incubator-gluten/issues/7600.
+        // See: https://github.com/apache/gluten/issues/7600.
         return Some("Shuffle with empty output schema is not supported")
       }
       if (child.output.isEmpty) {
-        // See: https://github.com/apache/incubator-gluten/issues/7600.
+        // See: https://github.com/apache/gluten/issues/7600.
         return Some("Shuffle with empty input schema is not supported")
       }
     }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/ArrowCsvScanSuite.scala
@@ -97,8 +97,8 @@ class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
   }
 
   /**
-   * Test for GLUTEN-8453: https://github.com/apache/incubator-gluten/issues/8453. To make sure no
-   * error is thrown when caching an Arrow Java query plan.
+   * Test for GLUTEN-8453: https://github.com/apache/gluten/issues/8453. To make sure no error is
+   * thrown when caching an Arrow Java query plan.
    */
   test("csv scan v1 with table cache") {
     val df = spark.sql("select * from student")
@@ -107,7 +107,7 @@ class ArrowCsvScanWithTableCacheSuite extends ArrowCsvScanSuiteBase {
   }
 }
 
-/** Since https://github.com/apache/incubator-gluten/pull/5850. */
+/** Since https://github.com/apache/gluten/pull/5850. */
 @Ignore
 abstract class ArrowCsvScanSuite extends ArrowCsvScanSuiteBase {
 

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1988,7 +1988,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
   }
 
-  // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+  // Enable the test after fixing https://github.com/apache/gluten/issues/6827
   ignore("Test round expression") {
     val df1 = runQueryAndCompare("SELECT round(cast(0.5549999999999999 as double), 2)") { _ => }
     checkLengthAndPlan(df1, 1)
@@ -2022,7 +2022,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
   }
 
-  // Since https://github.com/apache/incubator-gluten/pull/7330.
+  // Since https://github.com/apache/gluten/pull/7330.
   test("field names contain non-ASCII characters") {
     withTempPath {
       path =>

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxColumnarCacheSuite.scala
@@ -109,7 +109,7 @@ class VeloxColumnarCacheSuite extends VeloxWholeStageTransformerSuite with Adapt
     }
   }
 
-  // See issue https://github.com/apache/incubator-gluten/issues/8497.
+  // See issue https://github.com/apache/gluten/issues/8497.
   test("Input fallen back vanilla Spark columnar scan") {
     def withId(id: Int): Metadata =
       new MetadataBuilder().putLong("parquet.field.id", id).build()

--- a/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/extension/columnar/transition/VeloxTransitionSuite.scala
@@ -82,7 +82,7 @@ class VeloxTransitionSuite extends SharedSparkSession with TransitionSuiteBase {
     val out = BackendTransitions.insert(in, outputsColumnar = false)
     // No explicit transition needed for ArrowNative-to-Velox.
     // FIXME: Add explicit transitions.
-    //  See https://github.com/apache/incubator-gluten/issues/7313.
+    //  See https://github.com/apache/gluten/issues/7313.
     assert(
       out == VeloxColumnarToRowExec(
         BatchUnary(

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -482,7 +482,7 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  // FIXME: Ignored: https://github.com/apache/incubator-gluten/issues/7600.
+  // FIXME: Ignored: https://github.com/apache/gluten/issues/7600.
   ignore("monotonically_increasintestg_id") {
     runQueryAndCompare("""SELECT monotonically_increasing_id(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {

--- a/cpp-ch/local-engine/Parser/ExpressionParser.cpp
+++ b/cpp-ch/local-engine/Parser/ExpressionParser.cpp
@@ -345,7 +345,7 @@ ExpressionParser::NodeRawConstPtr ExpressionParser::parseExpression(ActionsDAG &
             }
             else if ((isMap(denull_input_type) || isArray(denull_input_type) || isTuple(denull_input_type)) && isString(denull_output_type))
             {
-                /// https://github.com/apache/incubator-gluten/issues/9049
+                /// https://github.com/apache/gluten/issues/9049
                 result_node = toFunctionNode(actions_dag, "sparkCastComplexTypesToString", args);
             }
             else if (isString(denull_input_type) && substrait_type.has_bool_())
@@ -357,7 +357,7 @@ ExpressionParser::NodeRawConstPtr ExpressionParser::parseExpression(ActionsDAG &
             else if (isString(denull_input_type) && isInt(denull_output_type))
             {
                 /// Spark cast(x as INT) if x is String -> CH cast(trim(x) as INT)
-                /// Refer to https://github.com/apache/incubator-gluten/issues/4956 and https://github.com/apache/incubator-gluten/issues/8598
+                /// Refer to https://github.com/apache/gluten/issues/4956 and https://github.com/apache/gluten/issues/8598
                 const auto * trim_str_arg = addConstColumn(actions_dag, std::make_shared<DataTypeString>(), " \t\n\r\f");
                 args[0] = toFunctionNode(actions_dag, "trimBothSpark", {args[0], trim_str_arg});
                 args.emplace_back(addConstColumn(actions_dag, std::make_shared<DataTypeString>(), output_type->getName()));

--- a/cpp-ch/local-engine/Parser/scalar_function_parser/arrayHighOrderFunctions.cpp
+++ b/cpp-ch/local-engine/Parser/scalar_function_parser/arrayHighOrderFunctions.cpp
@@ -96,7 +96,7 @@ public:
         {
             /// Convert Array(T) to Array(U) if needed, Array(T) is the type of the first argument of transform.
             /// U is the argument type of lambda function. In some cases Array(T) is not equal to Array(U).
-            /// e.g. in the second query of https://github.com/apache/incubator-gluten/issues/6561, T is String, and U is Nullable(String)
+            /// e.g. in the second query of https://github.com/apache/gluten/issues/6561, T is String, and U is Nullable(String)
             /// The difference of both types will result in runtime exceptions in function capture.
             const auto & src_array_type = parsed_args[0]->result_type;
             DataTypePtr dst_array_type = std::make_shared<DataTypeArray>(lambda_args.front().type);

--- a/cpp-ch/local-engine/Storages/Output/NormalFileWriter.cpp
+++ b/cpp-ch/local-engine/Storages/Output/NormalFileWriter.cpp
@@ -39,7 +39,7 @@ const std::vector<std::string> FileNameGenerator::SUPPORT_PLACEHOLDERS{"{id}", "
 
 /// For Nullable(Map(K, V)) or Nullable(Array(T)), if the i-th row is null, we must make sure its nested data is empty.
 /// It is for ORC/Parquet writing compatiability. For more details, refer to
-/// https://github.com/apache/incubator-gluten/issues/8022 and https://github.com/apache/incubator-gluten/issues/8021
+/// https://github.com/apache/gluten/issues/8022 and https://github.com/apache/gluten/issues/8021
 static ColumnPtr truncateNestedDataIfNull(const ColumnPtr & column)
 {
     if (const auto * col_const = checkAndGetColumn<ColumnConst>(column.get()))
@@ -166,7 +166,7 @@ DB::Block NormalFileWriter::castBlock(const DB::Block & block) const
 
     /// In case input block didn't have the same types as the preferred schema, we cast the input block to the preferred schema.
     /// Notice that preferred_schema is the actual file schema, which is also the data schema of current inserted table.
-    /// Refer to issue: https://github.com/apache/incubator-gluten/issues/6588
+    /// Refer to issue: https://github.com/apache/gluten/issues/6588
     size_t index = 0;
     const auto & preferred_schema = file->getPreferredSchema();
     for (auto & column : res)

--- a/cpp/velox/operators/plannodes/CudfVectorStream.cc
+++ b/cpp/velox/operators/plannodes/CudfVectorStream.cc
@@ -57,7 +57,7 @@ bool CudfVectorStreamBase::hasNext() {
     // driver to make the current task open to spilling.
     //
     // When a task is getting spilled, it should have been suspended so has zero running threads, otherwise there's
-    // possibility that this spill call hangs. See https://github.com/apache/incubator-gluten/issues/7243.
+    // possibility that this spill call hangs. See https://github.com/apache/gluten/issues/7243.
     // As of now, non-zero running threads usually happens when:
     // 1. Task A spills task B;
     // 2. Task A tries to grow buffers created by task B, during which spill is requested on task A again.

--- a/cpp/velox/operators/plannodes/RowVectorStream.cc
+++ b/cpp/velox/operators/plannodes/RowVectorStream.cc
@@ -60,7 +60,7 @@ bool RowVectorStream::hasNext() {
     // driver to make the current task open to spilling.
     //
     // When a task is getting spilled, it should have been suspended so has zero running threads, otherwise there's
-    // possibility that this spill call hangs. See https://github.com/apache/incubator-gluten/issues/7243.
+    // possibility that this spill call hangs. See https://github.com/apache/gluten/issues/7243.
     // As of now, non-zero running threads usually happens when:
     // 1. Task A spills task B;
     // 2. Task A tries to grow buffers created by task B, during which spill is requested on task A again.

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -60,7 +60,7 @@ void VeloxColumnarBatchSerializer::append(const std::shared_ptr<ColumnarBatch>& 
   auto rowVector = VeloxColumnarBatch::from(veloxPool_.get(), batch)->getRowVector();
   if (serializer_ == nullptr) {
     // Using first batch's schema to create the Velox serializer. This logic was introduced in
-    // https://github.com/apache/incubator-gluten/pull/1568. It's a bit suboptimal because the schemas
+    // https://github.com/apache/gluten/pull/1568. It's a bit suboptimal because the schemas
     // across different batches may vary.
     auto numRows = rowVector->size();
     auto rowType = asRowType(rowVector->type());

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -651,7 +651,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::WindowRel& windo
   }
 
   if (types.empty()) {
-    // See: https://github.com/apache/incubator-gluten/issues/7600.
+    // See: https://github.com/apache/gluten/issues/7600.
     LOG_VALIDATION_MSG("Validation failed for empty input schema in WindowRel.");
     return false;
   }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ remote_theme: pmarsceill/just-the-docs
 
 aux_links:
   "Gluten on Github":
-    - "//github.com/apache/incubator-gluten"
+    - "//github.com/apache/gluten"
 
 plugins:
   - jekyll-optional-front-matter # GitHub Pages

--- a/docs/developers/HowTo.md
+++ b/docs/developers/HowTo.md
@@ -163,7 +163,7 @@ to let it override the corresponding C standard functions entirely. It may help 
 Now, both Parquet and DWRF format files are supported, related scripts and files are under the directory of `${GLUTEN_HOME}/backends-velox/workload/tpch`.
 The file `README.md` under `${GLUTEN_HOME}/backends-velox/workload/tpch` offers some useful help, but it's still not enough and exact.
 
-One way of run TPC-H test is to run velox-be by workflow, you can refer to [velox_backend.yml](https://github.com/apache/incubator-gluten/blob/main/.github/workflows/velox_backend.yml#L280)
+One way of run TPC-H test is to run velox-be by workflow, you can refer to [velox_backend.yml](https://github.com/apache/gluten/blob/main/.github/workflows/velox_backend.yml#L280)
 
 Here we will explain how to run TPC-H on Velox backend with the Parquet file format.
 1. First, prepare the datasets, you have two choices.

--- a/docs/developers/NewToGluten.md
+++ b/docs/developers/NewToGluten.md
@@ -128,7 +128,7 @@ compiling Gluten.
 Note: If you have previously compiled Velox in release mode, use the command below to compile in debug mode.
 
 ```bash
-cd incubator-gluten/ep/build-velox/build/velox_ep
+cd gluten/ep/build-velox/build/velox_ep
 
 # Build the Velox debug version in <velox_home>/_build/debug
 make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DENABLE_HDFS=ON -DVELOX_BUILD_TESTING=OFF  -DVELOX_ENABLE_DUCKDB=ON -DVELOX_BUILD_TEST_UTILS=ON"
@@ -396,7 +396,7 @@ valgrind --leak-check=yes ./exec_backend_test
 ## Run TPC-H and TPC-DS
 
 We supply `<gluten_home>/tools/gluten-it` to execute these queries.
-See [velox_backend_x86.yml](https://github.com/apache/incubator-gluten/blob/main/.github/workflows/velox_backend_x86.yml).
+See [velox_backend_x86.yml](https://github.com/apache/gluten/blob/main/.github/workflows/velox_backend_x86.yml).
 
 ## Enable Gluten for Spark
 

--- a/docs/developers/QueryTrace.md
+++ b/docs/developers/QueryTrace.md
@@ -6,7 +6,7 @@ parent: Developer Overview
 ---
 
 # Background
-Currently, we have [MicroBenchmarks](https://github.com/apache/incubator-gluten/blob/main/docs/developers/MicroBenchmarks.md) to profile the Velox plan execution in stage level, now we have query trace replayer to specify plan node id to profile in operator level.
+Currently, we have [MicroBenchmarks](https://github.com/apache/gluten/blob/main/docs/developers/MicroBenchmarks.md) to profile the Velox plan execution in stage level, now we have query trace replayer to specify plan node id to profile in operator level.
 
 We cannot profile operator level directly because ValueStreamNode cannot serialize and deserialize, so we should generate benchmark first, and then enable query trace in benchmark which replaces the ValueStreamNode to ValuesNode.
 

--- a/docs/developers/SubstraitModifications.md
+++ b/docs/developers/SubstraitModifications.md
@@ -17,23 +17,23 @@ alternatives like `AdvancedExtension` could be considered.
 
 ## Modifications to algebra.proto
 
-* Added `JsonReadOptions` and `TextReadOptions` in `FileOrFiles`([#1584](https://github.com/apache/incubator-gluten/pull/1584)).
-* Changed join type `JOIN_TYPE_SEMI` to `JOIN_TYPE_LEFT_SEMI` and `JOIN_TYPE_RIGHT_SEMI`([#408](https://github.com/apache/incubator-gluten/pull/408)).
+* Added `JsonReadOptions` and `TextReadOptions` in `FileOrFiles`([#1584](https://github.com/apache/gluten/pull/1584)).
+* Changed join type `JOIN_TYPE_SEMI` to `JOIN_TYPE_LEFT_SEMI` and `JOIN_TYPE_RIGHT_SEMI`([#408](https://github.com/apache/gluten/pull/408)).
 * Added `WindowRel`, added `column_name` and `window_type` in `WindowFunction`,
-changed `Unbounded` in `WindowFunction` into `Unbounded_Preceding` and `Unbounded_Following`, and added WindowType([#485](https://github.com/apache/incubator-gluten/pull/485)).
-* Added `output_schema` in RelRoot([#1901](https://github.com/apache/incubator-gluten/pull/1901)).
-* Added `ExpandRel`([#1361](https://github.com/apache/incubator-gluten/pull/1361)).
-* Added `GenerateRel`([#574](https://github.com/apache/incubator-gluten/pull/574)).
-* Added `PartitionColumn` in `LocalFiles`([#2405](https://github.com/apache/incubator-gluten/pull/2405)).
-* Added `WriteRel` ([#3690](https://github.com/apache/incubator-gluten/pull/3690)).
-* Added `TopNRel` ([#5409](https://github.com/apache/incubator-gluten/pull/5409)).
-* Added `ref` field in window bound `Preceding` and `Following` ([#5626](https://github.com/apache/incubator-gluten/pull/5626)).
-* Added `BucketSpec` field in `WriteRel`([#8386](https://github.com/apache/incubator-gluten/pull/8386))
-* Added `StreamKafka` in `ReadRel`([#8321](https://github.com/apache/incubator-gluten/pull/8321))
+changed `Unbounded` in `WindowFunction` into `Unbounded_Preceding` and `Unbounded_Following`, and added WindowType([#485](https://github.com/apache/gluten/pull/485)).
+* Added `output_schema` in RelRoot([#1901](https://github.com/apache/gluten/pull/1901)).
+* Added `ExpandRel`([#1361](https://github.com/apache/gluten/pull/1361)).
+* Added `GenerateRel`([#574](https://github.com/apache/gluten/pull/574)).
+* Added `PartitionColumn` in `LocalFiles`([#2405](https://github.com/apache/gluten/pull/2405)).
+* Added `WriteRel` ([#3690](https://github.com/apache/gluten/pull/3690)).
+* Added `TopNRel` ([#5409](https://github.com/apache/gluten/pull/5409)).
+* Added `ref` field in window bound `Preceding` and `Following` ([#5626](https://github.com/apache/gluten/pull/5626)).
+* Added `BucketSpec` field in `WriteRel`([#8386](https://github.com/apache/gluten/pull/8386))
+* Added `StreamKafka` in `ReadRel`([#8321](https://github.com/apache/gluten/pull/8321))
 
 ## Modifications to type.proto
 
-* Added `Nothing` in `Type`([#791](https://github.com/apache/incubator-gluten/pull/791)).
-* Added `names` in `Struct`([#1878](https://github.com/apache/incubator-gluten/pull/1878)).
-* Added `PartitionColumns` in `NamedStruct`([#320](https://github.com/apache/incubator-gluten/pull/320)).
-* Remove `PartitionColumns` and add `column_types` in `NamedStruct`([#2405](https://github.com/apache/incubator-gluten/pull/2405)).
+* Added `Nothing` in `Type`([#791](https://github.com/apache/gluten/pull/791)).
+* Added `names` in `Struct`([#1878](https://github.com/apache/gluten/pull/1878)).
+* Added `PartitionColumns` in `NamedStruct`([#320](https://github.com/apache/gluten/pull/320)).
+* Remove `PartitionColumns` and add `column_types` in `NamedStruct`([#2405](https://github.com/apache/gluten/pull/2405)).

--- a/docs/developers/velox-backend-build-in-docker.md
+++ b/docs/developers/velox-backend-build-in-docker.md
@@ -28,8 +28,8 @@ FROM apache/gluten:vcpkg-centos-7
 
 # Build Gluten Jar
 RUN source /opt/rh/devtoolset-11/enable && \
-    git clone https://github.com/apache/incubator-gluten.git && \
-    cd incubator-gluten && \
+    git clone https://github.com/apache/gluten.git && \
+    cd gluten && \
     ./dev/builddeps-veloxbe.sh --run_setup_script=OFF --enable_s3=ON --enable_gcs=ON --enable_abfs=ON --enable_vcpkg=ON --build_arrow=OFF && \
     mvn clean package -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Pspark-3.4 -DskipTests
 ```
@@ -39,7 +39,7 @@ The command builds Gluten jar in 'glutenimage':
 ```
 docker build -t glutenimage -f dockerfile
 ```
-The gluten jar can be copied from glutenimage:/incubator-gluten/package/target/gluten-velox-bundle-*.jar
+The gluten jar can be copied from glutenimage:/gluten/package/target/gluten-velox-bundle-*.jar
 
 # Dynamic link
 The dynamic link approach needs to install the dependencies libraries. It then dynamically link the .so files into libvelox.so and libgluten.so. Currently, Centos-7/8/9 and
@@ -52,8 +52,8 @@ FROM apache/gluten:centos-8-jdk8
 
 # Build Gluten Jar
 RUN source /opt/rh/devtoolset-11/enable && \
-    git clone https://github.com/apache/incubator-gluten.git && \
-    cd incubator-gluten && \
+    git clone https://github.com/apache/gluten.git && \
+    cd gluten && \
     ./dev/builddeps-veloxbe.sh --run_setup_script=ON --enable_hdfs=ON --enable_vcpkg=OFF --build_arrow=OFF && \
     mvn clean package -Pbackends-velox -Pceleborn -Piceberg -Pdelta -Pspark-3.4 -DskipTests && \
     ./dev/build-thirdparty.sh
@@ -65,4 +65,4 @@ The command builds Gluten jar in 'glutenimage':
 ```
 docker build -t glutenimage -f dockerfile
 ```
-The gluten jar can be copied from glutenimage:/incubator-gluten/package/target/gluten-velox-bundle-*.jar and glutenimage:/incubator-gluten/package/target/gluten-thirdparty-lib-*.jar
+The gluten jar can be copied from glutenimage:/gluten/package/target/gluten-velox-bundle-*.jar and glutenimage:/gluten/package/target/gluten-thirdparty-lib-*.jar

--- a/docs/get-started/ClickHouse.md
+++ b/docs/get-started/ClickHouse.md
@@ -52,7 +52,7 @@ You need to install the following software manually:
 
 Then, get Gluten code:
 ```shell
-git clone https://github.com/apache/incubator-gluten.git
+git clone https://github.com/apache/gluten.git
 ```
 
 #### Setup ClickHouse backend development environment
@@ -64,7 +64,7 @@ clone gluten repo
 
 
 ```shell
-git clone https://github.com/apache/incubator-gluten.git
+git clone https://github.com/apache/gluten.git
 ```
 
 clone Kyligence/ClickHouse repo
@@ -176,8 +176,8 @@ The prerequisites are the same as the one mentioned above. Compile Gluten with C
 - for Spark 3.3.1
 
 ```
-    git clone https://github.com/apache/incubator-gluten.git
-    cd incubator-gluten/
+    git clone https://github.com/apache/gluten.git
+    cd gluten/
     export MAVEN_OPTS="-Xmx8g -XX:ReservedCodeCacheSize=2g"
     mvn clean install -Pbackends-clickhouse -Phadoop-2.7.4 -Pspark-3.3 -Dhadoop.version=2.8.5 -DskipTests -Dcheckstyle.skip
     ls -al backends-clickhouse/target/gluten-XXXXX-spark-3.3-jar-with-dependencies.jar

--- a/docs/get-started/Velox.md
+++ b/docs/get-started/Velox.md
@@ -44,7 +44,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 ## config maven, like proxy in ~/.m2/settings.xml
 
 ## fetch gluten code
-git clone https://github.com/apache/incubator-gluten.git
+git clone https://github.com/apache/gluten.git
 ```
 
 # Build Gluten with Velox Backend
@@ -173,7 +173,7 @@ cp /path/to/hdfs-client.xml hdfs-client.xml
 
 One typical deployment on Spark/HDFS cluster is to enable [short-circuit reading](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/ShortCircuitLocalReads.html). Short-circuit reads provide a substantial performance boost to many applications.
 
-By default libhdfs3 does not set the default hdfs domain socket path to support HDFS short-circuit read. If this feature is required in HDFS setup, users may need to setup the domain socket path correctly by patching the libhdfs3 source code or by setting the correct config environment. In Gluten the short-circuit domain socket path is set to "/var/lib/hadoop-hdfs/dn_socket" in [build-velox.sh](https://github.com/apache/incubator-gluten/blob/main/ep/build-velox/src/build-velox.sh) So we need to make sure the folder existed and user has write access as below script.
+By default libhdfs3 does not set the default hdfs domain socket path to support HDFS short-circuit read. If this feature is required in HDFS setup, users may need to setup the domain socket path correctly by patching the libhdfs3 source code or by setting the correct config environment. In Gluten the short-circuit domain socket path is set to "/var/lib/hadoop-hdfs/dn_socket" in [build-velox.sh](https://github.com/apache/gluten/blob/main/ep/build-velox/src/build-velox.sh) So we need to make sure the folder existed and user has write access as below script.
 
 ```
 sudo mkdir -p /var/lib/hadoop-hdfs/
@@ -412,7 +412,7 @@ Spark3.3 has 387 functions in total. ~240 are commonly used. To get the support 
 To identify what can be offloaded in a query and detailed fallback reasons, user can follow below steps to retrieve corresponding logs.
 
 ```
-1) Enable Gluten by proper [configuration](https://github.com/apache/incubator-gluten/blob/main/docs/Configuration.md).
+1) Enable Gluten by proper [configuration](https://github.com/apache/gluten/blob/main/docs/Configuration.md).
 
 2) Disable Spark AQE to trigger plan validation in Gluten
 spark.sql.adaptive.enabled = false

--- a/docs/get-started/VeloxGPU.md
+++ b/docs/get-started/VeloxGPU.md
@@ -23,7 +23,7 @@ parent: Getting-Started
 - **NVIDIA Drivers**: Compatible with CUDA 12.8.
 - **Container Toolkit**: Install `nvidia-container-toolkit` ([guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)).
 - **System Reboot**: Required after driver installation.
-- **Environment Setup**: Use [`start-cudf.sh`](https://github.com/apache/incubator-gluten/tree/main/dev/start-cudf.sh) for host configuration .
+- **Environment Setup**: Use [`start-cudf.sh`](https://github.com/apache/gluten/tree/main/dev/start-cudf.sh) for host configuration .
 
 ---
 
@@ -86,4 +86,4 @@ Single Operator like Hash Agg shows 5x speedup.
 
 ## **9. Relevant Resources**
 1. [CUDF Docs](https://docs.rapids.ai/api/cudf/stable/libcudf_docs/) - GPU operator APIs.
-2. [Gluten GPU Issue #9098](https://github.com/apache/incubator-gluten/issues/8851) - Development tracker.
+2. [Gluten GPU Issue #9098](https://github.com/apache/gluten/issues/8851) - Development tracker.

--- a/docs/get-started/VeloxStageResourceAdj.md
+++ b/docs/get-started/VeloxStageResourceAdj.md
@@ -72,4 +72,4 @@ And the execution plan will like following with ApplyResourceProfile node insert
 • Tested with YARN/Kubernetes; other resource managers may need validation.
 
 
-For issues or feedback, refer to [GLUTEN-8018](https://github.com/apache/incubator-gluten/issues/8018).
+For issues or feedback, refer to [GLUTEN-8018](https://github.com/apache/gluten/issues/8018).

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ The basic rule of Gluten's design is that we would reuse spark's whole control f
 ## 1.3 Target User
 
 Gluten's target user is anyone who wants to accelerate SparkSQL fundamentally. As a plugin to Spark, Gluten doesn't require any change for dataframe API or SQL query, but only requires user to make correct configuration.
-See Gluten configuration properties [here](https://github.com/apache/incubator-gluten/blob/main/docs/Configuration.md).
+See Gluten configuration properties [here](https://github.com/apache/gluten/blob/main/docs/Configuration.md).
 
 ## 1.4 References
 

--- a/docs/velox-backend-limitations.md
+++ b/docs/velox-backend-limitations.md
@@ -9,9 +9,9 @@ must fall back to vanilla spark, etc.
 ### Override of Spark classes (For Spark3.2 and Spark3.3)
 Gluten avoids to modify Spark's existing code and use Spark APIs if possible. However, some APIs aren't exposed in Vanilla spark and we have to copy the Spark file and do the hardcode changes. The list of override classes can be found as ignoreClasses in package/pom.xml . If you use customized Spark, you may check if the files are modified in your spark, otherwise your changes will be overrided.
 
-So you need to ensure preferentially load the Gluten jar to overwrite the jar of vanilla spark. Refer to [How to prioritize loading Gluten jars in Spark](https://github.com/apache/incubator-gluten/blob/main/docs/velox-backend-troubleshooting.md#incompatible-class-error-when-using-native-writer).
+So you need to ensure preferentially load the Gluten jar to overwrite the jar of vanilla spark. Refer to [How to prioritize loading Gluten jars in Spark](https://github.com/apache/gluten/blob/main/docs/velox-backend-troubleshooting.md#incompatible-class-error-when-using-native-writer).
 
-If not officially supported spark3.2/3.3 version is used, NoSuchMethodError can be thrown at runtime. More details see [issue-4514](https://github.com/apache/incubator-gluten/issues/4514).
+If not officially supported spark3.2/3.3 version is used, NoSuchMethodError can be thrown at runtime. More details see [issue-4514](https://github.com/apache/gluten/issues/4514).
 
 ### Fallbacks
 Except the unsupported operators, functions, file formats, data sources listed in , there are some known cases also fall back to Vanilla Spark. 
@@ -156,7 +156,7 @@ CSV read will also fall back to vanilla Spark and log warning when user specifie
 
 ### Utilizing Map Type as Hash Keys in ColumnarShuffleExchange
 Spark uses the `spark.sql.legacy.allowHashOnMapType` configuration to support hash map key functions. 
-Gluten enables this configuration during the creation of ColumnarShuffleExchange, as shown in the code [link](https://github.com/apache/incubator-gluten/blob/0dacac84d3bf3d2759a5dd7e0735147852d2845d/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala#L355-L363). 
+Gluten enables this configuration during the creation of ColumnarShuffleExchange, as shown in the code [link](https://github.com/apache/gluten/blob/0dacac84d3bf3d2759a5dd7e0735147852d2845d/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala#L355-L363). 
 This method bypasses Spark's unresolved checks and creates projects with the hash(mapType) operator before ColumnarShuffleExchange. 
 However, if `spark.sql.legacy.allowHashOnMapType` is disabled in a test environment, projects using the hash(mapType) expression may throw an `Invalid call to dataType on unresolved object` exception during validation, causing them to fallback to vanilla Spark, as referenced in the code [link](https://github.com/apache/spark/blob/de5fa426e23b84fc3c2bddeabcd2e1eda515abd5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala#L291-L296).
  Enabling this configuration allows the project to be offloaded to Velox.

--- a/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/memory/listener/ManagedReservationListener.java
@@ -32,7 +32,7 @@ public class ManagedReservationListener implements ReservationListener {
   private final SimpleMemoryUsageRecorder sharedUsage;
   // Lock shared by task. Using a common lock avoids ABBA deadlock
   // when multiple listeners created under the same TMM.
-  // See: https://github.com/apache/incubator-gluten/issues/6622
+  // See: https://github.com/apache/gluten/issues/6622
   private final Object sharedLock;
 
   public ManagedReservationListener(

--- a/gluten-arrow/src/main/java/org/apache/spark/sql/execution/unsafe/UnsafeByteArray.java
+++ b/gluten-arrow/src/main/java/org/apache/spark/sql/execution/unsafe/UnsafeByteArray.java
@@ -157,7 +157,7 @@ public class UnsafeByteArray implements Externalizable, KryoSerializable {
    * It's needed once the broadcast variable is garbage collected. Since now, we don't have an
    * elegant way to free the underlying memory in off-heap.
    *
-   * <p>Since: https://github.com/apache/incubator-gluten/pull/8127.
+   * <p>Since: https://github.com/apache/gluten/pull/8127.
    */
   public void finalize() throws Throwable {
     release();

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/DynamicOffHeapSizingMemoryTarget.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/DynamicOffHeapSizingMemoryTarget.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The memory target used by dynamic off-heap sizing. Since
- * https://github.com/apache/incubator-gluten/issues/5439.
+ * https://github.com/apache/gluten/issues/5439.
  */
 @Experimental
 public class DynamicOffHeapSizingMemoryTarget implements MemoryTarget, KnownNameAndStats {
@@ -143,7 +143,7 @@ public class DynamicOffHeapSizingMemoryTarget implements MemoryTarget, KnownName
     }
 
     // Only JVM shrinking can reclaim space from the total JVM memory.
-    // See https://github.com/apache/incubator-gluten/issues/9276.
+    // See https://github.com/apache/gluten/issues/9276.
     long totalHeapMemory = Runtime.getRuntime().totalMemory();
     long freeHeapMemory = Runtime.getRuntime().freeMemory();
     long usedOffHeapMemory = USED_OFF_HEAP_BYTES.get();

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
@@ -87,11 +87,11 @@ public final class MemoryTargets {
       // We don't need to retry on OOM in the case one single task occupies the whole executor.
       return consumer;
     }
-    // Since https://github.com/apache/incubator-gluten/pull/8132.
+    // Since https://github.com/apache/gluten/pull/8132.
     // Retry of spilling is needed in multi-slot and legacy mode (formerly named as share mode)
     // because the maxMemoryPerTask defined by vanilla Spark's ExecutionMemoryPool is dynamic.
     //
-    // See the original issue https://github.com/apache/incubator-gluten/issues/8128.
+    // See the original issue https://github.com/apache/gluten/issues/8128.
     return new RetryOnOomMemoryTarget(
         consumer,
         () -> {

--- a/gluten-core/src/main/scala/org/apache/gluten/config/GlutenCoreConfig.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/config/GlutenCoreConfig.scala
@@ -171,7 +171,7 @@ object GlutenCoreConfig extends ConfigRegistry {
       .intConf
       .createWithDefaultString("-1")
 
-  // Since https://github.com/apache/incubator-gluten/issues/5439.
+  // Since https://github.com/apache/gluten/issues/5439.
   val DYNAMIC_OFFHEAP_SIZING_ENABLED =
     buildStaticConf("spark.gluten.memory.dynamic.offHeap.sizing.enabled")
       .experimental()
@@ -189,7 +189,7 @@ object GlutenCoreConfig extends ConfigRegistry {
       .booleanConf
       .createWithDefault(false)
 
-  // Since https://github.com/apache/incubator-gluten/issues/5439.
+  // Since https://github.com/apache/gluten/issues/5439.
   val DYNAMIC_OFFHEAP_SIZING_MEMORY_FRACTION =
     buildStaticConf("spark.gluten.memory.dynamic.offHeap.sizing.memory.fraction")
       .experimental()

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenColumnarRule.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/GlutenColumnarRule.scala
@@ -95,7 +95,7 @@ case class GlutenColumnarRule(
       case _ =>
         throw new IllegalStateException(
           "This should not happen. Please leave an issue at" +
-            " https://github.com/apache/incubator-gluten.")
+            " https://github.com/apache/gluten.")
     }
     val vanillaPlan = Transitions.insert(originalPlan, outputsColumnar)
     val applier = applierBuilder.apply(session)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/RewriteSparkPlanRulesManager.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/RewriteSparkPlanRulesManager.scala
@@ -75,7 +75,7 @@ class RewriteSparkPlanRulesManager private (
     } catch {
       case e: Exception =>
         // TODO: Remove this catch block
-        //  See https://github.com/apache/incubator-gluten/issues/7766
+        //  See https://github.com/apache/gluten/issues/7766
         (origin, Option(e.getMessage))
     }
   }

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/adaptive/GlutenCost.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/adaptive/GlutenCost.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 
-/** Since https://github.com/apache/incubator-gluten/pull/6143. */
+/** Since https://github.com/apache/gluten/pull/6143. */
 class GlutenCost(val eval: CostEvaluator, val plan: SparkPlan) extends Cost {
   override def compare(that: Cost): Int = that match {
     case that: GlutenCost if plan eq that.plan =>

--- a/gluten-core/src/main/scala/org/apache/spark/sql/execution/adaptive/GlutenCostEvaluator.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/sql/execution/adaptive/GlutenCostEvaluator.scala
@@ -25,7 +25,7 @@ import org.apache.spark.util.Utils
 /**
  * This [[CostEvaluator]] is to force use the new physical plan when cost is equal.
  *
- * Since https://github.com/apache/incubator-gluten/pull/6143.
+ * Since https://github.com/apache/gluten/pull/6143.
  */
 case class GlutenCostEvaluator() extends CostEvaluator with SQLConfHelper {
 

--- a/gluten-flink/docs/Flink.md
+++ b/gluten-flink/docs/Flink.md
@@ -57,7 +57,7 @@ mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
 ## config maven, like proxy in ~/.m2/settings.xml
 
 ## fetch gluten code
-git clone https://github.com/apache/incubator-gluten.git
+git clone https://github.com/apache/gluten.git
 ```
 
 # Build Gluten Flink with Velox Backend
@@ -126,7 +126,7 @@ bin/flink run examples/table/StreamSQLExample.jar
 Then you can get the result in `log/flink-*-taskexecutor-*.out`.
 And you can see an operator named `gluten-cal` from the web frontend of your flink job.
 
-**Notice: current this example will cause npe until  [issue-10315](https://github.com/apache/incubator-gluten/issues/10315) get resolved.**
+**Notice: current this example will cause npe until  [issue-10315](https://github.com/apache/gluten/issues/10315) get resolved.**
 
 #### All operators executed by native
 Another example supports all operators executed by native. 

--- a/gluten-hudi/src/main/scala/org/apache/gluten/execution/OffloadHudiScan.scala
+++ b/gluten-hudi/src/main/scala/org/apache/gluten/execution/OffloadHudiScan.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 
 import org.apache.spark.sql.execution.SparkPlan
 
-/** Since https://github.com/apache/incubator-gluten/pull/6049. */
+/** Since https://github.com/apache/gluten/pull/6049. */
 case class OffloadHudiScan() extends OffloadSingleNode {
   override def offload(plan: SparkPlan): SparkPlan = {
     plan match {

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -155,7 +155,7 @@ case class IcebergScanTransformer(
         return ValidationResult.failed("Delete file format puffin is not supported")
       }
     }
-    // https://github.com/apache/incubator-gluten/issues/11135
+    // https://github.com/apache/gluten/issues/11135
     if (metadata.propertyAsBoolean(TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA, false)) {
       return ValidationResult.failed("Not support read the file with accept any schema")
     }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SubstraitBackend.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SubstraitBackend.scala
@@ -92,7 +92,7 @@ trait SubstraitBackend extends Backend with Logging {
 
 object SubstraitBackend extends Logging {
 
-  /** Since https://github.com/apache/incubator-gluten/pull/2247. */
+  /** Since https://github.com/apache/gluten/pull/2247. */
   private def postBuildInfoEvent(sc: SparkContext): Unit = {
     // export gluten version to property to spark
     System.setProperty("gluten.version", GlutenBuildInfo.VERSION)
@@ -134,7 +134,7 @@ object SubstraitBackend extends Logging {
 
     // Disable vanilla columnar readers, to prevent columnar-to-columnar conversions.
     // FIXME: Do we still need this trick since
-    //  https://github.com/apache/incubator-gluten/pull/1931 was merged?
+    //  https://github.com/apache/gluten/pull/1931 was merged?
     if (!conf.get(GlutenConfig.VANILLA_VECTORIZED_READERS_ENABLED)) {
       // FIXME Hongze 22/12/06
       //  BatchScan.scala in shim was not always loaded by class loader.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -170,7 +170,7 @@ class GlutenConfig(conf: SQLConf) extends GlutenCoreConfig(conf) {
       .equals("org.apache.spark.shuffle.sort.ColumnarShuffleManager")
 
   // Whether to use CelebornShuffleManager.
-  // TODO: Deprecate the API: https://github.com/apache/incubator-gluten/issues/10107.
+  // TODO: Deprecate the API: https://github.com/apache/gluten/issues/10107.
   def isUseCelebornShuffleManager: Boolean =
     conf
       .getConfString("spark.shuffle.manager", "sort")

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ValidatablePlan.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ValidatablePlan.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedException
 /**
  * Base interface for a Gluten query plan that is also open to validation calls.
  *
- * Since https://github.com/apache/incubator-gluten/pull/2185.
+ * Since https://github.com/apache/gluten/pull/2185.
  */
 trait ValidatablePlan extends GlutenPlan with LogLevelUtil {
   protected def glutenConf: GlutenConfig = GlutenConfig.get

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/WholeStageTransformer.scala
@@ -87,7 +87,7 @@ trait TransformSupport extends ValidatablePlan {
    */
   def columnarInputRDDs: Seq[RDD[ColumnarBatch]]
 
-  // Since https://github.com/apache/incubator-gluten/pull/2185.
+  // Since https://github.com/apache/gluten/pull/2185.
   protected def doNativeValidation(context: SubstraitContext, node: RelNode): ValidationResult = {
     if (node != null && enableNativeValidation) {
       val planNode = PlanBuilder.makePlan(context, Lists.newArrayList(node))

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ScalarSubqueryTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ScalarSubqueryTransformer.scala
@@ -32,7 +32,7 @@ case class ScalarSubqueryTransformer(substraitExprName: String, query: ScalarSub
     if (TransformerState.underValidationState) {
       return ExpressionBuilder.makeLiteral(null, query.dataType, true)
     }
-    // After https://github.com/apache/incubator-gluten/pull/5862, we do not need to execute
+    // After https://github.com/apache/gluten/pull/5862, we do not need to execute
     // subquery manually so the exception behavior is same with vanilla Spark.
     // Note that, this code change is just for simplify. The subquery has already been materialized
     // before doing transform.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/LoggedRule.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/LoggedRule.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.execution.SparkPlan
 
-/** Since https://github.com/apache/incubator-gluten/pull/7606. */
+/** Since https://github.com/apache/gluten/pull/7606. */
 class LoggedRule(delegate: Rule[SparkPlan]) extends Rule[SparkPlan] with Logging with LogLevelUtil {
 
   override val ruleName: String = delegate.ruleName

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MiscColumnarRules.scala
@@ -47,7 +47,7 @@ object MiscColumnarRules {
     override def apply(plan: SparkPlan): SparkPlan = {
       val out = plan.transformWithSubqueries {
         case p =>
-          // Since https://github.com/apache/incubator-gluten/pull/1851.
+          // Since https://github.com/apache/gluten/pull/1851.
           //
           // When AQE is on, the AQE sub-query cache should already be filled with
           // row-based SubqueryBroadcastExec for reusing. Thus we are doing the same

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PruneNestedColumnsInHiveTableScan.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PruneNestedColumnsInHiveTableScan.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.hive.HiveTableScanNestedColumnPruning
 
-// Since https://github.com/apache/incubator-gluten/pull/7268.
+// Since https://github.com/apache/gluten/pull/7268.
 // Used only by CH backend as of now.
 object PruneNestedColumnsInHiveTableScan extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = plan.transformUp {

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
@@ -67,7 +67,7 @@ abstract class ColumnarWriteFilesExec protected (
    * processing or columnar processing. It's true because Spark only calls `doExecuteWrite` of the
    * object.
    *
-   * Since https://github.com/apache/incubator-gluten/pull/6745.
+   * Since https://github.com/apache/gluten/pull/6745.
    */
   override def batchType(): Convention.BatchType = BackendsApiManager.getSettings.primaryBatchType
   override def rowType(): RowType = {

--- a/gluten-substrait/src/main/scala/org/apache/spark/util/SparkPlanRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/util/SparkPlanRules.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 
 object SparkPlanRules extends Logging {
-  // Since https://github.com/apache/incubator-gluten/pull/1523
+  // Since https://github.com/apache/gluten/pull/1523
   def extendedColumnarRule(ruleNamesStr: String): SparkSession => Rule[SparkPlan] =
     (session: SparkSession) => {
       val ruleNames = ruleNamesStr.split(",").filter(_.nonEmpty)

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -729,7 +729,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("DATE_FROM_UNIX_DATE")
     .exclude("UNIX_SECONDS")
     .exclude("TIMESTAMP_SECONDS") // refer to https://github.com/ClickHouse/ClickHouse/issues/69280
-    .exclude("TIMESTAMP_MICROS") // refer to https://github.com/apache/incubator-gluten/issues/7127
+    .exclude("TIMESTAMP_MICROS") // refer to https://github.com/apache/gluten/issues/7127
     .exclude("SPARK-33498: GetTimestamp,UnixTimestamp,ToUnixTimestamp with parseError")
     .exclude("SPARK-34739,SPARK-35889: add a year-month interval to a timestamp")
     .exclude("SPARK-34761,SPARK-35889: add a day-time interval to a timestamp")
@@ -880,7 +880,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("REPEAT")
     .exclude("ParseUrl")
     .exclude("SPARK-33468: ParseUrl in ANSI mode should fail if input string is not a valid url")
-    .exclude("FORMAT") // refer https://github.com/apache/incubator-gluten/issues/6765
+    .exclude("FORMAT") // refer https://github.com/apache/gluten/issues/6765
     .exclude(
       "soundex unit test"
     ) // CH and spark returns different results when input non-ASCII characters

--- a/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -357,9 +357,9 @@ class VeloxTestSettings extends BackendTestSettings {
     // Not useful and time consuming.
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL")
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class")
-    // https://github.com/apache/incubator-gluten/pull/9145.
+    // https://github.com/apache/gluten/pull/9145.
     .exclude("SPARK-17515: CollectLimit.execute() should perform per-partition limits")
-    // https://github.com/apache/incubator-gluten/pull/9145.
+    // https://github.com/apache/gluten/pull/9145.
     .exclude("SPARK-19650: An action on a Command should not trigger a Spark job")
   enableSuite[GlutenDatasetAggregatorSuite]
   enableSuite[GlutenDatasetOptimizationSuite]
@@ -369,9 +369,9 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("dropDuplicates: columns with same column name")
     .exclude("groupBy.as")
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .exclude("$.store.book")
-    // https://github.com/apache/incubator-gluten/issues/10948
+    // https://github.com/apache/gluten/issues/10948
     .exclude("$['key with spaces']")
     .exclude("$")
     .exclude("$.store.book[0]")
@@ -415,7 +415,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
     .exclude("File source v2: support partition pruning")
-    // https://github.com/apache/incubator-gluten/pull/9145.
+    // https://github.com/apache/gluten/pull/9145.
     .excludeGlutenTest("SPARK-25237 compute correct input metrics in FileScanRDD")
   enableSuite[GlutenEnsureRequirementsSuite]
     // Rewrite to change the shuffle partitions for optimizing repartition
@@ -640,7 +640,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-17091: Convert IN predicate to Parquet filter push-down")
     .exclude("Support Parquet column index")
     .exclude("SPARK-34562: Bloom filter push down")
-    // https://github.com/apache/incubator-gluten/issues/7174
+    // https://github.com/apache/gluten/issues/7174
     .excludeGlutenTest("Filter applied on merged Parquet schema with new column should work")
   enableSuite[GlutenParquetInteroperabilitySuite]
     .exclude("parquet timestamp conversion")

--- a/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark32/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -126,7 +126,7 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
     checkEvaluation(Round(12345.67890123456789, 6), 12345.678901)
     checkEvaluation(Round(44, -1), 40)
     checkEvaluation(Round(78, 1), 78)
-    // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+    // Enable the test after fixing https://github.com/apache/gluten/issues/6827
     // checkEvaluation(Round(0.5549999999999999, 2), 0.55)
     checkEvaluation(BRound(2.5, 0), 2.0)
     checkEvaluation(BRound(3.5, 0), 4.0)

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -399,7 +399,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
   enableSuite[GlutenJsonExpressionsSuite]
     .exclude(
       "$.store.basket[0][*].b"
-    ) // issue: https://github.com/apache/incubator-gluten/issues/8529
+    ) // issue: https://github.com/apache/gluten/issues/8529
     .exclude("from_json - invalid data")
     .exclude("from_json - input=object, schema=array, output=array of single row")
     .exclude("from_json - input=empty object, schema=array, output=array of single row with null")
@@ -749,7 +749,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("DATE_FROM_UNIX_DATE")
     .exclude("UNIX_SECONDS")
     .exclude("TIMESTAMP_SECONDS") // refer to https://github.com/ClickHouse/ClickHouse/issues/69280
-    .exclude("TIMESTAMP_MICROS") // refer to https://github.com/apache/incubator-gluten/issues/7127
+    .exclude("TIMESTAMP_MICROS") // refer to https://github.com/apache/gluten/issues/7127
     .exclude("SPARK-33498: GetTimestamp,UnixTimestamp,ToUnixTimestamp with parseError")
     .exclude("SPARK-34739,SPARK-35889: add a year-month interval to a timestamp")
     .exclude("SPARK-34761,SPARK-35889: add a day-time interval to a timestamp")
@@ -797,9 +797,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("default")
     .exclude("SPARK-37967: Literal.create support ObjectType")
   enableSuite[GlutenMathExpressionsSuite]
-    .exclude("unhex") // https://github.com/apache/incubator-gluten/issues/7232
-    .exclude("round/bround/floor/ceil") // https://github.com/apache/incubator-gluten/issues/7233
-    .exclude("atan2") // https://github.com/apache/incubator-gluten/issues/7233
+    .exclude("unhex") // https://github.com/apache/gluten/issues/7232
+    .exclude("round/bround/floor/ceil") // https://github.com/apache/gluten/issues/7233
+    .exclude("atan2") // https://github.com/apache/gluten/issues/7233
   enableSuite[GlutenMiscExpressionsSuite]
   enableSuite[GlutenNondeterministicSuite]
     .exclude("MonotonicallyIncreasingID")
@@ -856,7 +856,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("REPEAT")
     .exclude("ParseUrl")
     .exclude("SPARK-33468: ParseUrl in ANSI mode should fail if input string is not a valid url")
-    .exclude("FORMAT") // refer https://github.com/apache/incubator-gluten/issues/6765
+    .exclude("FORMAT") // refer https://github.com/apache/gluten/issues/6765
     .exclude(
       "soundex unit test"
     ) // CH and spark returns different results when input non-ASCII characters

--- a/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -153,9 +153,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenGeneratorExpressionSuite]
   enableSuite[GlutenIntervalExpressionsSuite]
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .exclude("$.store.book")
-    // https://github.com/apache/incubator-gluten/issues/10948
+    // https://github.com/apache/gluten/issues/10948
     .exclude("$['key with spaces']")
     .exclude("$")
     .exclude("$.store.book[0]")
@@ -803,7 +803,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("File source v2: support passing data filters to FileScan without partitionFilters")
     // DISABLED: GLUTEN-4893 Vanilla UT checks scan operator by exactly matching the class type
     .exclude("File source v2: support partition pruning")
-    // https://github.com/apache/incubator-gluten/pull/9145.
+    // https://github.com/apache/gluten/pull/9145.
     .excludeGlutenTest("SPARK-25237 compute correct input metrics in FileScanRDD")
   enableSuite[GlutenFileScanSuite]
   enableSuite[GlutenGeneratorFunctionSuite]
@@ -845,9 +845,9 @@ class VeloxTestSettings extends BackendTestSettings {
     // Not useful and time consuming.
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL")
     .exclude("SPARK-33084: Add jar support Ivy URI in SQL -- jar contains udf class")
-    // https://github.com/apache/incubator-gluten/pull/9145.
+    // https://github.com/apache/gluten/pull/9145.
     .exclude("SPARK-17515: CollectLimit.execute() should perform per-partition limits")
-    // https://github.com/apache/incubator-gluten/pull/9145.
+    // https://github.com/apache/gluten/pull/9145.
     .exclude("SPARK-19650: An action on a Command should not trigger a Spark job")
   enableSuite[GlutenSQLQueryTestSuite]
   enableSuite[GlutenStatisticsCollectionSuite]

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -285,7 +285,7 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
     checkEvaluation(Round(1.12345678901234567, 8), 1.12345679)
     checkEvaluation(Round(-0.98765432109876543, 5), -0.98765)
     checkEvaluation(Round(12345.67890123456789, 6), 12345.678901)
-    // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+    // Enable the test after fixing https://github.com/apache/gluten/issues/6827
     // checkEvaluation(Round(0.5549999999999999, 2), 0.55)
     checkEvaluation(Round(-35, -1), -40)
     checkEvaluation(Round(44, -1), 40)

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -647,7 +647,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("DATE_FROM_UNIX_DATE")
     .exclude("UNIX_SECONDS")
     .exclude("TIMESTAMP_SECONDS") // refer to https://github.com/ClickHouse/ClickHouse/issues/69280
-    .exclude("TIMESTAMP_MICROS") // refer to https://github.com/apache/incubator-gluten/issues/7127
+    .exclude("TIMESTAMP_MICROS") // refer to https://github.com/apache/gluten/issues/7127
     .exclude("SPARK-33498: GetTimestamp,UnixTimestamp,ToUnixTimestamp with parseError")
     .exclude("SPARK-34739,SPARK-35889: add a year-month interval to a timestamp")
     .exclude("SPARK-34761,SPARK-35889: add a day-time interval to a timestamp")
@@ -791,7 +791,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("REPEAT")
     .exclude("ParseUrl")
     .exclude("SPARK-33468: ParseUrl in ANSI mode should fail if input string is not a valid url")
-    .exclude("FORMAT") // refer https://github.com/apache/incubator-gluten/issues/6765
+    .exclude("FORMAT") // refer https://github.com/apache/gluten/issues/6765
     .exclude(
       "soundex unit test"
     ) // CH and spark returns different results when input non-ASCII characters

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -151,9 +151,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenHigherOrderFunctionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .exclude("$.store.book")
-    // https://github.com/apache/incubator-gluten/issues/10948
+    // https://github.com/apache/gluten/issues/10948
     .exclude("$['key with spaces']")
     .exclude("$")
     .exclude("$.store.book[0]")

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -250,7 +250,7 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
     checkEvaluation(BRound(-3.5, 0), -4.0)
     checkEvaluation(BRound(-0.35, 1), -0.4)
     checkEvaluation(BRound(-35, -1), -40)
-    // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+    // Enable the test after fixing https://github.com/apache/gluten/issues/6827
     // checkEvaluation(Round(0.5549999999999999, 2), 0.55)
     checkEvaluation(BRound(BigDecimal("45.00"), -1), BigDecimal(40))
     checkEvaluation(checkDataTypeAndCast(RoundFloor(Literal(2.5), Literal(0))), Decimal(2))

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -1046,7 +1046,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .excludeCH(
       "SPARK-45882: BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning")
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .includeCH("$.store.book")
     .includeCH("$")
     .includeCH("$.store.book[0]")

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -151,9 +151,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenHigherOrderFunctionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .exclude("$.store.book")
-    // https://github.com/apache/incubator-gluten/issues/10948
+    // https://github.com/apache/gluten/issues/10948
     .exclude("$['key with spaces']")
     .exclude("$")
     .exclude("$.store.book[0]")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -253,7 +253,7 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
     checkEvaluation(Round(1.12345678901234567, 8), 1.12345679)
     checkEvaluation(Round(-0.98765432109876543, 5), -0.98765)
     checkEvaluation(Round(12345.67890123456789, 6), 12345.678901)
-    // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+    // Enable the test after fixing https://github.com/apache/gluten/issues/6827
     // checkEvaluation(Round(0.5549999999999999, 2), 0.55)
     checkEvaluation(BRound(BigDecimal("45.00"), -1), BigDecimal(40))
     checkEvaluation(checkDataTypeAndCast(RoundFloor(Literal(2.5), Literal(0))), Decimal(2))

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -1022,7 +1022,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .excludeCH(
       "SPARK-45882: BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning")
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .includeCH("$.store.book")
     .includeCH("$")
     .includeCH("$.store.book[0]")

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -163,9 +163,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenHigherOrderFunctionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/10948
+    // https://github.com/apache/gluten/issues/10948
     .exclude("$['key with spaces']")
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .exclude("$.store.book")
     .exclude("$")
     .exclude("$.store.book[0]")
@@ -625,7 +625,7 @@ class VeloxTestSettings extends BackendTestSettings {
     // error message mismatch is accepted
     .exclude("schema mismatch failure error message for parquet reader")
     .exclude("schema mismatch failure error message for parquet vectorized reader")
-    // https://github.com/apache/incubator-gluten/issues/11220
+    // https://github.com/apache/gluten/issues/11220
     .excludeByPrefix("SPARK-40819")
     .excludeByPrefix("SPARK-46056") // TODO: fix in Spark-4.0
     .exclude("CANNOT_MERGE_SCHEMAS: Failed merging schemas")
@@ -947,7 +947,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-41048: Improve output partitioning and ordering with AQE cache")
     // Rewrite this test since it checks the physical operator which is changed in Gluten
     .exclude("SPARK-27439: Explain result should match collected result after view change")
-    // https://github.com/apache/incubator-gluten/issues/11570
+    // https://github.com/apache/gluten/issues/11570
     .exclude("getRows: binary")
   enableSuite[GlutenDataFrameTimeWindowingSuite]
   enableSuite[GlutenDataFrameTungstenSuite]

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -253,7 +253,7 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
     checkEvaluation(Round(1.12345678901234567, 8), 1.12345679)
     checkEvaluation(Round(-0.98765432109876543, 5), -0.98765)
     checkEvaluation(Round(12345.67890123456789, 6), 12345.678901)
-    // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+    // Enable the test after fixing https://github.com/apache/gluten/issues/6827
     // checkEvaluation(Round(0.5549999999999999, 2), 0.55)
     checkEvaluation(BRound(BigDecimal("45.00"), -1), BigDecimal(40))
     checkEvaluation(checkDataTypeAndCast(RoundFloor(Literal(2.5), Literal(0))), Decimal(2))

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -1022,7 +1022,7 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .excludeCH(
       "SPARK-45882: BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning")
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .includeCH("$.store.book")
     .includeCH("$")
     .includeCH("$.store.book[0]")

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -171,9 +171,9 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenHigherOrderFunctionsSuite]
   enableSuite[GlutenIntervalExpressionsSuite]
   enableSuite[GlutenJsonExpressionsSuite]
-    // https://github.com/apache/incubator-gluten/issues/10948
+    // https://github.com/apache/gluten/issues/10948
     .exclude("$['key with spaces']")
-    // https://github.com/apache/incubator-gluten/issues/8102
+    // https://github.com/apache/gluten/issues/8102
     .exclude("$.store.book")
     .exclude("$")
     .exclude("$.store.book[0]")
@@ -409,7 +409,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenV2SessionCatalogTableSuite]
   enableSuite[GlutenCSVv1Suite]
   enableSuite[GlutenCSVv2Suite]
-  // https://github.com/apache/incubator-gluten/issues/11505
+  // https://github.com/apache/gluten/issues/11505
   enableSuite[GlutenCSVLegacyTimeParserSuite]
     .exclude("Write timestamps correctly in ISO8601 format by default")
     .exclude("csv with variant")
@@ -586,7 +586,7 @@ class VeloxTestSettings extends BackendTestSettings {
     // error message mismatch is accepted
     .exclude("schema mismatch failure error message for parquet reader")
     .exclude("schema mismatch failure error message for parquet vectorized reader")
-    // https://github.com/apache/incubator-gluten/issues/11220
+    // https://github.com/apache/gluten/issues/11220
     .excludeByPrefix("SPARK-40819")
     .excludeByPrefix("SPARK-46056") // TODO: fix in Spark-4.0
     .exclude("CANNOT_MERGE_SCHEMAS: Failed merging schemas")
@@ -917,7 +917,7 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-41048: Improve output partitioning and ordering with AQE cache")
     // Rewrite this test since it checks the physical operator which is changed in Gluten
     .exclude("SPARK-27439: Explain result should match collected result after view change")
-    // https://github.com/apache/incubator-gluten/issues/11570
+    // https://github.com/apache/gluten/issues/11570
     .exclude("getRows: binary")
   enableSuite[GlutenDataFrameTimeWindowingSuite]
   enableSuite[GlutenDataFrameTungstenSuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenMathExpressionsSuite.scala
@@ -253,7 +253,7 @@ class GlutenMathExpressionsSuite extends MathExpressionsSuite with GlutenTestsTr
     checkEvaluation(Round(1.12345678901234567, 8), 1.12345679)
     checkEvaluation(Round(-0.98765432109876543, 5), -0.98765)
     checkEvaluation(Round(12345.67890123456789, 6), 12345.678901)
-    // Enable the test after fixing https://github.com/apache/incubator-gluten/issues/6827
+    // Enable the test after fixing https://github.com/apache/gluten/issues/6827
     // checkEvaluation(Round(0.5549999999999999, 2), 0.55)
     checkEvaluation(BRound(BigDecimal("45.00"), -1), BigDecimal(40))
     checkEvaluation(checkDataTypeAndCast(RoundFloor(Literal(2.5), Literal(0))), Decimal(2))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@
 site_name: Gluten
 
 repo_name: 'Fork on GitHub '
-repo_url: "https://github.com/apache/incubator-gluten.git"
+repo_url: "https://github.com/apache/gluten.git"
 edit_uri: ""
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <name>Gluten Parent Pom</name>
   <description>Apache Gluten</description>
-  <url>https://github.com/apache/incubator-gluten.git</url>
+  <url>https://github.com/apache/gluten.git</url>
 
   <organization>
     <name>Apache Software Foundation</name>
@@ -52,9 +52,9 @@
   </modules>
 
   <scm>
-    <connection>scm:git:git://github.com/apache/incubator-gluten.git</connection>
-    <developerConnection>scm:git:ssh://github.com:apache/incubator-gluten.git</developerConnection>
-    <url>https://github.com/apache/incubator-gluten/tree/main</url>
+    <connection>scm:git:git://github.com/apache/gluten.git</connection>
+    <developerConnection>scm:git:ssh://github.com:apache/gluten.git</developerConnection>
+    <url>https://github.com/apache/gluten/tree/main</url>
   </scm>
 
   <properties>

--- a/shims/common/src/main/scala/org/apache/gluten/GlutenBuildInfo.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/GlutenBuildInfo.scala
@@ -20,7 +20,7 @@ import java.util.Properties
 
 import scala.util.Try
 
-/** Since https://github.com/apache/incubator-gluten/pull/1973. */
+/** Since https://github.com/apache/gluten/pull/1973. */
 object GlutenBuildInfo {
   private val buildFile = "gluten-build-info.properties"
   private val buildFileStream =

--- a/shims/common/src/main/scala/org/apache/gluten/execution/BatchCarrierRow.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/execution/BatchCarrierRow.scala
@@ -96,7 +96,7 @@ object BatchCarrierRow {
  * A [[BatchCarrierRow]] implementation that is backed by a
  * [[org.apache.spark.sql.vectorized.ColumnarBatch]].
  *
- * Serialization code originated since https://github.com/apache/incubator-gluten/issues/9270.
+ * Serialization code originated since https://github.com/apache/gluten/issues/9270.
  */
 abstract class TerminalRow extends BatchCarrierRow {
   def batch(): ColumnarBatch

--- a/tools/gluten-it/README.md
+++ b/tools/gluten-it/README.md
@@ -6,13 +6,13 @@ The project makes it easy to test Gluten build locally.
 
 Gluten is a native Spark SQL implementation as a standard Spark plug-in.
 
-https://github.com/apache/incubator-gluten
+https://github.com/apache/gluten
 
 ## Getting Started
 
 ### 1. Build Gluten
 
-See official Gluten build guidance https://github.com/apache/incubator-gluten#build-from-source.
+See official Gluten build guidance https://github.com/apache/gluten#build-from-source.
 
 ### 2. Build and run gluten-it
 

--- a/tools/gluten-te/centos/defaults.conf
+++ b/tools/gluten-te/centos/defaults.conf
@@ -11,7 +11,7 @@ DEFAULT_NON_INTERACTIVE=OFF
 DEFAULT_PRESERVE_CONTAINER=OFF
 
 # The codes will be used in build
-DEFAULT_GLUTEN_REPO=https://github.com/apache/incubator-gluten.git
+DEFAULT_GLUTEN_REPO=https://github.com/apache/gluten.git
 DEFAULT_GLUTEN_BRANCH=main
 
 # Create debug build

--- a/tools/gluten-te/ubuntu/README.md
+++ b/tools/gluten-te/ubuntu/README.md
@@ -1,6 +1,6 @@
 # Portable Test Environment of Gluten (gluten-te)
 
-Build and run [gluten](https://github.com/apache/incubator-gluten) and [gluten-it](https://github.com/apache/incubator-gluten/tree/main/tools/gluten-it) in a portable docker container, from scratch.
+Build and run [gluten](https://github.com/apache/gluten) and [gluten-it](https://github.com/apache/gluten/tree/main/tools/gluten-it) in a portable docker container, from scratch.
 
 # Prerequisites
 
@@ -9,7 +9,7 @@ Only Linux and MacOS are currently supported. Before running the scripts, make s
 # Getting Started (Build Gluten code, Velox backend)
 
 ```sh
-git clone -b main https://github.com/apache/incubator-gluten.git gluten # Gluten main code
+git clone -b main https://github.com/apache/gluten.git gluten # Gluten main code
 
 export HTTP_PROXY_HOST=myproxy.example.com # in case you are behind http proxy
 export HTTP_PROXY_PORT=55555 # in case you are behind http proxy
@@ -21,7 +21,7 @@ tools/gluten-te/ubuntu/examples/buildhere-veloxbe/run.sh
 # Getting Started (TPC, Velox backend)
 
 ```sh
-git clone -b main https://github.com/apache/incubator-gluten.git gluten # Gluten main code
+git clone -b main https://github.com/apache/gluten.git gluten # Gluten main code
 
 export HTTP_PROXY_HOST=myproxy.example.com # in case you are behind http proxy
 export HTTP_PROXY_PORT=55555 # in case you are behind http proxy
@@ -32,7 +32,7 @@ cd gluten/gluten-te
 
 # Configurations
 
-See the [config file](https://github.com/apache/incubator-gluten/blob/main/tools/gluten-te/ubuntu/defaults.conf). You can modify the file to configure gluten-te, or pass env variables during running the scripts.
+See the [config file](https://github.com/apache/gluten/blob/main/tools/gluten-te/ubuntu/defaults.conf). You can modify the file to configure gluten-te, or pass env variables during running the scripts.
 
 # Example Usages
 

--- a/tools/gluten-te/ubuntu/defaults.conf
+++ b/tools/gluten-te/ubuntu/defaults.conf
@@ -11,7 +11,7 @@ DEFAULT_NON_INTERACTIVE=OFF
 DEFAULT_PRESERVE_CONTAINER=OFF
 
 # The codes will be used in build
-DEFAULT_GLUTEN_REPO=https://github.com/apache/incubator-gluten.git
+DEFAULT_GLUTEN_REPO=https://github.com/apache/gluten.git
 DEFAULT_GLUTEN_BRANCH=main
 
 # Create debug build

--- a/tools/workload/benchmark_velox/analysis/sparklog.ipynb
+++ b/tools/workload/benchmark_velox/analysis/sparklog.ipynb
@@ -5912,7 +5912,7 @@
     "    \n",
     "    pr_link=''\n",
     "    if pr:\n",
-    "        pr_link=f'https://github.com/apache/incubator-gluten/pull/{pr}'\n",
+    "        pr_link=f'https://github.com/apache/gluten/pull/{pr}'\n",
     "        title=!wget --quiet -O - $pr_link | sed -n -e 's!.*<title>\\(.*\\)</title>.*!\\1!p'\n",
     "        if not title:\n",
     "            raise Exception(f'Failed to fetch PR link: {pr_link}')\n",

--- a/tools/workload/benchmark_velox/initialize.ipynb
+++ b/tools/workload/benchmark_velox/initialize.ipynb
@@ -313,7 +313,7 @@
     "\n",
     "```bash\n",
     "cd ~\n",
-    "git clone https://github.com/apache/incubator-gluten.git gluten\n",
+    "git clone https://github.com/apache/gluten.git gluten\n",
     "```"
    ]
   },
@@ -2229,7 +2229,7 @@
    "source": [
     "import os\n",
     "if not os.path.exists('gluten'):\n",
-    "    !git clone https://github.com/apache/incubator-gluten.git gluten"
+    "    !git clone https://github.com/apache/gluten.git gluten"
    ]
   },
   {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace all references to the old incubator repository paths after Apache Gluten graduated as a TLP:

- \pache/incubator-gluten\  \pache/gluten\
- \pache/incubator-gluten-site\  \pache/gluten-site\
- \incubator-gluten\ directory/path references  \gluten\

### Files updated (106 files):
- **pom.xml**: SCM URLs
- **CI workflows**: \.github/\ clone URLs and paths
- **Documentation**: README.md, CONTRIBUTING.md, docs/\*
- **Docker files**: \dev/docker/Dockerfile.*\
- **Build/Release scripts**: \dev/release/package-release.sh\
- **Source code comments**: GitHub issue/PR links in Scala/Java/C++ code
- **Config files**: \mkdocs.yml\, \docs/_config.yml\, \.idea/vcs.xml\
- **Tools**: \	ools/gluten-te/\, \	ools/gluten-it/\, \	ools/workload/\

### Not changed:
- \	ools/qualification-tool/src/test/resources/event-files/\  these are recorded Spark event logs (historical test data)

Part of graduation tasks: https://github.com/apache/gluten/issues/11713