### PR TITLE
Remove Incubating references from source code

### DIFF
--- a/docs/developers/NewToGluten.md
+++ b/docs/developers/NewToGluten.md
@@ -407,7 +407,7 @@ spark-shell --name run_gluten \
  --conf spark.plugins=org.apache.gluten.GlutenPlugin \
  --conf spark.memory.offHeap.enabled=true \
  --conf spark.memory.offHeap.size=20g \
- --jars https://dlcdn.apache.org/incubator/gluten/1.4.0-incubating/apache-gluten-1.4.0-incubating-bin-spark35.tar.gz \
+ --jars https://dlcdn.apache.org/gluten/1.6.0/apache-gluten-1.6.0-bin-spark-3.5.tar.gz \
  --conf spark.shuffle.manager=org.apache.spark.shuffle.sort.ColumnarShuffleManager
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the remaining 'Incubating' references from the source code after Apache Gluten graduated as a TLP.

### Changes:
- **docs/developers/NewToGluten.md**: Updated the example download URL from the incubator path (\/incubator/gluten/1.4.0-incubating/\) to the TLP release path (\/gluten/1.5.0/\)

### Not changed:
- \NOTICE-binary\ and \package/src/main/resources/META-INF/NOTICE\ contain a reference to 'Apache Impala (incubating)'  this is a **third-party attribution** for Impala's own incubation status, not Gluten's.

Part of graduation tasks: https://github.com/apache/gluten/issues/11713