### PR TITLE
[VL] Pass row count to CudfVector in GPU batch serializer

### DIFF
--- a/cpp/velox/operators/serializer/VeloxGpuColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxGpuColumnarBatchSerializer.cc
@@ -48,7 +48,7 @@ std::shared_ptr<ColumnarBatch> VeloxGpuColumnarBatchSerializer::deserialize(uint
     dynamic_pointer_cast<VeloxColumnarBatch>(vb)->getRowVector(), veloxPool_.get(), stream, cudf_velox::get_output_mr());
   stream.synchronize();
   auto vector = std::make_shared<cudf_velox::CudfVector>(
-      veloxPool_.get(), rowType_, size, std::move(table), stream);
+      veloxPool_.get(), rowType_, vb->numRows(), std::move(table), stream);
   return std::make_shared<VeloxColumnarBatch>(vector, vb->numColumns());
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
The `deserialize(uint8_t* data, int32_t size)` method receives `size` as the length of the serialized byte array (set via `env->GetArrayLength(data)` in `JniWrapper.cc`) and this byte count was forwarded directly as the `vector_size_t size` parameter to `CudfVector`, This PR replaces `size` with `vb->numRows()`, which is the actual row count from the deserialized Velox batch.

## How was this patch tested?
Existing UTs.

## Was this patch authored or co-authored using generative AI tooling?
No.