### PR TITLE
[CI] Fix the concurrency of code format check

### DIFF
--- a/.github/workflows/code_format.yml
+++ b/.github/workflows/code_format.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Code Format Check
+name: Cpp Code Format Check
 on:
   pull_request:
     paths:

--- a/.github/workflows/scala_code_format.yml
+++ b/.github/workflows/scala_code_format.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Code Format Check
+name: Scala Code Format Check
 on:
   pull_request:
     paths:
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
 
-  scala-format-check:
+  format-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Because the group is `apache/incubator-gluten-mybranch-Code Format Check`, so the latter one may be cancelled.
```
concurrency:
  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
  cancel-in-progress: true
```
