### PR TITLE
[CORE] Refactor common expression mappings out of Spark shims

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
@@ -304,7 +304,6 @@ object ExpressionMappings {
     Sig[Sec](SEC),
     Sig[Csc](CSC),
     Sig[KnownNullable](KNOWN_NULLABLE),
-    Sig[Empty2Null](EMPTY2NULL),
     Sig[TimestampAdd](TIMESTAMP_ADD),
     Sig[TimestampDiff](TIMESTAMP_DIFF),
     Sig[RoundFloor](FLOOR),

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
@@ -299,7 +299,16 @@ object ExpressionMappings {
     // Decimal
     Sig[UnscaledValue](UNSCALED_VALUE),
     // Generator function
-    Sig[Stack](STACK)
+    Sig[Stack](STACK),
+    Sig[SplitPart](SPLIT_PART),
+    Sig[Sec](SEC),
+    Sig[Csc](CSC),
+    Sig[KnownNullable](KNOWN_NULLABLE),
+    Sig[Empty2Null](EMPTY2NULL),
+    Sig[TimestampAdd](TIMESTAMP_ADD),
+    Sig[TimestampDiff](TIMESTAMP_DIFF),
+    Sig[RoundFloor](FLOOR),
+    Sig[RoundCeil](CEIL)
   ) ++ SparkShimLoader.getSparkShims.scalarExpressionMappings
 
   /** Mapping Spark aggregate expression to Substrait function name */
@@ -328,7 +337,8 @@ object ExpressionMappings {
     Sig[Kurtosis](KURTOSIS),
     Sig[ApproximatePercentile](APPROX_PERCENTILE),
     Sig[HyperLogLogPlusPlus](APPROX_COUNT_DISTINCT),
-    Sig[Percentile](PERCENTILE)
+    Sig[Percentile](PERCENTILE),
+    Sig[RegrR2](REGR_R2)
   ) ++ SparkShimLoader.getSparkShims.aggregateExpressionMappings
 
   /** Mapping Spark window expression to Substrait function name */
@@ -349,7 +359,10 @@ object ExpressionMappings {
     Sig[NullIf](NULLIF),
     Sig[Nvl](NVL),
     Sig[Nvl2](NVL2),
-    Sig[Right](RIGHT)
+    Sig[Right](RIGHT),
+    Sig[ArraySize](ARRAY_SIZE),
+    Sig[ILike](ILIKE),
+    Sig[MapContainsKey](MAP_CONTAINS_KEY)
   ) ++ SparkShimLoader.getSparkShims.runtimeReplaceableExpressionMappings
 
   def blacklistExpressionMap: Map[Class[_], String] = {

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.sql.shims.spark33
 
 import org.apache.gluten.execution.datasource.GlutenFormatFactory
-import org.apache.gluten.expression.Sig
+import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 import org.apache.gluten.utils.ExceptionUtils
 

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -17,8 +17,7 @@
 package org.apache.gluten.sql.shims.spark33
 
 import org.apache.gluten.execution.datasource.GlutenFormatFactory
-import org.apache.gluten.expression.{ExpressionNames, Sig}
-import org.apache.gluten.expression.ExpressionNames.{CEIL, FLOOR, KNOWN_NULLABLE, TIMESTAMP_ADD}
+import org.apache.gluten.expression.Sig
 import org.apache.gluten.sql.shims.SparkShims
 import org.apache.gluten.utils.ExceptionUtils
 
@@ -56,33 +55,11 @@ import scala.collection.mutable
 
 class Spark33Shims extends SparkShims {
 
-  override def scalarExpressionMappings: Seq[Sig] = {
-    Seq(
-      Sig[SplitPart](ExpressionNames.SPLIT_PART),
-      Sig[Sec](ExpressionNames.SEC),
-      Sig[Csc](ExpressionNames.CSC),
-      Sig[KnownNullable](KNOWN_NULLABLE),
-      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
-      Sig[TimestampAdd](TIMESTAMP_ADD),
-      Sig[TimestampDiff](ExpressionNames.TIMESTAMP_DIFF),
-      Sig[RoundFloor](FLOOR),
-      Sig[RoundCeil](CEIL)
-    )
-  }
+  override def scalarExpressionMappings: Seq[Sig] = Seq()
 
-  override def aggregateExpressionMappings: Seq[Sig] = {
-    Seq(
-      Sig[RegrR2](ExpressionNames.REGR_R2)
-    )
-  }
+  override def aggregateExpressionMappings: Seq[Sig] = Seq()
 
-  override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
-    Seq(
-      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
-      Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY)
-    )
-  }
+  override def runtimeReplaceableExpressionMappings: Seq[Sig] = Seq()
 
   override def isNullIntolerant(expr: Expression): Boolean = expr.isInstanceOf[NullIntolerant]
 

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.execution.{FileSourceScanExec, PartitionedFileUtil, QueryExecution, SparkPlan, SparkPlanner}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.FileFormatWriter.Empty2Null
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeLike
@@ -53,7 +54,9 @@ import scala.collection.mutable
 
 class Spark33Shims extends SparkShims {
 
-  override def scalarExpressionMappings: Seq[Sig] = Seq()
+  override def scalarExpressionMappings: Seq[Sig] = {
+    Seq(Sig[Empty2Null](ExpressionNames.EMPTY2NULL))
+  }
 
   override def aggregateExpressionMappings: Seq[Sig] = Seq()
 

--- a/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
+++ b/shims/spark33/src/main/scala/org/apache/gluten/sql/shims/spark33/Spark33Shims.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.RegrR2
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -36,7 +35,6 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.execution.{FileSourceScanExec, PartitionedFileUtil, QueryExecution, SparkPlan, SparkPlanner}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.FileFormatWriter.Empty2Null
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeLike

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -17,7 +17,6 @@
 package org.apache.gluten.sql.shims.spark34
 
 import org.apache.gluten.expression.{ExpressionNames, Sig}
-import org.apache.gluten.expression.ExpressionNames.KNOWN_NULLABLE
 import org.apache.gluten.sql.shims.SparkShims
 import org.apache.gluten.utils.ExceptionUtils
 
@@ -63,15 +62,6 @@ class Spark34Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[SplitPart](ExpressionNames.SPLIT_PART),
-      Sig[Sec](ExpressionNames.SEC),
-      Sig[Csc](ExpressionNames.CSC),
-      Sig[KnownNullable](KNOWN_NULLABLE),
-      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
-      Sig[TimestampAdd](ExpressionNames.TIMESTAMP_ADD),
-      Sig[TimestampDiff](ExpressionNames.TIMESTAMP_DIFF),
-      Sig[RoundFloor](ExpressionNames.FLOOR),
-      Sig[RoundCeil](ExpressionNames.CEIL),
       Sig[Mask](ExpressionNames.MASK),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),
@@ -83,7 +73,6 @@ class Spark34Shims extends SparkShims {
 
   override def aggregateExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[RegrR2](ExpressionNames.REGR_R2),
       Sig[RegrSlope](ExpressionNames.REGR_SLOPE),
       Sig[RegrIntercept](ExpressionNames.REGR_INTERCEPT),
       Sig[RegrSXY](ExpressionNames.REGR_SXY),
@@ -94,10 +83,7 @@ class Spark34Shims extends SparkShims {
   override def runtimeReplaceableExpressionMappings: Seq[Sig] = {
     Seq(
       Sig[ArrayCompact](ExpressionNames.ARRAY_COMPACT),
-      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
-      Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY),
       Sig[Get](ExpressionNames.GET)
     )
   }

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -62,6 +62,7 @@ class Spark34Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
+      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -64,16 +64,7 @@ class Spark35Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[SplitPart](ExpressionNames.SPLIT_PART),
-      Sig[Sec](ExpressionNames.SEC),
-      Sig[Csc](ExpressionNames.CSC),
-      Sig[KnownNullable](ExpressionNames.KNOWN_NULLABLE),
-      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
-      Sig[TimestampAdd](ExpressionNames.TIMESTAMP_ADD),
-      Sig[TimestampDiff](ExpressionNames.TIMESTAMP_DIFF),
-      Sig[RoundFloor](ExpressionNames.FLOOR),
-      Sig[RoundCeil](ExpressionNames.CEIL),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),
       Sig[ArrayAppend](ExpressionNames.ARRAY_APPEND),
@@ -85,7 +76,6 @@ class Spark35Shims extends SparkShims {
 
   override def aggregateExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[RegrR2](ExpressionNames.REGR_R2),
       Sig[RegrSlope](ExpressionNames.REGR_SLOPE),
       Sig[RegrIntercept](ExpressionNames.REGR_INTERCEPT),
       Sig[RegrSXY](ExpressionNames.REGR_SXY),
@@ -97,10 +87,7 @@ class Spark35Shims extends SparkShims {
     Seq(
       Sig[ArrayCompact](ExpressionNames.ARRAY_COMPACT),
       Sig[ArrayPrepend](ExpressionNames.ARRAY_PREPEND),
-      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
-      Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY),
       Sig[Get](ExpressionNames.GET),
       Sig[Luhncheck](ExpressionNames.LUHN_CHECK)
     )

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -64,6 +64,7 @@ class Spark35Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
+      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -67,6 +67,7 @@ class Spark40Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
+      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -67,16 +67,7 @@ class Spark40Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[SplitPart](ExpressionNames.SPLIT_PART),
-      Sig[Sec](ExpressionNames.SEC),
-      Sig[Csc](ExpressionNames.CSC),
-      Sig[KnownNullable](ExpressionNames.KNOWN_NULLABLE),
-      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
-      Sig[TimestampAdd](ExpressionNames.TIMESTAMP_ADD),
-      Sig[TimestampDiff](ExpressionNames.TIMESTAMP_DIFF),
-      Sig[RoundFloor](ExpressionNames.FLOOR),
-      Sig[RoundCeil](ExpressionNames.CEIL),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),
       Sig[ArrayAppend](ExpressionNames.ARRAY_APPEND),
@@ -90,7 +81,6 @@ class Spark40Shims extends SparkShims {
 
   override def aggregateExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[RegrR2](ExpressionNames.REGR_R2),
       Sig[RegrSlope](ExpressionNames.REGR_SLOPE),
       Sig[RegrIntercept](ExpressionNames.REGR_INTERCEPT),
       Sig[RegrSXY](ExpressionNames.REGR_SXY),
@@ -102,10 +92,7 @@ class Spark40Shims extends SparkShims {
     Seq(
       Sig[ArrayCompact](ExpressionNames.ARRAY_COMPACT),
       Sig[ArrayPrepend](ExpressionNames.ARRAY_PREPEND),
-      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
-      Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY),
       Sig[Get](ExpressionNames.GET),
       Sig[Luhncheck](ExpressionNames.LUHN_CHECK)
     )

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -66,6 +66,7 @@ class Spark41Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
+      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -66,16 +66,7 @@ class Spark41Shims extends SparkShims {
 
   override def scalarExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[SplitPart](ExpressionNames.SPLIT_PART),
-      Sig[Sec](ExpressionNames.SEC),
-      Sig[Csc](ExpressionNames.CSC),
-      Sig[KnownNullable](ExpressionNames.KNOWN_NULLABLE),
-      Sig[Empty2Null](ExpressionNames.EMPTY2NULL),
       Sig[Mask](ExpressionNames.MASK),
-      Sig[TimestampAdd](ExpressionNames.TIMESTAMP_ADD),
-      Sig[TimestampDiff](ExpressionNames.TIMESTAMP_DIFF),
-      Sig[RoundFloor](ExpressionNames.FLOOR),
-      Sig[RoundCeil](ExpressionNames.CEIL),
       Sig[ArrayInsert](ExpressionNames.ARRAY_INSERT),
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),
       Sig[ArrayAppend](ExpressionNames.ARRAY_APPEND),
@@ -89,7 +80,6 @@ class Spark41Shims extends SparkShims {
 
   override def aggregateExpressionMappings: Seq[Sig] = {
     Seq(
-      Sig[RegrR2](ExpressionNames.REGR_R2),
       Sig[RegrSlope](ExpressionNames.REGR_SLOPE),
       Sig[RegrIntercept](ExpressionNames.REGR_INTERCEPT),
       Sig[RegrSXY](ExpressionNames.REGR_SXY),
@@ -101,10 +91,7 @@ class Spark41Shims extends SparkShims {
     Seq(
       Sig[ArrayCompact](ExpressionNames.ARRAY_COMPACT),
       Sig[ArrayPrepend](ExpressionNames.ARRAY_PREPEND),
-      Sig[ArraySize](ExpressionNames.ARRAY_SIZE),
       Sig[EqualNull](ExpressionNames.EQUAL_NULL),
-      Sig[ILike](ExpressionNames.ILIKE),
-      Sig[MapContainsKey](ExpressionNames.MAP_CONTAINS_KEY),
       Sig[Get](ExpressionNames.GET),
       Sig[Luhncheck](ExpressionNames.LUHN_CHECK)
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR refactors expression mappings after dropping Spark 3.2 support, simplifying the codebase by moving shared mappings out of version-specific shims and reducing duplication.

## How was this patch tested?

CI

## Was this patch authored or co-authored using generative AI tooling?

No.
