### PR TITLE
[VL] Close ColumnarBatch in ColumnarCollectLimitExec for skipped batches

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarCollectLimitExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarCollectLimitExec.scala
@@ -83,9 +83,7 @@ case class ColumnarCollectLimitExec(
                 ColumnarBatches.retain(batch)
                 batch
               } else {
-                val sliced = VeloxColumnarBatches.slice(batch, startIndex, needed)
-                batch.close()
-                sliced
+                VeloxColumnarBatches.slice(batch, startIndex, needed)
               }
 
             rowsToCollect -= needed


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR closes `ColumnarBatch` for skipped batches in `ColumnarCollectLimitExec`.

`ColumnarCollectLimitExec.fetchNextBatch()` leaks memory for skipped batches - when a batch falls entirely within the offset range, it is consumed from the input iterator but never closed.   

The `ColumnarBatch` object is small but it holds a JNI handle to a native Velox vector. Since ColumnarBatch has no finalizer, the native memory is only freed by an explicit close() call. 

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
