### PR TITLE
[CH] Close ColumnarBatch in CHColumnarCollectLimitExec for skipped batches

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHColumnarCollectLimitExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHColumnarCollectLimitExec.scala
@@ -66,6 +66,7 @@ case class CHColumnarCollectLimitExec(limit: Int, offset: Int, child: SparkPlan)
 
           if (rowsToSkip >= batchSize) {
             rowsToSkip -= batchSize
+            batch.close()
           } else {
             val startIndex = rowsToSkip
             val leftoverAfterSkip = batchSize - startIndex


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR closes` ColumnarBatch` for skipped batches in `CHColumnarCollectLimitExec`

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
