### PR TITLE
[GLUTEN-DOCS] Fix broken mkdocs navigation and add getting-started guide

### DIFF
--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -1,11 +1,86 @@
 ---
 layout: page
-title: Getting-Started
+title: Getting Started
 nav_order: 2
 has_children: true
-permalink: /Getting-Started/
+permalink: /getting-started/
 ---
-# Getting Started with Gluten for Apache Spark
+# Getting Started with Apache Gluten
 
+Apache Gluten is a plugin that accelerates Apache Spark SQL by offloading execution to native engines. It requires no changes to your existing Spark SQL queries or DataFrame API code and only needs configuration changes.
 
+## Choosing a Backend
+
+Gluten supports two native backends:
+
+| Backend | Description | Guide |
+|---------|-------------|-------|
+| **Velox** | Meta's C++ execution library| [Velox Backend](Velox.md) |
+| **ClickHouse** | Column-oriented DBMS ported as a native library| [ClickHouse Backend](ClickHouse.md) |
+
+## Quick Start (Velox Backend)
+
+### 1. Prerequisites
+
+- **OS**: Ubuntu 20.04/22.04 or CentOS 7/8 (other Linux distros may work with static build but are not officially tested)
+- **JDK**: OpenJDK 8 or 17 (Spark 4.0 requires JDK 17+)
+- **Spark**: 3.2.2, 3.3.1, 3.4.4, 3.5.5, or 4.0.0-preview
+- **Scala**: 2.12 (Spark 4.0 requires Scala 2.13)
+
+### 2. Build
+
+```bash
+## Set JAVA_HOME (JDK 8 or 17)
+export JAVA_HOME=/path/to/your/jdk
+export PATH=$JAVA_HOME/bin:$PATH
+
+## Clone and build
+git clone https://github.com/apache/gluten.git
+cd gluten
+./dev/buildbundle-veloxbe.sh
+```
+
+See the [Build Guide](build-guide.md) for build options and parameters.
+
+### 3. Deploy
+
+Add the Gluten jar and required configuration to your Spark session. Off-heap memory must be enabled, and the columnar shuffle manager is needed for native shuffle support:
+
+```bash
+spark-shell \
+  --master yarn --deploy-mode client \
+  --conf spark.plugins=org.apache.gluten.GlutenPlugin \
+  --conf spark.memory.offHeap.enabled=true \
+  --conf spark.memory.offHeap.size=20g \
+  --conf spark.shuffle.manager=org.apache.spark.shuffle.sort.ColumnarShuffleManager \
+  --jars /path/to/gluten-velox-bundle-*.jar
+```
+
+Adjust `offHeap.size` based on your environment.
+
+Alternatively, you can enable **dynamic off-heap sizing** (experimental) to let Gluten manage the off-heap/on-heap split automatically based on `spark.executor.memory`:
+
+```bash
+spark-shell \
+  --master yarn --deploy-mode client \
+  --conf spark.plugins=org.apache.gluten.GlutenPlugin \
+  --conf spark.gluten.memory.dynamic.offHeap.sizing.enabled=true \
+  --conf spark.shuffle.manager=org.apache.spark.shuffle.sort.ColumnarShuffleManager \
+  --jars /path/to/gluten-velox-bundle-*.jar
+```
+
+With dynamic sizing, `spark.memory.offHeap.enabled` and `spark.memory.offHeap.size` are not needed - Velox uses the on-heap size as its memory budget. See [Dynamic Off-Heap Sizing](../developers/VeloxDynamicSizingOffheap.md) for details.
+
+See the [Velox Backend](Velox.md) guide for a complete example with executor and driver settings.
+
+### 4. Verify
+
+Run a simple query and check the Spark UI for nodes containing `Transformer` or `Velox` or `Columnar` in the query plan, which indicate native execution.
+
+## Next Steps
+
+- [Configuration](../Configuration.md) — Tune Gluten settings
+- [Velox Configuration](../velox-configuration.md) — Velox-specific knobs
+- [Gluten UI](GlutenUI.md) — Monitor native execution in Spark UI
+- [Troubleshooting](../velox-backend-troubleshooting.md) — Common issues and solutions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,16 +20,56 @@ edit_uri: ""
 
 
 nav:
-- User Guide: User-Guide.md
-- Prerequisite: Prerequisite.md
-- Installation: Installation.md
-- InstallationNotes: InstallationNotes.md
-- Configuration: Configuration.md
-- SparkInstallation: SparkInstallation.md
-- ApacheArrowInstallation: ApacheArrowInstallation.md
-- OAP Installation Guide: OAP-Installation-Guide.md
-- OAP Developer Guide: OAP-Developer-Guide.md
-- Version Selector: "../"
+- Home: index.md
+- Getting Started:
+  - get-started/getting-started.md
+  - Velox Backend: get-started/Velox.md
+  - ClickHouse Backend: get-started/ClickHouse.md
+  - Build Guide: get-started/build-guide.md
+  - Gluten UI: get-started/GlutenUI.md
+  - Velox with S3: get-started/VeloxS3.md
+  - Velox with ABFS: get-started/VeloxABFS.md
+  - Velox with GCS: get-started/VeloxGCS.md
+  - Velox with Delta Lake: get-started/VeloxDelta.md
+  - Velox with Iceberg: get-started/VeloxIceberg.md
+  - Velox with GPU: get-started/VeloxGPU.md
+  - Velox with QAT: get-started/VeloxQAT.md
+  - Velox Local Caching: get-started/VeloxLocalCache.md
+  - Stage Resource Adjustment: get-started/VeloxStageResourceAdj.md
+- Configuration:
+  - Gluten Configuration: Configuration.md
+  - Velox Configuration: velox-configuration.md
+  - Spark Configuration: velox-spark-configuration.md
+  - Parquet Write Configuration: velox-parquet-write-configuration.md
+- Velox Backend Reference:
+  - Support Progress: velox-backend-support-progress.md
+  - Limitations: velox-backend-limitations.md
+  - Scalar Functions: velox-backend-scalar-function-support.md
+  - Aggregate Functions: velox-backend-aggregate-function-support.md
+  - Window Functions: velox-backend-window-function-support.md
+  - Generator Functions: velox-backend-generator-function-support.md
+  - Troubleshooting: velox-backend-troubleshooting.md
+- Developers:
+  - Overview: developers/README.md
+  - New to Gluten: developers/NewToGluten.md
+  - How To: developers/HowTo.md
+  - How to Release: developers/HowToRelease.md
+  - C++ Coding Style: developers/CppCodingStyle.md
+  - Substrait Modifications: developers/SubstraitModifications.md
+  - Micro Benchmarks: developers/MicroBenchmarks.md
+  - Velox UDF and UDAF: developers/VeloxUDF.md
+  - Velox Function Development: developers/velox-function-development-guide.md
+  - Velox Backend CI: developers/velox-backend-CI.md
+  - Build in Docker: developers/velox-backend-build-in-docker.md
+  - Query Trace: developers/QueryTrace.md
+  - Memory Profiling: developers/ProfileMemoryOfGlutenWithVelox.md
+  - Dynamic Off-Heap Sizing: developers/VeloxDynamicSizingOffheap.md
+  - Partial Project: developers/PartialProject.md
+  - Bloop Integration: developers/bloop-integration.md
+  - Debug CH Backend: developers/clickhouse-backend-debug.md
+  - Jemalloc with CH: developers/UsingJemallocWithCH.md
+  - Gperftools with CH: developers/UsingGperftoolsInCH.md
+  - Improvement Proposals: developers/improvement-proposals.md
 
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR updates the existing mkdocs.yml navigation which had entries (User-Guide.md, Prerequisite.md, Installation.md, etc.) that all pointed to nonexistent files and also updates the getting-started.md page.

## How was this patch tested?
Doc changes only

## Was this patch authored or co-authored using generative AI tooling?
No
