### PR TITLE
[MINOR] Fix Link to Package Repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There are two ways to acquire Gluten jar for the above configuration.
 
 ### Use Released JAR
 
-Please download the tar package [here](https://downloads.apache.org/gluten/), then extract Gluten JAR from it.
+Please download the tar package [here](https://gluten.apache.org/downloads/), then extract Gluten JAR from it.
 Additionally, Gluten provides nightly builds based on the main branch for early testing. The nightly build JARs are available at [Apache Gluten Nightlies](https://nightlies.apache.org/gluten/).
 They have been verified on Centos 7/8/9, Ubuntu 20.04/22.04.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR fixes the link to the package repository from `downloads.apache.org/incubator/gluten/` to `downloads.apache.org/gluten/` in the README. This is a follow-up to https://github.com/apache/gluten/pull/11735.