### PR TITLE
[GLUTEN-11888] [VL] Remove the synchronized lock in VeloxBroadcastBuildSideCache

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxBroadcastBuildSideCache.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxBroadcastBuildSideCache.scala
@@ -57,7 +57,7 @@ object VeloxBroadcastBuildSideCache
 
   def getOrBuildBroadcastHashTable(
       broadcast: Broadcast[BuildSideRelation],
-      broadcastContext: BroadcastHashJoinContext): BroadcastHashTable = synchronized {
+      broadcastContext: BroadcastHashJoinContext): BroadcastHashTable = {
 
     buildSideRelationCache
       .get(
@@ -76,14 +76,13 @@ object VeloxBroadcastBuildSideCache
   }
 
   /** This is callback from c++ backend. */
-  def get(broadcastHashtableId: String): Long =
-    synchronized {
-      Option(buildSideRelationCache.getIfPresent(broadcastHashtableId))
-        .map(_.pointer)
-        .getOrElse(0)
-    }
+  def get(broadcastHashtableId: String): Long = {
+    Option(buildSideRelationCache.getIfPresent(broadcastHashtableId))
+      .map(_.pointer)
+      .getOrElse(0)
+  }
 
-  def invalidateBroadcastHashtable(broadcastHashtableId: String): Unit = synchronized {
+  def invalidateBroadcastHashtable(broadcastHashtableId: String): Unit = {
     // Cleanup operations on the backend are idempotent.
     buildSideRelationCache.invalidate(broadcastHashtableId)
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
VeloxBroadcastBuildSideCache is managed by Caffe, which is already thread-safe. So we don't need to add manual synchronization.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Existing tests
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?
no
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->


Related issue: #11888