### PR TITLE
[VL] Find the aggregate function name by matching result type

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -165,17 +165,36 @@ RowTypePtr getJoinOutputType(
   VELOX_FAIL("Output should include left or right columns.");
 }
 
+// The base names can be referred from 'velox/expression/FunctionSignature.cpp'.
+std::string typeBaseName(const TypePtr& type) {
+  if (type->isDecimal()) {
+    return "decimal";
+  }
+  if (type->isPrimitiveType()) {
+    return type->toString();
+  }
+
+  if (type->kind() == TypeKind::ARRAY) {
+    return "array";
+  }
+
+  if (type->kind() == TypeKind::MAP) {
+    return "map";
+  }
+
+  if (type->kind() == TypeKind::ROW) {
+    return "row";
+  }
+  VELOX_UNREACHABLE("Unknown type: {}", type->toString());
+}
+
 // Get the function name suffix used by merge_extract companion function when having the same intermediate type across
 // signatures. Correponds to Velox 'toSuffixString', and the base name can be referred from
 // 'velox/expression/FunctionSignature.cpp'.
 std::string companionFunctionSuffix(const TypePtr& type) {
   // For primitive and decimal types, return their names.
-  if (type->isDecimal()) {
-    return "DECIMAL";
-  }
-
-  if (type->isPrimitiveType()) {
-    return type->toString();
+  if (type->isDecimal() || type->isPrimitiveType()) {
+    return typeBaseName(type);
   }
 
   if (type->kind() == TypeKind::ARRAY) {
@@ -199,6 +218,25 @@ std::string companionFunctionSuffix(const TypePtr& type) {
   result += "_end";
   result += name;
   return result;
+}
+
+// Compatible with 'validateBaseTypeAndCollectTypeParams' in 'velox/expression/FunctionSignature.cpp'.
+bool isBuiltinTypeName(const std::string& typeName) {
+  return TypeKindName::tryToTypeKind(typeName).has_value() || isDecimalName(typeName) || isDateName(typeName) ||
+      hasType(typeName);
+}
+
+// Checks if the companion function entry has a matching return type for the given result type.
+bool hasMatchingReturnType(const exec::CompanionSignatureEntry& entry, const TypePtr& returnType) {
+  const auto returnTypeName = boost::algorithm::to_upper_copy(typeBaseName(returnType));
+  for (const auto& signature : entry.signatures) {
+    const auto signatureTypeName = boost::algorithm::to_upper_copy(signature->returnType().baseName());
+    // Non-built-in type is allowed for a generic type match.
+    if (!isBuiltinTypeName(signatureTypeName) || signatureTypeName == returnTypeName) {
+      return true;
+    }
+  }
+  return false;
 }
 
 } // namespace
@@ -278,32 +316,31 @@ std::string SubstraitToVeloxPlanConverter::toAggregationFunctionName(
       suffix = "_partial";
       break;
     case core::AggregationNode::Step::kFinal: {
-      auto functionName = baseName + "_merge_extract";
+      const auto functionName = baseName + "_merge_extract";
       auto signatures = exec::getAggregateFunctionSignatures(functionName);
       if (signatures.has_value() && signatures.value().size() > 0) {
         // The merge_extract function is registered without suffix.
         return functionName;
       }
-      // The merge_extract function must be registered with suffix based on
-      // result type. First try exact concrete type suffix.
-      auto suffixedName = functionName + "_" + companionFunctionSuffix(resultType);
-      signatures = exec::getAggregateFunctionSignatures(suffixedName);
+
+      // The merge_extract function should be registered with suffix based on result type.
+      const auto fullName = functionName + "_" + companionFunctionSuffix(resultType);
+      signatures = exec::getAggregateFunctionSignatures(fullName);
       if (signatures.has_value() && signatures.value().size() > 0) {
-        return suffixedName;
+        return fullName;
       }
-      // When companion functions are registered with generic type variables
-      // (e.g., "collect_set_merge_extract_array_T"), look up companion
-      // function names from the aggregate function registry.
+
+      // When a function uses generic type variables in its signature (e.g., ..._T), infer the function by matching the
+      // result type allow non-built-in names.
       auto companionSigs = exec::getCompanionFunctionSignatures(baseName);
       if (companionSigs.has_value()) {
         for (const auto& entry : companionSigs->mergeExtract) {
-          auto entrySigs = exec::getAggregateFunctionSignatures(entry.functionName);
-          if (entrySigs.has_value() && entrySigs.value().size() > 0) {
+          if (hasMatchingReturnType(entry, resultType)) {
             return entry.functionName;
           }
         }
       }
-      VELOX_FAIL("Cannot find function signature for {} in final aggregation step.", suffixedName);
+      VELOX_FAIL("Cannot find function signature for {} in final aggregation step.", baseName);
     }
     case core::AggregationNode::Step::kIntermediate:
       suffix = "_merge";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Find the aggregate function name by matching the result type, rather than returning an arbitrary aggregate function name blindly.
Follow-up for: https://github.com/apache/gluten/pull/11891.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

With existing UTs.

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No