### PR TITLE
[VL] Fix native `Union` result name

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -582,6 +582,55 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
   }
 
+  test("native union_all with two level union keeps distinct output columns") {
+    withTempView("union_src_a", "union_src_b", "union_src_c") {
+      Seq(
+        ("valueA", "value1", "value11", "value111"),
+        ("valueA", "value2", "value22", "value222")
+      ).toDF("col1", "col2", "col3", "col4")
+        .createOrReplaceTempView("union_src_a")
+      Seq(
+        ("valueB", "value3", "value33", "value333"),
+        ("valueB", "value4", "value44", "value444")
+      ).toDF("col1", "col2", "col3", "col4")
+        .createOrReplaceTempView("union_src_b")
+
+      withSQLConf(GlutenConfig.NATIVE_UNION_ENABLED.key -> "true") {
+        compareDfResultsAgainstVanillaSpark(
+          () =>
+            spark.sql("""
+                        |with deduplicated_data as (
+                        |  select col1, col2, col3, col4
+                        |  from (
+                        |    select
+                        |      u.col1,
+                        |      u.col2,
+                        |      u.col3,
+                        |      u.col4,
+                        |      row_number() over (partition by u.col2 order by u.col5 desc) as rn
+                        |    from (
+                        |      select col1, col2, col3, col4, 98 as col5 from union_src_a
+                        |      union all
+                        |      select col1, col2, col3, col4, 100 as col5 from union_src_b
+                        |    ) u
+                        |  ) t
+                        |  where t.rn = 1
+                        |)
+                        |select col1, col2, col3, col4
+                        |from deduplicated_data
+                        |where col1 != 'valueC'
+                        |union all
+                        |select col1, col2, col3, col4
+                        |from deduplicated_data
+                        |where col1 = 'valueC'
+                        |""".stripMargin),
+          compareResult = true,
+          checkGlutenPlan[UnionExecTransformer]
+        )
+      }
+    }
+  }
+
   test("union two tables") {
     runQueryAndCompare("""
                          |select count(orderkey) from (

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1244,7 +1244,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
       const RowTypePtr outRowType = asRowType(children[0]->outputType());
       std::vector<std::string> outNames;
       for (int32_t colIdx = 0; colIdx < outRowType->size(); ++colIdx) {
-        const auto name = outRowType->childAt(colIdx)->name();
+        // Using field names from the unified output row type instead child type names
+        const auto name = outRowType->nameOf(colIdx);
         outNames.push_back(name);
       }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->
Fix native union result use column type name as column name, which lead to same data type column has same data, but is not right result. eg all string columns has same data value as the first string column

```const auto name = outRowType->childAt(colIdx)->name();```
result name is column type name
```const auto name = outRowType->nameOf(colIdx);```
result name is column name

with conf spark.gluten.sql.native.union=true and use sql like 
```
with deduplicated_data as (
  select col1, col2, col3, col4, col6
  from (
    select
      u.col1,
      u.col2,
      u.col3,
      u.col4,
      u.col6,
      row_number() over (partition by u.col2 order by u.col5 desc) as rn
    from (
      select col1, col2, col3, col4, 98 as col5, '' as col6 from union_src_a
      union all
      select col1, col2, col3, col4, 100 as col5, '' as col6 from union_src_b
    ) u
  ) t
  where t.rn = 1
)
select col1, col2, col3, col4
from deduplicated_data
where col1 != 'valueC'
union all
select col1, col2, col3, col4
from deduplicated_data
where col1 = 'valueC'
``` can reproduce the error

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
test at our produce env, and add unit test
## Was this patch authored or co-authored using generative AI tooling?
yes, co-authored by cursor
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
