### PR TITLE
Update GitHub CI workflows for TLP graduation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,5 +16,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Gluten Discussions
-    url: https://github.com/apache/incubator-gluten/discussions
+    url: https://github.com/apache/gluten/discussions
     about: Ask questions or discuss new feature ideas here.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 Thank you for submitting a pull request! Here are some tips:
 
 1. For first-time contributors, please read our contributing guide:
-   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
+   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
 2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
 3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
    Velox or ClickHouse backend, respectively.

--- a/.github/workflows/dev_cron/pr_issue_linker.js
+++ b/.github/workflows/dev_cron/pr_issue_linker.js
@@ -29,7 +29,7 @@ function detectIssueID(title) {
 }
 
 async function appendToPRDescription(github, context, pullRequestNumber, issuesID) {
-  const issueURL = `https://github.com/apache/incubator-gluten/issues/${issuesID}`;
+  const issueURL = `https://github.com/apache/gluten/issues/${issuesID}`;
   const issueReference = `#${issuesID}`
 
   // Fetch the current PR description.

--- a/.github/workflows/velox_weekly.yml
+++ b/.github/workflows/velox_weekly.yml
@@ -62,7 +62,7 @@ jobs:
           export PATH=$JAVA_HOME/bin:$PATH
           
           # action/checkout does not work centos7 anymore, so we clone the branch instead.
-          git clone -b main --depth=1 https://github.com/apache/incubator-gluten.git && cd incubator-gluten/
+          git clone -b main --depth=1 https://github.com/apache/gluten.git && cd gluten/
           if [ ${{ github.event_name }} = "pull_request" ]; then
             git fetch origin ${{ github.ref }}:pr_branch && git checkout pr_branch
           fi


### PR DESCRIPTION
## What Changes Were Proposed In This Pull Request?

Update all \incubator-gluten\ references to \gluten\ in GitHub CI workflows and templates:

- \.github/ISSUE_TEMPLATE/config.yml\ - discussions URL
- \.github/PULL_REQUEST_TEMPLATE\ - contributing guide URL
- \.github/workflows/dev_cron/pr_issue_linker.js\ - issue URL
- \.github/workflows/velox_weekly.yml\ - clone URL and directory name

## How Was This Patch Tested?

No functional changes, only URL/path updates.

Part of: https://github.com/apache/gluten/issues/11713