### PR TITLE
Remove DISCLAIMER file after TLP graduation

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,7 +1,0 @@
-Apache Gluten is a Top Level Project (TLP) at the Apache Software
-Foundation (ASF).
-
-This product includes software developed at The Apache Software
-Foundation (http://www.apache.org/).
-
-http://gluten.apache.org

--- a/dev/release/package-release.sh
+++ b/dev/release/package-release.sh
@@ -57,7 +57,6 @@ for v in $SPARK_VERSIONS; do
 
   echo "Packaging for Spark $v (Scala $SCALA)..."
   tar -czf apache-gluten-${RELEASE_VERSION}-bin-spark-${v}.tar.gz \
-      ${GLUTEN_HOME}/DISCLAIMER \
       $JAR
 done
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the DISCLAIMER file and its references after Apache Gluten graduated as a TLP.

### Changes:
- **DISCLAIMER**: Deleted  no longer needed for a Top Level Project
- **dev/release/package-release.sh**: Removed the line that includes DISCLAIMER in binary release tarballs

Part of graduation tasks: https://github.com/apache/gluten/issues/11713