### PR TITLE
fix: redact credentials from repo URL in gluten-build-info.properties

### DIFF
--- a/dev/gluten-build-info.sh
+++ b/dev/gluten-build-info.sh
@@ -31,7 +31,8 @@ function echo_revision_info() {
   echo revision=$(git rev-parse HEAD)
   echo revision_time=$(git show -s --format=%ci HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo url=$(git config --get remote.origin.url)
+  # Strip embedded credentials (user:pass@) from the URL to avoid exposing them in the build info.
+  echo url=$(git config --get remote.origin.url | sed 's|://[^:@]*:[^@]*@|://|')
 }
 
 function echo_velox_revision_info() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Close #11750 . Strip embedded user:pass@ from the git remote URL when writing the build info properties file to avoid leaking credentials in logs.

## How was this patch tested?

Manual test.

## Was this patch authored or co-authored using generative AI tooling?

No.