### PR TITLE
[MINOR] Expose Gluten and component build information to SparkConf

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/GlutenPlugin.scala
@@ -62,6 +62,7 @@ private[gluten] class GlutenDriverPlugin extends DriverPlugin with Logging {
 
     val components = Component.sorted()
     printComponentInfo(components)
+    setComponentInfoConfig(conf, components)
     components.foreach(_.onDriverStart(sc, pluginContext))
     Collections.emptyMap()
   }
@@ -169,6 +170,16 @@ private object GlutenDriverPlugin extends Logging {
         "\n=============================================================="
       )
     logInfo(loggingInfo)
+  }
+
+  private def setComponentInfoConfig(conf: SparkConf, components: Seq[Component]): Unit = {
+    components.foreach {
+      c =>
+        c.info().foreach {
+          case (k, v) =>
+            conf.set(s"spark.gluten.component.$k", v)
+        }
+    }
   }
 }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SubstraitBackend.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SubstraitBackend.scala
@@ -50,6 +50,7 @@ trait SubstraitBackend extends Backend with Logging {
     }
 
     postBuildInfoEvent(sc)
+    setBuildInfoConfig(conf)
 
     setPredefinedConfigs(conf)
 
@@ -123,6 +124,13 @@ object SubstraitBackend extends Logging {
       val event = GlutenBuildInfoEvent(glutenBuildInfo.toMap)
       GlutenUIUtils.postEvent(sc, event)
     }
+  }
+
+  private def setBuildInfoConfig(conf: SparkConf): Unit = {
+    conf.set("spark.gluten.branch", GlutenBuildInfo.BRANCH)
+    conf.set("spark.gluten.revision", GlutenBuildInfo.REVISION)
+    conf.set("spark.gluten.revisionTime", GlutenBuildInfo.REVISION_TIME)
+    conf.set("spark.gluten.buildTime", GlutenBuildInfo.BUILD_DATE)
   }
 
   private def setPredefinedConfigs(conf: SparkConf): Unit = {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Currently, Gluten build information is not injected into the Spark configuration, which causes difficulties in certain troubleshooting and tracking scenarios. For example:
1. To find out which specific Git revision a job is running on, we have to grep the driver's syslog. Since driver logs are deleted much earlier than Spark History logs, this information becomes unavailable once the syslog is purged.
2. We have a tracking table that stores all configs of our running jobs. Without the build metadata in the config, it's hard to tell when a job starts running on a newer version of Gluten.
Therefore, this PR sets the Gluten build information as part of the Spark configurations. With this change, we can simply check the build revision by looking at the Spark UI:
<img width="1409" height="65" alt="image" src="https://github.com/user-attachments/assets/2e0dc204-6de2-402a-8e14-f46abbf5ea72" />