### PR TITLE
[GLUTEN-9456][VL] Override clone in `GlutenDirectBufferedInput`

### DIFF
--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -156,7 +156,7 @@ jobs:
           path: /root/.m2/repository/org/apache/arrow/
       - name: Setup tzdata
         run: |
-          #sed -i 's|http://archive|http://us.archive|g' /etc/apt/sources.list
+          sed -i 's|http://archive|http://eu.archive|g' /etc/apt/sources.list
           if [ "${{ matrix.os }}" = "ubuntu:22.04" ]; then
             apt-get update
             TZ="Etc/GMT" DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata

--- a/cpp/velox/memory/GlutenDirectBufferedInput.h
+++ b/cpp/velox/memory/GlutenDirectBufferedInput.h
@@ -67,6 +67,32 @@ class GlutenDirectBufferedInput : public facebook::velox::dwio::common::DirectBu
     }
     coalescedLoads_.clear();
   }
+
+  std::unique_ptr<facebook::velox::dwio::common::BufferedInput> clone() const override {
+    return std::unique_ptr<facebook::velox::dwio::common::BufferedInput>(new GlutenDirectBufferedInput(
+        input_, fileNum_, tracker_, groupId_, ioStatistics_, ioStats_, executor_, options_));
+  }
+
+ private:
+  // Constructor used by clone().
+  GlutenDirectBufferedInput(
+      std::shared_ptr<facebook::velox::dwio::common::ReadFileInputStream> input,
+      facebook::velox::StringIdLease fileNum,
+      std::shared_ptr<facebook::velox::cache::ScanTracker> tracker,
+      facebook::velox::StringIdLease groupId,
+      std::shared_ptr<facebook::velox::io::IoStatistics> ioStatistics,
+      std::shared_ptr<facebook::velox::IoStats> ioStats,
+      folly::Executor* executor,
+      const facebook::velox::io::ReaderOptions& readerOptions)
+      : DirectBufferedInput(
+            std::move(input),
+            std::move(fileNum),
+            std::move(tracker),
+            std::move(groupId),
+            std::move(ioStatistics),
+            std::move(ioStats),
+            executor,
+            readerOptions) {}
 };
 
 } // namespace gluten


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

`StructColumnReader::loadRowGroup` clones the buffered input. To keep using
custom `DirectBufferedInput` after cloning, we need to override clone.

https://github.com/facebookincubator/velox/blob/22b90045ef5737c737593fbedde1f6f4f64d6dc5/velox/dwio/parquet/reader/StructColumnReader.cpp#L124

Depends on https://github.com/facebookincubator/velox/pull/17147.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

Existing tests.

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.

Related issue: #9456