### PR TITLE
[GLUTEN-11550][UT] Enable GlutenMergeIntoDataFrameSuite and GlutenSparkSessionJobTaggingAndCancellationSuite

### DIFF
--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -252,7 +252,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataSourceV2OptionSuite]
   enableSuite[GlutenDataSourceV2UtilsSuite]
   // TODO: 4.x enableSuite[GlutenGroupBasedUpdateTableSuite]  // 1 failure
-  // TODO: 4.x enableSuite[GlutenMergeIntoDataFrameSuite]  // 1 failure
+  enableSuite[GlutenMergeIntoDataFrameSuite]
   enableSuite[GlutenProcedureSuite]
   enableSuite[GlutenPushablePredicateSuite]
   enableSuite[GlutenV1ReadFallbackWithCatalogSuite]
@@ -839,7 +839,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenSessionStateSuite]
   // TODO: 4.x enableSuite[GlutenSetCommandSuite]  // 1 failure
   enableSuite[GlutenSparkSessionBuilderSuite]
-  // TODO: 4.x enableSuite[GlutenSparkSessionJobTaggingAndCancellationSuite]  // 1 failure
+  enableSuite[GlutenSparkSessionJobTaggingAndCancellationSuite]
   enableSuite[GlutenTPCDSCollationQueryTestSuite]
   enableSuite[GlutenTPCDSModifiedPlanStabilitySuite]
   enableSuite[GlutenTPCDSModifiedPlanStabilityWithStatsSuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -263,7 +263,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenDataSourceV2OptionSuite]
   enableSuite[GlutenDataSourceV2UtilsSuite]
   // TODO: 4.x enableSuite[GlutenGroupBasedUpdateTableSuite]  // 1 failure
-  // TODO: 4.x enableSuite[GlutenMergeIntoDataFrameSuite]  // 1 failure
+  enableSuite[GlutenMergeIntoDataFrameSuite]
   enableSuite[GlutenProcedureSuite]
   enableSuite[GlutenPushablePredicateSuite]
   enableSuite[GlutenV1ReadFallbackWithCatalogSuite]
@@ -804,7 +804,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenSessionStateSuite]
   // TODO: 4.x enableSuite[GlutenSetCommandSuite]  // 1 failure
   enableSuite[GlutenSparkSessionBuilderSuite]
-  // TODO: 4.x enableSuite[GlutenSparkSessionJobTaggingAndCancellationSuite]  // 1 failure
+  enableSuite[GlutenSparkSessionJobTaggingAndCancellationSuite]
   enableSuite[GlutenTPCDSCollationQueryTestSuite]
   enableSuite[GlutenTPCDSModifiedPlanStabilitySuite]
   enableSuite[GlutenTPCDSModifiedPlanStabilityWithStatsSuite]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable 2 test suites that were disabled in #11512 but actually pass with GlutenPlugin loaded. Follow-up to #11800 which changed their traits to load GlutenPlugin but did not re-verify pre-existing disabled suites.

| Suite | Trait | spark40 | spark41 |
|-------|-------|---------|---------|
| GlutenSparkSessionJobTaggingAndCancellationSuite | GlutenTestsTrait | ✅ 4 passed | ✅ 5 passed |
| GlutenMergeIntoDataFrameSuite | GlutenSQLTestsTrait | ✅ 29 passed | ✅ 31 passed |

### How was this patch tested?

Ran both suites on spark40 and spark41 via `run-scala-test.sh --mvnd` — all passed.

Related issue: #11550