### PR TITLE
[VL] Use CPUThreadPoolExecutor as DBI executors

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -314,7 +314,7 @@ void VeloxBackend::initConnector(const std::shared_ptr<velox::config::ConfigBase
       ioThreads >= 0,
       kVeloxIOThreads + " was set to negative number " + std::to_string(ioThreads) + ", this should not happen.");
   if (ioThreads > 0) {
-    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(ioThreads);
+    ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(ioThreads);
   }
   velox::connector::registerConnector(
       std::make_shared<velox::connector::hive::HiveConnector>(kHiveConnectorId, hiveConf, ioExecutor_.get()));

--- a/cpp/velox/compute/VeloxBackend.h
+++ b/cpp/velox/compute/VeloxBackend.h
@@ -90,7 +90,7 @@ class VeloxBackend {
   std::shared_ptr<facebook::velox::cache::AsyncDataCache> asyncDataCache_;
 
   std::unique_ptr<folly::IOThreadPoolExecutor> ssdCacheExecutor_;
-  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_;
   std::shared_ptr<facebook::velox::memory::MmapAllocator> cacheAllocator_;
 
   std::string cachePathPrefix_;


### PR DESCRIPTION
The main difference of IOThreadPoolExecutor and CPUThreadPoolExecutor is the scheduling:

*folly::IOThreadPoolExecutor is built on top of EventBase, and each thread in this executor runs a single‑threaded event loop. When you call executor_->add() from inside one of its own threads, the task is enqueued back into the same thread’s EventBase, so it executes sequentially on that same thread.*


Executor Type | Thread Model | Adding from same thread | Parallel?
-- | -- | -- | --
IOThreadPoolExecutor | 1 EventBase per thread | Runs sequentially on same thread | ❌ 
CPUThreadPoolExecutor | Worker threads + shared queue | May run on any thread |  ✅


In case of Parquet scan, the load are usually column chunk based. Like below. Each pread is a column chunk. If we use IOThreadPoolExecutor, all the columns are loaded sequentially in one thread, which will block the main thread until the used columns data returns. It's not what we expected. 
<img width="2170" height="210" alt="image" src="https://github.com/user-attachments/assets/53464ff8-4a1a-4ea6-8a97-264f55739e7a" />

If we switch to CPUThreadPoolExecutor, The column chunks will be fetched in parallel. Like below. Then the data may be returned quicker.
<img width="677" height="430" alt="image" src="https://github.com/user-attachments/assets/08d94082-b1a2-476c-b26f-901e9268ad7d" />

Here is the elapsed time of two typical IO bound queries performance:

| |IOPool|CPUPool|
|-|-|-|
|Q88|50s|42s|
|Q4|68s|59s|

Note Velox parquet scan is still far away from optimal. The throughput is only about 1/4 of S3 benchmark can get. Currently the async fetch is through rowgroup prefetch and split prefetch. All requests are send to S3 without priorities no matter it's prefetched or ondemand. We should list all the requests as a queue and fetch in priority categories.

The prefetch shouldn't be rowgroup or split based but the memory based. Parquet scan may also support spill, using multiple threads to fetch remote storage data into memory or local disk as faster as possible.