### PR TITLE
[CH] Remove RAS

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -164,22 +164,6 @@ object CHRuleApi {
   }
 
   /**
-   * Registers Gluten's columnar rules. These rules will be executed only when RAS (relational
-   * algebra selector) is enabled by spark.gluten.ras.enabled=true.
-   *
-   * These rules are covered by CI test job spark-test-spark35-ras.
-   */
-  private def injectRas(injector: RasInjector): Unit = {
-    // CH backend doesn't work with RAS at the moment. Inject a rule that aborts any
-    // execution calls.
-    injector.injectPreTransform(
-      _ =>
-        new SparkPlanRules.AbortRule(
-          "Clickhouse backend doesn't yet have RAS support, please try disabling RAS and" +
-            " rerunning the application"))
-  }
-
-  /**
    * Since https://github.com/apache/gluten/pull/883.
    *
    * TODO: Remove this since tricky to maintain.


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/apache/gluten/pull/11735 mistakenly reintroduced RAS, causing CH CI to fail.
```
16:29:12  [ERROR] /home/jenkins/agent/workspace/gluten/gluten-ci/ut-stage-5/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala:172: error: not found: type RasInjector
16:29:12  [ERROR]   private def injectRas(injector: RasInjector): Unit = {
16:29:12  [ERROR]                                   ^
16:29:12  [ERROR] 1 error
16:29:12  [ERROR] exception compilation error occurred!!!
16:29:12  org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
16:29:12      at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:355)
16:29:12      at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:253)
16:29:12      at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:236)
16:29:12      at scala_maven_executions.JavaMainCallerByFork.run (JavaMainCallerByFork.java:95)
```

## How was this patch tested?

CI.

## Was this patch authored or co-authored using generative AI tooling?

No.
