### PR TITLE
Only apply VeloxParquetWriterInjects and NativeWritePostRule for Spark 3.3

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxListenerApi.scala
@@ -239,9 +239,8 @@ class VeloxListenerApi extends ListenerApi with Logging {
 
     // Inject backend-specific implementations to override spark classes.
     GlutenFormatFactory.register(new VeloxParquetWriterInjects)
-    // Only register VeloxParquetWriterInjects and NativeWritePostRule for Spark 3.2 and 3.3
-    val sparkVersion = SparkShimLoader.getSparkVersion
-    if (sparkVersion.startsWith("3.2") || sparkVersion.startsWith("3.3")) {
+    // Only register NativeWritePostRule for Spark 3.3
+    if (SparkShimLoader.getSparkVersion.startsWith("3.3")) {
       GlutenFormatFactory.injectPostRuleFactory(
         session => GlutenWriterColumnarRules.NativeWritePostRule(session))
     }


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

VeloxParquetWriterInjects and NativeWritePostRule is only used to offload spark32 and spark33's writer.
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Existing tests
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?
no
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
