### PR TITLE
[MINOR] Split Iceberg test resources into separate Maven entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1792,6 +1792,8 @@
                   <resources>
                     <resource>
                       <directory>${project.basedir}/src-iceberg/test/resources</directory>
+                    </resource>
+                    <resource>
                       <directory>${project.basedir}/src-iceberg${iceberg.binary.version}/test/resources</directory>
                     </resource>
                   </resources>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Maven Resource accepts a single directory per resource entry. Split the Iceberg
test resource directories into separate resource entries to match the existing
pattern used by other profiles and avoid dropping one directory during model
processing.
https://maven.apache.org/plugins/maven-resources-plugin/examples/resource-directory.html

## How was this patch tested?

CI

## Was this patch authored or co-authored using generative AI tooling?

No.
