### PR TITLE
Update dev scripts and Dockerfiles for TLP graduation

### DIFF
--- a/dev/docker/Dockerfile.centos7-gcc13-static-build
+++ b/dev/docker/Dockerfile.centos7-gcc13-static-build
@@ -35,7 +35,7 @@ RUN set -ex; \
        -e 's/mirror\.centos\.org/vault.centos.org/' \
        /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
     yum install -y git patch sudo java-1.8.0-openjdk-devel ccache; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     cd /opt/gluten && bash ./dev/vcpkg/setup-build-depends.sh; \
     yum remove gcc -y && yum clean all; \

--- a/dev/docker/Dockerfile.centos7-static-build
+++ b/dev/docker/Dockerfile.centos7-static-build
@@ -35,7 +35,7 @@ RUN set -ex; \
        -e 's/mirror\.centos\.org/vault.centos.org/' \
        /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
     yum install -y git patch sudo java-1.8.0-openjdk-devel ccache; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     cd /opt/gluten && bash ./dev/vcpkg/setup-build-depends.sh; \
     mkdir -p ${VCPKG_PATH}; \

--- a/dev/docker/Dockerfile.centos8-dynamic-build
+++ b/dev/docker/Dockerfile.centos8-dynamic-build
@@ -36,7 +36,7 @@ RUN set -ex; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.6.1/apache-celeborn-0.6.1-bin.tgz?action=download -O /opt/apache-celeborn-0.6.1-bin.tgz; \
     wget -nv ${mirror_host}/uniffle/0.10.0/apache-uniffle-0.10.0-bin.tar.gz?action=download -O /opt/apache-uniffle-0.10.0-bin.tar.gz; \
     wget -nv ${mirror_host}/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz?action=download -O /opt/hadoop-2.8.5.tar.gz; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten/.github/workflows/util/; \
     ./install-resources.sh 3.3; \
     ./install-resources.sh 3.4; \

--- a/dev/docker/Dockerfile.centos8-gcc13-static-build
+++ b/dev/docker/Dockerfile.centos8-gcc13-static-build
@@ -33,7 +33,7 @@ RUN set -ex; \
     pip3 install cmake; \
     rpm -qa | grep tzdata; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \
     if [ "$(uname -m)" = "aarch64" ]; then \

--- a/dev/docker/Dockerfile.centos8-static-build
+++ b/dev/docker/Dockerfile.centos8-static-build
@@ -33,7 +33,7 @@ RUN set -ex; \
     yum install -y java-1.8.0-openjdk-devel patch git perl; \
     rpm -qa | grep tzdata; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten && bash ./dev/vcpkg/setup-build-depends.sh; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \

--- a/dev/docker/Dockerfile.centos9-dynamic-build
+++ b/dev/docker/Dockerfile.centos9-dynamic-build
@@ -34,7 +34,7 @@ RUN set -ex; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.6.1/apache-celeborn-0.6.1-bin.tgz?action=download -O /opt/apache-celeborn-0.6.1-bin.tgz; \
     wget -nv ${mirror_host}/uniffle/0.10.0/apache-uniffle-0.10.0-bin.tar.gz?action=download -O /opt/apache-uniffle-0.10.0-bin.tar.gz; \
     wget -nv ${mirror_host}/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz?action=download -O /opt/hadoop-2.8.5.tar.gz; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten/.github/workflows/util/; \
     ./install-resources.sh 3.3; \
     ./install-resources.sh 3.4; \

--- a/dev/docker/Dockerfile.centos9-static-build
+++ b/dev/docker/Dockerfile.centos9-static-build
@@ -30,7 +30,7 @@ RUN set -ex; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-17-openjdk-devel patch git perl; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten && bash ./dev/vcpkg/setup-build-depends.sh; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \

--- a/dev/docker/cudf/Dockerfile
+++ b/dev/docker/cudf/Dockerfile
@@ -25,7 +25,7 @@ RUN yum install -y sudo patch perl && \
     dnf autoremove -y && dnf clean all; \
     rm -rf /opt/rh/gcc-toolset-12 && ln -s /opt/rh/gcc-toolset-14 /opt/rh/gcc-toolset-12; \
     ln -sf /usr/local/bin/cmake /usr/bin && \
-    git clone --depth=1 https://github.com/apache/incubator-gluten /opt/gluten && \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten && \
     cd /opt/gluten && \
     source /opt/rh/gcc-toolset-14/enable && \
     bash ./dev/buildbundle-veloxbe.sh --run_setup_script=OFF --build_arrow=ON --spark_version=3.4 --build_tests=ON --build_benchmarks=ON --enable_gpu=ON && \

--- a/dev/release/package-release.sh
+++ b/dev/release/package-release.sh
@@ -62,14 +62,14 @@ for v in $SPARK_VERSIONS; do
 done
 
 SRC_ZIP="${TAG}.zip"
-SRC_DIR="incubator-gluten-${RELEASE_VERSION}"
+SRC_DIR="gluten-${RELEASE_VERSION}"
 
 echo "Packaging source code..."
-wget https://github.com/apache/incubator-gluten/archive/refs/tags/${SRC_ZIP}
+wget https://github.com/apache/gluten/archive/refs/tags/${SRC_ZIP}
 unzip -q ${SRC_ZIP}
 
 # Rename folder to remove "rc*" for formal release.
-mv incubator-gluten-${TAG_VERSION} ${SRC_DIR}
+mv gluten-${TAG_VERSION} ${SRC_DIR}
 # Remove .git and .github and other unwanted files from the source dir.
 rm -rf ${SRC_DIR}/.git \
        ${SRC_DIR}/.github \


### PR DESCRIPTION
## What Changes Were Proposed In This Pull Request?

Update all \incubator-gluten\ references to \gluten\ in dev scripts and Dockerfiles:

**Dockerfiles (git clone URL):**
- \dev/docker/Dockerfile.centos7-gcc13-static-build\
- \dev/docker/Dockerfile.centos7-static-build\
- \dev/docker/Dockerfile.centos8-dynamic-build\
- \dev/docker/Dockerfile.centos8-gcc13-static-build\
- \dev/docker/Dockerfile.centos8-static-build\
- \dev/docker/Dockerfile.centos9-dynamic-build\
- \dev/docker/Dockerfile.centos9-static-build\
- \dev/docker/cudf/Dockerfile\

**Release script:**
- \dev/release/package-release.sh\ - source directory name and download URL

## How Was This Patch Tested?

No functional changes, only URL/path updates.

Part of: https://github.com/apache/gluten/issues/11713