### PR TITLE
[INFRA] Fix Scala 2.13 build on JDK 8 by using release 8 instead of 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <os.full.name>unknown</os.full.name>
     <!-- To build built-in backend c++ codes -->
     <scala.recompile.mode>all</scala.recompile.mode>
+    <scala.release.version>${java.version}</scala.release.version>
     <!-- For unit tests -->
     <fasterxml.version>2.15.0</fasterxml.version>
     <junit.version>4.13.1</junit.version>
@@ -1030,7 +1031,7 @@
                   <arg>-deprecation</arg>
                   <arg>-feature</arg>
                   <arg>-explaintypes</arg>
-                  <arg>-release:${java.version}</arg>
+                  <arg>-release:${scala.release.version}</arg>
                   <arg>-Wconf:any:e</arg>
                   <arg>-Wconf:cat=deprecation:wv</arg>
                   <arg>-Wunused:imports</arg>
@@ -1099,9 +1100,7 @@
       </activation>
       <properties>
         <java.version>1.8</java.version>
-        <!-- scala-maven-plugin 4.9.2 injects '-release 1.8' into scalac args,
-             which fails under JDK 8. Pin to 4.8.0 where this bug does not exist. -->
-        <scala.compiler.version>4.8.0</scala.compiler.version>
+        <scala.release.version>8</scala.release.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Fix build error under JDK 8 and Scala 2.13:
```
[ERROR] scalac error: '1.8' is not a valid choice for '-release'
[INFO]   scalac -help  gives more information
[ERROR] scalac error: bad option: '-release:1.8'
[INFO]   scalac -help  gives more information
[ERROR] exception compilation error occurred!!!
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
```

## How was this patch tested?

Local build test.

## Was this patch authored or co-authored using generative AI tooling?

No.
