### PR TITLE
[GLUTEN-11550][UT] Fix PlanStability test suites for Velox backend

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
@@ -371,7 +371,15 @@ abstract class BroadcastHashJoinExecTransformerBase(
     JoinUtils.getDirectJoinOutputSeq(joinType, left.output, right.output, getClass.getSimpleName)
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    val mode = HashedRelationBroadcastMode(buildKeyExprs, isNullAwareAntiJoin)
+    // Use the same bound+rewritten keys as Spark's BroadcastHashJoinExec to ensure
+    // the mode matches the BroadcastExchange created by EnsureRequirements.
+    val (bKeys, bOutput) = buildSide match {
+      case BuildLeft => (leftKeys, left.output)
+      case BuildRight => (rightKeys, right.output)
+    }
+    val boundBuildKeys =
+      BindReferences.bindReferences(HashJoin.rewriteKeyExpr(bKeys), bOutput)
+    val mode = HashedRelationBroadcastMode(boundBuildKeys, isNullAwareAntiJoin)
     buildSide match {
       case BuildLeft =>
         BroadcastDistribution(mode) :: UnspecifiedDistribution :: Nil

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
@@ -16,28 +16,67 @@
  */
 package org.apache.spark.sql
 
+import org.apache.spark.sql.catalyst.util.resourceToString
+import org.apache.spark.sql.execution.exchange.ValidateRequirements
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Gluten plan stability suites verify that Gluten-transformed plans satisfy Spark's distribution
+ * and ordering requirements (via ValidateRequirements). Golden file comparison against vanilla
+ * Spark plans is skipped because Gluten intentionally produces different physical plans using
+ * native Transformer operators.
+ */
+trait GlutenPlanStabilityTestTrait {
+  self: PlanStabilitySuite =>
+
+  override protected def testQuery(tpcdsGroup: String, query: String, suffix: String = ""): Unit = {
+    val queryString = resourceToString(
+      s"$tpcdsGroup/$query.sql",
+      classLoader = Thread.currentThread().getContextClassLoader)
+    withSQLConf(
+      SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
+      SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      val qe = sql(queryString).queryExecution
+      val plan = qe.executedPlan
+      assert(
+        ValidateRequirements.validate(plan),
+        s"ValidateRequirements failed for $tpcdsGroup/$query$suffix")
+    }
+  }
+}
+
 class GlutenTPCDSV1_4_PlanStabilitySuite
   extends TPCDSV1_4_PlanStabilitySuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSV1_4_PlanStabilityWithStatsSuite
   extends TPCDSV1_4_PlanStabilityWithStatsSuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSV2_7_PlanStabilitySuite
   extends TPCDSV2_7_PlanStabilitySuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSV2_7_PlanStabilityWithStatsSuite
   extends TPCDSV2_7_PlanStabilityWithStatsSuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSModifiedPlanStabilitySuite
   extends TPCDSModifiedPlanStabilitySuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSModifiedPlanStabilityWithStatsSuite
   extends TPCDSModifiedPlanStabilityWithStatsSuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
-class GlutenTPCHPlanStabilitySuite extends TPCHPlanStabilitySuite with GlutenTestsCommonTrait {}
+class GlutenTPCHPlanStabilitySuite
+  extends TPCHPlanStabilitySuite
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
@@ -16,28 +16,67 @@
  */
 package org.apache.spark.sql
 
+import org.apache.spark.sql.catalyst.util.resourceToString
+import org.apache.spark.sql.execution.exchange.ValidateRequirements
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Gluten plan stability suites verify that Gluten-transformed plans satisfy Spark's distribution
+ * and ordering requirements (via ValidateRequirements). Golden file comparison against vanilla
+ * Spark plans is skipped because Gluten intentionally produces different physical plans using
+ * native Transformer operators.
+ */
+trait GlutenPlanStabilityTestTrait {
+  self: PlanStabilitySuite =>
+
+  override protected def testQuery(tpcdsGroup: String, query: String, suffix: String = ""): Unit = {
+    val queryString = resourceToString(
+      s"$tpcdsGroup/$query.sql",
+      classLoader = Thread.currentThread().getContextClassLoader)
+    withSQLConf(
+      SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
+      SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      val qe = sql(queryString).queryExecution
+      val plan = qe.executedPlan
+      assert(
+        ValidateRequirements.validate(plan),
+        s"ValidateRequirements failed for $tpcdsGroup/$query$suffix")
+    }
+  }
+}
+
 class GlutenTPCDSV1_4_PlanStabilitySuite
   extends TPCDSV1_4_PlanStabilitySuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSV1_4_PlanStabilityWithStatsSuite
   extends TPCDSV1_4_PlanStabilityWithStatsSuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSV2_7_PlanStabilitySuite
   extends TPCDSV2_7_PlanStabilitySuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSV2_7_PlanStabilityWithStatsSuite
   extends TPCDSV2_7_PlanStabilityWithStatsSuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSModifiedPlanStabilitySuite
   extends TPCDSModifiedPlanStabilitySuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
 class GlutenTPCDSModifiedPlanStabilityWithStatsSuite
   extends TPCDSModifiedPlanStabilityWithStatsSuite
-  with GlutenTestsCommonTrait {}
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}
 
-class GlutenTPCHPlanStabilitySuite extends TPCHPlanStabilitySuite with GlutenTestsCommonTrait {}
+class GlutenTPCHPlanStabilitySuite
+  extends TPCHPlanStabilitySuite
+  with GlutenSQLTestsBaseTrait
+  with GlutenPlanStabilityTestTrait {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

#11512 introduced PlanStability test suites for Spark 4.0 and 4.1 by extending Spark's original suites with `GlutenTestsCommonTrait`. While the tests appeared to pass, they were **not actually loading the Gluten plugin** — they were effectively running vanilla Spark, which trivially passes golden file comparison against Spark's own approved plans.

This PR fixes the suites properly by:

1. **Switching from `GlutenTestsCommonTrait` to `GlutenSQLTestsBaseTrait`**, which configures `spark.plugins=org.apache.gluten.GlutenPlugin` and other Gluten-specific settings (off-heap memory, columnar shuffle, etc.), ensuring the Gluten native engine is actually loaded.

2. **Fixing `BroadcastHashJoinExecTransformerBase.requiredChildDistribution`** — it used raw `buildKeyExprs` (`AttributeReference`) to construct `HashedRelationBroadcastMode`, while Spark's `EnsureRequirements` creates `BroadcastExchange` with bound+rewritten keys (`BoundReference`). This mode mismatch caused `ValidateRequirements.validate(plan)` to fail for every query containing a `BroadcastHashJoin` when AQE is disabled. Fixed by aligning with Spark's `BroadcastHashJoinExec` using `BindReferences.bindReferences(HashJoin.rewriteKeyExpr(keys), output)`.

3. **Adding `GlutenPlanStabilityTestTrait`** that overrides `testQuery()` to validate plans via `ValidateRequirements` instead of golden file comparison, since Gluten intentionally produces different physical plans with native Transformer operators (e.g., `BroadcastHashJoinExecTransformer`, `ColumnarExchange`).

### How was this patch tested?

All 7 test suites pass on both Spark 4.0 and 4.1 **with Gluten plugin loaded**:

| Suite | Tests | Spark 4.0 | Spark 4.1 |
|-------|-------|-----------|-----------|
| `GlutenTPCDSV1_4_PlanStabilitySuite` | 97 | ✅ | ✅ |
| `GlutenTPCDSV1_4_PlanStabilityWithStatsSuite` | 97 | ✅ | ✅ |
| `GlutenTPCDSV2_7_PlanStabilitySuite` | 32 | ✅ | ✅ |
| `GlutenTPCDSV2_7_PlanStabilityWithStatsSuite` | 32 | ✅ | ✅ |
| `GlutenTPCDSModifiedPlanStabilitySuite` | 21 | ✅ | ✅ |
| `GlutenTPCDSModifiedPlanStabilityWithStatsSuite` | 21 | ✅ | ✅ |
| `GlutenTPCHPlanStabilitySuite` | 22 | ✅ | ✅ |

### TODO

- [x] Verify `requiredChildDistribution` change has no broader impact (only affects AQE-disabled path)
- [ ] Implement Gluten-specific golden file comparison for plan stability regression detection

Related issue: #11550